### PR TITLE
Widget: Fix invisible text and gap in widget configuration screen

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetConfigurationActivity.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetConfigurationActivity.kt
@@ -7,8 +7,13 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.capod.common.compose.waitForState
@@ -53,6 +58,15 @@ class WidgetConfigurationActivity : Activity2() {
         setContent {
             val themeState by generalSettings.themeState.collectAsState(initial = generalSettings.currentThemeState)
             CapodTheme(state = themeState) {
+                val backgroundColor = MaterialTheme.colorScheme.background
+                val useDarkIcons = backgroundColor.luminance() > 0.5f
+                SideEffect {
+                    window.decorView.setBackgroundColor(backgroundColor.toArgb())
+                    val insetsController = WindowCompat.getInsetsController(window, window.decorView)
+                    insetsController.isAppearanceLightStatusBars = useDarkIcons
+                    insetsController.isAppearanceLightNavigationBars = useDarkIcons
+                }
+
                 val state by waitForState(vm.state)
                 state?.let { currentState ->
                     WidgetConfigurationScreen(

--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetConfigurationScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetConfigurationScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -113,7 +115,7 @@ fun WidgetConfigurationScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.systemBars),
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)),
     ) {
         Column(
             modifier = Modifier
@@ -326,7 +328,7 @@ fun WidgetConfigurationScreen(
 
         // Bottom bar
         Surface(tonalElevation = 3.dp) {
-            Column {
+            Column(modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Bottom))) {
                 if (!state.isPro) {
                     Text(
                         text = stringResource(R.string.common_feature_requires_pro_msg),


### PR DESCRIPTION
## What changed

Fixed invisible title text in the widget configuration screen when the system dark/light mode differs from the app's theme setting. Also eliminated a white gap at the bottom of the screen behind the navigation bar.

## Technical Context

- The widget configuration activity called `enableEdgeToEdge()` but never synced the Android window background color with the Compose Material theme, causing text to render in the wrong color against the background
- MainActivity already handled this correctly via a `SideEffect` block — the same pattern is now applied to the widget config activity
- The bottom action bar (Cancel/OK buttons) stopped at the navigation bar inset, leaving a visible white strip; it now extends under the nav bar
