### PR TITLE
General: Fix brief screen flash before onboarding on fresh install

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
@@ -18,6 +18,7 @@ import eu.darken.capod.common.navigation.NavigationController
 import eu.darken.capod.common.navigation.NavigationEntry
 import eu.darken.capod.common.theming.CapodTheme
 import eu.darken.capod.common.uix.Activity2
+import eu.darken.capod.main.core.GeneralSettings
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,14 +26,21 @@ class MainActivity : Activity2() {
 
     @Inject lateinit var navCtrl: NavigationController
     @Inject lateinit var navigationEntries: Set<@JvmSuppressWildcards NavigationEntry>
+    @Inject lateinit var generalSettings: GeneralSettings
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         enableEdgeToEdge()
 
+        val startDestination: NavKey = if (generalSettings.isOnboardingDone.value) {
+            Nav.Main.Overview
+        } else {
+            Nav.Main.Onboarding
+        }
+
         setContent {
-            val backStack = rememberNavBackStack(Nav.Main.Overview)
+            val backStack = rememberNavBackStack(startDestination)
             navCtrl.setup(backStack)
 
             CapodTheme {

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -49,12 +49,6 @@ class OverviewViewModel @Inject constructor(
     private val profilesRepo: DeviceProfilesRepo,
 ) : ViewModel4(dispatcherProvider) {
 
-    init {
-        if (!generalSettings.isOnboardingDone.value) {
-            navTo(Nav.Main.Onboarding, popUpTo = Nav.Main.Overview, inclusive = true)
-        }
-    }
-
     val requestPermissionEvent = SingleEventFlow<Permission>()
     val launchUpgradeFlow = SingleEventFlow<(Activity) -> Unit>()
 


### PR DESCRIPTION
## What changed

Fixed a brief flash of the main dashboard screen before the onboarding screen appeared on fresh installs.

## Technical Context

- Root cause: nav backstack was hardcoded to start with the Overview destination, and the onboarding redirect happened asynchronously in the ViewModel — too late to prevent the first frame from rendering
- Fix: moved the onboarding check into MainActivity.onCreate() so the correct start destination is determined before the backstack is created
- Removed the redundant async onboarding check from OverviewViewModel.init
