### PR TITLE
Improve UI performance

### DIFF
--- a/app-common/src/main/java/eu/darken/capod/common/flow/FlowExtensions.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/flow/FlowExtensions.kt
@@ -7,6 +7,7 @@ import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.error.hasCause
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlin.time.Duration
 
@@ -71,4 +72,11 @@ fun <T> Flow<T>.setupCommonEventHandlers(tag: String, identifier: () -> String) 
             log(tag, ERROR) { "${identifier()} failed: ${it.asLog()}" }
             throw it
         }
+    }
+
+fun <T> Flow<T>.throttleLatest(delayMillis: Long): Flow<T> = this
+    .conflate()
+    .transform {
+        emit(it)
+        delay(delayMillis)
     }

--- a/app-wear/src/main/java/eu/darken/capod/wear/ui/overview/OverviewFragmentVM.kt
+++ b/app-wear/src/main/java/eu/darken/capod/wear/ui/overview/OverviewFragmentVM.kt
@@ -9,6 +9,7 @@ import eu.darken.capod.common.debug.autoreport.DebugSettings
 import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.flow.combine
+import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.common.livedata.SingleLiveEvent
 import eu.darken.capod.common.permissions.Permission
 import eu.darken.capod.common.uix.ViewModel3
@@ -76,7 +77,7 @@ class OverviewFragmentVM @Inject constructor(
         permissionTool.missingPermissions,
         debugSettings.isDebugModeEnabled.flow,
         bluetoothManager.isBluetoothEnabled,
-        podMonitor.mainDevice,
+        podMonitor.mainDevice.throttleLatest(1000),
     ) { _, permissions, isDebugMode, isBluetoothEnabled, _ ->
         val items = mutableListOf<OverviewAdapter.Item>()
 

--- a/app/src/main/java/eu/darken/capod/App.kt
+++ b/app/src/main/java/eu/darken/capod/App.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.HiltAndroidApp
 import eu.darken.capod.common.coroutine.AppScope
 import eu.darken.capod.common.debug.autoreport.AutoReporting
 import eu.darken.capod.common.debug.logging.*
+import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.ui.widget.WidgetManager
 import eu.darken.capod.monitor.core.PodMonitor
@@ -49,6 +50,7 @@ open class App : Application(), Configuration.Provider {
 
         podMonitor.mainDevice
             .distinctUntilChanged()
+            .throttleLatest(1000)
             .onEach {
                 log(TAG) { "Main device changed, refreshing widgets." }
                 widgetManager.refreshWidgets()

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewFragmentVM.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewFragmentVM.kt
@@ -9,6 +9,7 @@ import eu.darken.capod.common.coroutine.DispatcherProvider
 import eu.darken.capod.common.debug.autoreport.DebugSettings
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.flow.combine
+import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.common.livedata.SingleLiveEvent
 import eu.darken.capod.common.navigation.navVia
 import eu.darken.capod.common.permissions.Permission
@@ -96,6 +97,7 @@ class OverviewFragmentVM @Inject constructor(
             }
         }
         .catch { errorEvents.postValue(it) }
+        .throttleLatest(1000)
 
     val listItems: LiveData<List<OverviewAdapter.Item>> = combine(
         updateTicker,

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorWorker.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorWorker.kt
@@ -17,6 +17,7 @@ import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.flow.setupCommonEventHandlers
+import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.main.core.GeneralSettings
 import eu.darken.capod.main.core.MonitorMode
 import eu.darken.capod.main.core.PermissionTool
@@ -101,6 +102,7 @@ class MonitorWorker @AssistedInject constructor(
             .setupCommonEventHandlers(TAG) { "PodMonitor" }
             .onStart { setForeground(monitorNotifications.getForegroundInfo(null)) }
             .distinctUntilChanged()
+            .throttleLatest(1000)
             .onEach { currentDevice ->
                 notificationManager.notify(
                     MonitorNotifications.NOTIFICATION_ID,


### PR DESCRIPTION
Throttle pod device data for the UI, notifications and widgets.
We don't need faster updates than 1 per second.
(We keep reactions at maximum speed tho)