### PR TITLE
chore: Remove stale CLAUDE.md exclusion from _config.yml

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,6 @@
 	  "Bash(git checkout:*)",
 	  "Bash(git branch:*)",
 	  "Bash(git stash:*)",
-	  "Bash(git pop:*)",
 	  "Bash(gh issue list:*)",
 	  "Bash(gh pr list:*)",
 	  "Bash(gh label list:*)",

--- a/_config.yml
+++ b/_config.yml
@@ -26,4 +26,3 @@ exclude:
   - app
   - app-common
   - CONTRIBUTING.md
-  - CLAUDE.md


### PR DESCRIPTION
## Summary
- Remove dead `CLAUDE.md` entry from Jekyll `exclude:` list in `_config.yml` — file was moved to `.claude/CLAUDE.md` in 4e279ca
- Remove stale `Bash(git pop:*)` permission from `.claude/settings.json`

## Test plan
- Verify `_config.yml` no longer references `CLAUDE.md`
- No build impact (Jekyll config and Claude settings are not part of the Gradle build)