### PR TITLE
Fix: Prevent crash from dependency injection failure in monitoring service

### DIFF
--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -114,7 +114,15 @@ class MonitorService : Service() {
             return
         }
 
-        super.onCreate()
+        try {
+            super.onCreate()
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Hilt DI failed in onCreate(), stopping service: ${e.asLog()}" }
+            Bugs.report(tag = TAG, "Hilt DI failed in onCreate()", exception = e)
+            foregroundStartFailed = true
+            stopSelf()
+            return
+        }
         log(TAG, VERBOSE) { "onCreate()" }
 
         // Replace early notification with the full one from injected MonitorNotifications.


### PR DESCRIPTION
## What changed

Prevented a potential crash that could happen if the monitoring service's dependency injection fails during startup. Instead of crashing the entire app, the service now stops gracefully and reports the error.

## Technical Context

- `MonitorService.onCreate()` already calls `startForeground()` before `super.onCreate()` (Hilt DI) to satisfy the FGS timeout. However, if DI then throws (e.g., `SecurityException` from Bluetooth access, DataStore I/O failure, or the app being started in a restricted context like backup/restore), the unhandled exception crashes the process.
- Wrapping `super.onCreate()` in try-catch lets the service stop cleanly via `stopSelf()` while the foreground notification is still up — satisfying the system's FGS requirement without killing the app.
- The DI failure is reported via `Bugs.report()` so it surfaces in crash analytics rather than being silently swallowed.
- Complements #451 which addresses the premature FGS timer start from `App.onCreate()`.
