### PR TITLE
Device: Fix profile editing always opening in create mode

### DIFF
--- a/app/src/main/java/eu/darken/capod/profiles/ui/creation/DeviceProfileCreationNavigation.kt
+++ b/app/src/main/java/eu/darken/capod/profiles/ui/creation/DeviceProfileCreationNavigation.kt
@@ -13,7 +13,9 @@ import javax.inject.Inject
 
 class DeviceProfileCreationNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Main.DeviceProfileCreation> { DeviceProfileCreationScreenHost() }
+        entry<Nav.Main.DeviceProfileCreation> { key ->
+            DeviceProfileCreationScreenHost(profileId = key.profileId)
+        }
     }
 
     @Module

--- a/app/src/main/java/eu/darken/capod/profiles/ui/creation/DeviceProfileCreationScreen.kt
+++ b/app/src/main/java/eu/darken/capod/profiles/ui/creation/DeviceProfileCreationScreen.kt
@@ -58,7 +58,12 @@ import eu.darken.capod.common.toHex
 import eu.darken.capod.pods.core.PodDevice
 
 @Composable
-fun DeviceProfileCreationScreenHost(vm: DeviceProfileCreationViewModel = hiltViewModel()) {
+fun DeviceProfileCreationScreenHost(
+    profileId: String? = null,
+    vm: DeviceProfileCreationViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(Unit) { vm.initialize(profileId) }
+
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 


### PR DESCRIPTION
## What changed

Fixed device profile editing always opening in create mode instead of edit mode. Also fixed a false "unsaved changes" warning appearing when leaving the profile creation screen without making any edits.

## Technical Context

- Root cause: Navigation 3 does not auto-populate SavedStateHandle from NavKey args, so profileId was always null — every edit opened as a new profile
- Fix: pass profileId explicitly from the Navigation 3 entry lambda instead of relying on SavedStateHandle
- Replaced SavedStateHandle-based initialization with an explicit initialize() method to avoid stale state when re-entering the screen
- Set _initialState to match defaults in create mode so hasUnsavedChanges correctly returns false when nothing was edited
- Reset initialization flag on every exit path to prevent stale state on re-entry
