### PR TITLE
fix(ci): Narrow APK glob to avoid uploading duplicates

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -65,7 +65,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/beta/*.apk
+          files: app/build/outputs/apk/foss/beta/eu.darken.capod-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,7 +77,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/release/*.apk
+          files: app/build/outputs/apk/foss/release/eu.darken.capod-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The `copyTo()`-based APK renaming (from the AGP 9 upgrade) leaves both the original and renamed APK in the output directory
- The `*.apk` glob in the release workflow matches both, uploading duplicate APKs to GitHub releases
- Narrow the glob to `eu.darken.capod-*.apk` to only match renamed APKs