### PR TITLE
Widget: Fix layout for devices with single charge detection

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetProvider.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetProvider.kt
@@ -298,9 +298,10 @@ class WidgetProvider : AppWidgetProvider() {
             if (podDevice is HasEarDetection && podDevice.isBeingWorn) View.VISIBLE else View.GONE
         )
 
-        if (this is HasChargeDetectionDual) {
-            setViewVisibility(R.id.headphones_charging, if (isHeadsetBeingCharged) View.VISIBLE else View.GONE)
-        }
+        setViewVisibility(
+            R.id.headphones_charging,
+            if (podDevice is HasChargeDetectionDual && podDevice.isHeadsetBeingCharged) View.VISIBLE else View.GONE
+        )
     }
 
     companion object {


### PR DESCRIPTION
The instance check was being done on the wrong value, so it was never `true`.