### PR TITLE
fix: Handle display cutouts in landscape mode

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/eu/darken/capod/common/EdgeToEdgeHelper.kt
@@ -2,7 +2,6 @@ package eu.darken.capod.common
 
 import android.app.Activity
 import android.view.View
-import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import eu.darken.capod.common.debug.logging.logTag
@@ -20,12 +19,14 @@ class EdgeToEdgeHelper(activity: Activity) {
         bottom: Boolean = false,
     ) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v: View, insets: WindowInsetsCompat ->
-            val systemBars: Insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
+
             v.setPadding(
-                if (left) systemBars.left else v.paddingLeft,
-                if (top) systemBars.top else v.paddingTop,
-                if (right) systemBars.right else v.paddingRight,
-                if (bottom) systemBars.bottom else v.paddingBottom,
+                if (left) maxOf(systemBars.left, displayCutout.left) else v.paddingLeft,
+                if (top) maxOf(systemBars.top, displayCutout.top) else v.paddingTop,
+                if (right) maxOf(systemBars.right, displayCutout.right) else v.paddingRight,
+                if (bottom) maxOf(systemBars.bottom, displayCutout.bottom) else v.paddingBottom,
             )
             insets
         }


### PR DESCRIPTION
## Summary
- EdgeToEdgeHelper now considers both `systemBars()` and `displayCutout()` insets when applying padding
- Uses `maxOf()` to take the larger value, ensuring UI content is not obscured by camera cutouts in landscape orientation
- Backward compatible (display cutout insets are 0 on devices without cutouts)

## Test plan
- [x] Install on a device with a camera cutout (notch/punch hole)
- [x] Open the app in landscape mode (both left and right orientations)
- [x] Verify cards in OverviewFragment are not obscured by the camera cutout
- [x] Test in portrait mode to ensure no regression