### PR TITLE
New compatibility option for receiving BLE data

### DIFF
--- a/app-common/src/main/AndroidManifest.xml
+++ b/app-common/src/main/AndroidManifest.xml
@@ -23,4 +23,13 @@
         android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />
 
+    <application>
+        <receiver
+            android:name=".bluetooth.BleScanResultReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="eu.darken.capod.bluetooth.DELIVER_SCAN_RESULTS" />
+            </intent-filter>
+        </receiver>
+    </application>
 </manifest>

--- a/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultForwarder.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultForwarder.kt
@@ -1,0 +1,33 @@
+package eu.darken.capod.common.bluetooth
+
+import android.bluetooth.le.ScanResult
+import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BleScanResultForwarder @Inject constructor() {
+
+    private val forwarder = MutableSharedFlow<Collection<ScanResult>>(
+        replay = 0,
+        extraBufferCapacity = 128,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val results: Flow<Collection<ScanResult>> = forwarder
+
+    fun forward(scanResults: Collection<ScanResult>) {
+        log(TAG, VERBOSE) { "forward($scanResults)" }
+        val success = forwarder.tryEmit(scanResults)
+        if (!success) log(TAG, WARN) { "Failed to forward (overflow?) $scanResults" }
+    }
+
+    companion object {
+        private val TAG = logTag("Bluetooth", "BleScanner", "Forwarder")
+    }
+}

--- a/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultReceiver.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultReceiver.kt
@@ -59,6 +59,6 @@ class BleScanResultReceiver : BroadcastReceiver() {
 
     companion object {
         private val TAG = logTag("Bluetooth", "BleScanner", "Forwarder", "Receiver")
-        val ACTION = "eu.darken.capod.bluetooth.DELIVER_SCAN_RESULTS"
+        const val ACTION = "eu.darken.capod.bluetooth.DELIVER_SCAN_RESULTS"
     }
 }

--- a/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultReceiver.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultReceiver.kt
@@ -22,7 +22,7 @@ class BleScanResultReceiver : BroadcastReceiver() {
     @Inject lateinit var scanResultForwarder: BleScanResultForwarder
 
     override fun onReceive(context: Context, intent: Intent) {
-        log(TAG) { "onReceive($context, $intent)" }
+        log(TAG, VERBOSE) { "onReceive($context, $intent)" }
         if (intent.action != ACTION) {
             log(TAG, WARN) { "Unknown action: ${intent.action}" }
             return

--- a/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultReceiver.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/bluetooth/BleScanResultReceiver.kt
@@ -1,0 +1,64 @@
+package eu.darken.capod.common.bluetooth
+
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanResult
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.capod.common.coroutine.AppScope
+import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class BleScanResultReceiver : BroadcastReceiver() {
+
+    @Inject @AppScope lateinit var appScope: CoroutineScope
+    @Inject lateinit var scanResultForwarder: BleScanResultForwarder
+
+    override fun onReceive(context: Context, intent: Intent) {
+        log(TAG) { "onReceive($context, $intent)" }
+        if (intent.action != ACTION) {
+            log(TAG, WARN) { "Unknown action: ${intent.action}" }
+            return
+        }
+        if (intent.extras == null) {
+            log(TAG) { "Extras are null!" }
+            return
+        }
+
+        val errorCode = intent.getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, 0)
+        log(TAG, VERBOSE) { "errorCode=$errorCode" }
+        if (errorCode != 0) {
+            log(TAG, WARN) { "ScanCallback error code: $errorCode" }
+            return
+        }
+
+        val callbackType = intent.getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, -1)
+        log(TAG, VERBOSE) { "callbackType=$callbackType" }
+
+        val scanResults = intent.getParcelableArrayListExtra<ScanResult>(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT)
+        log(TAG, VERBOSE) { "scanResults=$scanResults" }
+
+        if (scanResults == null) {
+            log(TAG) { "Scan results were empty!" }
+            return
+        }
+
+        val pending = goAsync()
+        appScope.launch {
+            scanResultForwarder.forward(scanResults)
+            pending.finish()
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Bluetooth", "BleScanner", "Forwarder", "Receiver")
+        val ACTION = "eu.darken.capod.bluetooth.DELIVER_SCAN_RESULTS"
+    }
+}

--- a/app-common/src/main/java/eu/darken/capod/common/notifications/PendingIntentCompat.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/notifications/PendingIntentCompat.kt
@@ -9,4 +9,9 @@ object PendingIntentCompat {
     } else {
         0
     }
+    val FLAG_MUTABLE: Int = if (hasApiLevel(31)) {
+        PendingIntent.FLAG_MUTABLE
+    } else {
+        0
+    }
 }

--- a/app-common/src/main/java/eu/darken/capod/main/core/GeneralSettings.kt
+++ b/app-common/src/main/java/eu/darken/capod/main/core/GeneralSettings.kt
@@ -33,9 +33,12 @@ class GeneralSettings @Inject constructor(
     val mainDeviceAddress = preferences.createFlowPreference<String?>("core.maindevice.address", null)
     val mainDeviceModel = preferences.createFlowPreference("core.maindevice.model", PodDevice.Model.UNKNOWN, moshi)
 
-    val isOffloadedFilteringDisabled =
-        preferences.createFlowPreference("core.compat.offloaded.filtering.disabled", false)
+    val isOffloadedFilteringDisabled = preferences.createFlowPreference(
+        "core.compat.offloaded.filtering.disabled",
+        false
+    )
     val isOffloadedBatchingDisabled = preferences.createFlowPreference("core.compat.offloaded.batching.disabled", false)
+    val useIndirectScanResultCallback = preferences.createFlowPreference("core.compat.indirectcallback.enabled", false)
 
     override val preferenceDataStore: PreferenceDataStore = PreferenceStoreMapper(
         monitorMode,
@@ -45,6 +48,7 @@ class GeneralSettings @Inject constructor(
         mainDeviceAddress,
         isOffloadedFilteringDisabled,
         isOffloadedBatchingDisabled,
+        useIndirectScanResultCallback,
         debugSettings.isAutoReportingEnabled,
     )
 }

--- a/app-common/src/main/res/drawable/ic_strategy_24.xml
+++ b/app-common/src/main/res/drawable/ic_strategy_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.91 5.5L9.21 7.79L7.79 9.21L5.5 6.91L3.21 9.21L1.79 7.79L4.09 5.5L1.79 3.21L3.21 1.79L5.5 4.09L7.79 1.79L9.21 3.21M22.21 16.21L20.79 14.79L18.5 17.09L16.21 14.79L14.79 16.21L17.09 18.5L14.79 20.79L16.21 22.21L18.5 19.91L20.79 22.21L22.21 20.79L19.91 18.5M20.4 6.83L17.18 11L15.6 9.73L16.77 8.23A9.08 9.08 0 0 0 10.11 13.85A4.5 4.5 0 1 1 7.5 13A4 4 0 0 1 8.28 13.08A11.27 11.27 0 0 1 16.43 6.26L15 5.18L16.27 3.6M10 17.5A2.5 2.5 0 1 0 7.5 20A2.5 2.5 0 0 0 10 17.5Z" />
+</vector>

--- a/app/src/main/java/eu/darken/capod/monitor/core/receiver/BluetoothEventReceiver.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/receiver/BluetoothEventReceiver.kt
@@ -25,9 +25,9 @@ class BluetoothEventReceiver : BroadcastReceiver() {
     @Inject @AppScope lateinit var appScope: CoroutineScope
 
     override fun onReceive(context: Context, intent: Intent) {
-        log { "onReceive($context, $intent)" }
+        log(TAG) { "onReceive($context, $intent)" }
         if (!EXPECTED_ACTIONS.contains(intent.action)) {
-            log(WARN) { "Unknown action: ${intent.action}" }
+            log(TAG, WARN) { "Unknown action: ${intent.action}" }
             return
         }
 
@@ -41,7 +41,7 @@ class BluetoothEventReceiver : BroadcastReceiver() {
         val supportedFeatures = ContinuityProtocol.BLE_FEATURE_UUIDS.filter { bluetoothDevice.hasFeature(it) }
 
         if (supportedFeatures.isEmpty()) {
-            log { "Device has no features we support." }
+            log(TAG) { "Device has no features we support." }
             return
         } else {
             log { "Device has the following we features we support $supportedFeatures" }
@@ -49,7 +49,7 @@ class BluetoothEventReceiver : BroadcastReceiver() {
 
         val pending = goAsync()
         appScope.launch {
-            log { "Starting monitor" }
+            log(TAG) { "Starting monitor" }
             monitorControl.startMonitor(bluetoothDevice, forceStart = false)
             pending.finish()
         }

--- a/app/src/main/java/eu/darken/capod/monitor/core/receiver/BluetoothEventReceiver.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/receiver/BluetoothEventReceiver.kt
@@ -27,7 +27,7 @@ class BluetoothEventReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         log { "onReceive($context, $intent)" }
         if (!EXPECTED_ACTIONS.contains(intent.action)) {
-            log(WARN) { "Unknown action: $intent.action" }
+            log(WARN) { "Unknown action: ${intent.action}" }
             return
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,4 +100,6 @@
     <string name="translators_thanks_description">darken</string>
 
     <string name="widget_description">A widget showing the last known device status.</string>
+    <string name="settings_compat_indirectcallback_title">Indirect data delivery</string>
+    <string name="settings_compat_indirectcallback_summary">Use an alternative method to receive BLE data from the system (broadcast instead of callback).</string>
 </resources>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -61,6 +61,12 @@
             android:summary="@string/settings_compat_offloaded_batching_disabled_summary"
             android:title="@string/settings_compat_offloaded_batching_disabled_title" />
 
+        <CheckBoxPreference
+            android:icon="@drawable/ic_strategy_24"
+            android:key="core.compat.indirectcallback.enabled"
+            android:summary="@string/settings_compat_indirectcallback_summary"
+            android:title="@string/settings_compat_indirectcallback_title" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_other_label">


### PR DESCRIPTION
Alternative method to receive BLE scan results via PendingIntents instead of direct callbacks.
This may allow some buggy ROMs to receive BLE data.

e.g. on a Pixel 5 @ 13:
* No batching and no filtering -> AirPods BLE data missing
* No batching, no filtering, no direct callbacks -> AirPods BLE data is returned

The same didn't work on a Samsung S22 5G though :shrug: 