### PR TITLE
General: Rename debug recorder button from Close to Keep

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/debug/recording/ui/RecorderScreen.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/ui/RecorderScreen.kt
@@ -390,7 +390,7 @@ private fun BottomActionBar(
                     onClick = onKeep,
                     modifier = Modifier.weight(1f),
                 ) {
-                    Text(text = stringResource(R.string.general_close_action))
+                    Text(text = stringResource(R.string.debug_debuglog_screen_keep_action))
                 }
                 androidx.compose.material3.Button(
                     onClick = onShare,

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Is die ontfoutrekord suksesvol gestuur? Die rekord sal uitgevee word.</string>
     <string name="support_contact_sent_title">E-pos gestuur?</string>
     <string name="support_contact_sent_message">Is die e-pos suksesvol gestuur? Die aangehegte ontfoutrekord sal uitgevee word.</string>
+    <string name="debug_debuglog_screen_keep_action">Hou</string>
 </resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">የዲባግ ምዝግብ ማስታወሻ በተሳካ ሁኔታ ተልኳል? ምዝግብ ማስታወሻው ይሰረዛል።</string>
     <string name="support_contact_sent_title">ኢሜይል ተልኳል?</string>
     <string name="support_contact_sent_message">ኢሜይሉ በተሳካ ሁኔታ ተልኳል? ተያይዞ የቀረበው የዲባግ ምዝግብ ማስታወሻ ይሰረዛል።</string>
+    <string name="debug_debuglog_screen_keep_action">ያቆዩ</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -377,4 +377,5 @@
     <string name="support_debuglog_sent_message">هل تم إرسال سجل التصحيح بنجاح؟ سيتم حذف السجل.</string>
     <string name="support_contact_sent_title">هل تم إرسال البريد الإلكتروني؟</string>
     <string name="support_contact_sent_message">هل تم إرسال البريد الإلكتروني بنجاح؟ سيتم حذف سجل التصحيح المرفق.</string>
+    <string name="debug_debuglog_screen_keep_action">احتفظ</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Sazlama jurnalı uğurla göndərildi? Jurnal silinəcək.</string>
     <string name="support_contact_sent_title">E-poçt göndərildi?</string>
     <string name="support_contact_sent_message">E-poçt uğurla göndərildi? Əlavə edilmiş sazlama jurnalı silinəcək.</string>
+    <string name="debug_debuglog_screen_keep_action">Saxla</string>
 </resources>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -369,4 +369,5 @@
     <string name="support_debuglog_sent_message">Адладачны журнал быў паспяхова адпраўлены? Журнал будзе выдалены.</string>
     <string name="support_contact_sent_title">Электронны ліст адпраўлены?</string>
     <string name="support_contact_sent_message">Электронны ліст быў паспяхова адпраўлены? Прыкладзены адладачны журнал будзе выдалены.</string>
+    <string name="debug_debuglog_screen_keep_action">Захаваць</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Изпратен ли е успешно дневникът за отстраняване на грешки? Логът ще бъде изтрит.</string>
     <string name="support_contact_sent_title">Имейлът изпратен ли е?</string>
     <string name="support_contact_sent_message">Изпратен ли е успешно имейлът? Прикаченият дневник за отстраняване на грешки ще бъде изтрит.</string>
+    <string name="debug_debuglog_screen_keep_action">Запази</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">ডিবাগ লগটি সফলভাবে পাঠানো হয়েছে? লগটি মুছে ফেলা হবে।</string>
     <string name="support_contact_sent_title">ইমেইল পাঠানো হয়েছে?</string>
     <string name="support_contact_sent_message">ইমেইলটি সফলভাবে পাঠানো হয়েছে? সংযুক্ত ডিবাগ লগটি মুছে ফেলা হবে।</string>
+    <string name="debug_debuglog_screen_keep_action">রাখুন</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">S\'ha enviat correctament el registre de depuració? El registre s\'eliminarà.</string>
     <string name="support_contact_sent_title">S\'ha enviat el correu electrònic?</string>
     <string name="support_contact_sent_message">S\'ha enviat correctament el correu electrònic? El registre de depuració adjunt s\'eliminarà.</string>
+    <string name="debug_debuglog_screen_keep_action">Conserva</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -369,4 +369,5 @@
     <string name="support_debuglog_sent_message">Byl protokol ladění úspěšně odeslán? Protokol bude smazán.</string>
     <string name="support_contact_sent_title">E-mail odeslán?</string>
     <string name="support_contact_sent_message">Byl e-mail úspěšně odeslán? Přiložený protokol ladění bude smazán.</string>
+    <string name="debug_debuglog_screen_keep_action">Ponechat</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Blev fejlloggen sendt korrekt? Loggen vil blive slettet.</string>
     <string name="support_contact_sent_title">E-mail sendt?</string>
     <string name="support_contact_sent_message">Blev e-mailen sendt korrekt? Den vedhæftede fejllog vil blive slettet.</string>
+    <string name="debug_debuglog_screen_keep_action">Behold</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Wurde das Debug-Protokoll erfolgreich gesendet? Das Protokoll wird gelöscht.</string>
     <string name="support_contact_sent_title">E-Mail gesendet?</string>
     <string name="support_contact_sent_message">Wurde die E-Mail erfolgreich gesendet? Das angehängte Debug-Protokoll wird gelöscht.</string>
+    <string name="debug_debuglog_screen_keep_action">Behalten</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Στάλθηκε επιτυχώς το αρχείο καταγραφής εντοπισμού σφαλμάτων; Το αρχείο καταγραφής θα διαγραφεί.</string>
     <string name="support_contact_sent_title">Email εστάλη;</string>
     <string name="support_contact_sent_message">Στάλθηκε επιτυχώς το email; Το συνημμένο αρχείο καταγραφής εντοπισμού σφαλμάτων θα διαγραφεί.</string>
+    <string name="debug_debuglog_screen_keep_action">Διατήρηση</string>
 </resources>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">¿Se envió el log de depuración correctamente? El log será eliminado.</string>
     <string name="support_contact_sent_title">¿Email enviado?</string>
     <string name="support_contact_sent_message">¿Se envió el email correctamente? El log de depuración adjunto será eliminado.</string>
+    <string name="debug_debuglog_screen_keep_action">Conservar</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">¿El registro de depuración se envió correctamente? El registro será eliminado.</string>
     <string name="support_contact_sent_title">¿Correo enviado?</string>
     <string name="support_contact_sent_message">¿El correo se envió correctamente? El registro de depuración adjunto será eliminado.</string>
+    <string name="debug_debuglog_screen_keep_action">Conservar</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">¿Se envió el registro de depuración correctamente? El registro se eliminará.</string>
     <string name="support_contact_sent_title">¿Correo enviado?</string>
     <string name="support_contact_sent_message">¿Se envió el correo electrónico correctamente? El registro de depuración adjunto se eliminará.</string>
+    <string name="debug_debuglog_screen_keep_action">Conservar</string>
 </resources>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -251,7 +251,7 @@
     <string name="profiles_drag_handle_description">Järjekorra muutmiseks lohista</string>
     <string name="profiles_delete_title">Eemalda Profiil</string>
     <string name="profiles_delete_message">Kas soovid kindlasti seda profiili kustutada? Seda toimingut ei saa tagasi võtta.</string>
-    <string name="profiles_delete_action">Delete</string>
+    <string name="profiles_delete_action">Kustuta</string>
     <string name="profiles_basic_info_title">Seadme teave</string>
     <string name="profiles_basic_info_description">Seadistage seadme nime, mudelit ja valikulist Bluetooth-sidumist.</string>
     <string name="profiles_signal_quality_title">Väikseim signaali kvaliteet</string>
@@ -310,7 +310,7 @@
         <item quantity="one">%1$d fail valmis (%2$s)</item>
         <item quantity="other">%1$d faili valmis (%2$s)</item>
     </plurals>
-    <string name="debug_debuglog_screen_discard_action">Delete</string>
+    <string name="debug_debuglog_screen_discard_action">Kustuta</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d silumislogi (%2$s)</item>
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Kas silumislogi saadeti edukalt? Logi kustutatakse.</string>
     <string name="support_contact_sent_title">E-kiri saadeti?</string>
     <string name="support_contact_sent_message">Kas e-kiri saadeti edukalt? Manustatud silumislogi kustutatakse.</string>
+    <string name="debug_debuglog_screen_keep_action">Hoia alles</string>
 </resources>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Arazketa-loga behar bezala bidali al da? Loga ezabatuko da.</string>
     <string name="support_contact_sent_title">Mezu elektronikoa bidali da?</string>
     <string name="support_contact_sent_message">Mezu elektronikoa behar bezala bidali al da? Erantsitako arazketa-loga ezabatuko da.</string>
+    <string name="debug_debuglog_screen_keep_action">Gorde</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">آیا لاگ اشکال‌زدایی با موفقیت ارسال شد؟ لاگ حذف خواهد شد.</string>
     <string name="support_contact_sent_title">ایمیل ارسال شد؟</string>
     <string name="support_contact_sent_message">آیا ایمیل با موفقیت ارسال شد؟ لاگ اشکال‌زدایی پیوست‌شده حذف خواهد شد.</string>
+    <string name="debug_debuglog_screen_keep_action">نگه داشتن</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Lähetettiin virheenkorjausloki onnistuneesti? Loki poistetaan.</string>
     <string name="support_contact_sent_title">Sähköposti lähetetty?</string>
     <string name="support_contact_sent_message">Lähetettiin sähköposti onnistuneesti? Liitetty virheenkorjausloki poistetaan.</string>
+    <string name="debug_debuglog_screen_keep_action">Säilytä</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Matagumpay bang naipadala ang debug log? Ang log ay matatanggal.</string>
     <string name="support_contact_sent_title">Naipadala na ang email?</string>
     <string name="support_contact_sent_message">Matagumpay bang naipadala ang email? Ang kalakip na debug log ay matatanggal.</string>
+    <string name="debug_debuglog_screen_keep_action">Itago</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d fichiers sont prêts (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Supprimer</string>
+    <string name="debug_debuglog_screen_keep_action">Conserver</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d journal de débogage (%2$s)</item>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d ficheiros listos (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Eliminar</string>
+    <string name="debug_debuglog_screen_keep_action">Gardar</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d rexistro de depuración (%2$s)</item>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d फ़ाइलें तैयार (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">मिटाएं</string>
+    <string name="debug_debuglog_screen_keep_action">रखें</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d डीबग लॉग (%2$s)</item>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -313,6 +313,7 @@
         <item quantity="other">%1$d datoteka spremno (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Izbriši</string>
+    <string name="debug_debuglog_screen_keep_action">Zadrži</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d debug zapisnik (%2$s)</item>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d fájl kész (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Törlés</string>
+    <string name="debug_debuglog_screen_keep_action">Megőrzés</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d hibakeresési napló (%2$s)</item>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d Ֆայլեր պատրաստուաց են (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Ջնջել</string>
+    <string name="debug_debuglog_screen_keep_action">Պահպանել</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d Կարգաբերման մատյան (%2$s)</item>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d file siap (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Hapus</string>
+    <string name="debug_debuglog_screen_keep_action">Simpan</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d log debug (%2$s)</item>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d skráar tilbúnar (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Eyða</string>
+    <string name="debug_debuglog_screen_keep_action">Geyma</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d kembingarskrá (%2$s)</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d file pronti (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Elimina</string>
+    <string name="debug_debuglog_screen_keep_action">Conserva</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d log di debug (%2$s)</item>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -315,6 +315,7 @@
         <item quantity="other">%1$d קבצים מוכנים (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">מחיקה</string>
+    <string name="debug_debuglog_screen_keep_action">שמור</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">יומן ניפוי באגים %1$d (%2$s)</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d つのファイルが準備完了 (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">削除</string>
+    <string name="debug_debuglog_screen_keep_action">保持</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d件のデバッグログ (%2$s)</item>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d ფაილი მზადაა (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">წაშლა</string>
+    <string name="debug_debuglog_screen_keep_action">შენახვა</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d გამართვის ჟურნალი (%2$s)</item>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d ឯកសាររួចរាល់ (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">លុប</string>
+    <string name="debug_debuglog_screen_keep_action">រក្សាទុក</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d កំណត់ហេតុបំបាត់កំហុស (%2$s)</item>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d pel amade (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Jêbirin</string>
+    <string name="debug_debuglog_screen_keep_action">Bihêle</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d tomara çareserkirinê (%2$s)</item>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d ಫೈಲ್‌ಗಳು ಸಿದ್ಧವಾಗಿವೆ (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">ಅಳಿಸಿ</string>
+    <string name="debug_debuglog_screen_keep_action">ಇರಿಸಿ</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d ಡೀಬಗ್ ಲಾಗ್ (%2$s)</item>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d개 파일 준비됨 (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">삭제</string>
+    <string name="debug_debuglog_screen_keep_action">유지</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d개 디버그 로그 (%2$s)</item>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d файл даяр (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Жойуу</string>
+    <string name="debug_debuglog_screen_keep_action">Сактоо</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d мүчүлүштүк жазылмасы (%2$s)</item>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d ໄຟລ່ພ້ອມ (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">ລຶບ</string>
+    <string name="debug_debuglog_screen_keep_action">ເກັບຮັກສາ</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d ບັນທຶກດີບັກ (%2$s)</item>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -315,6 +315,7 @@
         <item quantity="other">%1$d failų paruošta (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Trinti</string>
+    <string name="debug_debuglog_screen_keep_action">Palikti</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d derinimo žurnalas (%2$s)</item>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -313,6 +313,7 @@
         <item quantity="other">%1$d faili gatavi (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Dzēst</string>
+    <string name="debug_debuglog_screen_keep_action">Paturēt</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="zero">%1$d atkļūdošanas žurnālu (%2$s)</item>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Дали логот за дебагирање е успешно испратен? Логот ќе биде избришан.</string>
     <string name="support_contact_sent_title">Е-поштата е испратена?</string>
     <string name="support_contact_sent_message">Дали е-поштата е успешно испратена? Приложениот лог за дебагирање ќе биде избришан.</string>
+    <string name="debug_debuglog_screen_keep_action">Задржи</string>
 </resources>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">ഡീബഗ് ലോഗ് വിജയകരമായി അയച്ചോ? ലോഗ് ഇല്ലാതാക്കപ്പെടും.</string>
     <string name="support_contact_sent_title">ഇമെയിൽ അയച്ചോ?</string>
     <string name="support_contact_sent_message">ഇമെയിൽ വിജയകരമായി അയച്ചോ? അറ്റാച്ച് ചെയ്ത ഡീബഗ് ലോഗ് ഇല്ലാതാക്കപ്പെടും.</string>
+    <string name="debug_debuglog_screen_keep_action">സൂക്ഷിക്കുക</string>
 </resources>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Дебаг лог амжилттай илгээгдсэн үү? Лог устгагдах болно.</string>
     <string name="support_contact_sent_title">Имэйл илгээсэн үү?</string>
     <string name="support_contact_sent_message">Имэйл амжилттай илгээгдсэн үү? Хавсаргасан дебаг лог устгагдах болно.</string>
+    <string name="debug_debuglog_screen_keep_action">Хадгалах</string>
 </resources>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">डीबग लॉग यशस्वीरित्या पाठवला का? लॉग हटवला जाईल.</string>
     <string name="support_contact_sent_title">ईमेल पाठवला?</string>
     <string name="support_contact_sent_message">ईमेल यशस्वीरित्या पाठवला का? संलग्न डीबग लॉग हटवला जाईल.</string>
+    <string name="debug_debuglog_screen_keep_action">ठेवा</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -357,4 +357,5 @@
     <string name="support_debuglog_sent_message">Adakah log debug berjaya dihantar? Log akan dipadamkan.</string>
     <string name="support_contact_sent_title">E-mel dihantar?</string>
     <string name="support_contact_sent_message">Adakah e-mel berjaya dihantar? Log debug yang dilampirkan akan dipadamkan.</string>
+    <string name="debug_debuglog_screen_keep_action">Simpan</string>
 </resources>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -357,4 +357,5 @@
     <string name="support_debuglog_sent_message">Debug log ကို အောင်မြင်စွာ ပို့ပြီးပြီလား? Log ကို ဖျက်ပစ်မည်။</string>
     <string name="support_contact_sent_title">အီးမေးလ် ပို့ပြီးပြီလား?</string>
     <string name="support_contact_sent_message">အီးမေးလ်ကို အောင်မြင်စွာ ပို့ပြီးပြီလား? ပူးတွဲပါသော debug log ကို ဖျက်ပစ်မည်။</string>
+    <string name="debug_debuglog_screen_keep_action">သိမ်းထားရန်</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Ble feilsøkingsloggen sendt? Loggen vil bli slettet.</string>
     <string name="support_contact_sent_title">E-post sendt?</string>
     <string name="support_contact_sent_message">Ble e-posten sendt? Den vedlagte feilsøkingsloggen vil bli slettet.</string>
+    <string name="debug_debuglog_screen_keep_action">Behold</string>
 </resources>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">डिबग लग सफलतापूर्वक पठाइयो? लग मेटिनेछ।</string>
     <string name="support_contact_sent_title">इमेल पठाइयो?</string>
     <string name="support_contact_sent_message">इमेल सफलतापूर्वक पठाइयो? संलग्न डिबग लग मेटिनेछ।</string>
+    <string name="debug_debuglog_screen_keep_action">राख्नुहोस्</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -361,4 +361,5 @@
     <string name="support_debuglog_sent_message">Is het foutopsporingslogboek succesvol verzonden? Het logboek wordt verwijderd.</string>
     <string name="support_contact_sent_title">E-mail verzonden?</string>
     <string name="support_contact_sent_message">Is de e-mail succesvol verzonden? Het bijgevoegde foutopsporingslogboek wordt verwijderd.</string>
+    <string name="debug_debuglog_screen_keep_action">Bewaren</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -371,4 +371,5 @@ K4r0lSz;</string>
     <string name="support_debuglog_sent_message">Czy dziennik debugowania został wysłany pomyślnie? Dziennik zostanie usunięty.</string>
     <string name="support_contact_sent_title">E-mail wysłany?</string>
     <string name="support_contact_sent_message">Czy e-mail został wysłany pomyślnie? Załączony dziennik debugowania zostanie usunięty.</string>
+    <string name="debug_debuglog_screen_keep_action">Zachowaj</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d arquivos prontos (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Apagar</string>
+    <string name="debug_debuglog_screen_keep_action">Manter</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d log de depuração (%2$s)</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d arquivos prontos (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Apagar</string>
+    <string name="debug_debuglog_screen_keep_action">Manter</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d registo de depuração (%2$s)</item>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d datotecas prontas (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Stritgar</string>
+    <string name="debug_debuglog_screen_keep_action">Mantegnair</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d protocol da debug (%2$s)</item>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -313,6 +313,7 @@
         <item quantity="other">%1$d fișiere gata (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Șterge</string>
+    <string name="debug_debuglog_screen_keep_action">Păstrați</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d jurnal de depanare (%2$s)</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -316,6 +316,7 @@ AL_Cool_T</string>
         <item quantity="other">Файлов готово: %1$d (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Удалить</string>
+    <string name="debug_debuglog_screen_keep_action">Сохранить</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d отладочный журнал (%2$s)</item>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d archivos prontos (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Iscancellare</string>
+    <string name="debug_debuglog_screen_keep_action">Mantene</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d log de debug (%2$s)</item>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d ගොනු සූදානම් (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">මකන්න</string>
+    <string name="debug_debuglog_screen_keep_action">තබා ගන්න</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d දෝෂහරණ ලොගය (%2$s)</item>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -308,7 +308,14 @@
     <string name="debug_debuglog_screen_sensitive_title">Citlivé informácie</string>
     <string name="debug_debuglog_screen_session_path_label">Cesta relácie</string>
     <string name="debug_debuglog_screen_log_files_label">Log súbory</string>
+    <plurals name="debug_debuglog_screen_log_files_ready">
+        <item quantity="one">%1$d súbor pripravený (%2$s)</item>
+        <item quantity="few">%1$d súbory pripravené (%2$s)</item>
+        <item quantity="many">%1$d súboru pripravených (%2$s)</item>
+        <item quantity="other">%1$d súborov pripravených (%2$s)</item>
+    </plurals>
     <string name="debug_debuglog_screen_discard_action">Vymazať</string>
+    <string name="debug_debuglog_screen_keep_action">Ponechať</string>
     <!-- Log management -->
     <string name="support_debuglog_clear_action">Vymazať uložené ladíace záznamy</string>
     <string name="support_debuglog_sessions_label">Ladíace relacie</string>
@@ -338,6 +345,12 @@
     <string name="support_contact_description_bug_hint">Popíšte, čo sa stalo a ako replikovať problém. Prosím, buďte špecifický.</string>
     <string name="support_contact_expected_label">Očakávané správanie</string>
     <string name="support_contact_expected_hint">Popíšte, čo ste očakávali, že sa stane.</string>
+    <plurals name="support_contact_word_count">
+        <item quantity="one">%1$d / %2$d slovo</item>
+        <item quantity="few">%1$d / %2$d slová</item>
+        <item quantity="many">%1$d / %2$d slova</item>
+        <item quantity="other">%1$d / %2$d slov</item>
+    </plurals>
     <string name="support_contact_debuglog_label">Ladiaci log</string>
     <string name="support_contact_debuglog_picker_hint">Priložte existujúci ladíaci záznam alebo nahrajte nový.</string>
     <string name="support_contact_debuglog_picker_empty">Žiadne ladíace záznamy sa nenašli. Najskôr nahraje jeden.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -315,6 +315,7 @@
         <item quantity="other">%1$d datotek je pripravljenih (%2$s).</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Izbriši</string>
+    <string name="debug_debuglog_screen_keep_action">Ohrani</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d dnevnik razhroščevanja (%2$s)</item>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d skedarë gati (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Fshije</string>
+    <string name="debug_debuglog_screen_keep_action">Mbaj</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d regjistër korrigjimi (%2$s)</item>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -313,6 +313,7 @@
         <item quantity="other">%1$d датотека су спремне (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Обриши</string>
+    <string name="debug_debuglog_screen_keep_action">Задржи</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d дневник грешака (%2$s)</item>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d filer redo (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Radera</string>
+    <string name="debug_debuglog_screen_keep_action">Behåll</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d felsökningslogg (%2$s)</item>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">faili %1$d ziko tayari (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Futa</string>
+    <string name="debug_debuglog_screen_keep_action">Hifadhi</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">kumbukumbu ya utatuzi %1$d (%2$s)</item>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d கோப்புகள் தயாராக உள்ளன (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">நீக்கு</string>
+    <string name="debug_debuglog_screen_keep_action">வைத்திரு</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d பிழைதிருத்தல் பதிவு (%2$s)</item>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d ఫైల్‌లు సిద్ధంగా ఉన్నాయి (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">తొలగించండి</string>
+    <string name="debug_debuglog_screen_keep_action">ఉంచు</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d డీబగ్ లాగ్ (%2$s)</item>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d ไฟล์พร้อม (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">ลบ</string>
+    <string name="debug_debuglog_screen_keep_action">เก็บไว้</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d ไฟล์ล็อกดีบัก (%2$s)</item>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d dosya hazır (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Sil</string>
+    <string name="debug_debuglog_screen_keep_action">Tut</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d hata ayıklama kaydı (%2$s)</item>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -315,6 +315,7 @@
         <item quantity="other">Файли %1$d готові (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Видалити</string>
+    <string name="debug_debuglog_screen_keep_action">Зберегти</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d журнал налагодження (%2$s)</item>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d فائلیں تیار ہیں (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">حذف کریں</string>
+    <string name="debug_debuglog_screen_keep_action">رکھیں</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d ڈیبگ لاگ (%2$s)</item>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d fayl tayyor (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">O\'chirish</string>
+    <string name="debug_debuglog_screen_keep_action">Saqlash</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d debug jurnali (%2$s)</item>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d tệp đã sẵn sàng (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Xoá</string>
+    <string name="debug_debuglog_screen_keep_action">Giữ lại</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d nhật ký gỡ lỗi (%2$s)</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d 文件已准备好(%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">删除</string>
+    <string name="debug_debuglog_screen_keep_action">保留</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d 条调试日志（%2$s）</item>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">%1$d 個檔案已就緒（%2$s）</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">刪除</string>
+    <string name="debug_debuglog_screen_keep_action">保留</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d 個偵錯記錄（%2$s）</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -309,6 +309,7 @@
         <item quantity="other">已準備好 %1$d 個檔案（%2$s）</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">刪除</string>
+    <string name="debug_debuglog_screen_keep_action">保留</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="other">%1$d 次除錯日誌（%2$s）</item>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -311,6 +311,7 @@
         <item quantity="other">%1$d amafayela alungele (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Susa</string>
+    <string name="debug_debuglog_screen_keep_action">Gcina</string>
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">
         <item quantity="one">%1$d irekhodi lokususa iziphazamiso (%2$s)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,6 +351,7 @@
         <item quantity="other">%1$d files ready (%2$s)</item>
     </plurals>
     <string name="debug_debuglog_screen_discard_action">Delete</string>
+    <string name="debug_debuglog_screen_keep_action">Keep</string>
 
     <!-- Log management -->
     <plurals name="support_debuglog_folder_summary">


### PR DESCRIPTION
## What changed

The debug recorder screen's keep button was labeled "Close" even though it keeps/saves the recording session. Renamed to "Keep" so the Delete / Keep / Share button trio is self-explanatory.

## Technical Context

- The button's `onClick` handler was already named `onKeep`, confirming the intended semantics
- Added a dedicated `debug_debuglog_screen_keep_action` string resource instead of reusing `general_close_action`, which is still used correctly by the popup dismiss button
- Translated across all 75 locales