### PR TITLE
Fix: Correct ear detection and volume swipe flags for multiple devices

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/PodModel.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/PodModel.kt
@@ -52,6 +52,7 @@ enum class PodModel(
         Features(
             hasDualPods = true,
             hasCase = true,
+            hasEarDetection = true,
         ),
         modelNumbers = setOf("A3050", "A3053", "A3054"), // earphones
     ),
@@ -70,8 +71,6 @@ enum class PodModel(
             hasNcOneAirpod = true,
             hasPressSpeed = true,
             hasPressHoldDuration = true,
-            hasVolumeSwipe = true,
-            hasVolumeSwipeLength = true,
             hasPersonalizedVolume = true,
             hasToneVolume = true,
             hasEndCallMuteMic = true,
@@ -179,6 +178,7 @@ enum class PodModel(
         "AirPods Max",
         R.drawable.device_airpods_max,
         Features(
+            hasEarDetection = true,
             hasAncControl = true,
             hasPressSpeed = true,
             hasPressHoldDuration = true,
@@ -192,6 +192,7 @@ enum class PodModel(
         "AirPods Max USB-C",
         R.drawable.device_airpods_max,
         Features(
+            hasEarDetection = true,
             hasAncControl = true,
             hasPressSpeed = true,
             hasPressHoldDuration = true,
@@ -218,7 +219,10 @@ enum class PodModel(
     BEATS_SOLO_PRO(
         "Beats Solo Pro",
         R.drawable.device_beats_headphones,
-        Features(hasAncControl = true),
+        Features(
+            hasEarDetection = true,
+            hasAncControl = true,
+        ),
         modelNumbers = setOf("A1881"), // headphones
     ),
 
@@ -244,7 +248,10 @@ enum class PodModel(
     BEATS_STUDIO_3(
         "Beats Studio 3",
         R.drawable.device_beats_studio3,
-        Features(hasAncControl = true),
+        Features(
+            hasEarDetection = true,
+            hasAncControl = true,
+        ),
         modelNumbers = setOf("A1914"), // headphones
     ),
 
@@ -255,7 +262,6 @@ enum class PodModel(
         Features(
             hasDualPods = true,
             hasCase = true,
-            hasEarDetection = true,
             hasAncControl = true,
         ),
         modelNumbers = setOf("A2512", "A2513", "A2514"), // L/R earbuds + case
@@ -268,7 +274,6 @@ enum class PodModel(
         Features(
             hasDualPods = true,
             hasCase = true,
-            hasEarDetection = true,
             hasAncControl = true,
         ),
         modelNumbers = setOf("A2871", "A2872", "A2952"), // L/R earbuds + case

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/ModelFeaturesTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/ModelFeaturesTest.kt
@@ -29,7 +29,7 @@ class ModelFeaturesTest : BaseTest() {
         val f = PodModel.AIRPODS_MAX.features
         f.hasDualPods shouldBe false
         f.hasCase shouldBe false
-        f.hasEarDetection shouldBe false
+        f.hasEarDetection shouldBe true
         f.hasAncControl shouldBe true
     }
 
@@ -61,9 +61,14 @@ class ModelFeaturesTest : BaseTest() {
     }
 
     @Test
-    fun `all ANC-capable models also have ear detection or are headphones`() {
+    fun `all ANC-capable dual-pod models have ear detection except Studio Buds`() {
+        val noEarDetectionAncModels = setOf(
+            PodModel.BEATS_STUDIO_BUDS,
+            PodModel.BEATS_STUDIO_BUDS_PLUS,
+        )
         PodModel.entries
             .filter { it.features.hasAncControl && it.features.hasDualPods }
+            .filter { it !in noEarDetectionAncModels }
             .forEach { model ->
                 model.features.hasEarDetection shouldBe true
             }


### PR DESCRIPTION
## What changed

Fixed incorrect feature flags for several device models. Removed ear detection from Beats Studio Buds and Studio Buds+ (neither actually has auto play/pause). Removed volume swipe controls from AirPods 4 ANC (only AirPods Pro has stem swipe gesture). Added missing ear/head detection for AirPods Max, AirPods Gen 4, Beats Solo Pro, and Beats Studio 3.

## Technical Context

- Flags were audited against Apple Support docs, spec sheets, and reviews. Only AirPods Pro 1 and Pro 3 had been tested against real devices previously.
- **Beats Studio Buds / Buds+**: Use proprietary Beats chip without in-ear detection. Multiple sources (9to5Mac, Macworld, Apple Support) confirm no auto play/pause.
- **AirPods 4 ANC**: Apple Support explicitly lists no volume swipe gesture. Volume swipe is exclusive to AirPods Pro 2/2 USB-C/3.
- **AirPods Max / Max USB-C, Beats Solo Pro, Beats Studio 3**: Apple Support docs confirm automatic ear/head detection for all of these.
- **AirPods Gen 4 (non-ANC)**: H2 chip with confirmed ear detection hardware.
- Updated the test invariant (all dual-pod ANC models must have ear detection) to exclude Studio Buds and Studio Buds+ since they are the exception.
- Ear detection additions for Max, Gen 4, Solo Pro, and Studio 3 are hardware-confirmed but untested with the AAP protocol layer.