### PR TITLE
fix: Use correct labels for upgrade and donate menu items

### DIFF
--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -5,14 +5,14 @@
     <item
         android:id="@+id/menu_item_donate"
         android:icon="@drawable/ic_baseline_heart_24"
-        android:title="@string/settings_general_label"
+        android:title="@string/general_donate_action"
         android:visible="false"
         tool:visible="true"
         app:showAsAction="always" />
     <item
         android:id="@+id/menu_item_upgrade"
         android:icon="@drawable/ic_baseline_stars_24"
-        android:title="@string/settings_general_label"
+        android:title="@string/general_upgrade_action"
         android:visible="false"
         tool:visible="true"
         app:showAsAction="always" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="general_copy_action">Copy</string>
     <string name="general_thank_you_label">Thank you</string>
     <string name="general_upgrade_action">Upgrade</string>
+    <string name="general_donate_action">Donate</string>
     <string name="general_check_action">Check</string>
     <string name="general_close_action">Close</string>
     <string name="general_save_action">Save</string>


### PR DESCRIPTION
## Summary
- Both `menu_item_upgrade` and `menu_item_donate` in the overflow menu were using `@string/settings_general_label` ("Settings") as their title instead of proper labels
- The upgrade item now uses the existing `@string/general_upgrade_action` ("Upgrade")
- The donate item now uses a new `@string/general_donate_action` ("Donate")

## Test plan
- [ ] Build both flavors (`assembleFossDebug`, `assembleGplayDebug`) and confirm compilation
- [ ] Long-press the upgrade/donate icon in the toolbar — tooltip should show "Upgrade" or "Donate" instead of "Settings"
- [ ] Verify TalkBack announces the correct label for the menu items