### PR TITLE
General: Merge one-pod mode settings into a single toggle

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
@@ -150,7 +150,6 @@ fun DeviceSettingsScreenHost(
         onNavigateUp = { vm.navUp() },
         onAncModeChange = { vm.setAncMode(it) },
         onConversationalAwarenessChange = { vm.setConversationalAwareness(it) },
-        onNcWithOneAirPodChange = { vm.setNcWithOneAirPod(it) },
         onPersonalizedVolumeChange = { vm.setPersonalizedVolume(it) },
         onToneVolumeChange = { vm.setToneVolume(it) },
         onAdaptiveAudioNoiseChange = { vm.setAdaptiveAudioNoise(it) },
@@ -187,7 +186,6 @@ fun DeviceSettingsScreen(
     onNavigateUp: () -> Unit,
     onAncModeChange: (AapSetting.AncMode.Value) -> Unit = {},
     onConversationalAwarenessChange: (Boolean) -> Unit = {},
-    onNcWithOneAirPodChange: (Boolean) -> Unit = {},
     onPersonalizedVolumeChange: (Boolean) -> Unit = {},
     onToneVolumeChange: (Int) -> Unit = {},
     onAdaptiveAudioNoiseChange: (Int) -> Unit = {},
@@ -325,7 +323,8 @@ fun DeviceSettingsScreen(
                             if (features.hasDualPods) {
                                 val onePodModeActive = reactions.autoPlay ||
                                     reactions.autoPause ||
-                                    (reactions.autoConnect && reactions.autoConnectCondition == AutoConnectCondition.IN_EAR)
+                                    (reactions.autoConnect && reactions.autoConnectCondition == AutoConnectCondition.IN_EAR) ||
+                                    features.hasNcOneAirpod
                                 SettingsBaseItem(
                                     title = stringResource(R.string.settings_onepod_mode_label),
                                     subtitle = stringResource(R.string.settings_onepod_mode_description),
@@ -450,7 +449,6 @@ fun DeviceSettingsScreen(
 
                 // ── Noise Control ────────────────────────────
                 val ancMode = device.ancMode
-                val ncOneAirpod = device.ncWithOneAirPod
                 val adaptiveNoise = device.adaptiveAudioNoise
                 if (features.hasAncControl && ancMode != null) {
                     val cycleMask = if (features.hasListeningModeCycle) {
@@ -471,7 +469,6 @@ fun DeviceSettingsScreen(
                                 enabled = enabled,
                             )
                             val hasNoiseExtras = (features.hasAdaptiveAudioNoise && adaptiveNoise != null) ||
-                                    (features.hasNcOneAirpod && ncOneAirpod != null) ||
                                     (!isPro && features.hasListeningModeCycle)
                             if (hasNoiseExtras) {
                                 HorizontalDivider(
@@ -485,16 +482,6 @@ fun DeviceSettingsScreen(
                                     onLevelChange = onAdaptiveAudioNoiseChange,
                                     enabled = enabled,
                                     isAdaptiveMode = ancMode.current == AapSetting.AncMode.Value.ADAPTIVE,
-                                )
-                            }
-                            if (features.hasNcOneAirpod && ncOneAirpod != null) {
-                                SettingsSwitchItem(
-                                    icon = Icons.TwoTone.Headphones,
-                                    title = stringResource(R.string.device_settings_nc_one_airpod_label),
-                                    subtitle = stringResource(R.string.device_settings_nc_one_airpod_description),
-                                    checked = ncOneAirpod.enabled,
-                                    onCheckedChange = onNcWithOneAirPodChange,
-                                    enabled = enabled,
                                 )
                             }
                             if (!isPro && features.hasListeningModeCycle) {

--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModel.kt
@@ -206,8 +206,6 @@ class DeviceSettingsViewModel @Inject constructor(
 
     fun setConversationalAwareness(enabled: Boolean) = send(AapCommand.SetConversationalAwareness(enabled))
 
-    fun setNcWithOneAirPod(enabled: Boolean) = send(AapCommand.SetNcWithOneAirPod(enabled))
-
     fun setPersonalizedVolume(enabled: Boolean) = send(AapCommand.SetPersonalizedVolume(enabled))
 
     fun setToneVolume(level: Int) = send(AapCommand.SetToneVolume(level))
@@ -299,7 +297,14 @@ class DeviceSettingsViewModel @Inject constructor(
 
     fun setOnePodMode(enabled: Boolean) {
         log(TAG, INFO) { "setOnePodMode($enabled)" }
-        launch { updateProfileNow { it.copy(onePodMode = enabled) } }
+        launch {
+            updateProfileNow { it.copy(onePodMode = enabled) }
+            // Opportunistic immediate sync — NcOnePodSender handles deferred/reconnect
+            val device = deviceMonitor.getDeviceForProfile(targetProfileId.value ?: return@launch)
+            if (device != null && device.isAapConnected && device.model.features.hasNcOneAirpod) {
+                sendInternal(AapCommand.SetNcWithOneAirPod(enabled))
+            }
+        }
     }
 
     fun setAutoPlay(enabled: Boolean) = launch {

--- a/app/src/main/java/eu/darken/capod/monitor/core/aap/AapLifecycleManager.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/aap/AapLifecycleManager.kt
@@ -26,6 +26,7 @@ class AapLifecycleManager @Inject constructor(
     private val aapKeyPersister: AapKeyPersister,
     private val stemConfigSender: StemConfigSender,
     private val stemPressReaction: StemPressReaction,
+    private val ncOnePodSender: NcOnePodSender,
 ) {
     fun start() {
         log(TAG) { "start()" }
@@ -34,6 +35,7 @@ class AapLifecycleManager @Inject constructor(
             aapKeyPersister.monitor(),
             stemConfigSender.monitor(),
             stemPressReaction.monitor(),
+            ncOnePodSender.monitor(),
         )
             .catch { e -> log(TAG, WARN) { "AAP lifecycle error: ${e.asLog()}" } }
             .setupCommonEventHandlers(TAG) { "aapActive" }

--- a/app/src/main/java/eu/darken/capod/monitor/core/aap/NcOnePodSender.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/aap/NcOnePodSender.kt
@@ -1,0 +1,58 @@
+package eu.darken.capod.monitor.core.aap
+
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.flow.setupCommonEventHandlers
+import eu.darken.capod.pods.core.apple.aap.AapConnectionManager
+import eu.darken.capod.pods.core.apple.aap.AapPodState
+import eu.darken.capod.pods.core.apple.aap.protocol.AapCommand
+import eu.darken.capod.profiles.core.AppleDeviceProfile
+import eu.darken.capod.profiles.core.DeviceProfilesRepo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NcOnePodSender @Inject constructor(
+    private val aapManager: AapConnectionManager,
+    private val profilesRepo: DeviceProfilesRepo,
+) {
+    fun monitor(): Flow<Unit> = combine(
+        aapManager.allStates,
+        profilesRepo.profiles,
+    ) { states, profiles ->
+        val appleProfiles = profiles.filterIsInstance<AppleDeviceProfile>()
+        states.entries
+            .filter { (_, s) -> s.connectionState == AapPodState.ConnectionState.READY }
+            .mapNotNull { (address, _) ->
+                val profile = appleProfiles.firstOrNull { it.address == address }
+                if (profile != null && profile.model.features.hasNcOneAirpod) {
+                    address to profile.onePodMode
+                } else {
+                    null
+                }
+            }
+    }
+        .distinctUntilChanged()
+        .onEach { commands ->
+            for ((address, enabled) in commands) {
+                try {
+                    aapManager.sendCommand(address, AapCommand.SetNcWithOneAirPod(enabled))
+                    log(TAG) { "Sent SetNcWithOneAirPod($enabled) to $address" }
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "SetNcWithOneAirPod send failed for $address: $e" }
+                }
+            }
+        }
+        .map { }
+        .setupCommonEventHandlers(TAG) { "ncOnePod" }
+
+    companion object {
+        private val TAG = logTag("Monitor", "NcOnePodSender")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="settings_compat_offloaded_batching_disabled_summary">Don\'t let the system group collected BLE data before forwarding it to us.</string>
 
     <string name="settings_onepod_mode_label">One pod mode</string>
-    <string name="settings_onepod_mode_description">Treat a single in-ear pod as worn. Auto play/pause and &quot;In ear&quot; auto-connect react to either pod instead of requiring both.</string>
+    <string name="settings_onepod_mode_description">Auto play/pause, auto-connect, and on supported models noise cancellation, react to a single pod instead of requiring both.</string>
     <string name="settings_popup_caseopen_label">Show case popup</string>
     <string name="settings_popup_caseopen_description">Show a popup when the device case is opened (experimental).</string>
     <string name="settings_popup_connected_label">Show connection popup</string>

--- a/app/src/test/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModelTest.kt
@@ -22,7 +22,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,7 +44,6 @@ import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.datastore.FakeDataStoreValue
 import testhelpers.livedata.InstantExecutorExtension
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(InstantExecutorExtension::class)
 class DeviceSettingsViewModelTest : BaseTest() {
 

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
@@ -19,7 +19,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -39,7 +38,6 @@ import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.datastore.FakeDataStoreValue
 import testhelpers.livedata.InstantExecutorExtension
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(InstantExecutorExtension::class)
 class OverviewViewModelTest : BaseTest() {
 

--- a/app/src/test/java/eu/darken/capod/monitor/core/DeviceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/DeviceMonitorTest.kt
@@ -23,7 +23,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,7 +36,6 @@ import testhelpers.BaseTest
 import testhelpers.TestTimeSource
 import java.time.Instant
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DeviceMonitorTest : BaseTest() {
 
     private val testDispatcher = UnconfinedTestDispatcher()

--- a/app/src/test/java/eu/darken/capod/monitor/core/aap/AapAutoConnectTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/aap/AapAutoConnectTest.kt
@@ -16,7 +16,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AapAutoConnectTest : BaseTest() {
 
     private val testDispatcher = UnconfinedTestDispatcher()

--- a/app/src/test/java/eu/darken/capod/monitor/core/aap/NcOnePodSenderTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/aap/NcOnePodSenderTest.kt
@@ -1,0 +1,255 @@
+package eu.darken.capod.monitor.core.aap
+
+import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.aap.AapConnectionManager
+import eu.darken.capod.pods.core.apple.aap.AapPodState
+import eu.darken.capod.pods.core.apple.aap.protocol.AapCommand
+import eu.darken.capod.profiles.core.AppleDeviceProfile
+import eu.darken.capod.profiles.core.DeviceProfile
+import eu.darken.capod.profiles.core.DeviceProfilesRepo
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class NcOnePodSenderTest : BaseTest() {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var aapManager: AapConnectionManager
+    private lateinit var profilesRepo: DeviceProfilesRepo
+
+    private lateinit var profilesFlow: MutableStateFlow<List<DeviceProfile>>
+    private lateinit var allStatesFlow: MutableStateFlow<Map<String, AapPodState>>
+
+    private val testAddress = "AA:BB:CC:DD:EE:FF"
+    private val testAddress2 = "11:22:33:44:55:66"
+
+    private val proProfile = AppleDeviceProfile(
+        label = "AirPods Pro 3",
+        model = PodModel.AIRPODS_PRO3,
+        address = testAddress,
+        onePodMode = false,
+    )
+
+    private val nonNcProfile = AppleDeviceProfile(
+        label = "AirPods Gen 3",
+        model = PodModel.UNKNOWN,
+        address = testAddress2,
+        onePodMode = true,
+    )
+
+    @BeforeEach
+    fun setup() {
+        profilesFlow = MutableStateFlow(emptyList())
+        allStatesFlow = MutableStateFlow(emptyMap())
+
+        aapManager = mockk(relaxed = true) {
+            every { allStates } returns allStatesFlow
+        }
+
+        profilesRepo = mockk(relaxUnitFun = true) {
+            every { profiles } returns profilesFlow
+        }
+    }
+
+    private fun createSender() = NcOnePodSender(
+        aapManager = aapManager,
+        profilesRepo = profilesRepo,
+    )
+
+    @Test
+    fun `sends enabled when READY and onePodMode is true`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = true))
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(true))
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `sends disabled when READY and onePodMode is false`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = false))
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(false))
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `does not send when device does not support NC one airpod`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(nonNcProfile)
+        allStatesFlow.value = mapOf(
+            testAddress2 to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { aapManager.sendCommand(any(), any<AapCommand.SetNcWithOneAirPod>()) }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `does not send when connection is not READY`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = true))
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.CONNECTING)
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { aapManager.sendCommand(any(), any<AapCommand.SetNcWithOneAirPod>()) }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `sends again when onePodMode toggles`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+
+        // Enable
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = true))
+        advanceUntilIdle()
+
+        // Disable
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = false))
+        advanceUntilIdle()
+
+        coVerify(ordering = io.mockk.Ordering.ORDERED) {
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(true))
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(false))
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `does not resend for unrelated state changes`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = true))
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+        advanceUntilIdle()
+
+        // Unrelated AAP state change (e.g. battery update) — same READY, same profile
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(
+                connectionState = AapPodState.ConnectionState.READY,
+                lastMessageAt = java.time.Instant.now(),
+            )
+        )
+        advanceUntilIdle()
+
+        // Should only have sent once — distinctUntilChanged filters the second emission
+        coVerify(exactly = 1) {
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(true))
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `handles send failure without crashing the flow`() = runTest(testDispatcher) {
+        coEvery {
+            aapManager.sendCommand(any(), any<AapCommand.SetNcWithOneAirPod>())
+        } throws RuntimeException("Connection lost")
+
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(proProfile.copy(onePodMode = true))
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+        advanceUntilIdle()
+
+        // Flow should survive the exception
+        coVerify(exactly = 1) {
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(true))
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `does not send to unmatched addresses`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        // Profile for testAddress, but AAP connection on a different address
+        profilesFlow.value = listOf(proProfile)
+        allStatesFlow.value = mapOf(
+            "XX:XX:XX:XX:XX:XX" to AapPodState(connectionState = AapPodState.ConnectionState.READY)
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { aapManager.sendCommand(any(), any<AapCommand.SetNcWithOneAirPod>()) }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `only sends to NC-capable device when multiple devices connected`() = runTest(testDispatcher) {
+        val sender = createSender()
+        val job = launch { sender.monitor().toList() }
+
+        profilesFlow.value = listOf(
+            proProfile.copy(onePodMode = true),
+            nonNcProfile,
+        )
+        allStatesFlow.value = mapOf(
+            testAddress to AapPodState(connectionState = AapPodState.ConnectionState.READY),
+            testAddress2 to AapPodState(connectionState = AapPodState.ConnectionState.READY),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            aapManager.sendCommand(testAddress, AapCommand.SetNcWithOneAirPod(true))
+        }
+        coVerify(exactly = 0) {
+            aapManager.sendCommand(testAddress2, any<AapCommand.SetNcWithOneAirPod>())
+        }
+
+        job.cancel()
+    }
+}

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManagerTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManagerTest.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -26,7 +25,6 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AapConnectionManagerTest : BaseTest() {
 
     private val testDispatcher = UnconfinedTestDispatcher()


### PR DESCRIPTION
## What changed

The separate "Noise Cancellation with One AirPod" toggle (in the Noise Control section) has been merged into the existing "One pod mode" toggle (in the Reactions section). Toggling one-pod mode now also keeps noise cancellation active when wearing a single AirPod, on supported models.

## Technical Context

- The two settings had different storage mechanisms: one-pod mode was an app-local profile boolean, while NC-with-one-AirPod was a firmware setting sent over AAP. A new `NcOnePodSender` (following the `StemConfigSender` pattern) syncs the firmware NC setting from the profile on AAP connect/reconnect, so the setting is applied even if the user toggles it while disconnected.
- The one-pod mode toggle's enablement gate now includes `hasNcOneAirpod`, so on NC-capable devices (Pro, Pro 2, Pro 3, Gen4 ANC) the toggle is usable even without autoplay/autopause enabled.
- The ViewModel sends the AAP command immediately on toggle for responsiveness, with the deferred sender as a fallback for reconnect scenarios. The duplicate send is idempotent.
