### PR TITLE
Allow keeping "connected" notification after disconnect

### DIFF
--- a/app-common/src/main/java/eu/darken/capod/main/core/GeneralSettings.kt
+++ b/app-common/src/main/java/eu/darken/capod/main/core/GeneralSettings.kt
@@ -30,6 +30,9 @@ class GeneralSettings @Inject constructor(
 
     val useExtraMonitorNotification = preferences.createFlowPreference("core.monitor.notification.connected", false)
 
+    val keepConnectedNotificationAfterDisconnect =
+        preferences.createFlowPreference("core.monitor.notification.connected.keepafterdisconnected", false)
+
     val scannerMode = preferences.createFlowPreference("core.scanner.mode", ScannerMode.BALANCED, moshi)
 
     val showAll = preferences.createFlowPreference("core.showall.enabled", true)
@@ -61,6 +64,7 @@ class GeneralSettings @Inject constructor(
     override val preferenceDataStore: PreferenceDataStore = PreferenceStoreMapper(
         monitorMode,
         useExtraMonitorNotification,
+        keepConnectedNotificationAfterDisconnect,
         scannerMode,
         showAll,
         minimumSignalQuality,

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorWorker.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorWorker.kt
@@ -95,6 +95,13 @@ class MonitorWorker @AssistedInject constructor(
             Result.success()
         }
     } finally {
+        if (generalSettings.useExtraMonitorNotification.value && !generalSettings.keepConnectedNotificationAfterDisconnect.value) {
+            try {
+                notificationManager.cancel(MonitorNotifications.NOTIFICATION_ID_CONNECTED)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to cancel connected notification: ${e.message}" }
+            }
+        }
         this.workerScope.cancel("Worker finished (withError?=$finishedWithError).")
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="settings_monitor_mode_description">Under which circumstances this app monitors Bluetooth data.</string>
     <string name="settings_monitor_connected_notification_label">Extra notification</string>
     <string name="settings_monitor_connected_notification_description">Shows an extra notification when a device is connected. This lets you hide the permanent \"No devices\" notification by disabling the \"Device status\" channel.</string>
+    <string name="settings_keep_notification_after_disconnect_label">Keep notification after disconnect</string>
+    <string name="settings_keep_notification_after_disconnect_description">Continue showing the last known battery levels even after your AirPods disconnect</string>
     <string name="settings_scanner_mode_label">Scanner mode</string>
     <string name="settings_scanner_mode_description">Should the Bluetooth Low Energy data scanner prioritize performance or conserve energy?</string>
     <string name="settings_autopause_label">Auto pause</string>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -90,6 +90,13 @@
             android:summary="@string/settings_monitor_connected_notification_description"
             android:title="@string/settings_monitor_connected_notification_label" />
 
+        <eu.darken.capod.common.preferences.MaterialSwitchPreference
+            android:icon="@drawable/ic_message_24"
+            android:key="core.monitor.notification.connected.keepafterdisconnected"
+            android:summary="@string/settings_keep_notification_after_disconnect_description"
+            android:title="@string/settings_keep_notification_after_disconnect_label"
+            android:dependency="core.monitor.notification.connected" />
+
         <Preference
             android:fragment="eu.darken.capod.main.ui.settings.general.debug.DebugSettingsFragment"
             android:icon="@drawable/ic_baseline_bug_report_24"


### PR DESCRIPTION
This commit introduces a new setting that allows users to keep the "connected" notification visible even after the monitored device disconnects.

When this setting is enabled and the "Extra notification" is also active, the `MonitorWorker` will no longer cancel the connected notification upon finishing. This provides users with the option to see the last known battery levels after disconnection.

A new preference `keepConnectedNotificationAfterDisconnect` is added to `GeneralSettings` and the UI.

Closes #319 