### PR TITLE
chore: Remove redundant gradle.properties after AGP 9 upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,32 +1,9 @@
 # Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.nonTransitiveRClass=true
-android.nonFinalResIds=true
-org.gradle.unsafe.configuration-cache=false
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
+# Required by androidx.navigation.safeargs plugin
+android.useAndroidX=true
+# Temporary AGP 9 opt-outs (must migrate before AGP 10)
 android.builtInKotlin=false
 android.newDsl=false


### PR DESCRIPTION
## Summary
- Remove 15 gradle.properties that are now redundant or unnecessary defaults after AGP 9.0.0 upgrade
- Keep only `jvmargs`, `kotlin.code.style`, `useAndroidX` (required by SafeArgs plugin), and temporary AGP 9 opt-outs (`builtInKotlin`, `newDsl`)

## Test plan
- [x] `./gradlew assembleFossDebug` passes
- [x] `./gradlew assembleFossRelease` passes (validates R8 property removal)
- [x] `./gradlew testFossDebugUnitTest` passes