### PR TITLE
Device: Add tracker link when advanced settings are unavailable

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
@@ -146,6 +146,7 @@ fun DeviceSettingsScreenHost(
         onShowPopUpOnConnectionChange = { vm.setShowPopUpOnConnection(it) },
         onFixMonitorMode = { vm.setMonitorModeAutomatic() },
         onOpenIssueTracker = { vm.openIssueTracker() },
+        onOpenAapTracker = { vm.openAapCompatibilityTracker() },
     )
 }
 
@@ -181,6 +182,7 @@ fun DeviceSettingsScreen(
     onShowPopUpOnConnectionChange: (Boolean) -> Unit = {},
     onFixMonitorMode: () -> Unit = {},
     onOpenIssueTracker: () -> Unit = {},
+    onOpenAapTracker: () -> Unit = {},
 ) {
     val device = state.device
     val features = device?.model?.features
@@ -336,7 +338,7 @@ fun DeviceSettingsScreen(
                 if (state.isClassicallyConnected) {
                     // Device is connected for audio but AAP isn't available — show passive info
                     item("aap_unavailable_info") {
-                        AapUnavailableCard()
+                        AapUnavailableCard(onOpenTracker = onOpenAapTracker)
                     }
                 } else {
                     // Device is nearby but not connected — prompt user to connect

--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModel.kt
@@ -431,6 +431,10 @@ class DeviceSettingsViewModel @Inject constructor(
         webpageTool.open("https://github.com/d4rken-org/capod/issues")
     }
 
+    fun openAapCompatibilityTracker() {
+        webpageTool.open("https://github.com/d4rken-org/capod/issues/538")
+    }
+
     companion object {
         private val TAG = logTag("DeviceSettings", "VM")
         private const val OFF_BIT = 0x01

--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/AapUnavailableCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/AapUnavailableCard.kt
@@ -9,7 +9,9 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -18,7 +20,9 @@ import eu.darken.capod.common.compose.Preview2
 import eu.darken.capod.common.compose.PreviewWrapper
 
 @Composable
-internal fun AapUnavailableCard() {
+internal fun AapUnavailableCard(
+    onOpenTracker: () -> Unit = {},
+) {
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -36,6 +40,13 @@ internal fun AapUnavailableCard() {
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(
+                onClick = onOpenTracker,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(stringResource(R.string.device_settings_aap_unavailable_action))
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,6 +469,7 @@
     <string name="device_settings_not_connected_open_settings_action">Open Bluetooth Settings</string>
     <string name="device_settings_aap_unavailable_label">Advanced settings unavailable</string>
     <string name="device_settings_aap_unavailable_description">Advanced AirPods settings require a Bluetooth feature that is not available on this phone. This may be resolved by a future Android update from your device manufacturer.</string>
+    <string name="device_settings_aap_unavailable_action">View compatibility tracker</string>
     <string name="device_settings_category_sound_label">Sound</string>
     <string name="device_settings_category_controls_label">Controls</string>
     <string name="device_settings_nc_one_airpod_label">ANC with one pod</string>


### PR DESCRIPTION
## What changed

When advanced AirPods settings aren't available because the phone's ROM is missing the L2CAP Bluetooth fix — i.e. the "Advanced settings unavailable" card on the device settings screen — users now see a new "View compatibility tracker" button. Tapping it opens #538, the community tracker where affected users can see which ROMs are known to include the fix and contribute their own report.

## Technical Context

- The card's visibility is already gated upstream: it only shows when the pod is classically connected over Bluetooth but AAP could not be established (`DeviceSettingsScreen.kt` around line 335), so this is the right audience for the link.
- Added a new `openAapCompatibilityTracker()` function on the ViewModel instead of parameterising the existing `openIssueTracker()`, so existing callers (experimental-feature note in `ReactionsCard`) aren't silently redirected if the tracker URL ever changes.
- Single new string `device_settings_aap_unavailable_action`; Crowdin will fan out the translations on the next sync.
