### PR TITLE
Add PUSH_NOTIFICATIONS permission to AndroidManifest.xml for wearos

### DIFF
--- a/app-wear/src/main/AndroidManifest.xml
+++ b/app-wear/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     package="eu.darken.capod">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-
+    <uses-permission android:name="android.permission.PUSH_NOTIFICATIONS" />
+    
     <uses-feature android:name="android.hardware.type.watch" />
 
     <application

--- a/app-wear/src/main/AndroidManifest.xml
+++ b/app-wear/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     package="eu.darken.capod">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.PUSH_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     
     <uses-feature android:name="android.hardware.type.watch" />
 


### PR DESCRIPTION
Fixes https://github.com/d4rken-org/capod/issues/154 by adding the required `uses-permission` for push notifications tag in `AndroidManifest.xml` for wearos.