### PR TITLE
Widget: Complete placement after upgrade purchase

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
@@ -29,10 +30,14 @@ import eu.darken.capod.common.navigation.NavigationController
 import eu.darken.capod.common.navigation.NavigationEntry
 import eu.darken.capod.common.theming.CapodTheme
 import eu.darken.capod.common.uix.Activity2
+import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.core.GeneralSettings
 import eu.darken.capod.main.core.currentThemeState
 import eu.darken.capod.main.core.themeState
 import eu.darken.capod.reaction.ui.popup.PopUpWindow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import eu.darken.capod.common.datastore.valueBlocking
 
@@ -43,11 +48,25 @@ class MainActivity : Activity2() {
     @Inject lateinit var navigationEntries: Set<@JvmSuppressWildcards NavigationEntry>
     @Inject lateinit var generalSettings: GeneralSettings
     @Inject lateinit var popUpWindow: PopUpWindow
+    @Inject lateinit var upgradeRepo: UpgradeRepo
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         enableEdgeToEdge()
+
+        if (intent?.getBooleanExtra(EXTRA_UPGRADE_FOR_RESULT, false) == true) {
+            lifecycleScope.launch {
+                upgradeRepo.upgradeInfo
+                    .filter { it.isPro }
+                    .take(1)
+                    .collect {
+                        log(TAG) { "Upgrade completed, finishing with RESULT_OK" }
+                        setResult(RESULT_OK)
+                        finish()
+                    }
+            }
+        }
 
         val startDestination: NavKey = if (generalSettings.isOnboardingDone.valueBlocking) {
             Nav.Main.Overview
@@ -127,6 +146,7 @@ class MainActivity : Activity2() {
 
     companion object {
         const val EXTRA_NAVIGATE_TO_UPGRADE = "navigate_to_upgrade"
+        const val EXTRA_UPGRADE_FOR_RESULT = "upgrade_for_result"
         private val TAG = logTag("MainActivity")
     }
 }

--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetConfigurationActivity.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetConfigurationActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.SideEffect
@@ -26,6 +27,7 @@ import eu.darken.capod.main.ui.MainActivity
 import eu.darken.capod.main.core.GeneralSettings
 import eu.darken.capod.main.core.currentThemeState
 import eu.darken.capod.main.core.themeState
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -38,6 +40,24 @@ class WidgetConfigurationActivity : Activity2() {
     @ApplicationContext @Inject lateinit var appContext: Context
 
     private var widgetId: Int = AppWidgetManager.INVALID_APPWIDGET_ID
+
+    private val upgradeLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode != RESULT_OK) {
+            log(TAG) { "Upgrade flow canceled or incomplete (resultCode=${result.resultCode})" }
+            return@registerForActivityResult
+        }
+        lifecycleScope.launch {
+            val currentState = vm.state.first()
+            if (!currentState.canConfirm) {
+                log(TAG) { "Upgrade completed, but widget config is not valid, staying in config" }
+                return@launch
+            }
+            log(TAG) { "Upgrade completed, auto-confirming widget selection" }
+            confirmSelection(currentState.isAncWidget)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -87,9 +107,10 @@ class WidgetConfigurationActivity : Activity2() {
                             if (currentState.isPro) {
                                 confirmSelection(currentState.isAncWidget)
                             } else {
-                                startActivity(
+                                upgradeLauncher.launch(
                                     Intent(this@WidgetConfigurationActivity, MainActivity::class.java).apply {
                                         putExtra(MainActivity.EXTRA_NAVIGATE_TO_UPGRADE, true)
+                                        putExtra(MainActivity.EXTRA_UPGRADE_FOR_RESULT, true)
                                     }
                                 )
                             }


### PR DESCRIPTION
## What changed

Placing a widget as a non-Pro user and then completing the upgrade purchase used to leave the user on the dashboard — the configured widget was silently discarded instead of being placed on the home screen, forcing the user to start widget setup over.

## Technical Context

- Root cause: `WidgetConfigurationActivity` launched `MainActivity` via `startActivity()` and never finished itself. On upgrade success, only the Upgrade destination inside MainActivity's nav stack was popped (landing on Overview); `WidgetConfigurationActivity` stayed unreachable behind MainActivity and `setResult(RESULT_OK)` was never called, so the Android widget host treated placement as canceled.
- Introduced `EXTRA_UPGRADE_FOR_RESULT` as a separate signal from the existing `EXTRA_NAVIGATE_TO_UPGRADE`, so in-app upgrade navigations (PressControls, Settings) are unaffected and still only pop the Upgrade destination.
- Rotation works without savedInstanceState: the flag is read from the retained `Intent` (not removed), so `onCreate` after rotation re-subscribes and still fires on cached `isPro=true` via `filter { isPro }.take(1)`.
- Auto-confirm is gated on `state.canConfirm` so a process-death recovery (losing the in-memory draft) returns the user to the config screen rather than placing a widget with default/invalid state.
- Works for both gplay billing and FOSS sponsor flows — both signal success via `UpgradeRepo.upgradeInfo`.
