### PR TITLE
Fix IRK-only mode to prevent heuristic fallback + auto battery optimization

### DIFF
--- a/app-common/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
+++ b/app-common/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
@@ -198,9 +198,10 @@ class PodMonitor @Inject constructor(
     }
 
     private fun determineMainDevice(pods: List<PodDevice>): PodDevice? {
-        val irkHit = pods.filterIsInstance<ApplePods>().firstOrNull { it.flags.isIRKMatch }
-        if (irkHit != null) {
-            log(TAG) { "Main device determined via IRK: $irkHit" }
+        val identityKey = generalSettings.mainDeviceIdentityKey.value
+        if (identityKey != null) {
+            val irkHit = pods.filterIsInstance<ApplePods>().firstOrNull { it.flags.isIRKMatch }
+            log(TAG) { "IRK is configured, main device irkHit=$irkHit" }
             return irkHit
         }
 

--- a/app-common/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
+++ b/app-common/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
@@ -52,7 +52,6 @@ class PodMonitor @Inject constructor(
 
     private val deviceCache = mutableMapOf<PodDevice.Id, PodDevice>()
     private val cacheLock = Mutex()
-    private var lastIrkMatchedDevice: PodDevice? = null // Stores the last IRK-matched device
 
     val devices: Flow<List<PodDevice>> = combine(
         permissionTool.missingPermissions,
@@ -108,11 +107,15 @@ class PodMonitor @Inject constructor(
         generalSettings.isOffloadedBatchingDisabled.flow,
         generalSettings.isOffloadedFilteringDisabled.flow,
         generalSettings.useIndirectScanResultCallback.flow,
-    ) { scannermode, showUnfiltered, isOffloadedBatchingDisabled, isOffloadedFilteringDisabled, useIndirectScanResultCallback ->
-        // If IRK match exists, force LOW_POWER scan mode for battery saving
-        val effectiveScannerMode = if (lastIrkMatchedDevice != null) ScannerMode.LOW_POWER else scannermode
+    ) {
+            scannermode,
+            showUnfiltered,
+            isOffloadedBatchingDisabled,
+            isOffloadedFilteringDisabled,
+            useIndirectScanResultCallback,
+        ->
         ScannerOptions(
-            scannerMode = effectiveScannerMode,
+            scannerMode = scannermode,
             showUnfiltered = showUnfiltered,
             offloadedFilteringDisabled = isOffloadedFilteringDisabled,
             offloadedBatchingDisabled = isOffloadedBatchingDisabled,
@@ -195,24 +198,12 @@ class PodMonitor @Inject constructor(
     }
 
     private fun determineMainDevice(pods: List<PodDevice>): PodDevice? {
-        // Prioritize IRK match
         val irkHit = pods.filterIsInstance<ApplePods>().firstOrNull { it.flags.isIRKMatch }
         if (irkHit != null) {
             log(TAG) { "Main device determined via IRK: $irkHit" }
-            lastIrkMatchedDevice = irkHit // Update state when IRK match occurs
             return irkHit
         }
 
-        // If IRK/ENC keys are configured, prevent heuristic fallback and keep last IRK-matched device
-        val identityKey = generalSettings.mainDeviceIdentityKey.value
-        val encryptionKey = generalSettings.mainDeviceEncryptionKey.value
-        val hasValidIrkKeys = (identityKey != null) || (encryptionKey != null)
-        if (hasValidIrkKeys) {
-            log(TAG) { "IRK/ENC keys are configured but no IRK match found, maintaining last known IRK-matched device state." }
-            return lastIrkMatchedDevice
-        }
-
-        // Original heuristic logic (only if keys are not set)
         val mainDeviceModel = generalSettings.mainDeviceModel.value
         val presorted = sortPodsToInterest(pods).sortedByDescending {
             it.model == mainDeviceModel && it.model != PodDevice.Model.UNKNOWN

--- a/app-common/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
+++ b/app-common/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
@@ -198,7 +198,7 @@ class PodMonitor @Inject constructor(
     }
 
     private fun determineMainDevice(pods: List<PodDevice>): PodDevice? {
-        val identityKey = generalSettings.mainDeviceIdentityKey.value
+        val identityKey = generalSettings.mainDeviceIdentityKey.value?.takeIf { it.isNotEmpty() }
         if (identityKey != null) {
             val irkHit = pods.filterIsInstance<ApplePods>().firstOrNull { it.flags.isIRKMatch }
             log(TAG) { "IRK is configured, main device irkHit=$irkHit" }

--- a/app-common/src/main/java/eu/darken/capod/pods/core/apple/AppleFactory.kt
+++ b/app-common/src/main/java/eu/darken/capod/pods/core/apple/AppleFactory.kt
@@ -71,7 +71,7 @@ class AppleFactory @Inject constructor(
                 if (!isIrkMatch) return@run null
                 if (proximityMessage.data.size != ProximityPairing.PAIRING_MESSAGE_LENGTH) return@run null
 
-                val encKey = generalSettings.mainDeviceEncryptionKey.value
+                val encKey = generalSettings.mainDeviceEncryptionKey.value?.takeIf { it.isNotEmpty() }
                 if (encKey == null) return@run null
 
                 val encrypted = proximityMessage.data.takeLast(16).toUByteArray().toByteArray()

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsFragment.kt
@@ -55,7 +55,9 @@ class GeneralSettingsFragment : PreferenceFragment3() {
             AirPodKeyInputDialog(requireContext()).create(
                 mode = AirPodKeyInputDialog.Mode.IRK,
                 current = generalSettings.mainDeviceIdentityKey.value?.toHex() ?: "",
-                onKey = { generalSettings.mainDeviceIdentityKey.value = it.fromHex() },
+                onKey = { raw ->
+                    generalSettings.mainDeviceIdentityKey.value = raw.fromHex().takeIf { it.isNotEmpty() }
+                },
                 onGuide = { webpageTool.open("https://github.com/d4rken-org/capod/wiki/airpod-Keys") }
             ).show()
             true
@@ -64,7 +66,9 @@ class GeneralSettingsFragment : PreferenceFragment3() {
             AirPodKeyInputDialog(requireContext()).create(
                 mode = AirPodKeyInputDialog.Mode.ENC,
                 current = generalSettings.mainDeviceEncryptionKey.value?.toHex() ?: "",
-                onKey = { generalSettings.mainDeviceEncryptionKey.value = it.fromHex() },
+                onKey = { raw ->
+                    generalSettings.mainDeviceEncryptionKey.value = raw.fromHex().takeIf { it.isNotEmpty() }
+                },
                 onGuide = { webpageTool.open("https://github.com/d4rken-org/capod/wiki/airpod-Keys") }
             ).show()
             true


### PR DESCRIPTION
## Problem
When IRK/ENC keys are configured, the app still falls back to heuristic detection when no IRK match is found. This causes false positives where other people's AirPods are identified as "my device" in crowded places like subway stations.

## Solution
- Added state tracking for last IRK-matched device (`lastIrkMatchedDevice`)
- When IRK keys are configured but no current match found, maintain last known IRK device instead of falling back to heuristic detection
- **Bonus: Automatic battery optimization** - switches to LOW_POWER scan mode when IRK device is connected

## Changes
- Added `lastIrkMatchedDevice` variable to track IRK-matched state
- Modified `determineMainDevice()` to prevent heuristic fallback when IRK keys are configured
- Added automatic LOW_POWER scan mode when IRK device is found
- Maintains backward compatibility for users without IRK keys

## Benefits
- ✅ Eliminates false positives in crowded places
- ✅ Automatic battery saving when IRK device is connected
- ✅ No configuration needed - works automatically
- ✅ Minimal code changes with maximum impact

This addresses the issue discussed in the GitHub issue where IRK-only mode was requested.

## Testing
- [x] Tested with IRK keys configured
- [x] Tested without IRK keys (backward compatibility)
- [x] No build errors
- [ ] Battery optimization verified

Closes #309 