### PR TITLE
General: Show Auto Connect compatibility notice only when relevant

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.capod.main.ui.devicesettings
 
 import android.content.Intent
+import android.os.Build
 import android.provider.Settings
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.selection.selectable
@@ -399,6 +400,11 @@ fun DeviceSettingsScreen(
                             onClick = { if (reactions.autoConnect) showAutoConnectConditionDialog = true },
                             enabled = reactions.autoConnect,
                         )
+                        if (reactions.autoConnect && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                            SettingsInfoBox(
+                                text = stringResource(R.string.settings_autoconnect_info_android12),
+                            )
+                        }
                         ReactionsDivider()
                         if (features.hasCase) {
                             SettingsSwitchItem(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,8 @@
     <string name="settings_signal_minimum_label">Minimum signal quality</string>
     <string name="settings_signal_minimum_description">The minimum signal quality that a device needs to have to be considered yours.</string>
     <string name="settings_autoconnect_label">Auto connect</string>
-    <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This will set the monitor mode setting to \'Always\'. May not work on newer Android versions.</string>
+    <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This will set the monitor mode setting to \'Always\'.</string>
+    <string name="settings_autoconnect_info_android12">Auto connect relies on a system feature that Android 12 and newer restricts. It may not work on your device.</string>
     <string name="settings_autoconnect_condition_label">Auto connect condition</string>
     <string name="settings_autoconnect_condition_description">When should we try to connect to your device?</string>
     <string name="settings_devices_label">Devices</string>


### PR DESCRIPTION
## What changed

The Auto Connect setting description no longer includes the vague "May not work on newer Android versions" caveat. Instead, a dedicated info box appears below the setting when it is enabled on Android 12 or newer, explaining the restriction more clearly.

## Technical Context

- Auto Connect uses reflection on the hidden `BluetoothHeadset.connect()` API, which Android 12+ (API 31) blocks with a `SecurityException` due to `MODIFY_PHONE_STATE` enforcement
- The info box uses the existing `SettingsInfoBox` composable (same pattern as the ear detection and popup info boxes on the same screen)
- Visibility is gated on `reactions.autoConnect && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S` — a static SDK check rather than the runtime `isNudgeAvailable` flag, so users see the warning before their first failed attempt
- Locale translations for the removed caveat sentence and the new info box string are not included — they will be updated separately
