### PR TITLE
Device: Document AAP Set Band Edges as RF band gating

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngine.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngine.kt
@@ -590,7 +590,7 @@ internal class AapSessionEngine(
             AapMessageType.UARP_DATA.value,                     // 0x004F
             AapMessageType.UNKNOWN_0X50.value,                  // 0x0050
             AapMessageType.SOURCE_CONTEXT.value,                // 0x0052
-            AapMessageType.SET_BAND_EDGES.value,                // 0x0054 (neighbouring opcode; distinct from 0x53 PmeConfig/hearing-aid which CAPod decodes)
+            AapMessageType.SET_BAND_EDGES.value,                // 0x0054 RF band gating (push-only; see AapMessageType kdoc)
             AapMessageType.UNKNOWN_0X55.value,                  // 0x0055
             AapMessageType.SLEEP_DETECTION_UPDATE.value,        // 0x0057
             AapMessageType.UNKNOWN_0X58.value,                  // 0x0058

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/AapMessageType.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/AapMessageType.kt
@@ -98,6 +98,16 @@ enum class AapMessageType(val value: Int, val wiresharkName: String) {
      */
     PME_CONFIG(0x0053, "PME Config"),
 
+    /**
+     * Configures the AirPods radio's allowed RF bands. AirPods Pro 2 USB-C
+     * and newer can transmit on 5 GHz / 6 GHz U-NII bands in addition to
+     * 2.4 GHz ISM — Apple uses this for the proprietary lossless audio mode
+     * with Apple Vision Pro. The "type" field is a band code from Apple's
+     * `BSM_BAND_CODE_*` enum (0x0 = ISM24, 0x1/0x2/0x3 = U-NII-1/3/4,
+     * 0x4–0x7 = U-NII-5A/B/C/D, 0x8 = INVALID; identified via FCC firmware
+     * analysis). "Set Band Edges" is the label the Wireshark AAP dissector
+     * uses for this opcode. CAPod observes but does not decode the payload.
+     */
     SET_BAND_EDGES(0x0054, "Set Band Edges"),
     UNKNOWN_0X55(0x0055, "Unknown"),
     USB_SPATIAL_SENSOR_DATA_REQUEST(0x0056, "USB Spatial Sensor Data Request"),


### PR DESCRIPTION
## What changed

No user-facing behavior change. Internal documentation update: comments in AAP protocol code now describe message type `0x0054` ("Set Band Edges") as configuring the AirPods radio's allowed RF bands — not the EQ-related guess that was inherited from the earlier "Personal Mixing Engine" reading of the neighbouring `0x0053` message.

## Technical Context

- Affirmative source: a PR #544 follow-up comment from an external contributor pointed out that `0x0054` gates radio frequency bands. AirPods Pro 2 USB-C and newer can transmit on 5 GHz / 6 GHz U-NII bands in addition to 2.4 GHz ISM — Apple uses this for the proprietary lossless audio mode with Apple Vision Pro.
- The "type" field is a band code from Apple's `BSM_BAND_CODE_*` enum (identified via FCC firmware analysis): `0x0 = ISM24`, `0x1 = U-NII-1`, `0x2 = U-NII-3`, `0x3 = U-NII-4`, `0x4–0x7 = U-NII-5A/B/C/D`, `0x8 = INVALID`.
- Scope is deliberately comments-only — no new `AapCommand.SetBandEdges(...)` subclass, no payload decoder. CAPod still observes-but-does-not-decode this opcode; adding structure now would be premature without sample captures.
- The inline comment in `AapSessionEngine` no longer carries the "neighbouring opcode" framing, since the kdoc on `AapMessageType` now carries the full story.

Refs #544.
