### PR TITLE
Refactor buildSrc and update dependencies

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -21,7 +21,6 @@ android {
         buildConfigField("String", "VERSION_NAME", "\"${ProjectConfig.Version.name}\"")
         buildConfigField("String", "APPLICATION_ID", "\"${ProjectConfig.packageName}\"")
         buildConfigField("String", "GITSHA", "\"${lastCommitHash()}\"")
-        buildConfigField("String", "BUILDTIME", "\"${buildTime()}\"")
     }
 
     buildFeatures {
@@ -77,6 +76,7 @@ android {
         unitTests {
             isIncludeAndroidResources = true
         }
+        //noinspection WrongGradleMethod
         tasks.withType<Test> {
             useJUnitPlatform()
         }

--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         minSdk = ProjectConfig.minSdk
-        targetSdk = ProjectConfig.targetSdk
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/app-common/src/main/java/eu/darken/capod/common/BuildConfigWrap.kt
+++ b/app-common/src/main/java/eu/darken/capod/common/BuildConfigWrap.kt
@@ -37,7 +37,6 @@ object BuildConfigWrap {
     val VERSION_CODE: Long = BuildConfig.VERSION_CODE.toLong()
     val VERSION_NAME: String = BuildConfig.VERSION_NAME
     val GIT_SHA: String = BuildConfig.GITSHA
-    val BUILDTIME: String = BuildConfig.BUILDTIME
 
     val VERSION_DESCRIPTION_LONG: String = "v$VERSION_NAME ($VERSION_CODE) [$GIT_SHA] ${FLAVOR}_$BUILD_TYPE"
     val VERSION_DESCRIPTION_SHORT: String = "v$VERSION_NAME [$GIT_SHA] $FLAVOR"

--- a/app-wear/build.gradle.kts
+++ b/app-wear/build.gradle.kts
@@ -9,7 +9,7 @@ apply(plugin = "androidx.navigation.safeargs.kotlin")
 
 android {
     compileSdk = ProjectConfig.compileSdk
-    namespace = "${ProjectConfig.packageName}"
+    namespace = ProjectConfig.packageName
 
     defaultConfig {
         applicationId = ProjectConfig.packageName
@@ -23,7 +23,6 @@ android {
         testInstrumentationRunner = "eu.darken.capod.HiltTestRunner"
 
         buildConfigField("String", "GITSHA", "\"${lastCommitHash()}\"")
-        buildConfigField("String", "BUILDTIME", "\"${buildTime()}\"")
     }
 
     signingConfigs {

--- a/app-wear/build.gradle.kts
+++ b/app-wear/build.gradle.kts
@@ -85,10 +85,10 @@ android {
         val variantOutputImpl = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
         val variantName: String = variantOutputImpl.name
 
-        if (listOf("release", "beta").any { variantName.toLowerCase().contains(it) }) {
+        if (listOf("release", "beta").any { variantName.lowercase().contains(it) }) {
             val outputFileName = ProjectConfig.packageName + "-WEAROS" +
                     "-v${defaultConfig.versionName}-${defaultConfig.versionCode}" +
-                    "-${variantName.toUpperCase()}.apk"
+                    "-${variantName.uppercase()}.apk"
 
             variantOutputImpl.outputFileName = outputFileName
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,10 +88,10 @@ android {
         val variantOutputImpl = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
         val variantName: String = variantOutputImpl.name
 
-        if (listOf("release", "beta").any { variantName.toLowerCase().contains(it) }) {
+        if (listOf("release", "beta").any { variantName.lowercase().contains(it) }) {
             val outputFileName = ProjectConfig.packageName +
                     "-v${defaultConfig.versionName}-${defaultConfig.versionCode}" +
-                    "-${variantName.toUpperCase()}.apk"
+                    "-${variantName.uppercase()}.apk"
 
             variantOutputImpl.outputFileName = outputFileName
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.google.devtools.ksp") version "2.1.21-2.0.1" apply false
+    id("com.google.devtools.ksp") version "2.2.10-2.0.2" apply false
 }
 
 buildscript {
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.11.0")
+        classpath("com.android.tools.build:gradle:8.12.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.AndroidX.Navigation.core}")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.android.tools.build:gradle:8.11.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
+    implementation("com.android.tools.build:gradle:8.12.2")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10")
     implementation("com.squareup:javapoet:1.13.0")
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -61,9 +61,9 @@ fun DependencyHandlerScope.addDagger() {
 }
 
 fun DependencyHandlerScope.addMoshi() {
-    implementation("com.squareup.moshi:moshi:${Versions.Moshi.core}")
-    implementation("com.squareup.moshi:moshi-adapters:${Versions.Moshi.core}")
-    add("ksp", "com.squareup.moshi:moshi-kotlin-codegen:${Versions.Moshi.core}")
+    implementation("com.squareup.moshi:moshi:1.15.2")
+    implementation("com.squareup.moshi:moshi-adapters:1.15.2")
+    add("ksp", "com.squareup.moshi:moshi-kotlin-codegen:1.15.2")
 }
 
 fun DependencyHandlerScope.addOkio() {
@@ -112,26 +112,26 @@ fun DependencyHandlerScope.addBaseAndroidUi() {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVers")
 }
 
-fun DependencyHandlerScope.addTesting(junit: Boolean = true, instrumentation: Boolean = true) {
-    testImplementation("junit:junit:${Versions.Junit.legacy}")
+fun DependencyHandlerScope.addTesting() {
+    testImplementation("junit:junit:4.13.2")
 
-    testImplementation("org.junit.vintage:junit-vintage-engine:${Versions.Junit.jupiter}")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.Junit.jupiter}")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.Junit.jupiter}")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:${Versions.Junit.jupiter}")
+    testImplementation("org.junit.vintage:junit-vintage-engine:5.7.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
 
-    testImplementation("androidx.test:core-ktx:${Versions.AndroidX.Testing.coreKtx}")
+    testImplementation("androidx.test:core-ktx:1.4.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 
-    testImplementation("io.mockk:mockk:${Versions.Mockk.core}")
-    androidTestImplementation("io.mockk:mockk-android:${Versions.Mockk.android}")
+    testImplementation("io.mockk:mockk:1.12.4")
+    androidTestImplementation("io.mockk:mockk-android:1.12.4")
 
-    testImplementation("io.kotest:kotest-runner-junit5:${Versions.Kotest.core}")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:${Versions.Kotest.core}")
-    testImplementation("io.kotest:kotest-property-jvm:${Versions.Kotest.core}")
-    androidTestImplementation("io.kotest:kotest-assertions-core-jvm:${Versions.Kotest.core}")
-    androidTestImplementation("io.kotest:kotest-property-jvm:${Versions.Kotest.core}")
+    testImplementation("io.kotest:kotest-runner-junit5:4.6.4")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:4.6.4")
+    testImplementation("io.kotest:kotest-property-jvm:4.6.4")
+    androidTestImplementation("io.kotest:kotest-assertions-core-jvm:4.6.4")
+    androidTestImplementation("io.kotest:kotest-property-jvm:4.6.4")
 
     debugImplementation("androidx.fragment:fragment-testing:1.4.1")
 }

--- a/buildSrc/src/main/java/ProjectConfig.kt
+++ b/buildSrc/src/main/java/ProjectConfig.kt
@@ -1,6 +1,5 @@
 import java.io.File
 import java.io.FileInputStream
-import java.time.Instant
 import java.util.Properties
 
 object ProjectConfig {
@@ -34,8 +33,6 @@ fun lastCommitHash(): String = Runtime.getRuntime().exec("git rev-parse --short 
     process.destroy()
     output.trim()
 }
-
-fun buildTime(): Instant = Instant.now()
 
 fun com.android.build.api.dsl.SigningConfig.setupCredentials(
     signingPropsPath: File? = null

--- a/buildSrc/src/main/java/ProjectConfig.kt
+++ b/buildSrc/src/main/java/ProjectConfig.kt
@@ -1,7 +1,3 @@
-import com.android.build.api.dsl.Packaging
-import com.android.build.gradle.LibraryExtension
-import org.gradle.api.Action
-import org.gradle.api.JavaVersion
 import java.io.File
 import java.io.FileInputStream
 import java.time.Instant
@@ -40,51 +36,6 @@ fun lastCommitHash(): String = Runtime.getRuntime().exec("git rev-parse --short 
 }
 
 fun buildTime(): Instant = Instant.now()
-
-/**
- * Configures the [kotlinOptions][org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions] extension.
- */
-private fun LibraryExtension.kotlinOptions(configure: Action<org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions>): Unit =
-    (this as org.gradle.api.plugins.ExtensionAware).extensions.configure("kotlinOptions", configure)
-
-fun LibraryExtension.setupLibraryDefaults() {
-    compileSdk = ProjectConfig.compileSdk
-
-    defaultConfig {
-        minSdk = ProjectConfig.minSdk
-        targetSdk = ProjectConfig.targetSdk
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-        }
-    }
-
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-        freeCompilerArgs = freeCompilerArgs + listOf(
-            "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-            "-opt-in=kotlinx.coroutines.FlowPreview",
-            "-opt-in=kotlin.time.ExperimentalTime",
-            "-opt-in=kotlin.RequiresOptIn"
-        )
-    }
-
-    fun Packaging.() {
-        resources.excludes += "DebugProbesKt.bin"
-    }
-}
 
 fun com.android.build.api.dsl.SigningConfig.setupCredentials(
     signingPropsPath: File? = null

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -5,36 +5,12 @@ object Versions {
     }
 
     object Dagger {
-        const val core = "2.56.2"
-    }
-
-    object Moshi {
-        const val core = "1.15.2"
+        const val core = "2.57.1"
     }
 
     object AndroidX {
-        const val core = ""
-
         object Navigation {
-            const val core = "2.8.9"
+            const val core = "2.9.3"
         }
-
-        object Testing {
-            const val coreKtx = "1.4.0"
-        }
-    }
-
-    object Junit {
-        const val legacy = "4.13.2"
-        const val jupiter = "5.7.1"
-    }
-
-    object Mockk {
-        const val core = "1.12.4"
-        const val android = "1.12.4"
-    }
-
-    object Kotest {
-        const val core = "4.6.4"
     }
 }


### PR DESCRIPTION
This commit refactors the `buildSrc` module by:
- Removing the `setupLibraryDefaults()` extension function from `ProjectConfig.kt` as its functionality is largely covered by standard Gradle plugin configurations.
- Inlining version numbers for Moshi and various testing libraries directly into `Dependencies.kt`, removing them from `Versions.kt`. This simplifies version management for these specific libraries.
- Removing unused version declarations from `Versions.kt`.

Additionally, this commit updates the following dependencies:
- Kotlin from 2.1.21 to 2.2.10
- Android Gradle Plugin from 8.11.0 to 8.12.2
- KSP from 2.1.21-2.0.1 to 2.2.10-2.0.2
- Dagger from 2.56.2 to 2.57.1
- AndroidX Navigation from 2.8.9 to 2.9.3

The `targetSdk` was also removed from the `app-common` module's `defaultConfig` as it's typically inherited or set at the app level.