### PR TITLE
Fix: Stop auto-connect from retrying when blocked by Android

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
+++ b/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
@@ -304,6 +304,9 @@ class BluetoothManager2 @Inject constructor(
         emit(wrappedDevices)
     }
 
+    private var _isNudgeAvailable: Boolean = true
+    val isNudgeAvailable: Boolean get() = _isNudgeAvailable
+
     suspend fun nudgeConnection(device: BluetoothDevice2): Boolean = getBluetoothProfile().map { bluetoothProfile ->
         try {
             log(TAG) { "Nudging Android connection to $device" }
@@ -317,6 +320,12 @@ class BluetoothManager2 @Inject constructor(
             log(TAG) { "Nudged connection to $device" }
             true
         } catch (e: Exception) {
+            val isSecurityException = e is SecurityException ||
+                (e is java.lang.reflect.InvocationTargetException && e.cause is SecurityException)
+            if (isSecurityException) {
+                log(TAG, ERROR) { "nudgeConnection is permanently unavailable: missing MODIFY_PHONE_STATE permission" }
+                _isNudgeAvailable = false
+            }
             Bugs.report(tag = TAG, "BluetoothHeadset.connect(device) is unavailable", exception = e)
             false
         }

--- a/app/src/main/java/eu/darken/capod/reaction/core/autoconnect/AutoConnect.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/autoconnect/AutoConnect.kt
@@ -99,6 +99,12 @@ class AutoConnect @Inject constructor(
                 log(TAG) { "Auto connect condition ($condition) is not fullfilled: ${decision.reason}" }
                 return@map
             }
+
+            if (!bluetoothManager.isNudgeAvailable) {
+                log(TAG, WARN) { "nudgeConnection is not available on this device, skipping" }
+                return@map
+            }
+
             val result = bluetoothManager.nudgeConnection(bondedDevice)
             log(TAG) { "nudgeConnection($bondedDevice) returned $result" }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="settings_signal_minimum_label">Minimum signal quality</string>
     <string name="settings_signal_minimum_description">The minimum signal quality that a device needs to have to be considered yours.</string>
     <string name="settings_autoconnect_label">Auto connect</string>
-    <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This will set the monitor mode setting to \'Always\'.</string>
+    <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This will set the monitor mode setting to \'Always\'. May not work on newer Android versions.</string>
     <string name="settings_autoconnect_condition_label">Auto connect condition</string>
     <string name="settings_autoconnect_condition_description">When should we try to connect to your device?</string>
     <string name="settings_devices_label">Devices</string>


### PR DESCRIPTION
## What changed

Fixed auto-connect repeatedly failing every second on newer Android versions. The app now detects when the connection method is blocked by the OS and stops retrying. Also added a note in the setting description that this feature may not work on newer Android versions.

## Technical Context

- Root cause: `BluetoothHeadset.connect()` is a hidden API that now requires `MODIFY_PHONE_STATE` — a system-only permission that third-party apps cannot obtain. Confirmed on both Samsung S22 Ultra and Pixel 8 running Android 16.
- On failure, `nudgeConnection` was silently returning `false` without distinguishing permanent from transient failures. AutoConnect would retry on every BLE scan result (~1s), spamming the same SecurityException indefinitely.
- Fix detects `SecurityException` (direct or wrapped in `InvocationTargetException`) and sets `isNudgeAvailable = false` for the process lifetime. AutoConnect checks this flag before calling `nudgeConnection`.
- There is no viable public API alternative for programmatic Bluetooth audio profile connection from third-party apps. CompanionDeviceManager, GATT, intents — none can trigger HFP/A2DP connection.
