### PR TITLE
Reaction: Note long-press stem actions disable ANC cycling

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/stemactions/StemActionConfigScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/stemactions/StemActionConfigScreen.kt
@@ -37,7 +37,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.capod.R
 import eu.darken.capod.common.navigation.NavigationEventHandler
+import eu.darken.capod.common.settings.InfoBoxType
 import eu.darken.capod.common.settings.SettingsCategoryHeader
+import eu.darken.capod.common.settings.SettingsInfoBox
 import eu.darken.capod.reaction.core.stem.StemAction
 
 @Composable
@@ -178,6 +180,15 @@ fun StemActionConfigScreen(
                     onLeftChange = onLeftLong,
                     onRightChange = onRightLong,
                 )
+            }
+
+            if (state.leftLong != StemAction.NONE || state.rightLong != StemAction.NONE) {
+                item("long_anc_cycle_info") {
+                    SettingsInfoBox(
+                        text = stringResource(R.string.stem_actions_long_press_anc_cycle_info),
+                        type = InfoBoxType.INFO,
+                    )
+                }
             }
 
             item("bottom_spacer") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -521,6 +521,7 @@
     <string name="stem_actions_double_press">Double Press</string>
     <string name="stem_actions_triple_press">Triple Press</string>
     <string name="stem_actions_long_press">Long Press</string>
+    <string name="stem_actions_long_press_anc_cycle_info">Assigning a long-press action also disables cycling Noise Control modes (e.g. Noise Cancellation, Transparency) by holding the stem on the AirPods.</string>
     <string name="stem_actions_left">Left</string>
     <string name="stem_actions_right">Right</string>
     <string name="stem_action_none">Default</string>


### PR DESCRIPTION
## What changed

Added an info box in the Stem Actions configuration screen that appears when a long-press action is assigned to either AirPod. The box explains that assigning any long-press action disables the AirPods' built-in behavior of cycling Noise Control modes (Noise Cancellation, Transparency, etc.) when pressing and holding the stem.

## Technical Context

- Assigning any non-default long-press action on either side causes bit `0x08` to be set in the `SetStemConfig` mask, which makes the AirPods forward long-press events to the app instead of cycling ANC natively. This side effect was not surfaced anywhere in the UI.
- Used `InfoBoxType.INFO` rather than `WARNING` — this is an intentional trade-off, not a failure state.
- Trigger matches the real underlying behavior: the notice shows whenever either `leftLong` or `rightLong` is non-`NONE`, because the mask bit is claimed as soon as either side is set.
