### PR TITLE
Device: Fix app getting stuck in scanning loop without Bluetooth

### DIFF
--- a/app/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/PodMonitor.kt
@@ -59,8 +59,7 @@ class PodMonitor @Inject constructor(
         bluetoothManager.isBluetoothEnabled
     ) { missingPermissions, isBluetoothEnabled ->
         log(TAG) { "devices: missingPermissions=$missingPermissions, isBluetoothEnabled=$isBluetoothEnabled" }
-        // We just want to retrigger if permissions change.
-        isBluetoothEnabled
+        missingPermissions.isEmpty() && isBluetoothEnabled
     }
         .flatMapLatest { isReady ->
             if (!isReady) {
@@ -76,9 +75,14 @@ class PodMonitor @Inject constructor(
             flowOf(sortPodsToInterest(devices))
         }
         .retryWhen { cause, attempt ->
-            log(TAG, WARN) { "PodMonitor failed (attempt=$attempt), will retry: ${cause.asLog()}" }
-            delay(3000)
-            true
+            if (cause is SecurityException) {
+                log(TAG, WARN) { "PodMonitor failed due to missing permission, not retrying: ${cause.asLog()}" }
+                false
+            } else {
+                log(TAG, WARN) { "PodMonitor failed (attempt=$attempt), will retry: ${cause.asLog()}" }
+                delay(3000)
+                true
+            }
         }
         .onStart { emit(emptyList()) }
         .replayingShare(appScope)


### PR DESCRIPTION
## What changed

Fixed the app getting stuck in an endless scanning loop on devices without Bluetooth (e.g. emulators). The scanner would retry every 3 seconds forever when Bluetooth permissions couldn't be granted, flooding the log and wasting resources.

## Technical Context

- Root cause: `PodMonitor.devices` combined `missingPermissions` and `isBluetoothEnabled` but only used `isBluetoothEnabled` to gate scanning — permissions were logged but ignored
- When `BleScanner.startScan()` threw `SecurityException` (missing `BLUETOOTH_SCAN`), the `retryWhen` operator always returned `true`, causing infinite retries with 3-second delay
- Fix gates scanning on `missingPermissions.isEmpty() && isBluetoothEnabled` — when permissions are later granted, the combine re-emits and scanning starts naturally
- Added defense-in-depth: `retryWhen` now returns `false` for `SecurityException` since it requires user action to resolve (unlike transient errors which can legitimately recover)
- `BluetoothManager2` already had proper retry limits (max 3 with backoff) — `PodMonitor` was the only unbounded retry
