### PR TITLE
General: Improve diagnostics for unknown AAP protocol messages

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/AapConnection.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/AapConnection.kt
@@ -74,6 +74,8 @@ internal class AapConnection(
     private var lastAncCommandSentAt: Long = 0L
     private var lastCommandedAncMode: AapSetting.AncMode.Value? = null
     private var ancResendJob: Job? = null
+    private var lastSentCommand: AapCommand? = null
+    private var lastSentAt: Long = 0L
 
     /**
      * Opens the L2CAP socket, sends the handshake, and launches the read loop.
@@ -275,7 +277,10 @@ internal class AapConnection(
                 val sock = socket ?: throw IOException("Socket is null")
                 sock.outputStream.write(bytes)
                 sock.outputStream.flush()
-                if (command is AapCommand.SetAncMode) lastAncCommandSentAt = timeSource.currentTimeMillis()
+                val now = timeSource.currentTimeMillis()
+                if (command is AapCommand.SetAncMode) lastAncCommandSentAt = now
+                lastSentCommand = command
+                lastSentAt = now
                 val hex = bytes.joinToString(" ") { "%02X".format(it) }
                 log(TAG, VERBOSE) { "SEND cmd=$command len=${bytes.size} raw=$hex" }
             }
@@ -457,7 +462,12 @@ internal class AapConnection(
             return
         }
 
-        log(TAG) { "Unhandled message: cmd=0x${"%04X".format(message.commandType)} payload=${message.payload.size}B" }
+        val payloadHex = message.payload.joinToString(" ") { "%02X".format(it) }
+        val sinceSend = if (lastSentAt == 0L) -1L else timeSource.currentTimeMillis() - lastSentAt
+        val lastSend = lastSentCommand?.let { it::class.simpleName } ?: "none"
+        log(TAG, INFO) {
+            "Unhandled cmd=0x${"%04X".format(message.commandType)} payload=${message.payload.size}B [$payloadHex] sinceLastSend=${sinceSend}ms lastSend=$lastSend"
+        }
     }
 
     private fun cleanupSocket() {


### PR DESCRIPTION
## What changed

No user-facing behavior change. Diagnostic-only: when the AAP decoder receives a message it can't decode, the log line now includes the payload bytes, how long ago the last command was sent, and what that last command was. Makes it possible to correlate unknown device-pushed opcodes with the command that likely triggered them.

## Technical Context

- Generic `lastSentCommand` / `lastSentAt` tracking recorded in `sendRaw`, alongside the existing ANC-specific timestamp which still drives ANC debounce logic.
- The old `"Unhandled message: cmd=0xNNNN payload=NB"` line (DEBUG) is replaced with an INFO line carrying the payload hex, `sinceLastSend` ms, and the `AapCommand` subclass that was sent. Bumped to INFO so the signal lands in default debug recordings without bumping the overall verbosity.
- Motivation: AirPods Pro 3 emits several undocumented opcodes (`0x004C`, `0x0052`, `0x0055`, a settings-envelope frame with setting ID `0x38`) that currently fall through the decoder. Having payload + correlation in the log makes it feasible to build up a response map from field logs instead of having to add a bespoke handler per opcode.
- The symptom that prompted this: `SetPersonalizedVolume` appears to have no audible effect on Pro 3 and the `0x004C` responses captured in earlier logs stop appearing in later sessions — so the correlation data is what we need next to tell "device ignoring our write" apart from "device acked via an opcode we're not decoding".
