### PR TITLE
Fix IRK match flag in AppleFactory

### DIFF
--- a/app-common/src/main/java/eu/darken/capod/pods/core/apple/AppleFactory.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/apple/AppleFactory.kt
@@ -88,7 +88,7 @@ class AppleFactory @Inject constructor(
             scanResult = scanResult,
             payload = payload,
             flags = ApplePods.Flags(
-                isIRKMatch = true,
+                isIRKMatch = isIrkMatch,
             ),
         )
     }


### PR DESCRIPTION
This commit corrects the `isIRKMatch` flag assignment in `AppleFactory.kt`. Previously, it was hardcoded to `true`. Now, it correctly uses the `isIrkMatch` variable determined by the Identity Resolving Key (IRK) comparison.

Fixes https://github.com/d4rken-org/capod/issues/290#issuecomment-2968950876