### PR TITLE
General: Move monitoring settings to their own category

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -128,6 +128,25 @@ fun GeneralSettingsScreen(
     ) { innerPadding ->
         LazyColumn(modifier = Modifier.padding(innerPadding)) {
             item {
+                SettingsCategoryHeader(text = stringResource(R.string.settings_category_monitoring_label))
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_monitor_mode_label),
+                    subtitle = stringResource(state.monitorMode.labelRes),
+                    icon = Icons.TwoTone.DisabledVisible,
+                    onClick = { showMonitorModeDialog = true },
+                )
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_scanner_mode_label),
+                    subtitle = stringResource(state.scannerMode.labelRes),
+                    icon = Icons.TwoTone.SettingsBluetooth,
+                    onClick = { showScannerModeDialog = true },
+                )
+            }
+            item {
                 SettingsCategoryHeader(text = stringResource(R.string.settings_category_appearance_label))
             }
             item {
@@ -161,22 +180,6 @@ fun GeneralSettingsScreen(
                     icon = Icons.TwoTone.Palette,
                     onClick = { showColorDialog = true },
                     enabled = !isMaterialYouActive,
-                )
-            }
-            item {
-                SettingsBaseItem(
-                    title = stringResource(R.string.settings_monitor_mode_label),
-                    subtitle = stringResource(state.monitorMode.labelRes),
-                    icon = Icons.TwoTone.DisabledVisible,
-                    onClick = { showMonitorModeDialog = true },
-                )
-            }
-            item {
-                SettingsBaseItem(
-                    title = stringResource(R.string.settings_scanner_mode_label),
-                    subtitle = stringResource(state.scannerMode.labelRes),
-                    icon = Icons.TwoTone.SettingsBluetooth,
-                    onClick = { showScannerModeDialog = true },
                 )
             }
             item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
     <string name="ui_theme_color_disabled_materialyou">Uses wallpaper colors</string>
 
     <!-- Settings categories -->
+    <string name="settings_category_monitoring_label">Monitoring</string>
     <string name="settings_category_appearance_label">Appearance</string>
 
     <!-- Unsaved changes dialog -->


### PR DESCRIPTION
## What changed

- Monitor mode and scanner mode settings are moved out of the "Appearance" section into a new "Monitoring" category in General settings.

## Technical Context

- These are functional settings that control Bluetooth scanning behavior, not visual preferences. Grouping them under "Appearance" was misleading; the new category better reflects their purpose.
- No logic changes; only the XML preference ordering and a new category header were added.
