### PR TITLE
Improve automatic monitor mode

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsEvents.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsEvents.kt
@@ -1,0 +1,5 @@
+package eu.darken.capod.main.ui.settings.general
+
+sealed class GeneralSettingsEvents {
+    object SelectDeviceAddressEvent : GeneralSettingsEvents()
+}

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsFragment.kt
@@ -61,6 +61,13 @@ class GeneralSettingsFragment : PreferenceFragment3() {
                 true
             }
         }
+
+        vm.events.observe2 {
+            when (it) {
+                GeneralSettingsEvents.SelectDeviceAddressEvent -> mainDeviceAddressPref.performClick()
+            }
+        }
+
         mainDeviceModelPref.setOnPreferenceClickListener {
             val dialog = ModelSelectionDialogFactory(requireContext()).create(
                 PodDevice.Model.values().toList(),

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsFragmentVM.kt
@@ -5,20 +5,40 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.capod.common.bluetooth.BluetoothManager2
 import eu.darken.capod.common.coroutine.DispatcherProvider
 import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.flow.withPrevious
+import eu.darken.capod.common.livedata.SingleLiveEvent
 import eu.darken.capod.common.uix.ViewModel3
+import eu.darken.capod.main.core.GeneralSettings
+import eu.darken.capod.main.core.MonitorMode
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @HiltViewModel
 class GeneralSettingsFragmentVM @Inject constructor(
-    private val handle: SavedStateHandle,
-    private val dispatcherProvider: DispatcherProvider,
-    private val bluetoothManager: BluetoothManager2,
+    @Suppress("unused") private val handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    bluetoothManager: BluetoothManager2,
+    private val generalSettings: GeneralSettings,
 ) : ViewModel3(dispatcherProvider) {
 
     val bondedDevices = bluetoothManager.bondedDevices()
         .map { it.toList() }
         .asLiveData2()
+
+    val events = SingleLiveEvent<GeneralSettingsEvents>()
+
+    init {
+
+        generalSettings.monitorMode.flow
+            .withPrevious()
+            .filter { (old, new) ->
+                old != new && new == MonitorMode.AUTOMATIC && generalSettings.mainDeviceAddress.value == null
+            }
+            .onEach { events.postValue(GeneralSettingsEvents.SelectDeviceAddressEvent) }
+            .launchInViewModel()
+    }
 
     companion object {
         private val TAG = logTag("Settings", "General", "VM")


### PR DESCRIPTION
AUTOMATIC monitormode requires the device address to be selected, otherwise we can't determine when the AirPods connect/disconnect. 

To improve this:
* Let's popup the selection dialog if the mode changes and no address has been selected.
* If we are running in AUTOMATIC mode and don't have an address, then as fallback keep running while there are other connected headset devices.

Closes #52

Maybe.