### PR TITLE
General: Improve advanced settings unavailable message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,7 +441,7 @@
     <string name="device_settings_not_connected_connect_action">Connect</string>
     <string name="device_settings_not_connected_open_settings_action">Open Bluetooth Settings</string>
     <string name="device_settings_aap_unavailable_label">Advanced settings unavailable</string>
-    <string name="device_settings_aap_unavailable_description">This phone\'s Bluetooth does not support the connection required for advanced AirPods settings.</string>
+    <string name="device_settings_aap_unavailable_description">Advanced AirPods settings require a Bluetooth feature that is not available on this phone. This may be resolved by a future Android update from your device manufacturer.</string>
     <string name="device_settings_category_sound_label">Sound</string>
     <string name="device_settings_category_controls_label">Controls</string>
     <string name="device_settings_nc_one_airpod_label">Noise Cancellation with One AirPod</string>


### PR DESCRIPTION
## What changed

Improved the message shown when advanced AirPods settings are unavailable. Instead of only saying Bluetooth doesn't support the required connection, the message now tells users this may be resolved by a future Android update from their device manufacturer.

## Technical Context

- The previous wording blamed hardware ("this phone's Bluetooth does not support") which left users with no recourse. The new wording frames it as a software gap that may be resolved by an Android update, which is accurate — the underlying L2CAP socket API is available on newer Android versions.
- Kept wording generic ("future Android update") rather than naming specific versions, since the card can appear for multiple failure reasons beyond permanent platform unsupport.