### PR TITLE
Fix: Reduce foreground service timeout crash on cold start

### DIFF
--- a/app/src/main/java/eu/darken/capod/App.kt
+++ b/app/src/main/java/eu/darken/capod/App.kt
@@ -14,7 +14,7 @@ import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.ui.widget.WidgetManager
 import eu.darken.capod.monitor.core.PodMonitor
 import eu.darken.capod.monitor.core.devicesWithProfiles
-import eu.darken.capod.monitor.core.worker.MonitorControl
+
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
@@ -27,7 +27,6 @@ import javax.inject.Inject
 open class App : Application() {
 
     @Inject lateinit var autoReporting: AutomaticBugReporter
-    @Inject lateinit var monitorControl: MonitorControl
     @Inject lateinit var podMonitor: PodMonitor
     @Inject lateinit var widgetManager: WidgetManager
     @Inject lateinit var upgradeRepo: UpgradeRepo
@@ -40,8 +39,6 @@ open class App : Application() {
         autoReporting.setup(this)
 
         log(TAG) { "onCreate() done! ${Exception().asLog()}" }
-
-        monitorControl.startMonitor(forceStart = true)
 
         appScope.launch { widgetManager.refreshWidgets() }
 


### PR DESCRIPTION
## What changed

Reduced the chance of a crash that could happen when the app starts in the background after a Bluetooth event. The monitoring service could fail to start quickly enough on devices under heavy load, causing a system-level crash.

## Technical Context

- `App.onCreate()` called `startForegroundService()` eagerly, starting the system's 10-second foreground timeout clock before the BroadcastReceiver even ran. This meant the timeout window included both the remainder of `App.onCreate()` and the full `BluetoothEventReceiver.onReceive()` execution — time the service couldn't use to call `startForeground()`.
- The call was redundant: `BluetoothEventReceiver`, `BootCompletedReceiver`, and `OverviewViewModel` all independently start the monitoring service when needed.
- Removing it shifts the timeout start to the actual trigger point (the receiver), shrinking the window to just the service creation overhead.
- Verified against AOSP `ActiveServices.java` that the system already deduplicates redundant `startForegroundService()` calls and skips timeouts for already-foreground services — no app-level deduplication needed.
