### PR TITLE
General: Add wiki link to support screen

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/settings/support/SupportScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/support/SupportScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.BugReport
 import androidx.compose.material.icons.twotone.Cancel
+import androidx.compose.material.icons.automirrored.twotone.MenuBook
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -85,6 +86,7 @@ fun SupportScreenHost(vm: SupportViewModel = hiltViewModel()) {
             onContactDeveloper = { vm.goToContactSupport() },
             onDiscord = { vm.openUrl("https://discord.gg/rrxxng35jq") },
             onIssueTracker = { vm.openUrl("https://github.com/d4rken-org/capod/issues") },
+            onWiki = { vm.openUrl("https://github.com/d4rken-org/capod/wiki") },
             onTroubleShooter = { vm.goToTroubleShooter() },
             onDebugLogToggle = { vm.onDebugLogToggle() },
             onClearLogs = { vm.clearDebugLogs() },
@@ -122,6 +124,7 @@ fun SupportScreen(
     onContactDeveloper: () -> Unit,
     onDiscord: () -> Unit,
     onIssueTracker: () -> Unit,
+    onWiki: () -> Unit,
     onTroubleShooter: () -> Unit,
     onDebugLogToggle: () -> Unit,
     onClearLogs: () -> Unit,
@@ -156,6 +159,14 @@ fun SupportScreen(
             }
             item {
                 SettingsCategoryHeader(text = stringResource(R.string.settings_category_gethelp_label))
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_wiki_label),
+                    subtitle = stringResource(R.string.settings_wiki_description),
+                    icon = Icons.AutoMirrored.TwoTone.MenuBook,
+                    onClick = onWiki,
+                )
             }
             item {
                 SettingsBaseItem(
@@ -233,6 +244,7 @@ private fun SupportScreenPreview() = PreviewWrapper {
         onContactDeveloper = {},
         onDiscord = {},
         onIssueTracker = {},
+        onWiki = {},
         onTroubleShooter = {},
         onDebugLogToggle = {},
         onClearLogs = {},


### PR DESCRIPTION
## What changed

Added a link to the GitHub wiki (FAQ & Guides) in the app's support screen. It appears as the first entry in the "Get Help" section, making it easy for users to find answers before filing issues or contacting support.

## Technical Context

- Reuses existing `settings_wiki_label` and `settings_wiki_description` string resources (already defined and translated)
- Uses the same `MenuBook` icon as the wiki link on the main settings screen
- Placed first in the "Get Help" category so users check the FAQ before opening issues
