### PR TITLE
General: Ask to delete debug log after sharing it

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/debug/recording/ui/RecorderActivity.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/ui/RecorderActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
@@ -56,12 +57,44 @@ class RecorderActivity : Activity2() {
                     insetsController.isAppearanceLightNavigationBars = useDarkIcons
                 }
 
+                var hasShared by remember { mutableStateOf(false) }
+
                 LaunchedEffect(Unit) {
                     vm.events.collect { event ->
                         when (event) {
-                            is RecorderActivityVM.Event.ShareIntent -> startActivity(event.intent)
+                            is RecorderActivityVM.Event.ShareIntent -> {
+                                hasShared = true
+                                startActivity(event.intent)
+                            }
                             is RecorderActivityVM.Event.Finish -> finish()
                         }
+                    }
+                }
+
+                var showSentConfirm by remember { mutableStateOf(false) }
+
+                LifecycleResumeEffect(hasShared) {
+                    if (hasShared) {
+                        showSentConfirm = true
+                        hasShared = false
+                    }
+                    onPauseOrDispose {}
+                }
+
+                if (showSentConfirm) {
+                    LaunchedEffect(Unit) {
+                        MaterialAlertDialogBuilder(this@RecorderActivity).apply {
+                            setTitle(R.string.support_debuglog_sent_title)
+                            setMessage(R.string.support_debuglog_sent_message)
+                            setPositiveButton(R.string.general_done_action) { _, _ ->
+                                showSentConfirm = false
+                                vm.discard()
+                            }
+                            setNegativeButton(R.string.general_cancel_action) { _, _ ->
+                                showSentConfirm = false
+                            }
+                            setOnCancelListener { showSentConfirm = false }
+                        }.show()
                     }
                 }
 

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/support/contactform/ContactFormScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/support/contactform/ContactFormScreen.kt
@@ -69,13 +69,37 @@ fun ContactFormScreenHost(vm: ContactFormViewModel = hiltViewModel()) {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
-    LifecycleResumeEffect(Unit) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    var hasSentEmail by remember { mutableStateOf(false) }
+    var showSentConfirm by remember { mutableStateOf(false) }
+
+    LifecycleResumeEffect(hasSentEmail) {
         vm.refreshLogSessions()
+        if (hasSentEmail) {
+            showSentConfirm = true
+            hasSentEmail = false
+        }
         onPauseOrDispose {}
     }
 
-    val context = LocalContext.current
-    val snackbarHostState = remember { SnackbarHostState() }
+    if (showSentConfirm) {
+        LaunchedEffect(Unit) {
+            MaterialAlertDialogBuilder(context).apply {
+                setTitle(R.string.support_contact_sent_title)
+                setMessage(R.string.support_contact_sent_message)
+                setPositiveButton(R.string.general_done_action) { _, _ ->
+                    showSentConfirm = false
+                    vm.confirmSent()
+                }
+                setNegativeButton(R.string.general_cancel_action) { _, _ ->
+                    showSentConfirm = false
+                }
+                setOnCancelListener { showSentConfirm = false }
+            }.show()
+        }
+    }
 
     var showShortRecordingWarning by remember { mutableStateOf(false) }
 
@@ -84,8 +108,10 @@ fun ContactFormScreenHost(vm: ContactFormViewModel = hiltViewModel()) {
             when (event) {
                 is ContactFormViewModel.Event.OpenEmail -> {
                     try {
+                        hasSentEmail = true
                         context.startActivity(event.intent)
                     } catch (e: ActivityNotFoundException) {
+                        hasSentEmail = false
                         snackbarHostState.showSnackbar(
                             context.getString(R.string.support_contact_no_email_app)
                         )

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/support/contactform/ContactFormViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/support/contactform/ContactFormViewModel.kt
@@ -151,6 +151,15 @@ class ContactFormViewModel @Inject constructor(
         if (result != null) autoSelectSessionId = result.sessionId
     }
 
+    fun confirmSent() = launch {
+        val selectedId = stater.value().selectedSessionId
+        if (selectedId != null) {
+            log(TAG) { "confirmSent() deleting session $selectedId" }
+            sessionManager.deleteSession(selectedId)
+        }
+        navUp()
+    }
+
     fun send() = launch {
         val currentState = stater.value()
         if (!currentState.canSend) return@launch

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -399,4 +399,10 @@
     <string name="support_contact_debuglog_delete_title">Delete debug log?</string>
     <string name="support_contact_debuglog_delete_message">This debug log will be permanently deleted.</string>
 
+    <!-- Post-share confirmation -->
+    <string name="support_debuglog_sent_title">Log sent?</string>
+    <string name="support_debuglog_sent_message">Was the debug log sent successfully? The log will be deleted.</string>
+    <string name="support_contact_sent_title">Email sent?</string>
+    <string name="support_contact_sent_message">Was the email sent successfully? The attached debug log will be deleted.</string>
+
 </resources>


### PR DESCRIPTION
## What changed

After sharing a debug log or sending a contact form email, a confirmation dialog now appears when returning to the app. Tapping "Done" deletes the log and closes the screen, preventing accidental re-sends.

## Technical Context

- Both `RecorderActivity` (direct debug log share) and `ContactFormScreen` (contact form email) track whether the user left via a share/email intent using a `hasShared`/`hasSentEmail` flag
- A `LifecycleResumeEffect` checks the flag on resume and shows a `MaterialAlertDialogBuilder` dialog matching the existing dialog pattern in both screens
- In the contact form flow, `confirmSent()` deletes the attached debug session (if any) and navigates back via `navUp()`
- If the email app wasn't found (`ActivityNotFoundException`), the flag is reset so no dialog appears on resume
