### PR TITLE
Device: Warn when profile has no paired Bluetooth device selected

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
@@ -131,6 +131,7 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
         onToggleUnmatched = { vm.toggleUnmatchedDevices() },
         onAncModeChange = { device, mode -> vm.setAncMode(device, mode) },
         onDeviceSettings = { device -> vm.goToDeviceSettings(device) },
+        onEditProfile = { device -> vm.goToEditProfile(device) },
     )
 }
 
@@ -144,6 +145,7 @@ fun OverviewScreen(
     onToggleUnmatched: () -> Unit,
     onAncModeChange: (PodDevice, AapSetting.AncMode.Value) -> Unit = { _, _ -> },
     onDeviceSettings: (PodDevice) -> Unit = {},
+    onEditProfile: (PodDevice) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -236,6 +238,7 @@ fun OverviewScreen(
                         onAncModeChange = { mode -> onAncModeChange(device, mode) },
                         onUpgrade = onUpgrade,
                         onDeviceSettings = { onDeviceSettings(device) },
+                        onEditProfile = { onEditProfile(device) },
                     )
                 }
 
@@ -298,6 +301,7 @@ private fun PodDeviceCard(
     onAncModeChange: (AapSetting.AncMode.Value) -> Unit,
     onUpgrade: () -> Unit,
     onDeviceSettings: (() -> Unit)? = null,
+    onEditProfile: (() -> Unit)? = null,
 ) {
     when {
         device.hasDualPods -> DualPodsCard(
@@ -305,12 +309,14 @@ private fun PodDeviceCard(
             onAncModeChange = onAncModeChange,
             onUpgrade = onUpgrade,
             onDeviceSettings = onDeviceSettings,
+            onEditProfile = onEditProfile,
         )
         device.model != PodModel.UNKNOWN -> SinglePodsCard(
             device = device, isPro = isPro, showDebug = showDebug, now = now,
             onAncModeChange = onAncModeChange,
             onUpgrade = onUpgrade,
             onDeviceSettings = onDeviceSettings,
+            onEditProfile = onEditProfile,
         )
         else -> UnknownPodDeviceCard(device = device, showDebug = showDebug)
     }

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -158,6 +158,11 @@ class OverviewViewModel @Inject constructor(
         navTo(Nav.Main.DeviceSettings(address))
     }
 
+    fun goToEditProfile(device: PodDevice) {
+        val profileId = device.profileId ?: return
+        navTo(Nav.Main.DeviceProfileCreation(profileId = profileId))
+    }
+
     fun onUpgrade() {
         navTo(Nav.Main.Upgrade)
     }

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.BatteryChargingFull
 import androidx.compose.material.icons.twotone.GridView
 import androidx.compose.material.icons.twotone.Tune
+import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -65,6 +66,7 @@ fun DualPodsCard(
     onAncModeChange: ((AapSetting.AncMode.Value) -> Unit)? = null,
     onUpgrade: (() -> Unit)? = null,
     onDeviceSettings: (() -> Unit)? = null,
+    onEditProfile: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
@@ -145,6 +147,14 @@ fun DualPodsCard(
                             imageVector = Icons.TwoTone.Tune,
                             contentDescription = stringResource(R.string.device_settings_open_cd),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                } else if (device.profileId != null && device.address == null && onEditProfile != null) {
+                    IconButton(onClick = onEditProfile) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Warning,
+                            contentDescription = stringResource(R.string.overview_card_missing_paired_device_cd),
+                            tint = MaterialTheme.colorScheme.error,
                         )
                     }
                 }
@@ -427,5 +437,16 @@ private fun DualPodsCardCachedPreview() = PreviewWrapper {
         device = MockPodDataProvider.dualPodCachedOnly(),
         showDebug = false,
         now = Instant.now(),
+    )
+}
+
+@Preview2
+@Composable
+private fun DualPodsCardMissingAddressPreview() = PreviewWrapper {
+    DualPodsCard(
+        device = MockPodDataProvider.dualPodMonitoredMixed(),
+        showDebug = false,
+        now = Instant.now(),
+        onEditProfile = {},
     )
 }

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/SinglePodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/SinglePodsCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.BatteryChargingFull
 import androidx.compose.material.icons.twotone.Hearing
 import androidx.compose.material.icons.twotone.Tune
