### PR TITLE
Fix background execution errors.

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -32,7 +32,7 @@ object Versions {
         }
 
         object WorkManager {
-            const val core = "2.7.1"
+            const val core = "2.8.1"
         }
     }
 


### PR DESCRIPTION
Bump workmanager `2.7.1` -> `2.8.1` to fix

```java
android.app.ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false: service eu.darken.capod/androidx.work.impl.foreground.SystemForegroundService
```