### PR TITLE
Add ear detection limitation notice to reactions settings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="settings_autopause_description">Pause audio when removing the device from your ear.</string>
     <string name="settings_autopplay_label">Auto play</string>
     <string name="settings_autoplay_description">Start audio playback when device is worn.</string>
+    <string name="settings_eardetection_info_label">Ear detection note</string>
+    <string name="settings_eardetection_info_description">If ear detection only works for one pod, this is an Apple limitation. Only the \"primary pod\" (used for microphone) is detected. Configure on Apple devices: Settings → Bluetooth → AirPods → Microphone.</string>
     <string name="settings_fake_data_label">Fake data</string>
     <string name="settings_fake_data_description">Show fake data, i.e., simulate devices that don\’t exist.</string>
     <string name="settings_debug_label">Debug settings</string>

--- a/app/src/main/res/xml/preferences_reactions.xml
+++ b/app/src/main/res/xml/preferences_reactions.xml
@@ -21,6 +21,12 @@
             android:summary="@string/settings_autopause_description"
             android:title="@string/settings_autopause_label" />
 
+        <Preference
+            android:icon="@drawable/ic_baseline_question_mark_24"
+            android:selectable="false"
+            android:summary="@string/settings_eardetection_info_description"
+            android:title="@string/settings_eardetection_info_label" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/settings_autoconnect_label">


### PR DESCRIPTION
Explains that single-pod detection is an Apple limitation, not an app bug. Users experiencing this issue will now understand it only affects the "primary pod" (microphone pod) and can be configured in iOS settings.

Closes #38, Closes #329