### PR TITLE
General: Show hint to disable notification when extra notification is enabled

### DIFF
--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -172,9 +172,10 @@ class MonitorService : Service() {
             .distinctUntilChanged()
             .throttleLatest(1000)
             .onEach { currentDevice ->
+                val useExtraNotification = generalSettings.useExtraMonitorNotification.value
                 notificationManager.notify(
                     MonitorNotifications.NOTIFICATION_ID,
-                    notifications.getNotification(currentDevice),
+                    notifications.getNotification(currentDevice, showHint = useExtraNotification),
                 )
                 if (generalSettings.useExtraMonitorNotification.value && currentDevice != null) {
                     notificationManager.notify(

--- a/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
@@ -57,10 +57,17 @@ class MonitorNotifications @Inject constructor(
             setOngoing(true)
         }
 
-    private fun getBuilder(device: PodDevice?, channelId: String): NotificationCompat.Builder {
+    private fun getBuilder(device: PodDevice?, channelId: String, showHint: Boolean = false): NotificationCompat.Builder {
         if (device == null) {
             return baseBuilder(channelId).apply {
-                setStyle(NotificationCompat.BigTextStyle())
+                if (showHint) {
+                    setStyle(
+                        NotificationCompat.BigTextStyle()
+                            .bigText(context.getString(R.string.monitor_notification_extra_enabled_hint))
+                    )
+                } else {
+                    setStyle(NotificationCompat.BigTextStyle())
+                }
                 setContentTitle(context.getString(R.string.pods_none_label_short))
                 setSubText(context.getString(R.string.app_name))
             }
@@ -136,8 +143,8 @@ class MonitorNotifications @Inject constructor(
         }
     }
 
-    fun getNotification(podDevice: PodDevice?): Notification =
-        getBuilder(podDevice, NOTIFICATION_CHANNEL_ID).build()
+    fun getNotification(podDevice: PodDevice?, showHint: Boolean = false): Notification =
+        getBuilder(podDevice, NOTIFICATION_CHANNEL_ID, showHint).build()
 
     fun getNotificationConnected(podDevice: PodDevice?): Notification =
         getBuilder(podDevice, NOTIFICATION_CHANNEL_ID_CONNECTED).build()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
 
     <string name="notification_channel_device_status_label">Device status</string>
     <string name="notification_channel_device_status_connected_label">Connected device</string>
+    <string name="monitor_notification_extra_enabled_hint">You can disable this notification in system settings.</string>
 
     <string name="support_debuglog_label">Debug log</string>
     <string name="support_debuglog_desc">Record everything the app is doing into a text file that you can share.</string>


### PR DESCRIPTION
## What changed

When the "Extra notification" setting is enabled, the permanent "No device" notification now shows a hint telling users they can disable it in system settings. This helps users understand which notification channel to turn off to hide the persistent status notification while keeping the separate "Connected device" notification.

## Technical Context

- The hint only appears on the primary foreground notification (ID=1) when no device is detected and the extra notification setting is active
- When a device is connected, the notification switches to the custom device view — the hint is not shown
- Added a `showHint` parameter to `getBuilder()`/`getNotification()` with `false` default so existing callers (`getStartupNotification`, `getNotificationConnected`) are unaffected
- Uses `BigTextStyle.bigText()` to display the hint as expandable body text under the "No device" title
