### PR TITLE
Device: Fix AirPods features not working until app restart after granting permission

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
+++ b/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
@@ -268,11 +268,19 @@ class BluetoothManager2 @Inject constructor(
         }
         .retryWhen { cause, attempt ->
             log(TAG, WARN) { "connectedDevices Flow failed (attempt ${attempt + 1}): $cause" }
-            if (attempt < 3) {
-                delay(1000 * (attempt + 1))  // 1s, 2s, 3s exponential backoff
-                true  // Retry
-            } else {
-                false  // Give up after 3 attempts
+            when {
+                // BLUETOOTH_CONNECT not granted (or revoked). Keep retrying — the next
+                // attempt will succeed as soon as the user grants it. Terminating here
+                // would leave the stateIn StateFlow serving a stale emptyList() forever.
+                cause is SecurityException -> {
+                    delay(3_000L)
+                    true
+                }
+                attempt < 3 -> {
+                    delay(1000 * (attempt + 1))
+                    true
+                }
+                else -> false
             }
         }
         .catch { e ->

--- a/app/src/main/java/eu/darken/capod/monitor/core/aap/AapLifecycleManager.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/aap/AapLifecycleManager.kt
@@ -6,12 +6,20 @@ import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.flow.setupCommonEventHandlers
+import eu.darken.capod.common.permissions.Permission
+import eu.darken.capod.main.core.PermissionTool
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.retryWhen
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Launches AAP auto-connect and key persistence in [appScope],
@@ -27,17 +35,33 @@ class AapLifecycleManager @Inject constructor(
     private val aapLearnedSettingsPersister: AapLearnedSettingsPersister,
     private val stemConfigSender: StemConfigSender,
     private val stemPressReaction: StemPressReaction,
+    private val permissionTool: PermissionTool,
 ) {
     fun start() {
         log(TAG) { "start()" }
-        merge(
-            aapAutoConnect.monitor(),
-            aapKeyPersister.monitor(),
-            aapLearnedSettingsPersister.monitor(),
-            stemConfigSender.monitor(),
-            stemPressReaction.monitor(),
-        )
-            .catch { e -> log(TAG, WARN) { "AAP lifecycle error: ${e.asLog()}" } }
+        permissionTool.missingPermissions
+            .map { Permission.BLUETOOTH_CONNECT in it }
+            .distinctUntilChanged()
+            .flatMapLatest { missingConnect ->
+                if (missingConnect) {
+                    log(TAG) { "AAP lifecycle paused: BLUETOOTH_CONNECT missing" }
+                    emptyFlow()
+                } else {
+                    log(TAG) { "AAP lifecycle active: BLUETOOTH_CONNECT granted" }
+                    merge(
+                        aapAutoConnect.monitor(),
+                        aapKeyPersister.monitor(),
+                        aapLearnedSettingsPersister.monitor(),
+                        stemConfigSender.monitor(),
+                        stemPressReaction.monitor(),
+                    )
+                        .retryWhen { cause, attempt ->
+                            log(TAG, WARN) { "AAP lifecycle error (attempt ${attempt + 1}): ${cause.asLog()}" }
+                            delay((1_000L * (attempt + 1).coerceAtMost(5)).milliseconds)
+                            true
+                        }
+                }
+            }
             .setupCommonEventHandlers(TAG) { "aapActive" }
             .launchIn(appScope)
     }


### PR DESCRIPTION
## What changed

Fixed a bug where AirPods feature support (ANC toggle, stem controls, learned settings, firmware-level state) would stay broken until the app was force-stopped and relaunched, if the user granted the Bluetooth permission after first launch.

Typical repro: install the app, launch it, create a profile, then grant BLUETOOTH_CONNECT when prompted. BLE scanning started working but the Apple protocol layer never came up — the main screen and widget kept showing battery but no firmware-level features. Killing the app and reopening it fixed it.

## Technical Context

- Two independent flow-lifecycle bugs were in play. The first kept AAP from ever starting; the second kept it from ever receiving classic Bluetooth connection state even after the first was fixed.
- **AAP lifecycle (AapLifecycleManager)**: `start()` was called once from `DeviceMonitor.init` and subscribed a merged flow in `appScope`. On first launch without BLUETOOTH_CONNECT, the inner `bondedDevices().first()` threw `SecurityException`; the existing `.catch {}` absorbed it and the merged flow completed — the launched Job was done forever, with no resubscription when permission was granted. Fix: wrap the merge in `permissionTool.missingPermissions.flatMapLatest` gated on `Permission.BLUETOOTH_CONNECT`, plus an inner `retryWhen` with capped backoff for mid-run transient failures. Mirrors the established pattern in `MonitorService.doMonitor()`.
- **connectedDevices (BluetoothManager2)**: the upstream `retryWhen` gave up after 3 attempts and `.catch { emit(emptyList()) }` terminated the flow. The backing `stateIn` StateFlow then served its cached empty list to any new subscriber indefinitely — so even after the AAP lifecycle fix re-subscribed, `connectedDevices` remained frozen at `[]` and no AAP connect was ever attempted. Fix: in `retryWhen`, treat `SecurityException` as non-terminal and keep retrying with a 3s backoff; the next attempt succeeds as soon as the user grants the permission. The 3-attempt limit still applies to other causes.
- The permission-gate check is a no-op on pre-S (where `BLUETOOTH_CONNECT` doesn't exist in `Permission.entries`) because `PermissionTool.missingPermissions` already filters by `Permission.isRequired(context)` which enforces the API-level bound.
- Debug logs attached to the support email show the two failure modes sequentially: (1) `initialConnect` → `SecurityException` at `BluetoothManager2.kt:295` → `aapActive.onCompletion` (first bug), and after the first fix, (2) AAP lifecycle starts but every combine emission sees `connectedDevices=[]` because the BluetoothManager2 StateFlow stayed frozen from its earlier retry exhaustion (second bug).