### PR TITLE
Fix: Fix contact form retaining old text after sending

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.capod.common.debug.logging.log
@@ -78,6 +80,10 @@ class MainActivity : Activity2() {
                                 finish()
                             }
                         },
+                        entryDecorators = listOf(
+                            rememberSaveableStateHolderNavEntryDecorator(),
+                            rememberViewModelStoreNavEntryDecorator(),
+                        ),
                         entryProvider = entryProvider {
                             navigationEntries.forEach { entry ->
                                 entry.apply {


### PR DESCRIPTION
## What changed

Fixed an issue where the "Contact Developer" form would keep the previously entered text when reopening the screen after sending an email.

## Technical Context

- Root cause: `NavDisplay` in `MainActivity` was missing the `ViewModelStoreNavEntryDecorator`, so `hiltViewModel()` scoped all ViewModels to the Activity instead of their navigation entry. When an entry was popped from the back stack, its ViewModel survived and was reused on the next visit.
- The `lifecycle-viewmodel-navigation3:2.10.0` dependency was already in the project but never wired up — this connects it by adding `entryDecorators` to `NavDisplay`.
- This fixes the same class of stale-state bug for all screens, not just the contact form.
