### PR TITLE
Dependencies: Downgrade Navigation Core to 2.8.9

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -16,7 +16,7 @@ object Versions {
         const val core = ""
 
         object Navigation {
-            const val core = "2.9.0"
+            const val core = "2.8.9"
         }
 
         object Testing {


### PR DESCRIPTION
Navigation Core version 2.9.0 seems to have a bug causing an `ConcurrentModificationException`.

See:
https://issuetracker.google.com/issues/188860458
https://issuetracker.google.com/issues/417784831