### PR TITLE
Device: Log raw bytes of outgoing AAP commands for debugging

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/AapConnection.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/AapConnection.kt
@@ -276,7 +276,8 @@ internal class AapConnection(
                 sock.outputStream.write(bytes)
                 sock.outputStream.flush()
                 if (command is AapCommand.SetAncMode) lastAncCommandSentAt = timeSource.currentTimeMillis()
-                log(TAG) { "Sent command: $command (${bytes.size} bytes)" }
+                val hex = bytes.joinToString(" ") { "%02X".format(it) }
+                log(TAG, VERBOSE) { "SEND cmd=$command len=${bytes.size} raw=$hex" }
             }
         }
     }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Outgoing AAP commands (settings writes, ANC mode changes, renames, etc.) now log their raw hex bytes at VERBOSE level.

## Technical Context

- Previously `sendRaw` logged `"Sent command: $command (N bytes)"` at DEBUG, so bug-report logs showed the intent but not the actual wire bytes. For settings like PressSpeed where the device doesn't echo the change back, there was no way to verify from a log that the encoder produced what we expected.
- The new `SEND cmd=… len=… raw=…` line mirrors the existing incoming `MSG cmd=… raw=…` format at the same level, so a VERBOSE transcript now contains complete send/receive pairs.
- Drops the DEBUG summary line — the VERBOSE line is strictly more information and keeps the log at one line per send.
