### PR TITLE
fix: Call startForeground() before Hilt DI to prevent timing crash

### DIFF
--- a/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
@@ -37,11 +37,7 @@ class MonitorNotifications @Inject constructor(
     private val builder: NotificationCompat.Builder
 
     init {
-        NotificationChannel(
-            NOTIFICATION_CHANNEL_ID,
-            context.getString(R.string.notification_channel_device_status_label),
-            NotificationManager.IMPORTANCE_LOW
-        ).run { notificationManager.createNotificationChannel(this) }
+        ensureChannel(context)
         NotificationChannel(
             NOTIFICATION_CHANNEL_ID_CONNECTED,
             context.getString(R.string.notification_channel_device_status_connected_label),
@@ -51,7 +47,7 @@ class MonitorNotifications @Inject constructor(
         val openIntent = Intent(context, MainActivity::class.java)
         val openPi = PendingIntent.getActivity(
             context,
-            0,
+            PENDING_INTENT_REQUEST_CODE,
             openIntent,
             PendingIntentCompat.FLAG_IMMUTABLE
         )
@@ -164,10 +160,37 @@ class MonitorNotifications @Inject constructor(
 
     companion object {
         val TAG = logTag("Monitor", "Notifications")
-        private val NOTIFICATION_CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.device.status"
+        internal val NOTIFICATION_CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.device.status"
         private val NOTIFICATION_CHANNEL_ID_CONNECTED =
             "${BuildConfigWrap.APPLICATION_ID}.notification.channel.device.status.connected"
         internal const val NOTIFICATION_ID = 1
         internal const val NOTIFICATION_ID_CONNECTED = 2
+        private const val PENDING_INTENT_REQUEST_CODE = 0
+
+        fun ensureChannel(context: Context) {
+            val nm = context.getSystemService(NotificationManager::class.java)
+            nm.createNotificationChannel(
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    context.getString(R.string.notification_channel_device_status_label),
+                    NotificationManager.IMPORTANCE_LOW,
+                )
+            )
+        }
+
+        fun createEarlyNotification(context: Context): Notification {
+            val openPi = PendingIntent.getActivity(
+                context, PENDING_INTENT_REQUEST_CODE,
+                Intent(context, MainActivity::class.java),
+                PendingIntentCompat.FLAG_IMMUTABLE,
+            )
+            return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+                .setContentIntent(openPi)
+                .setSmallIcon(R.drawable.devic_earbuds_generic_both)
+                .setContentTitle(context.getString(R.string.app_name))
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .build()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Call `startForeground()` with a minimal notification BEFORE `super.onCreate()` (which triggers Hilt DI) to prevent `ForegroundServiceDidNotStartInTimeException` on cold background starts
- After DI completes, replace the early notification with the full one via a second `startForeground()` call
- Deduplicate notification channel creation by having the `init` block delegate to the new static `ensureChannel()` helper
- Extract `PENDING_INTENT_REQUEST_CODE` constant to make PendingIntent coupling explicit

## Context

When `BluetoothEventReceiver` fires in the background (e.g., AirPods connect while phone is in pocket), `MonitorService.onCreate()` calls `super.onCreate()` which triggers Hilt DI for 12 injected fields. The DI chain includes SharedPreferences disk I/O, layout inflation, Moshi reflection, and system service lookups that can exceed the ~5s foreground service timeout on production devices with cold caches.

## Test plan

- [ ] Build: `./gradlew assembleFossDebug`
- [ ] Test Bluetooth ACL connect while app is backgrounded
- [ ] Test device boot via `BootCompletedReceiver`
- [ ] Test app cold start from launcher
- [ ] Verify notification transitions smoothly from early to full
