### PR TITLE
Refactor PlayPause logic and fix behavior for SinglePods (e.g. AirPods Max)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,5 +31,10 @@
 	  "WebFetch(domain:issuetracker.google.com)"
 	],
 	"deny": []
+  },
+  "enabledPlugins": {
+	"android-translation@claude-code-cafe": true,
+	"debugbadger@claude-code-cafe": true,
+	"jvm-tools@claude-code-cafe": true
   }
 }

--- a/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
@@ -33,7 +33,7 @@ class PlayPause @Inject constructor(
     fun monitor() = combine(
         reactionSettings.autoPlay.flow,
         reactionSettings.autoPause.flow,
-        reactionSettings.onePodMode.flow,
+        reactionSettings.onePodMode.flow, // Included to restart pipeline when toggled; value read at decision time
     ) { play, pause, _ -> play || pause }
         .flatMapLatest { if (it) bluetoothManager.connectedDevices else emptyFlow() }
         .flatMapLatest {
@@ -194,7 +194,7 @@ class PlayPause @Inject constructor(
     data class EarDetectionState(
         val leftInEar: Boolean?,    // null for single pod devices
         val rightInEar: Boolean?,   // null for single pod devices
-        val isWorn: Boolean         // Always populated
+        val isWorn: Boolean         // Single-pod: device worn state. Dual-pod: equivalent to bothInEar (left && right).
     ) {
         val isDualPod: Boolean get() = leftInEar != null && rightInEar != null
         val isSinglePod: Boolean get() = !isDualPod


### PR DESCRIPTION
Fix edge case where removing a pod while both were in ears didn't trigger pause in one-pod mode. The aggregate boolean (isEitherPodInEar) stayed true, masking the individual pod removal.

See thread by `ZV`:
https://discord.com/channels/548521543039189022/1437499888068726814