### PR TITLE
fix: Pre-release cleanup of manifest, resource leaks, and dependencies

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
         </activity>
 
         <receiver
-            android:name=".bluetooth.BleScanResultReceiver"
+            android:name=".common.bluetooth.BleScanResultReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="eu.darken.capod.bluetooth.DELIVER_SCAN_RESULTS" />

--- a/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
+++ b/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
@@ -212,6 +212,7 @@ class BluetoothManager2 @Inject constructor(
                 context.registerReceiver(receiver, filter, null, handler)
             } catch (e: Exception) {
                 log(TAG, ERROR) { "monitorProfile(): Failed to register receiver: $e" }
+                handlerThread.quitSafely()
                 close(e)
                 return@callbackFlow
             }

--- a/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
@@ -105,11 +105,14 @@ class MonitorNotifications @Inject constructor(
 
             val batteryText = when (device) {
                 is DualPodDevice -> {
-                    val left = formatBatteryPercent(context, device.batteryLeftPodPercent)
-                    val right = formatBatteryPercent(context, device.batteryRightPodPercent)
+                    val leftPercent = device.batteryLeftPodPercent
+                    val rightPercent = device.batteryRightPodPercent
+                    val left = formatBatteryPercent(context, leftPercent)
+                    val right = formatBatteryPercent(context, rightPercent)
                     when {
                         device is HasCase -> {
-                            val case = formatBatteryPercent(context, device.batteryCasePercent)
+                            val casePercent = device.batteryCasePercent
+                            val case = formatBatteryPercent(context, casePercent)
                             "$left $case $right"
                         }
 
@@ -118,10 +121,12 @@ class MonitorNotifications @Inject constructor(
                 }
 
                 is SinglePodDevice -> {
-                    val headset = formatBatteryPercent(context, device.batteryHeadsetPercent)
+                    val headsetPercent = device.batteryHeadsetPercent
+                    val headset = formatBatteryPercent(context, headsetPercent)
                     when {
                         device is HasCase -> {
-                            val case = formatBatteryPercent(context, device.batteryCasePercent)
+                            val casePercent = device.batteryCasePercent
+                            val case = formatBatteryPercent(context, casePercent)
                             "$headset $case"
                         }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -86,7 +86,6 @@ fun DependencyHandlerScope.addBaseAndroid() {
 fun DependencyHandlerScope.addBaseAndroidUi() {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.3")
-    implementation("androidx.fragment:fragment-ktx:1.4.1")
 
     implementation("androidx.activity:activity-ktx:1.8.0")
     implementation("androidx.fragment:fragment-ktx:1.6.1")
@@ -94,7 +93,6 @@ fun DependencyHandlerScope.addBaseAndroidUi() {
     implementation("com.google.android.material:material:1.12.0")
 
     val lifecycleVers = "2.6.2"
-    implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVers")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycleVers")
     implementation("androidx.lifecycle:lifecycle-common-java8:$lifecycleVers")
@@ -123,5 +121,5 @@ fun DependencyHandlerScope.addTesting() {
     androidTestImplementation("io.kotest:kotest-assertions-core-jvm:4.6.4")
     androidTestImplementation("io.kotest:kotest-property-jvm:4.6.4")
 
-    debugImplementation("androidx.fragment:fragment-testing:1.4.1")
+    debugImplementation("androidx.fragment:fragment-testing:1.6.1")
 }


### PR DESCRIPTION
## Summary

Pre-release code review fixes before cutting a release from the current `main` branch (which includes the WorkManager→ForegroundService migration and battery display crash hardening).

- **Fix BleScanResultReceiver manifest package name**: `.bluetooth.BleScanResultReceiver` → `.common.bluetooth.BleScanResultReceiver` — the manifest entry didn't match the actual class location
- **Fix HandlerThread leak in BluetoothManager2**: Add `handlerThread.quitSafely()` before `close(e)` when `registerReceiver()` throws, since `awaitClose` never executes in that path
- **Cache battery values in MonitorNotifications**: Align with the hardening pattern from 5aa36b14 — cache battery properties to local variables before use to prevent concurrent modification issues
- **Remove duplicate fragment-ktx dependency**: Remove stale `1.4.1` declaration, keep `1.6.1`, and update `fragment-testing` to match
- **Remove deprecated lifecycle-extensions**: `lifecycle-extensions:2.2.0` has been deprecated since 2019; all its functionality is covered by the other lifecycle deps already declared

## Test plan

- [x] `./gradlew assembleFossDebug` — clean build
- [x] `./gradlew testFossDebugUnitTest` — all tests pass
- [x] `./gradlew lintFossDebug` — no new lint issues (pre-existing errors unchanged)