### PR TITLE
General: Bump Android Gradle Plugin to 9.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.0.1")
+        classpath("com.android.tools.build:gradle:9.1.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:9.0.1")
+    implementation("com.android.tools.build:gradle:9.1.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10")
     implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.2.10")
     implementation("org.jetbrains.kotlin:kotlin-serialization:2.2.10")


### PR DESCRIPTION
## What changed

No user-facing behavior change. Bumps the Android Gradle Plugin from 9.0.1 to 9.1.0.

## Technical Context

- Routine AGP patch-level upgrade; no build script or configuration changes required
