### PR TITLE
AirPods Pro 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Currently supported models:
 * AirPods 1. Generation
 * AirPods 2. Generation
 * AirPods 3. Generation
-* AirPods Pro
+* AirPods Pro 1. Generation
+* AirPods Pro 2. Generation
 * AirPods Max
 * Power Beats Pro
 * Power Beats 3

--- a/app-common/src/main/java/eu/darken/capod/pods/core/PodDevice.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/PodDevice.kt
@@ -78,6 +78,10 @@ interface PodDevice {
             "AirPods Pro",
             R.drawable.ic_device_airpods_gen2
         ),
+        @Json(name = "airpods.pro2") AIRPODS_PRO2(
+            "AirPods Pro 2",
+            R.drawable.ic_device_airpods_gen2
+        ),
         @Json(name = "airpods.max") AIRPODS_MAX(
             "AirPods Max",
             R.drawable.ic_device_generic_headphones

--- a/app-common/src/main/java/eu/darken/capod/pods/core/apple/AppleFactoryModule.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/apple/AppleFactoryModule.kt
@@ -19,6 +19,7 @@ abstract class AppleFactoryModule {
     @Binds @IntoSet abstract fun airPodsGen3(factory: AirPodsGen3.Factory): ApplePodsFactory<out ApplePods>
 
     @Binds @IntoSet abstract fun airPodsPro(factory: AirPodsPro.Factory): ApplePodsFactory<out ApplePods>
+    @Binds @IntoSet abstract fun airPodsPro2(factory: AirPodsPro2.Factory): ApplePodsFactory<out ApplePods>
     @Binds @IntoSet abstract fun airPodsMax(factory: AirPodsMax.Factory): ApplePodsFactory<out ApplePods>
 
     @Binds @IntoSet abstract fun beatsFlex(factory: BeatsFlex.Factory): ApplePodsFactory<out ApplePods>

--- a/app-common/src/main/java/eu/darken/capod/pods/core/apple/ApplePodsFactory.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/apple/ApplePodsFactory.kt
@@ -83,7 +83,7 @@ abstract class ApplePodsFactory<PodType : ApplePods>(private val tag: String) {
         if (definitive.contains(basic.caseLidState)) return null
 
         return history
-            .filterIsInstance<AirPodsPro>()
+            .filterIsInstance<AirPodsPro>() // TODO why is this AirPodsPro specific here?
             .lastOrNull { it.caseLidState != DualAirPods.LidState.NOT_IN_CASE }
             ?.caseLidState
     }

--- a/app-common/src/main/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2.kt
@@ -11,7 +11,7 @@ import eu.darken.capod.pods.core.apple.protocol.ProximityPairing
 import java.time.Instant
 import javax.inject.Inject
 
-data class AirPodsPro(
+data class AirPodsPro2(
     override val identifier: PodDevice.Id = PodDevice.Id(),
     override val seenLastAt: Instant = Instant.now(),
     override val seenFirstAt: Instant = Instant.now(),
@@ -24,7 +24,7 @@ data class AirPodsPro(
     private val cachedCaseState: LidState? = null
 ) : DualAirPods {
 
-    override val model: PodDevice.Model = PodDevice.Model.AIRPODS_PRO
+    override val model: PodDevice.Model = PodDevice.Model.AIRPODS_PRO2
 
     override val batteryCasePercent: Float?
         get() = super.batteryCasePercent ?: cachedBatteryPercentage
@@ -42,7 +42,7 @@ data class AirPodsPro(
         }
 
         override fun create(scanResult: BleScanResult, message: ProximityPairing.Message): ApplePods {
-            var basic = AirPodsPro(scanResult = scanResult, proximityMessage = message)
+            var basic = AirPodsPro2(scanResult = scanResult, proximityMessage = message)
             val result = searchHistory(basic)
 
             if (result != null) basic = basic.copy(identifier = result.id)
@@ -65,7 +65,7 @@ data class AirPodsPro(
     }
 
     companion object {
-        private val DEVICE_CODE = 0x0e20.toUShort()
-        private val TAG = logTag("PodDevice", "Apple", "AirPods", "Pro")
+        private val DEVICE_CODE = 0x1120.toUShort()
+        private val TAG = logTag("PodDevice", "Apple", "AirPods", "Pro2")
     }
 }

--- a/app-common/src/main/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2.kt
@@ -65,7 +65,7 @@ data class AirPodsPro2(
     }
 
     companion object {
-        private val DEVICE_CODE = 0x1120.toUShort()
+        private val DEVICE_CODE = 0x1420.toUShort()
         private val TAG = logTag("PodDevice", "Apple", "AirPods", "Pro2")
     }
 }

--- a/app-common/src/test/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2Test.kt
+++ b/app-common/src/test/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2Test.kt
@@ -8,32 +8,38 @@ import org.junit.jupiter.api.Test
 
 class AirPodsPro2Test : BaseAirPodsTest() {
 
+    /**
+     * https://github.com/d4rken-org/capod/issues/31#issuecomment-1256791084
+     */
     @Test
     fun `test AirPods Pro 2 - unknown setup from #31`() = runBlockingTest {
-        create<AirPodsPro2>("07 19 01 11 20 2B 88 0F 00 11 05 77 7B 0E E5 B8 AD 03 57 2F FA AA 2C F5 65 0F 52") {
+        create<AirPodsPro2>("07 19 01 14 20 55 88 F9 51 00 04 20 50 03 CA D5 C9 AC 0F FA 84 78 94 5A 4D DF F5") {
 
             rawPrefix shouldBe 0x01.toUByte()
-            rawDeviceModel shouldBe 0x1120.toUShort()
-            rawStatus shouldBe 0x2B.toUByte()
+            rawDeviceModel shouldBe 0x1420.toUShort()
+            rawStatus shouldBe 0x55.toUByte()
             rawPodsBattery shouldBe 0x88.toUByte()
-            rawFlags shouldBe 0x0.toUShort()
-            rawCaseBattery shouldBe 0xF.toUShort()
-            rawCaseLidState shouldBe 0x00.toUByte()
-            rawDeviceColor shouldBe 0x11.toUByte()
-            rawSuffix shouldBe 0x05.toUByte()
+            rawFlags shouldBe 0xF.toUShort()
+            rawCaseBattery shouldBe 0x9.toUShort()
+            rawCaseLidState shouldBe 0x51.toUByte()
+            rawDeviceColor shouldBe 0x0.toUByte()
+            rawSuffix shouldBe 0x04.toUByte()
 
             isLeftPodMicrophone shouldBe true
             isRightPodMicrophone shouldBe false
 
+            isLeftPodInEar shouldBe false
+            isRightPodInEar shouldBe false
+
             batteryLeftPodPercent shouldBe 0.8f
             batteryRightPodPercent shouldBe 0.8f
 
-            isCaseCharging shouldBe false
-            isRightPodCharging shouldBe false
-            isLeftPodCharging shouldBe false
-            batteryCasePercent shouldBe null
+            isCaseCharging shouldBe true
+            isRightPodCharging shouldBe true
+            isLeftPodCharging shouldBe true
+            batteryCasePercent shouldBe 0.9f
 
-            podStyle.identifier shouldBe HasAppleColor.DeviceColor.UNKNOWN.name
+            podStyle.identifier shouldBe HasAppleColor.DeviceColor.WHITE.name
         }
     }
 }

--- a/app-common/src/test/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2Test.kt
+++ b/app-common/src/test/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2Test.kt
@@ -1,0 +1,39 @@
+package eu.darken.capod.pods.core.apple.airpods
+
+import eu.darken.capod.pods.core.apple.BaseAirPodsTest
+import eu.darken.capod.pods.core.apple.HasAppleColor
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.Test
+
+class AirPodsPro2Test : BaseAirPodsTest() {
+
+    @Test
+    fun `test AirPods Pro 2 - unknown setup from #31`() = runBlockingTest {
+        create<AirPodsPro2>("07 19 01 11 20 2B 88 0F 00 11 05 77 7B 0E E5 B8 AD 03 57 2F FA AA 2C F5 65 0F 52") {
+
+            rawPrefix shouldBe 0x01.toUByte()
+            rawDeviceModel shouldBe 0x1120.toUShort()
+            rawStatus shouldBe 0x2B.toUByte()
+            rawPodsBattery shouldBe 0x88.toUByte()
+            rawFlags shouldBe 0x0.toUShort()
+            rawCaseBattery shouldBe 0xF.toUShort()
+            rawCaseLidState shouldBe 0x00.toUByte()
+            rawDeviceColor shouldBe 0x11.toUByte()
+            rawSuffix shouldBe 0x05.toUByte()
+
+            isLeftPodMicrophone shouldBe true
+            isRightPodMicrophone shouldBe false
+
+            batteryLeftPodPercent shouldBe 0.8f
+            batteryRightPodPercent shouldBe 0.8f
+
+            isCaseCharging shouldBe false
+            isRightPodCharging shouldBe false
+            isLeftPodCharging shouldBe false
+            batteryCasePercent shouldBe null
+
+            podStyle.identifier shouldBe HasAppleColor.DeviceColor.UNKNOWN.name
+        }
+    }
+}

--- a/app-common/src/test/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2Test.kt
+++ b/app-common/src/test/java/eu/darken/capod/pods/core/apple/airpods/AirPodsPro2Test.kt
@@ -42,4 +42,39 @@ class AirPodsPro2Test : BaseAirPodsTest() {
             podStyle.identifier shouldBe HasAppleColor.DeviceColor.WHITE.name
         }
     }
+
+    /**
+     * https://old.reddit.com/message/messages/1hst12h
+     */
+    @Test
+    fun `test AirPods Pro 2 - unknown setup from reddit user`() = runBlockingTest {
+        create<AirPodsPro2>("07 19 01 14 20 2B 9A 8F 01 00 04 0F 26 1A C4 2B FA 2F B9 B6 08 CD 60 CB DF 75 AB") {
+
+            rawPrefix shouldBe 0x01.toUByte()
+            rawDeviceModel shouldBe 0x1420.toUShort()
+            rawStatus shouldBe 0x2B.toUByte()
+            rawPodsBattery shouldBe 0x9A.toUByte()
+            rawFlags shouldBe 0x8.toUShort()
+            rawCaseBattery shouldBe 0xF.toUShort()
+            rawCaseLidState shouldBe 0x01.toUByte()
+            rawDeviceColor shouldBe 0x0.toUByte()
+            rawSuffix shouldBe 0x04.toUByte()
+
+            isLeftPodMicrophone shouldBe true
+            isRightPodMicrophone shouldBe false
+
+            isLeftPodInEar shouldBe true
+            isRightPodInEar shouldBe true
+
+            batteryLeftPodPercent shouldBe 1.0f
+            batteryRightPodPercent shouldBe 0.9f
+
+            isCaseCharging shouldBe false
+            isRightPodCharging shouldBe false
+            isLeftPodCharging shouldBe false
+            batteryCasePercent shouldBe null
+
+            podStyle.identifier shouldBe HasAppleColor.DeviceColor.WHITE.name
+        }
+    }
 }


### PR DESCRIPTION
Preliminary support for AirPods Pro 2, based on #31, assuming identifier is `11 20`.