+import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -61,6 +62,7 @@ fun SinglePodsCard(
     onAncModeChange: ((AapSetting.AncMode.Value) -> Unit)? = null,
     onUpgrade: (() -> Unit)? = null,
     onDeviceSettings: (() -> Unit)? = null,
+    onEditProfile: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
@@ -144,6 +146,14 @@ fun SinglePodsCard(
                             imageVector = Icons.TwoTone.Tune,
                             contentDescription = stringResource(R.string.device_settings_open_cd),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                } else if (device.profileId != null && device.address == null && onEditProfile != null) {
+                    IconButton(onClick = onEditProfile) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Warning,
+                            contentDescription = stringResource(R.string.overview_card_missing_paired_device_cd),
+                            tint = MaterialTheme.colorScheme.error,
                         )
                     }
                 }
@@ -297,5 +307,16 @@ private fun SinglePodsCardCachedPreview() = PreviewWrapper {
         device = MockPodDataProvider.singlePodCachedOnly(),
         showDebug = false,
         now = Instant.now(),
+    )
+}
+
+@Preview2
+@Composable
+private fun SinglePodsCardMissingAddressPreview() = PreviewWrapper {
+    SinglePodsCard(
+        device = MockPodDataProvider.singlePodMonitored(),
+        showDebug = false,
+        now = Instant.now(),
+        onEditProfile = {},
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,6 +474,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Single press to mute microphone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Double press to end call</string>
     <string name="device_settings_open_cd">Open device settings</string>
+    <string name="overview_card_missing_paired_device_cd">Profile has no paired Bluetooth device — tap to edit profile</string>
 
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>


### PR DESCRIPTION
## What changed

Users whose profile wasn't linked to a specific paired Bluetooth device (common after upgrading from older versions where device selection was optional) previously saw an empty settings screen with no way to figure out what was wrong — the ANC/AAP options wouldn't appear and there was no Connect button either.

The overview card now shows a warning icon in place of the usual settings icon when a profile has no paired device selected. Tapping it jumps straight to the profile editor so the user can pick their AirPods from the paired-devices list.

## Technical Context

- Root cause: `AppleDeviceProfile.address` is nullable, and `AapAutoConnect.initialConnect()` filters profiles by `it.address in connectedAddresses` — a null address silently never matches, so AAP never tries to connect. Three unrelated UI paths were also gated on `device.address != null` (overview card's settings icon at `SinglePodsCard.kt:141` / `DualPodsCard.kt:142`, the `DeviceSettings` nav route in `OverviewViewModel.goToDeviceSettings`, and the `NotConnectedCard` at `DeviceSettingsScreen.kt:245`), so the broken state had zero visible affordance for the user to diagnose or fix it. The reporter in #215 had to delete and recreate the profile because that was the only UI lever not hidden by the null-address gate.
- Affected cohorts: v2.x upgraders whose legacy `oldMainDeviceAddress` was empty at the single→multi migration (migration copies null and permanently flips `singleToMultiMigrationDone`), and v3.x/v4.x users who saved a profile without picking a bonded device — nothing required it before AAP landed in v5.0.0-beta0.
- Alternative considered and rejected: auto-backfilling the address by matching connected classic BT devices to null-address profiles by pod model. In environments with multiple bonded AirPods of the same model the unique-model heuristic has too many false-positive modes, so explicit user action is safer.
- The warning is gated on `device.profileId != null && device.address == null` so it never fires for anonymous BLE devices (which have their own existing UX).

Related to #215
