### PR TITLE
For some reason we can finish the widget update broadcast twice.

### DIFF
--- a/app-common/src/main/java/eu/darken/capod/common/BroadcastReceiverExtensions.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/BroadcastReceiverExtensions.kt
@@ -1,0 +1,10 @@
+import android.content.BroadcastReceiver
+import eu.darken.capod.common.debug.logging.log
+
+fun BroadcastReceiver.PendingResult.finish2(): Boolean = try {
+    finish()
+    true
+} catch (e: IllegalStateException) {
+    log { "BroadcastReceiver.PendingResult.finish() failed: $e" }
+    false
+}

--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetProvider.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetProvider.kt
@@ -22,6 +22,7 @@ import eu.darken.capod.main.ui.MainActivity
 import eu.darken.capod.monitor.core.PodDeviceCache
 import eu.darken.capod.monitor.core.PodMonitor
 import eu.darken.capod.pods.core.*
+import finish2
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -39,7 +40,7 @@ class WidgetProvider : AppWidgetProvider() {
 
     private fun executeAsync(
         tag: String,
-        timeout: Duration = Duration.ofSeconds(8),
+        timeout: Duration = Duration.ofSeconds(7),
         block: suspend () -> Unit
     ) {
         val start = System.currentTimeMillis()
@@ -52,7 +53,7 @@ class WidgetProvider : AppWidgetProvider() {
             } catch (e: Exception) {
                 log(TAG, ERROR) { "executeAsync($tag) failed: ${e.asLog()}" }
             } finally {
-                asyncBarrier.finish()
+                asyncBarrier.finish2()
                 val stop = System.currentTimeMillis()
                 log(TAG, VERBOSE) { "executeAsync($tag) DONE (${stop - start}ms) " }
             }


### PR DESCRIPTION
I can't yet determine why this race-condition occurs, due to the forced timeout, it shouldn't be due to exceeding the receiver ANR window...