### PR TITLE
Fix: Fix debug log sessions appearing in wrong order

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/debug/recording/core/DebugSessionManager.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/core/DebugSessionManager.kt
@@ -256,13 +256,27 @@ class DebugSessionManager @Inject constructor(
             return prefix + file.name.removeSuffix(".zip")
         }
 
+        private val TIMESTAMP_FORMAT = java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+            .withZone(java.time.ZoneOffset.UTC)
+
         @VisibleForTesting
-        internal fun parseCreatedAt(file: File): Instant = try {
-            val attrs = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
-            attrs.creationTime().toInstant()
-        } catch (e: Exception) {
-            log(TAG, WARN) { "Failed to read creation time for ${file.name}: ${e.message}" }
-            Instant.ofEpochMilli(file.lastModified())
+        internal fun parseCreatedAt(file: File): Instant {
+            val name = file.name.removeSuffix(".zip")
+            val parts = name.split("_")
+            // Format: capod_{version}_{yyyyMMddTHHmmssZ}_{suffix}
+            if (parts.size >= 3) {
+                try {
+                    return TIMESTAMP_FORMAT.parse(parts[2], Instant::from)
+                } catch (_: Exception) {
+                }
+            }
+            return try {
+                val attrs = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
+                attrs.creationTime().toInstant()
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to read creation time for ${file.name}: ${e.message}" }
+                Instant.ofEpochMilli(file.lastModified())
+            }
         }
 
         private fun computeDiskSize(file: File): Long {

--- a/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
@@ -98,7 +98,8 @@ class RecorderModule @Inject constructor(
     }
 
     private fun createSessionDir(): File {
-        val timestamp = System.currentTimeMillis()
+        val timestamp = java.time.ZonedDateTime.now(java.time.ZoneOffset.UTC)
+            .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"))
         val installIdPrefix = installId.id.take(8)
         val dirName = "capod_${BuildConfigWrap.VERSION_NAME}_${timestamp}_$installIdPrefix"
 

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/DebugSessionManagerSessionLogicTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/DebugSessionManagerSessionLogicTest.kt
@@ -31,11 +31,10 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
     @Nested
     inner class ParseCreatedAt {
         @Test
-        fun `returns creation time from file attributes`() {
-            val file = File(externalLogsDir, "capod_1.2.3_1709810400000_abcd1234").also { it.mkdirs() }
+        fun `returns creation time parsed from filename`() {
+            val file = File(externalLogsDir, "capod_1.2.3_20240307T112000Z_abcd1234").also { it.mkdirs() }
             val result = DebugSessionManager.parseCreatedAt(file)
-            // Should return a valid Instant (either from file attributes or lastModified fallback)
-            result.shouldBeInstanceOf<Instant>()
+            result shouldBe Instant.parse("2024-03-07T11:20:00Z")
         }
 
         @Test
@@ -97,7 +96,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `dir with valid core log returns Ready`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("some log content")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
@@ -105,7 +104,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
             result shouldHaveSize 1
             val session = result.first()
             session.shouldBeInstanceOf<DebugSession.Ready>()
-            session.id shouldBe "ext:capod_1.0_1700000000000_abcd1234"
+            session.id shouldBe "ext:capod_1.0_20231114T221320Z_abcd1234"
             session.logDir shouldBe sessionDir
             session.zipFile shouldBe null
             session.compressedSize shouldBe 0L
@@ -113,7 +112,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `dir with empty core log returns Failed EMPTY_LOG`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").createNewFile()
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
@@ -126,7 +125,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `dir with no core log returns Failed MISSING_LOG`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").mkdirs()
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").mkdirs()
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
@@ -138,7 +137,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `standalone non-empty zip returns Ready with null logDir`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").writeText("zipdata")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").writeText("zipdata")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
@@ -146,13 +145,13 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
             val session = result.first()
             session.shouldBeInstanceOf<DebugSession.Ready>()
             (session as DebugSession.Ready).logDir shouldBe null
-            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip")
-            session.compressedSize shouldBe File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").length()
+            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip")
+            session.compressedSize shouldBe File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").length()
         }
 
         @Test
         fun `standalone empty zip returns Failed CORRUPT_ZIP`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").createNewFile()
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").createNewFile()
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
@@ -164,16 +163,16 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `dir plus sibling zip reports combined diskSize`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content here")
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").writeText("zipdata12345")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").writeText("zipdata12345")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
             result shouldHaveSize 1
             val session = result.first() as DebugSession.Ready
             val expectedDirSize = sessionDir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
-            val zipFile = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip")
+            val zipFile = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip")
             val expectedZipSize = zipFile.length()
             session.diskSize shouldBe expectedDirSize + expectedZipSize
             session.zipFile shouldBe zipFile
@@ -182,8 +181,8 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `dir missing core log but valid sibling zip returns Ready with null logDir`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").mkdirs()
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").writeText("zipdata")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").mkdirs()
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").writeText("zipdata")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
@@ -191,12 +190,12 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
             val session = result.first()
             session.shouldBeInstanceOf<DebugSession.Ready>()
             (session as DebugSession.Ready).logDir shouldBe null
-            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip")
+            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip")
         }
 
         @Test
         fun `active recording dir returns Recording`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("recording in progress")
 
             val result = DebugSessionManager.scanSessions(
@@ -213,14 +212,14 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `ignores non-directory non-zip files`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234/core.log").writeText("log")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234/core.log").writeText("log")
             File(externalLogsDir, "random_notes.txt").writeText("not a session")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
             result shouldHaveSize 1
