### PR TITLE
fix(monitor): Prevent crash when OS denies foreground service start

### DIFF
--- a/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
@@ -184,13 +184,13 @@ class MonitorNotifications @Inject constructor(
                 Intent(context, MainActivity::class.java),
                 PendingIntentCompat.FLAG_IMMUTABLE,
             )
-            return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
-                .setContentIntent(openPi)
-                .setSmallIcon(R.drawable.device_earbuds_generic_both)
-                .setContentTitle(context.getString(R.string.app_name))
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setOngoing(true)
-                .build()
+            return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID).apply {
+                setContentIntent(openPi)
+                setSmallIcon(R.drawable.device_earbuds_generic_both)
+                setContentTitle(context.getString(R.string.app_name))
+                setPriority(NotificationCompat.PRIORITY_LOW)
+                setOngoing(true)
+            }.build()
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `promoteToForeground()` helper in `MonitorService` that catches
  `ForegroundServiceStartNotAllowedException` (Android 12+) and
  `SecurityException` from `startForeground()`, allowing the service
  to exit gracefully instead of crashing
- Guard `onStartCommand()` with a `foregroundStartFailed` flag so
  the service stops with `START_NOT_STICKY` when promotion was denied
- Both `startForeground()` calls (pre-DI and post-DI) now go through
  the same helper to cover OEM edge cases on the second call too
- Minor: convert `createEarlyNotification()` builder to `apply` syntax
  for consistency with the rest of the file

Closes #313
