### PR TITLE
Enhance Jekyll config and add auto-generated changelog page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+---
+layout: plain
+permalink: /changelog
+title: "Changelog"
+---
+
+# Changelog for CAPod
+
+{% for release in site.github.releases %}
+
+## {{ release.tag_name }} - {{ release.published_at | date: "%B %d, %Y" }}
+
+{% assign clean_body = release.body | strip %}
+{% assign no_comments = clean_body | replace: "<!-- Release notes generated using configuration in .github/release.yml", "" %}
+{% assign no_comments = no_comments | split: "-->" %}
+{% if no_comments.size > 1 %}
+{% assign clean_content = no_comments[1] | strip %}
+{% else %}
+{% assign clean_content = no_comments[0] | strip %}
+{% endif %}
+
+{% comment %} Make links clickable {% endcomment %}
+{% assign lines = clean_content | split: "
+" %}
+{% assign processed_lines = "" %}
+{% for line in lines %}
+{% if line contains "**Full Changelog**:" %}
+{% comment %} Handle Full Changelog links {% endcomment %}
+{% assign parts = line | split: ": " %}
+{% if parts.size > 1 %}
+{% assign url = parts[1] | strip %}
+{% assign clickable_line = "**[View Changes](" | append: url | append: ")**" %}
+{% assign processed_lines = processed_lines | append: clickable_line | append: "
+" %}
+{% else %}
+{% assign processed_lines = processed_lines | append: line | append: "
+" %}
+{% endif %}
+{% elsif line contains " in https://github.com/" and line contains "/pull/" %}
+{% comment %} Handle pull request links {% endcomment %}
+{% assign pr_parts = line | split: " in https://github.com/" %}
+{% if pr_parts.size > 1 %}
+{% assign before_url = pr_parts[0] %}
+{% assign after_url = pr_parts[1] %}
+{% assign url = "https://github.com/" | append: after_url %}
+{% assign pr_number = after_url | split: "/pull/" %}
+{% if pr_number.size > 1 %}
+{% assign pr_num = pr_number[1] | split: " " | first %}
+{% assign clickable_line = before_url | append: " in [#" | append: pr_num | append: "](" | append: url | append: ")" %}
+{% assign processed_lines = processed_lines | append: clickable_line | append: "
+" %}
+{% else %}
+{% assign processed_lines = processed_lines | append: line | append: "
+" %}
+{% endif %}
+{% else %}
+{% assign processed_lines = processed_lines | append: line | append: "
+" %}
+{% endif %}
+{% else %}
+{% assign processed_lines = processed_lines | append: line | append: "
+" %}
+{% endif %}
+{% endfor %}
+
+{% comment %} Check if there are any bullet points (actual release notes) {% endcomment %}
+{% if processed_lines contains "## " or processed_lines contains "- " %}
+{% assign spaced_content = processed_lines | replace: "
+
+- ", "
+
+- " %}
+  {{ spaced_content | markdownify }}
+  {% else %}
+  *No release notes available.*
+
+  {{ processed_lines | markdownify }}
+  {% endif %}
+
+---
+{% endfor %}

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,9 @@
 theme: minima
 plugins:
   - jekyll-relative-links
+  - jekyll-github-metadata
+  - jemoji
+
 relative_links:
   enabled: true
   collections: true

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,5 +1,5 @@
-Updates contain bugfixes, performance improvements and maybe new features.
-A detailed changelog is always available on GitHub.
+🐛 Bug fixes, 🚀 performance boosts, maybe even ✨ new features.
 
-FYI: It’s just me here, sometimes replies might take a bit. Sorry for that!
-¯\_(ツ)_/¯
+Changelog: https://capod.darken.eu/changelog
+
+FYI: It’s just me here — thanks for understanding if replies take a bit. ¯\_(ツ)_/¯


### PR DESCRIPTION
This commit updates the Jekyll configuration to include `jekyll-github-metadata` and `jemoji` plugins. It also introduces a `CHANGELOG.md` file that automatically generates a formatted changelog page from GitHub releases. The default changelog text for new app versions in Fastlane has also been updated to be more engaging and directly link to the new changelog page.