### PR TITLE
Device: Clearer warning when a profile has no paired device

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/compose/preview/MockPodDataProvider.kt
+++ b/app/src/main/java/eu/darken/capod/common/compose/preview/MockPodDataProvider.kt
@@ -255,6 +255,35 @@ object MockPodDataProvider {
         aap = null,
     )
 
+    /** Dual pods matched to a profile that has no paired Bluetooth device selected. */
+    fun dualPodMissingPairedDevice(): PodDevice = PodDevice(
+        profileId = "preview-dual-missing-paired",
+        ble = MockDualBlePodSnapshot(
+            _model = PodModel.AIRPODS_PRO2,
+            _label = "My AirPods Pro",
+            batteryLeftPodPercent = 0.80f,
+            batteryRightPodPercent = 0.45f,
+            _batteryCasePercent = 0.60f,
+            _isLeftPodCharging = true,
+            leftPodIcon = R.drawable.device_airpods_pro2_left,
+            rightPodIcon = R.drawable.device_airpods_pro2_right,
+            _caseIcon = R.drawable.device_airpods_pro2_case,
+        ),
+        aap = null,
+    )
+
+    /** Single pod matched to a profile that has no paired Bluetooth device selected. */
+    fun singlePodMissingPairedDevice(): PodDevice = PodDevice(
+        profileId = "preview-single-missing-paired",
+        ble = MockSingleBlePodSnapshot(
+            _model = PodModel.AIRPODS_MAX,
+            _label = "AirPods Max",
+            batteryHeadsetPercent = 0.85f,
+            _isBeingWorn = true,
+        ),
+        aap = null,
+    )
+
     /** Cached-only dual pod — device fully offline, showing last known state. */
     fun dualPodCachedOnly(): PodDevice = PodDevice(
         profileId = "preview-cached",

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.BatteryChargingFull
 import androidx.compose.material.icons.twotone.GridView
 import androidx.compose.material.icons.twotone.Tune
-import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -52,6 +51,7 @@ import eu.darken.capod.main.ui.overview.cards.components.BatteryCapsule
 import eu.darken.capod.main.ui.overview.cards.components.CompactBatterySummary
 import eu.darken.capod.main.ui.overview.cards.components.DebugSection
 import eu.darken.capod.main.ui.overview.cards.components.DeviceConnectionBadge
+import eu.darken.capod.main.ui.overview.cards.components.MissingPairedDeviceBanner
 import eu.darken.capod.main.ui.overview.cards.components.SignalIndicator
 import eu.darken.capod.main.ui.overview.cards.components.StatusChip
 import eu.darken.capod.main.ui.overview.cards.components.StatusChipRow
@@ -175,15 +175,15 @@ fun DualPodsCard(
                         )
                     }
                 }
