### PR TITLE
General: Reduce wait time for FOSS sponsor unlock

### DIFF
--- a/app/src/foss/java/eu/darken/capod/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/capod/upgrade/ui/UpgradeViewModel.kt
@@ -34,7 +34,7 @@ class UpgradeViewModel @Inject constructor(
         val openedAt = savedStateHandle.get<Long>(KEY_SPONSOR_OPENED_AT) ?: return
         savedStateHandle.remove<Long>(KEY_SPONSOR_OPENED_AT)
 
-        if (SystemClock.elapsedRealtime() - openedAt >= 10_000L) {
+        if (SystemClock.elapsedRealtime() - openedAt >= 5_000L) {
             upgradeControlFoss.upgrade(FossUpgrade.Reason.DONATED)
             navUp()
         } else {


### PR DESCRIPTION
## What changed

Reduced the time users need to spend on the GitHub Sponsors page before pro features unlock from 10 seconds to 5 seconds.

## Technical Context

- Changed the elapsed-time threshold in `UpgradeViewModel.onResume()` from `10_000L` to `5_000L`
- 10 seconds felt too long — users who genuinely visit the page shouldn't need to wait that long