-            result.first().id shouldBe "ext:capod_1.0_1700000000000_abcd1234"
+            result.first().id shouldBe "ext:capod_1.0_20231114T221320Z_abcd1234"
         }
 
         @Test
@@ -233,20 +232,20 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `cache directory gets cache prefix`() {
-            val sessionDir = File(cacheLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(cacheLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("cached log")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
             result shouldHaveSize 1
-            result.first().id shouldBe "cache:capod_1.0_1700000000000_abcd1234"
+            result.first().id shouldBe "cache:capod_1.0_20231114T221320Z_abcd1234"
         }
 
         @Test
         fun `empty core log with valid sibling zip returns Ready`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").createNewFile()
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").writeText("valid zip data")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").writeText("valid zip data")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
@@ -254,45 +253,45 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
             val session = result.first()
             session.shouldBeInstanceOf<DebugSession.Ready>()
             (session as DebugSession.Ready).logDir shouldBe null
-            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip")
+            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip")
         }
 
         @Test
         fun `multiple log directories are combined`() {
-            val extDir = File(externalLogsDir, "capod_1.0_1700000000000_aaaa1111").also { it.mkdirs() }
+            val extDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_aaaa1111").also { it.mkdirs() }
             File(extDir, "core.log").writeText("ext log")
 
-            val cacheDir = File(cacheLogsDir, "capod_1.0_1600000000000_bbbb2222").also { it.mkdirs() }
+            val cacheDir = File(cacheLogsDir, "capod_1.0_20200913T122640Z_bbbb2222").also { it.mkdirs() }
             File(cacheDir, "core.log").writeText("cache log")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
             result shouldHaveSize 2
-            result.any { it.id == "ext:capod_1.0_1700000000000_aaaa1111" } shouldBe true
-            result.any { it.id == "cache:capod_1.0_1600000000000_bbbb2222" } shouldBe true
+            result.any { it.id == "ext:capod_1.0_20231114T221320Z_aaaa1111" } shouldBe true
+            result.any { it.id == "cache:capod_1.0_20200913T122640Z_bbbb2222" } shouldBe true
         }
 
         @Test
         fun `sessions with same createdAt sorted by id ascending`() {
-            val dirA = File(externalLogsDir, "capod_1.0_1700000000000_aaaa").also { it.mkdirs() }
+            val dirA = File(externalLogsDir, "capod_1.0_20231114T221320Z_aaaa").also { it.mkdirs() }
             File(dirA, "core.log").writeText("log a")
 
-            val dirB = File(externalLogsDir, "capod_1.0_1700000000000_zzzz").also { it.mkdirs() }
+            val dirB = File(externalLogsDir, "capod_1.0_20231114T221320Z_zzzz").also { it.mkdirs() }
             File(dirB, "core.log").writeText("log b")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
             result shouldHaveSize 2
-            result[0].id shouldBe "ext:capod_1.0_1700000000000_aaaa"
-            result[1].id shouldBe "ext:capod_1.0_1700000000000_zzzz"
+            result[0].id shouldBe "ext:capod_1.0_20231114T221320Z_aaaa"
+            result[1].id shouldBe "ext:capod_1.0_20231114T221320Z_zzzz"
         }
 
         @Test
         fun `multiple sessions sorted by createdAt descending then id ascending`() {
-            val dirA = File(externalLogsDir, "capod_1.0_1600000000000_aaaa").also { it.mkdirs() }
+            val dirA = File(externalLogsDir, "capod_1.0_20200913T122640Z_aaaa").also { it.mkdirs() }
             File(dirA, "core.log").writeText("log a")
 
-            val dirB = File(externalLogsDir, "capod_1.0_1700000000000_bbbb").also { it.mkdirs() }
+            val dirB = File(externalLogsDir, "capod_1.0_20231114T221320Z_bbbb").also { it.mkdirs() }
             File(dirB, "core.log").writeText("log b")
 
             val result = DebugSessionManager.scanSessions(logDirectories = logDirs())
@@ -311,7 +310,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
     inner class IdRoundTrip {
         @Test
         fun `deriveSessionId on ext dir matches scanSessions output`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content")
 
             val derived = DebugSessionManager.deriveSessionId(sessionDir)
@@ -323,7 +322,7 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `deriveSessionId on cache dir matches scanSessions output`() {
-            val sessionDir = File(cacheLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(cacheLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content")
 
             val derived = DebugSessionManager.deriveSessionId(sessionDir)
@@ -335,9 +334,9 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `deriveSessionId on zip file matches scanSessions output`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").writeText("zipdata")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").writeText("zipdata")
 
-            val zipFile = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip")
+            val zipFile = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip")
             val derived = DebugSessionManager.deriveSessionId(zipFile)
             val scanned = DebugSessionManager.scanSessions(logDirectories = logDirs())
 
@@ -347,9 +346,9 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `deriveSessionId is consistent for dir and sibling zip`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content")
-            val zipFile = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").also {
+            val zipFile = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").also {
                 it.writeText("zipdata")
             }
 
@@ -364,15 +363,15 @@ class DebugSessionManagerSessionLogicTest : BaseTest() {
 
         @Test
         fun `same basename in ext and cache produces distinct IDs in both deriveSessionId and scanSessions`() {
-            val extDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val extDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(extDir, "core.log").writeText("ext log")
-            val cacheDir = File(cacheLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val cacheDir = File(cacheLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(cacheDir, "core.log").writeText("cache log")
 
             val extId = DebugSessionManager.deriveSessionId(extDir)
             val cacheId = DebugSessionManager.deriveSessionId(cacheDir)
-            extId shouldBe "ext:capod_1.0_1700000000000_abcd1234"
-            cacheId shouldBe "cache:capod_1.0_1700000000000_abcd1234"
+            extId shouldBe "ext:capod_1.0_20231114T221320Z_abcd1234"
+            cacheId shouldBe "cache:capod_1.0_20231114T221320Z_abcd1234"
 
             val scanned = DebugSessionManager.scanSessions(logDirectories = logDirs())
             scanned shouldHaveSize 2

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/DebugSessionManagerTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/DebugSessionManagerTest.kt
@@ -74,19 +74,19 @@ class DebugSessionManagerTest : BaseTest() {
     inner class ZippingIdsOverlay {
         @Test
         fun `session in zippingIds appears as Compressing`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("done recording")
 
-            val result = scanAndOverlay(zippingIds = setOf("ext:capod_1.0_1700000000000_abcd1234"))
+            val result = scanAndOverlay(zippingIds = setOf("ext:capod_1.0_20231114T221320Z_abcd1234"))
 
             result shouldHaveSize 1
             result.first().shouldBeInstanceOf<DebugSession.Compressing>()
-            result.first().id shouldBe "ext:capod_1.0_1700000000000_abcd1234"
+            result.first().id shouldBe "ext:capod_1.0_20231114T221320Z_abcd1234"
         }
 
         @Test
         fun `session not in zippingIds remains Ready`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("done recording")
 
             val result = scanAndOverlay(zippingIds = setOf("ext:some_other_session"))
@@ -100,10 +100,10 @@ class DebugSessionManagerTest : BaseTest() {
     inner class FailedZipIdsOverlay {
         @Test
         fun `session in failedZipIds appears as Failed ZIP_FAILED`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("done recording")
 
-            val result = scanAndOverlay(failedZipIds = setOf("ext:capod_1.0_1700000000000_abcd1234"))
+            val result = scanAndOverlay(failedZipIds = setOf("ext:capod_1.0_20231114T221320Z_abcd1234"))
 
             result shouldHaveSize 1
             val session = result.first()
@@ -113,9 +113,9 @@ class DebugSessionManagerTest : BaseTest() {
 
         @Test
         fun `already-failed session is not overridden by failedZipIds`() {
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").mkdirs()
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").mkdirs()
 
-            val result = scanAndOverlay(failedZipIds = setOf("ext:capod_1.0_1700000000000_abcd1234"))
+            val result = scanAndOverlay(failedZipIds = setOf("ext:capod_1.0_20231114T221320Z_abcd1234"))
 
             result shouldHaveSize 1
             val session = result.first()
@@ -128,16 +128,16 @@ class DebugSessionManagerTest : BaseTest() {
     inner class OrphanDetection {
         @Test
         fun `Ready session with logDir and sibling zip is not an orphan`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content")
-            File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip").writeText("zipdata")
+            File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip").writeText("zipdata")
 
             val sessions = scanAndOverlay()
 
             sessions shouldHaveSize 1
             val session = sessions.first() as DebugSession.Ready
             session.logDir shouldBe sessionDir
-            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_1700000000000_abcd1234.zip")
+            session.zipFile shouldBe File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234.zip")
 
             val orphans = sessions.filterIsInstance<DebugSession.Ready>().filter { ready ->
                 ready.logDir != null && (ready.zipFile == null || ready.compressedSize == 0L)
@@ -147,7 +147,7 @@ class DebugSessionManagerTest : BaseTest() {
 
         @Test
         fun `Ready session with logDir but no sibling zip is detected as orphan`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content")
 
             val sessions = scanAndOverlay()
@@ -162,15 +162,15 @@ class DebugSessionManagerTest : BaseTest() {
                 ready.logDir != null && (ready.zipFile == null || ready.compressedSize == 0L)
             }
             orphans shouldHaveSize 1
-            orphans.first().id shouldBe "ext:capod_1.0_1700000000000_abcd1234"
+            orphans.first().id shouldBe "ext:capod_1.0_20231114T221320Z_abcd1234"
         }
 
         @Test
         fun `orphan already in zippingIds is not re-detected`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("log content")
 
-            val zipping = setOf("ext:capod_1.0_1700000000000_abcd1234")
+            val zipping = setOf("ext:capod_1.0_20231114T221320Z_abcd1234")
             val sessions = scanAndOverlay(zippingIds = zipping)
 
             sessions shouldHaveSize 1
@@ -189,7 +189,7 @@ class DebugSessionManagerTest : BaseTest() {
     inner class DeleteGuards {
         @Test
         fun `active recording session cannot be zipped`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("recording in progress")
 
             val sessions = scanAndOverlay(activeDir = sessionDir, recordingStartedAt = 1700000000000L)
@@ -202,9 +202,9 @@ class DebugSessionManagerTest : BaseTest() {
         @Test
         fun `ext and cache sessions with same basename have different IDs`() {
             val cacheLogsDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
-            val extDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val extDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(extDir, "core.log").writeText("external log")
-            val cacheDir = File(cacheLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val cacheDir = File(cacheLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(cacheDir, "core.log").writeText("cache log")
 
             val sessions = DebugSessionManager.scanSessions(
@@ -213,15 +213,15 @@ class DebugSessionManagerTest : BaseTest() {
 
             sessions shouldHaveSize 2
             val ids = sessions.map { it.id }.toSet()
-            ids shouldBe setOf("ext:capod_1.0_1700000000000_abcd1234", "cache:capod_1.0_1700000000000_abcd1234")
+            ids shouldBe setOf("ext:capod_1.0_20231114T221320Z_abcd1234", "cache:capod_1.0_20231114T221320Z_abcd1234")
         }
 
         @Test
         fun `zipping session should not be deleted`() {
-            val sessionDir = File(externalLogsDir, "capod_1.0_1700000000000_abcd1234").also { it.mkdirs() }
+            val sessionDir = File(externalLogsDir, "capod_1.0_20231114T221320Z_abcd1234").also { it.mkdirs() }
             File(sessionDir, "core.log").writeText("done recording")
 
-            val zipping = setOf("ext:capod_1.0_1700000000000_abcd1234")
+            val zipping = setOf("ext:capod_1.0_20231114T221320Z_abcd1234")
             val sessions = scanAndOverlay(zippingIds = zipping)
 
             sessions shouldHaveSize 1


### PR DESCRIPTION
## What changed

Fixed debug log sessions sometimes appearing in the wrong order. Also changed the session directory naming to use a human-readable UTC timestamp (e.g. `20231114T221320Z`) instead of raw milliseconds, making it easier to identify sessions when browsing files.

## Technical Context

- Root cause: `parseCreatedAt` read filesystem creation time attributes, which differ between sequentially created directories. When two sessions shared the same logical timestamp, the sort tiebreaker (by ID) never kicked in because filesystem times were never truly equal.
- Fix: parse the timestamp from the directory name (`capod_{version}_{yyyyMMddTHHmmssZ}_{suffix}`) instead of querying filesystem attributes. Falls back to filesystem attributes for non-standard filenames.
- The human-readable format (`yyyyMMdd'T'HHmmss'Z'`) was chosen over epoch millis for debuggability — no backward compat concern since the feature hasn't been released yet.