-                if (device.profileId != null && device.address == null && onEditProfile != null) {
-                    IconButton(onClick = onEditProfile) {
-                        Icon(
-                            imageVector = Icons.TwoTone.Warning,
-                            contentDescription = stringResource(R.string.overview_card_missing_paired_device_cd),
-                            tint = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                }
+            }
+
+            if (!isCollapsed
+                && device.profileId != null
+                && !device.hasSelectedPairedDevice
+                && onEditProfile != null
+            ) {
+                Spacer(modifier = Modifier.height(12.dp))
+                MissingPairedDeviceBanner(onClick = onEditProfile)
             }
 
             if (isCollapsed) {
@@ -490,7 +490,7 @@ private fun DualPodsCardCollapsedPreview() = PreviewWrapper {
 @Composable
 private fun DualPodsCardMissingAddressPreview() = PreviewWrapper {
     DualPodsCard(
-        device = MockPodDataProvider.dualPodMonitoredMixed(),
+        device = MockPodDataProvider.dualPodMissingPairedDevice(),
         showDebug = false,
         now = SystemTimeSource.now(),
         onEditProfile = {},

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/SinglePodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/SinglePodsCard.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.BatteryChargingFull
 import androidx.compose.material.icons.twotone.Hearing
 import androidx.compose.material.icons.twotone.Tune
-import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -50,6 +49,7 @@ import eu.darken.capod.main.ui.overview.cards.components.AncModeSelector
 import eu.darken.capod.main.ui.overview.cards.components.CompactBatterySummary
 import eu.darken.capod.main.ui.overview.cards.components.DebugSection
 import eu.darken.capod.main.ui.overview.cards.components.DeviceConnectionBadge
+import eu.darken.capod.main.ui.overview.cards.components.MissingPairedDeviceBanner
 import eu.darken.capod.main.ui.overview.cards.components.SignalIndicator
 import eu.darken.capod.main.ui.overview.cards.components.StatusChip
 import eu.darken.capod.common.SystemTimeSource
@@ -157,15 +157,15 @@ fun SinglePodsCard(
                         )
                     }
                 }
-                if (device.profileId != null && device.address == null && onEditProfile != null) {
-                    IconButton(onClick = onEditProfile) {
-                        Icon(
-                            imageVector = Icons.TwoTone.Warning,
-                            contentDescription = stringResource(R.string.overview_card_missing_paired_device_cd),
-                            tint = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                }
+            }
+
+            if (!isCollapsed
+                && device.profileId != null
+                && !device.hasSelectedPairedDevice
+                && onEditProfile != null
+            ) {
+                Spacer(modifier = Modifier.height(12.dp))
+                MissingPairedDeviceBanner(onClick = onEditProfile)
             }
 
             if (isCollapsed) {
@@ -359,7 +359,7 @@ private fun SinglePodsCardCollapsedPreview() = PreviewWrapper {
 @Composable
 private fun SinglePodsCardMissingAddressPreview() = PreviewWrapper {
     SinglePodsCard(
-        device = MockPodDataProvider.singlePodMonitored(),
+        device = MockPodDataProvider.singlePodMissingPairedDevice(),
         showDebug = false,
         now = SystemTimeSource.now(),
         onEditProfile = {},

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/components/MissingPairedDeviceBanner.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/components/MissingPairedDeviceBanner.kt
@@ -1,0 +1,63 @@
+package eu.darken.capod.main.ui.overview.cards.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.Preview2
+import eu.darken.capod.common.compose.PreviewWrapper
+
+@Composable
+fun MissingPairedDeviceBanner(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        onClick = onClick,
+        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.4f),
+        shape = RoundedCornerShape(12.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {},
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .size(20.dp),
+            )
+            Text(
+                text = stringResource(R.string.overview_card_missing_paired_device),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun MissingPairedDeviceBannerPreview() = PreviewWrapper {
+    MissingPairedDeviceBanner(onClick = {})
+}

--- a/app/src/main/java/eu/darken/capod/monitor/core/PodDevice.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/PodDevice.kt
@@ -65,6 +65,13 @@ data class PodDevice(
     val model: PodModel get() = ble?.model ?: profileModel ?: cached?.model ?: PodModel.UNKNOWN
     /** Bonded BR/EDR address (from profile). Used for AAP commands. */
     val address: BluetoothAddress? get() = ble?.meta?.profile?.address ?: profileAddress ?: cached?.address
+    /**
+     * True when the matched profile has a selected paired Bluetooth device. Unlike [address],
+     * this never falls back to the cache, so a profile whose paired device was removed still
+     * reports `false` even while a stale cached address lingers.
+     */
+    val hasSelectedPairedDevice: Boolean
+        get() = (ble?.meta?.profile?.address ?: profileAddress) != null
     /** BLE scan address (RPA, rotates). */
     val bleAddress: BluetoothAddress? get() = ble?.address
     val identifier: BlePodSnapshot.Id? get() = ble?.identifier

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkel druk om mikrofoon te demp</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbel druk om oproep te beëindig</string>
     <string name="device_settings_open_cd">Maak toestel-instellings oop</string>
-    <string name="overview_card_missing_paired_device_cd">Profiel het geen gekoppelde Bluetooth-toestel nie — tik om profiel te wysig</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Mikrofoon</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ማይክሮፎኑን ለማጥፈት አንድ ጊዜ ጀን</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ጥሪን ለመጨረስ ሁለት ጊዜ ጀን</string>
     <string name="device_settings_open_cd">የመሣሪያ ቅንብሮችን ክፈት</string>
-    <string name="overview_card_missing_paired_device_cd">ፕሮፋይሉ ምንም ተጣምሮ የ Bluetooth መሳሪያ የለም — ፕሮፋይሉን ለማስተካከል መታ ያድርጉ</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">አጠቃላይ</string>
     <string name="device_settings_microphone_mode_label">ማይክሮፎን</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -480,7 +480,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ضغطة واحدة لكتم صوت الميكروفون</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ضغطة مزدوجة لإنهاء المكالمة</string>
     <string name="device_settings_open_cd">فتح إعدادات الجهاز</string>
-    <string name="overview_card_missing_paired_device_cd">الملف الشخصي لا يحتوي على جهاز بلوتوث مقترن — انقر للتعديل</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عام</string>
     <string name="device_settings_microphone_mode_label">ميكروفون</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Mikrofonu susdurmağ üçün bir dəfə basın</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Zəngi bitirmək üçün iki dəfə basın</string>
     <string name="device_settings_open_cd">Cihaz parametrlərini açın</string>
-    <string name="overview_card_missing_paired_device_cd">Profilin cütləşdirilmiş Bluetooth cihazı yoxdur — profili redaktə etmək üçün toxunun</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ümumi</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -470,7 +470,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Аднаразовы націск для адключэння мікрафона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двайны націск для завяршэння выкліку</string>
     <string name="device_settings_open_cd">Адкрыць налады прылады</string>
-    <string name="overview_card_missing_paired_device_cd">У профілі няма спалучанай прылады Bluetooth — дакраніцеся, каб рэдагаваць профіль</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Агульныя</string>
     <string name="device_settings_microphone_mode_label">Мікрафон</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Едно натискане за заглушаване на микрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двойно натискане за прекратяване на разговора</string>
     <string name="device_settings_open_cd">Отворете настройките на устройството</string>
-    <string name="overview_card_missing_paired_device_cd">Профилът няма свързано Bluetooth устройство — докоснете, за да редактирате профила</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Общи</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">মাইক্রোফোন মিউট করতে একবার চাপুন</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">কল শেষ করতে দুবার চাপুন</string>
     <string name="device_settings_open_cd">ডিভাইস সেটিংস খুলুন</string>
-    <string name="overview_card_missing_paired_device_cd">প্রোফাইলে কোনো পেয়ার করা ব্লুটুথ ডিভাইস নেই — প্রোফাইল সম্পাদনা করতে ট্যাপ করুন</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">সাধারণ</string>
     <string name="device_settings_microphone_mode_label">মাইক্রোফোন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Un sol toc per silenciar el micròfon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Doble toc per acabar la trucada</string>
     <string name="device_settings_open_cd">Obre la configuració del dispositiu</string>
-    <string name="overview_card_missing_paired_device_cd">El perfil no té cap dispositiu Bluetooth emparellat: toqueu per editar el perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micròfon</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -470,7 +470,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Jednorázový stisk pro ztlumení mikrofonu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojitý stisk pro ukončení hovoru</string>
     <string name="device_settings_open_cd">Otevřít nastavení zařízení</string>
-    <string name="overview_card_missing_paired_device_cd">Profil nemá spárované Bluetooth zařízení — klepnutím upravte profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Obecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkelt tryk for at slå mikrofon fra</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dobbelt tryk for at afslutte opkald</string>
     <string name="device_settings_open_cd">Åbn enhedsindstillinger</string>
-    <string name="overview_card_missing_paired_device_cd">Profilen har ingen parret Bluetooth-enhed — tryk for at redigere profilen</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Einmaliges Drücken zum Stummschalten des Mikrofons</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Zweimaliges Drücken zum Beenden des Anrufs</string>
     <string name="device_settings_open_cd">Geräteeinstellungen öffnen</string>
-    <string name="overview_card_missing_paired_device_cd">Profil hat kein gekoppeltes Bluetooth-Gerät — tippe zum Bearbeiten des Profils</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Allgemein</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Μία πίεση για σίγαση μικροφώνου</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Διπλή πίεση για τερματισμό κλήσης</string>
     <string name="device_settings_open_cd">Άνοιγμα ρυθμίσεων συσκευής</string>
-    <string name="overview_card_missing_paired_device_cd">Το προφίλ δεν έχει συζευγμένη συσκευή Bluetooth — πατήστε για επεξεργασία προφίλ</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Γενικά</string>
     <string name="device_settings_microphone_mode_label">Μικρόφωνο</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pulsación simple para silenciar el micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Doble pulsación para finalizar la llamada</string>
     <string name="device_settings_open_cd">Abrir configuración del dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">El perfil no tiene un dispositivo Bluetooth vinculado — tocá para editar el perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pulsación simple para silenciar el micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pulsación doble para terminar la llamada</string>
     <string name="device_settings_open_cd">Abrir ajustes del dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">El perfil no tiene un dispositivo Bluetooth vinculado — toca para editar el perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pulsación simple para silenciar el micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Doble pulsación para finalizar llamada</string>
     <string name="device_settings_open_cd">Abrir configuración del dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">El perfil no tiene ningún dispositivo Bluetooth emparejado — toca para editar el perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Ühe vajutusega vaigista mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Kahe vajutusega lõpeta kõne</string>
     <string name="device_settings_open_cd">Ava seadme seaded</string>
-    <string name="overview_card_missing_paired_device_cd">Profiilil pole seotud Bluetooth-seadet — profiili muutmiseks puuduta</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Üldine</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Sakapen bakar bat mikrofonoa mututzeko</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Bikoitz sakatu deia amaitzeko</string>
     <string name="device_settings_open_cd">Ireki gailuaren ezarpenak</string>
-    <string name="overview_card_missing_paired_device_cd">Profilek ez du parkatutako Bluetooth gailurik — sakatu profila editatzeko</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Orokorra</string>
     <string name="device_settings_microphone_mode_label">Mikrofonoa</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">یک‌بار فشار برای بی‌صدا کردن میکروفون</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">دوبار فشار برای پایان دادن تماس</string>
     <string name="device_settings_open_cd">باز کردن تنظیمات دستگاه</string>
-    <string name="overview_card_missing_paired_device_cd">پروفایل دستگاه بلوتوث جفت‌شده‌ای ندارد — برای ویرایش پروفایل ضربه بزنید</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">میکروفون</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Yksinkertainen painallus mykistää mikrofonin</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Kaksoispainallus lopettaa puhelun</string>
     <string name="device_settings_open_cd">Avaa laiteasetukset</string>
-    <string name="overview_card_missing_paired_device_cd">Profiililla ei ole liitettyä Bluetooth-laitetta – napauta muokataksesi profiilia</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Yleiset</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Isang pindutin para i-mute ang mikropono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dalawang pindutin para tapusin ang tawag</string>
     <string name="device_settings_open_cd">Buksan ang mga setting ng device</string>
-    <string name="overview_card_missing_paired_device_cd">Walang naka-pair na Bluetooth device ang profile — i-tap para i-edit ang profile</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Pangkalahatan</string>
     <string name="device_settings_microphone_mode_label">Mikropono</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Appui simple pour couper le microphone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Double appui pour terminer l’appel</string>
     <string name="device_settings_open_cd">Ouvrir les paramètres de l’appareil</string>
-    <string name="overview_card_missing_paired_device_cd">Le profil n\'a pas d\'appareil Bluetooth associé — appuyez pour modifier le profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Général</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Prema unha vez para silenciar o micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Prema dúas veces para finalizar a chamada</string>
     <string name="device_settings_open_cd">Abrir a configuración do dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">O perfil non ten ningún dispositivo Bluetooth emparellado: toca para editar o perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Xeral</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">माइक्रोफ़ोन म्यूट करने के लिए एक बार दबाएं</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कॉल समाप्त करने के लिए दो बार दबाएं</string>
     <string name="device_settings_open_cd">डिवाइस सेटिंग्स खोलें</string>
-    <string name="overview_card_missing_paired_device_cd">प्रोफ़ाइल में कोई पेयर किया हुआ ब्लूटूथ डिवाइस नहीं है — प्रोफ़ाइल संपादित करने के लिए टैप करें</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफ़ोन</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -465,7 +465,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Jedan pritisak za isključivanje mikrofona</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvostruki pritisak za završetak poziva</string>
     <string name="device_settings_open_cd">Otvori postavke uređaja</string>
-    <string name="overview_card_missing_paired_device_cd">Profil nema uparen Bluetooth uređaj — dodirnite za uređivanje profila</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Općenito</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Egyszeri nyomás a mikrofon némításához</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dupla nyomás a hívás befejezéséhez</string>
     <string name="device_settings_open_cd">Eszközbeállítások megnyitása</string>
-    <string name="overview_card_missing_paired_device_cd">A profilhoz nincs párosított Bluetooth-eszköz – koppintson a profil szerkesztéséhez</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Általános</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Մեկ սեղմում խոսափոնը անձայնեցնելու համար</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Կրկնակի սեղմում զանգը ավարտելու համար</string>
     <string name="device_settings_open_cd">Բացել սառքի կառավարումները</string>
-    <string name="overview_card_missing_paired_device_cd">Պրոֆիլն կցված Bluetooth-սարք չունի — հպեք պրոֆիլը խմբագրելու համար</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ընդհանուր</string>
     <string name="device_settings_microphone_mode_label">Խոսափող</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Tekan sekali untuk membisukan mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tekan dua kali untuk mengakhiri panggilan</string>
     <string name="device_settings_open_cd">Buka pengaturan perangkat</string>
-    <string name="overview_card_missing_paired_device_cd">Profil tidak memiliki Perangkat Bluetooth yang dipasangkan — ketuk untuk mengedit profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Eitt þrýsting til að þagga hátalara</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tvöföld þrýsting til að ljúka simátali</string>
     <string name="device_settings_open_cd">Opna tæki stillingar</string>
-    <string name="overview_card_missing_paired_device_cd">Prófíll á engan tengdan Bluetooth-tæki — ýttu til að breyta prófíl</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Álmennt</string>
     <string name="device_settings_microphone_mode_label">Hljóðnemi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Premere una volta per disattivare il microfono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Premere due volte per terminare la chiamata</string>
     <string name="device_settings_open_cd">Apri impostazioni dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">Il profilo non ha un dispositivo Bluetooth associato — tocca per modificare il profilo</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfono</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -464,7 +464,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">לחיצה אחת להשתקת מיקרופון</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">לחיצה כפולה לסיום שיחה</string>
     <string name="device_settings_open_cd">פתח הגדרות מכשיר</string>
-    <string name="overview_card_missing_paired_device_cd">לפרופיל אין מכשיר Bluetooth מצומד — הקש לעריכת הפרופיל</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">כללי</string>
     <string name="device_settings_microphone_mode_label">מיקרופון</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">シングルプレスでマイクをミュート</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ダブルプレスで通話を終了</string>
     <string name="device_settings_open_cd">デバイス設定を開く</string>
-    <string name="overview_card_missing_paired_device_cd">プロファイルにペアリング済みBluetoothデバイスがありません — タップしてプロファイルを編集</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">マイク</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ერთხელ დაჭერით მიკროფონის დადუმება</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ორჯერ დაჭერით ზარის დასრულება</string>
     <string name="device_settings_open_cd">მოწყობილობის პარამეტრების გახსნა</string>
-    <string name="overview_card_missing_paired_device_cd">პროფილს არ აქვს დაწყვილებული Bluetooth მოწყობილობა — შეეხეთ პროფილის რედაქტირებისთვის</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ზოგადი</string>
     <string name="device_settings_microphone_mode_label">მიკროფონი</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ចុចម្តងដើម្បិបិតមីក្រូហ្វូន</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ចុចពីរដងដើម្បិបញ្ចប់ការហឹល</string>
     <string name="device_settings_open_cd">បើកការកំណត់ឧបករណ៍</string>
-    <string name="overview_card_missing_paired_device_cd">គម្រោងមិនមានឧបករណ៍ Bluetooth ដែលបានភ្ជាប់គូរទេ — ចុចដើម្បីកែប្រែគម្រោង</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ជាទូទៅ</string>
     <string name="device_settings_microphone_mode_label">ไมโครโฟน</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Yek pêtin ji bo bîdengkirina mîkrofonê</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Du pêtin ji bo bidawîkirina bangê</string>
     <string name="device_settings_open_cd">Mîhengên cîhazê veke</string>
-    <string name="overview_card_missing_paired_device_cd">Profîl ti cîhazê Bluetooth-ê ya hevgirêdayî tune — ji bo guherandina profîlê bixin</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Giştî</string>
     <string name="device_settings_microphone_mode_label">Mîkrofon</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ಮೈಕ್ ಮ್ಯೂಟ್ ಮಾಡಲು ಒಂದು ಬಾರಿ ಬಗೆ ದಲ್ಲಿಸಿ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ಕರೆ ಮುಗಿಸಲು ಎರಡು ಬಾರಿ ಬಗೆ ದಲ್ಲಿಸಿ</string>
     <string name="device_settings_open_cd">ಸಾಧನ ಸೆಟ್ಟಿಂಗ್ಸ್ ತೆರೆಯಿರಿ</string>
-    <string name="overview_card_missing_paired_device_cd">ಪ್ರೊಫೈಲ್‌ಗೆ ಯಾವುದೇ ಜೋಡಿಸಲಾದ ಬ್ಲೂಟೂತ್ ಸಾಧನವಿಲ್ಲ — ಪ್ರೊಫೈಲ್ ಸಂಪಾದಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ಸಾಮಾನ್ಯ</string>
     <string name="device_settings_microphone_mode_label">ಮೈಕ್ರೊಫೋನ್</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -457,7 +457,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">한 번 눌러 마이크 음소거</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">두 번 눌러 통화 종료</string>
     <string name="device_settings_open_cd">기기 설정 열기</string>
-    <string name="overview_card_missing_paired_device_cd">프로필에 연결된 블루투스 기기가 없습니다 — 탭하여 프로필 편집</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">일반</string>
     <string name="device_settings_microphone_mode_label">마이크</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Микрофонду өчүрүү үчүн бир жолу басыңыз</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Чалууну аяктоо үчүн эки жолу басыңыз</string>
     <string name="device_settings_open_cd">Түзмөк жөндөөлөрүн ачуу</string>
-    <string name="overview_card_missing_paired_device_cd">Профилде жупташтырылган Bluetooth түзмөгү жок — профилди өзгөртүү үчүн таптап коюңуз</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Жалпы</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ກດໄວໝິ່ວໝິ່ວເພື່ອປິດເສີງໄມຂອບພາກ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ກດສອງຄັ້ງເພື່ອວາງສາຍການເຈຮາ</string>
     <string name="device_settings_open_cd">ເປີດການຕັ້ງຄ່າອຸປະກອນ</string>
-    <string name="overview_card_missing_paired_device_cd">ໂປຣໄຟລ໌ບໍ່ມີອຸປະກອນ Bluetooth ທີ່ຈັບຄູ່ — ແຕະເພື່ອແກ້ໄຂໂປຣໄຟລ໌</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ທົ່ວໄປ</string>
     <string name="device_settings_microphone_mode_label">ໄມໂຄຣໂຟນ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -470,7 +470,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Vienas paspaudimas nutildyti mikrofoną</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvigubas paspaudimas baigia skambučį</string>
     <string name="device_settings_open_cd">Atidaryti įrenginio nustatymus</string>
-    <string name="overview_card_missing_paired_device_cd">Profilis neturi susieto Bluetooth irenginio - bakstelekite, kad redaguotumete profili</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Bendrieji</string>
     <string name="device_settings_microphone_mode_label">Mikrofonas</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -465,7 +465,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Vienu reizi nospiežot, islēdz mikrofonu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Divas reizes nospiežot, beidz zvanu</string>
     <string name="device_settings_open_cd">Atvērt ierīces iestatījumus</string>
-    <string name="overview_card_missing_paired_device_cd">Profilam nav savienota Bluetooth ierīce — pieskarieties, lai rediģētu profilu</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Vispārīgi</string>
     <string name="device_settings_microphone_mode_label">Mikrofons</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Едно притискање за исклучување на микрофонот</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двојно притискање за прекинување на повикот</string>
     <string name="device_settings_open_cd">Отворете ги поставките на уредот</string>
-    <string name="overview_card_missing_paired_device_cd">Профилот нема спарен Bluetooth уред — допрете за уредување на профилот</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Генерално</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">മൈക്രോഫോൻ മ്യൂട്ട് ചെയ്യാൻ ഒറ്റ അമർത്തൽ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">കോൾ അവസാനിപ്പിക്കാൻ ഇരട്ട അമർത്തൽ</string>
     <string name="device_settings_open_cd">ഉപകരണ ക്രമീകരണങ്ങൾ തുറക്കുക</string>
-    <string name="overview_card_missing_paired_device_cd">പ്രൊഫൈലിൽ പെയർ ചെയ്ത ബ്ലൂടൂത്ത് ഉപകരണം ഇല്ല — പ്രൊഫൈൽ എഡിറ്റ് ചെയ്യാൻ ടാപ്പ് ചെയ്യുക</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">പൊതുവായ</string>
     <string name="device_settings_microphone_mode_label">മൈക്രോഫോൺ</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Микрофоныг хаахын тулд нэг дарна уу</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Дуудлага дуусгахын тулд хоёр дарна уу</string>
     <string name="device_settings_open_cd">Төхөөрөмжийн тохиргоо нээх</string>
-    <string name="overview_card_missing_paired_device_cd">Профайлд хосолсон Bluetooth төхөөрөмж байхгүй — профайл засахын тулд дарна уу</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ерөнхий</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">मायक्रोफोन म्यूट करण्यासाठी एकदा दाबा</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कॉल संपवण्यासाठी दोनदा दाबा</string>
     <string name="device_settings_open_cd">डिव्हाइस सेटिंग्ज उघडा</string>
-    <string name="overview_card_missing_paired_device_cd">प्रोफाइलमध्ये कोणतेही जोडलेले Bluetooth डिव्हाइस नाही — प्रोफाइल संपादित करण्यासाठी टॅप करा</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">मायक्रोफोन</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Tekan sekali untuk redam mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tekan dua kali untuk tamatkan panggilan</string>
     <string name="device_settings_open_cd">Buka tetapan peranti</string>
-    <string name="overview_card_missing_paired_device_cd">Profil tiada peranti Bluetooth yang dipasangkan — ketik untuk edit profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">မိုက်ခဖိသိမ်းရန် တစ်ကြိမ်နှိပ်ပါ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ဖုန်းပြတ်ရန် နှစ်ကြိမ်နှိပ်ပါ</string>
     <string name="device_settings_open_cd">ကိရိယာ ဆက်တင်များ ဖွင့်ထားပါ</string>
-    <string name="overview_card_missing_paired_device_cd">ပရိုဖိုင်တွင် Bluetooth စက်တွဲမရှိပါ — ပရိုဖိုင်တည်းဖြတ်ရန် တို့ပါ</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ယေဘူယျ</string>
     <string name="device_settings_microphone_mode_label">မိုက်ခရိုဖုန်း</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkelttrykk for å dempe mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dobbelttrykk for å avslutte samtale</string>
     <string name="device_settings_open_cd">Åpne enhetsinnstillinger</string>
-    <string name="overview_card_missing_paired_device_cd">Profilen har ingen paret Bluetooth-enhet – trykk for å redigere profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generelt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">माइक्रोफोन म्युट गर्न एकपटक थिच्नुहोस्</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कल समाप्त गर्न दुईपटक थिच्नुहोस्</string>
     <string name="device_settings_open_cd">उपकरण सेटिङहरू खोल्नुहोस्</string>
-    <string name="overview_card_missing_paired_device_cd">प्रोफाइलमा कुनै जोडिएको ब्लुटुथ उपकरण छैन — प्रोफाइल सम्पादन गर्न ट्याप गर्नुहोस्</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफोन</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Druk één keer om de microfoon te dempen</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbelklik om het gesprek te beëindigen</string>
     <string name="device_settings_open_cd">Apparaatinstellingen openen</string>
-    <string name="overview_card_missing_paired_device_cd">Er is geen Bluetooth-apparaat gekoppeld aan dit profiel — tik om het profiel te bewerken</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Microfoon</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -472,7 +472,6 @@ K4r0lSz;</string>
     <string name="device_settings_end_call_mute_mic_option_b_title">Pojedyncze naciśnięcie wycisza mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Naciśnij dwukrotnie, aby zakończyć połączenie</string>
     <string name="device_settings_open_cd">Otwórz ustawienia urządzenia</string>
-    <string name="overview_card_missing_paired_device_cd">Profil nie ma sparowanego urządzenia Bluetooth. Naciśnij, aby edytować profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ogólne</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pressionar uma vez para silenciar o microfone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pressionar duas vezes para encerrar a chamada</string>
     <string name="device_settings_open_cd">Abrir configurações do dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">O perfil não tem dispositivo Bluetooth emparelhado — toque para editar o perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Gerais</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pressão simples para silenciar microfone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pressão dupla para terminar chamada</string>
     <string name="device_settings_open_cd">Abrir definições do dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">O perfil não tem dispositivo Bluetooth emparelhado — toque para editar o perfil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Geral</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">In presser per tasar il microfon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dupel presser per terminar il clom</string>
     <string name="device_settings_open_cd">Avrir ils parameters da l\'apparat</string>
-    <string name="overview_card_missing_paired_device_cd">Il profil na ha nagin apparat Bluetooth collià — tucchettar per modifitgar il profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -465,7 +465,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Apăsare simplă pentru a dezactiva microfonul</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dublă apăsare pentru a încheia apelul</string>
     <string name="device_settings_open_cd">Deschide setările dispozitivului</string>
-    <string name="overview_card_missing_paired_device_cd">Profilul nu are niciun dispozitiv Bluetooth asociat — atinge pentru a edita profilul</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -471,7 +471,6 @@ AL_Cool_T</string>
     <string name="device_settings_end_call_mute_mic_option_b_title">Одинарное нажатие для отключения микрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двойное нажатие для завершения звонка</string>
     <string name="device_settings_open_cd">Открыть настройки устройства</string>
-    <string name="overview_card_missing_paired_device_cd">У профиля нет сопряжённого устройства Bluetooth — нажмите, чтобы изменить профиль</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Общее</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Premida sola pro mutar su micròfonu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dòpia premida pro terminare sa chiamada</string>
     <string name="device_settings_open_cd">Abri sas impostatziones de su dispositivo</string>
-    <string name="overview_card_missing_paired_device_cd">Su profilu non tenet unu dispositivu Bluetooth colligadu — toca pro modificare su profilu</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">මයික්‍රොෆෝනය නිශ්ශබ්ද කිරීමට එක් වරක් එබන්න</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ඇමතුම අවසන් කිරීමට දෙවරක් එබන්න</string>
     <string name="device_settings_open_cd">උපාංග සැකසීම් විවර්ත කරන්න</string>
-    <string name="overview_card_missing_paired_device_cd">පැතිකඩෙහි ගැලපෙන බ්ලූටූත් උපාංගයක් නැත — පැතිකඩ සංස්කරණය කිරීමට තට්ටු කරන්න</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">සාමාන්‍ය</string>
     <string name="device_settings_microphone_mode_label">ශබ්දවාහිනිය</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -470,7 +470,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Jedno stlačenie na stlmenie mikrofónu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojité stlačenie na ukončenie hovoru</string>
     <string name="device_settings_open_cd">Otvoriť nastavenia zariadenia</string>
-    <string name="overview_card_missing_paired_device_cd">Profil nemá sprárované Bluetooth zariadenie — klepnutím upravíte profil</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Všeobecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofón</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -470,7 +470,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">En pritisk za izklop mikrofona</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojni pritisk za končanje klica</string>
     <string name="device_settings_open_cd">Odpri nastavitve naprave</string>
-    <string name="overview_card_missing_paired_device_cd">Profil nima sparene naprave Bluetooth – tapnite za urejanje profila</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Splošno</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Shtypje e vetme për të hështur mikrofonin</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Shtypje e dyfishtë për të mbyllur thirrjen</string>
     <string name="device_settings_open_cd">Hap cilësimet e pajisjes</string>
-    <string name="overview_card_missing_paired_device_cd">Profili nuk ka asnjë pajisje Bluetooth të çiftëzuar — prekni për të redaktuar profilin</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Gjenerik</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -465,7 +465,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Једноструко притисак за искључивање микрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двоструко притисак за завршавање позива</string>
     <string name="device_settings_open_cd">Отворите подешавања уређаја</string>
-    <string name="overview_card_missing_paired_device_cd">Профил нема упарен Bluetooth уређај — додирните да бисте уредили профил</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Oпште</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkeltryck för att stänga av mikrofonen</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbeltryck för att avsluta samtal</string>
     <string name="device_settings_open_cd">Öppna enhetsinställningar</string>
-    <string name="overview_card_missing_paired_device_cd">Profilen har ingen ihopparad Bluetooth-enhet – tryck för att redigera profilen</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Allmänt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Bonyeza mara moja kuzima kipaza sauti</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Bonyeza mara mbili kumaliza simu</string>
     <string name="device_settings_open_cd">Fungua mipangilio ya kifaa</string>
-    <string name="overview_card_missing_paired_device_cd">Wasifu hauna kifaa cha Bluetooth kilichounganishwa — gonga ili kuhariri wasifu</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Jumla</string>
     <string name="device_settings_microphone_mode_label">Maikrofoni</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">மைக்ரோஃபோனை முடக்க ஒரே ஒரு அழுத்தம்</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">அழைப்பை முடிக்க இரண்டு முறை அழுத்தவும்</string>
     <string name="device_settings_open_cd">சாதன அமைப்புகளைத் திறக்கவும்</string>
-    <string name="overview_card_missing_paired_device_cd">சுயவிவரத்தில் இணைக்கப்பட்ட Bluetooth சாதனம் இல்லை — சுயவிவரத்தை திருத்த தட்டவும்</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">பொது</string>
     <string name="device_settings_microphone_mode_label">மைக்ரோஃபோன்</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">మైక్రోఫోన్ మ్యూట్ చేయడానికి ఒకసారి నొక్కండి</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">కాల్ ముగించడానికి రెండుసార్లు నొక్కండి</string>
     <string name="device_settings_open_cd">పరికర సెట్టింగ్‌లు తెరవండి</string>
-    <string name="overview_card_missing_paired_device_cd">ప్రొఫైల్‌కు పేర్డ్ బ్లూటూత్ పరికరం లేదు — ప్రొఫైల్ సవరించడానికి నొక్కండి</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">సాధారణ</string>
     <string name="device_settings_microphone_mode_label">మైక్రోఫోన్</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">กดครั้งเดียวเพื่อปิดเสียงไมโครโฟน</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">กดสองครั้งเพื่อวางสาย</string>
     <string name="device_settings_open_cd">เปิดการตั้งค่าอุปกรณ์</string>
-    <string name="overview_card_missing_paired_device_cd">โปรไฟล์ไม่มีอุปกรณ์ Bluetooth ที่จับคู่ไว้ — แตะเพื่อแก้ไขโปรไฟล์</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ทั่วไป</string>
     <string name="device_settings_microphone_mode_label">ไมโครโฟน</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Mikrofonu kapatıp açmak için tek basım</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Aramayı bitirmek için çift basım</string>
     <string name="device_settings_open_cd">Cihaz ayarlarını aç</string>
-    <string name="overview_card_missing_paired_device_cd">Profilin eşleştirilmiş Bluetooth cihazı yok — profili düzenlemek için dokunun</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Genel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -470,7 +470,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Одне натискання для вимкнення мікрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Подвійне натискання для завершення дзвінка</string>
     <string name="device_settings_open_cd">Відкрити налаштування пристрою</string>
-    <string name="overview_card_missing_paired_device_cd">Профіль не має спареного Bluetooth-пристрою — торкніться, щоб редагувати профіль</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Загальні</string>
     <string name="device_settings_microphone_mode_label">Мікрофон</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">مائیکروفون خاموش کرنے کے لیے ایک بار دبائیں</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">کال ختم کرنے کے لیے دو بار دبائیں</string>
     <string name="device_settings_open_cd">ڈیوائس کی ترتیبات کھولیں</string>
-    <string name="overview_card_missing_paired_device_cd">پروفائل میں کوئی جوڑا ہوا بلوٹوتھ ڈیوائس نہیں — پروفائل ترمیم کرنے کے لیے ٹیپ کریں</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">مائیکروفون</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Mikrofonni o\'chirish uchun bir marta bosing</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Qo\'ng\'iroqni tugatish uchun ikki marta bosing</string>
     <string name="device_settings_open_cd">Qurilma sozlamalarini ochish</string>
-    <string name="overview_card_missing_paired_device_cd">Profilda juftlashtirilgan Bluetooth qurilmasi yo\'q — profilni tahrirlash uchun bosing</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umumiy</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Nhấn một lần để tắt tiếng micro</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Nhấn hai lần để kết thúc cuộc gọi</string>
     <string name="device_settings_open_cd">Mở cài đặt thiết bị</string>
-    <string name="overview_card_missing_paired_device_cd">Hồ sơ không có thiết bị Bluetooth được ghép nối — nhấn để chỉnh sửa hồ sơ</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Chung</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">单按静音麦克风</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">双按结束通话</string>
     <string name="device_settings_open_cd">打开设备设置</string>
-    <string name="overview_card_missing_paired_device_cd">配置文件没有已配对的蓝牙设备 — 点击以编辑配置文件</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">常规</string>
     <string name="device_settings_microphone_mode_label">麦克风</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">單擊靜音麥克風</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">雙擊結束通話</string>
     <string name="device_settings_open_cd">開啟裝置設定</string>
-    <string name="overview_card_missing_paired_device_cd">配置檔案沒有配對的藍牙裝置——點按以編輯配置檔案</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -455,7 +455,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">單擊靖音麥克風</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">雙擊結束通話</string>
     <string name="device_settings_open_cd">開啟裝置設定</string>
-    <string name="overview_card_missing_paired_device_cd">設定檔沒有已配對的藍牙裝置——點按以編輯設定檔</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -460,7 +460,6 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Cindezela kanye ukuvimba umsindo wekhadi</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Cindezela kabili ukuqeda ikholi</string>
     <string name="device_settings_open_cd">Vula izilungiselelo zedivayisi</string>
-    <string name="overview_card_missing_paired_device_cd">Iphrofayili ayinayo idivayisi ye-Bluetooth ebhanjiwe — thepha ukulungisa iphrofayili</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Okujwayelekile</string>
     <string name="device_settings_microphone_mode_label">Imakrofoni</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,7 +506,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Single press to mute microphone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Double press to end call</string>
     <string name="device_settings_open_cd">Open device settings</string>
-    <string name="overview_card_missing_paired_device_cd">Profile has no paired Bluetooth device — tap to edit profile</string>
+    <string name="overview_card_missing_paired_device">This profile has no paired Bluetooth device.</string>
 
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>


### PR DESCRIPTION
## What changed

The overview device card used to show a red warning triangle in the corner when a profile had no paired Bluetooth device selected. The icon didn't explain what was wrong, and tapping it dropped users into the profile edit screen with no context.

It's now replaced with a softer inline banner between the card header and the battery summary that spells out the problem in plain text. Tapping it still opens the profile to select a paired device. The banner only appears when the card is expanded, so collapsed rows stay compact.

Also fixes a case where the warning would never show at all: after unpairing a device from its profile, a lingering cached address used to hide the old triangle. The new banner is gated on profile data only, so it shows up whenever the profile really has no paired device.

## Technical Context

- New `PodDevice.hasSelectedPairedDevice` reads only `ble.meta.profile.address` / `profileAddress` — never the cache fallback that `PodDevice.address` uses. That closes the post-unpair hole where the cached address kept the triangle hidden.
- `MissingPairedDeviceBanner` is its own composable rather than reusing `SettingsInfoBox` because the shared component has hardcoded outer padding that fights the card's column padding and no whole-surface `onClick`.
- The existing `SinglePodsCardMissingAddressPreview` / `DualPodsCardMissingAddressPreview` were never actually rendering the warning branch — the mocks carried hardcoded addresses. Added `singlePodMissingPairedDevice()` / `dualPodMissingPairedDevice()` fixtures so the previews now exercise the real path.
- Translation for the old `overview_card_missing_paired_device_cd` key was deleted from all 76 locale files to avoid `ExtraTranslation` lint warnings on `beta`/`release` builds. The new key will land in non-English locales on the next Crowdin sync.
