### PR TITLE
Fix: Fix crash when leaving the device profile screen

### DIFF
--- a/app/src/main/java/eu/darken/capod/profiles/ui/creation/DeviceProfileCreationScreen.kt
+++ b/app/src/main/java/eu/darken/capod/profiles/ui/creation/DeviceProfileCreationScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -343,7 +343,7 @@ private fun DeviceInfoCard(
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = modelExpanded) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
             )
             ExposedDropdownMenu(
                 expanded = modelExpanded,
@@ -395,7 +395,7 @@ private fun DeviceInfoCard(
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = deviceExpanded) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
             )
             ExposedDropdownMenu(
                 expanded = deviceExpanded,

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,7 +15,7 @@ object Versions {
     }
 
     object Compose {
-        const val bom = "2025.06.01"
+        const val bom = "2025.10.00"
     }
 
     object Navigation3 {


### PR DESCRIPTION
## What changed

Fixed a crash that could happen when navigating away from the device profile creation/edit screen.

## Technical Context

- Root cause: Material3's `ExposedDropdownMenuBox` has a bug where its internal `SoftKeyboardListener` accesses layout coordinates after the composable detaches from the view tree, throwing `IllegalStateException: LayoutCoordinate operations are only valid when isAttached is true`
- Fix: Bumped Compose BOM from `2025.06.01` to `2025.10.00`, which includes Material3 1.4.0 with the missing `isAttached` guard in `getAnchorBounds()`
- Also updated deprecated `MenuAnchorType` → `ExposedDropdownMenuAnchorType` (renamed in Material3 1.4.0)
