### PR TITLE
Adjust signal quality display

### DIFF
--- a/app-common/src/main/java/eu/darken/capod/pods/core/PodDeviceExtensions.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/PodDeviceExtensions.kt
@@ -25,8 +25,8 @@ fun SinglePodDevice.getBatteryLevelHeadset(context: Context): String =
         ?: context.getString(R.string.general_value_not_available_label)
 
 fun PodDevice.getSignalQuality(context: Context): String {
-    val percentage = 100 * signalQuality
-    return "~${percentage.roundToInt()}%"
+    val multiplier = 100 * signalQuality
+    return "${multiplier.roundToInt()}"
 }
 
 @DrawableRes


### PR DESCRIPTION
Remove ~ and % from signal quality value, it's not necessarily a 0 to 100 percent indicator.