### PR TITLE
General: Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #v4.7.0
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -14,7 +14,7 @@ runs:
       run: chmod +x gradlew
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.gradle/wrapper
@@ -24,7 +24,7 @@ runs:
           ${{ runner.os }}-gradle-wrapper-
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.gradle/caches
@@ -33,7 +33,7 @@ runs:
           ${{ runner.os }}-gradle-caches-
 
     - name: Cache Android Global Build-Cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.android/build-cache

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,5 +13,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-      - uses: gradle/actions/wrapper-validation@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c #v5.0.2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build only, skip release/upload'
+        type: boolean
+        default: true
 
 jobs:
   release-github:
@@ -24,23 +30,15 @@ jobs:
           echo "STORE_PATH=$(echo $TMP_KEYSTORE_FILE_PATH)" >> $GITHUB_ENV
 
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
-      - name: Get the version
-        id: tagger
-        uses: jimschubert/query-tag-action@0b288a5fff630fea2e96d61b99047ed823ca19dc #v2.2
-        with:
-          skip-unshallow: 'true'
-          abbrev: false
-          commit-ish: HEAD
-
       - name: Assemble beta APK
-        if: contains(steps.tagger.outputs.tag, '-beta')
+        if: contains(github.ref_name, '-beta')
         run: ./gradlew assembleFossBeta
         env:
           VERSION: ${{ github.ref }}
@@ -49,7 +47,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Assemble production APK
-        if: "!contains(steps.tagger.outputs.tag, '-beta')"
+        if: "!contains(github.ref_name, '-beta')"
         run: ./gradlew assembleFossRelease
         env:
           VERSION: ${{ github.ref }}
@@ -58,24 +56,24 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Create pre-release
-        if: contains(steps.tagger.outputs.tag, '-beta')
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
+        if: contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
         with:
           prerelease: true
-          tag_name: ${{ steps.tagger.outputs.tag }}
-          name: ${{ steps.tagger.outputs.tag }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: app/build/outputs/apk/foss/beta/eu.darken.capod-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        if: "!contains(steps.tagger.outputs.tag, '-beta')"
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
+        if: "!contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
         with:
           prerelease: false
-          tag_name: ${{ steps.tagger.outputs.tag }}
-          name: ${{ steps.tagger.outputs.tag }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: app/build/outputs/apk/foss/release/eu.darken.capod-*.apk
         env:
@@ -107,29 +105,21 @@ jobs:
           echo "SUPPLY_JSON_KEY=$(echo $TMP_SERVICEKEY_FILE_PATH)" >> $GITHUB_ENV
 
       - name: Checkout source code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
-      - name: Get the version
-        id: tagger
-        uses: jimschubert/query-tag-action@0b288a5fff630fea2e96d61b99047ed823ca19dc #v2.2
-        with:
-          skip-unshallow: 'true'
-          abbrev: false
-          commit-ish: HEAD
-
       - name: Set up ruby env
-        uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 #v1.229.0
+        uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 #v1.292.0
         with:
           ruby-version: 3.3.6
           bundler-cache: true
 
       - name: Assemble beta and upload to Google Play
-        if: contains(steps.tagger.outputs.tag, '-beta')
+        if: contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
         run: bundle exec fastlane beta
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
@@ -137,7 +127,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Assemble production and upload to Google Play
-        if: "!contains(steps.tagger.outputs.tag, '-beta')"
+        if: "!contains(github.ref_name, '-beta') && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
         run: bundle exec fastlane production
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}


### PR DESCRIPTION
## What changed

Updated all GitHub Actions to Node.js 24-compatible versions before the Node.js 20 deprecation (June 2nd, 2026). Replaced the abandoned `jimschubert/query-tag-action` with the built-in `github.ref_name`. Added a manual trigger with dry-run option to the release workflow.

## Technical Context

- Mirror of d4rken-org/bluemusic#185 — both projects share the same CI workflow structure
- `jimschubert/query-tag-action` is abandoned and unnecessary; `github.ref_name` is a built-in GitHub context that provides the same tag name
- `workflow_dispatch` with `dry_run` input allows manually testing the release build pipeline without actually publishing

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | v4.2.2 | v6.0.2 |
| actions/cache | v4.2.3 | v5.0.3 |
| actions/setup-java | v4.7.0 | v5.2.0 |
| softprops/action-gh-release | v2.2.1 | v2.5.0 |
| gradle/actions/wrapper-validation | v4.3.1 | v5.0.2 |
| ruby/setup-ruby | v1.229.0 | v1.292.0 |
| jimschubert/query-tag-action | v2.2 | removed |