### PR TITLE
General: Reduce debug log noise during normal operation

### DIFF
--- a/app/src/main/java/eu/darken/capod/App.kt
+++ b/app/src/main/java/eu/darken/capod/App.kt
@@ -10,6 +10,7 @@ import eu.darken.capod.common.debug.logging.LogCatLogger
 import eu.darken.capod.common.debug.logging.Logging
 import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
@@ -17,14 +18,18 @@ import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.ui.widget.WidgetManager
 import eu.darken.capod.monitor.core.DeviceMonitor
+import eu.darken.capod.monitor.core.PodDevice
 
 import eu.darken.capod.monitor.core.devicesWithProfiles
 
+import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.system.exitProcess
@@ -63,10 +68,10 @@ open class App : Application() {
         appScope.launch { widgetManager.refreshWidgets() }
 
         deviceMonitor.devicesWithProfiles()
-            .distinctUntilChanged()
+            .distinctUntilChangedBy { devices -> devices.map { it.toWidgetKey() } }
             .throttleLatest(1000)
             .onEach {
-                log(TAG) { "Main device changed, refreshing widgets." }
+                log(TAG, VERBOSE) { "Devices changed, refreshing widgets." }
                 widgetManager.refreshWidgets()
             }
             .launchIn(appScope)
@@ -94,3 +99,33 @@ open class App : Application() {
         }
     }
 }
+
+private data class WidgetDeviceKey(
+    val profileId: String?,
+    val model: PodModel,
+    val batteryLeft: Float?,
+    val batteryRight: Float?,
+    val batteryCase: Float?,
+    val batteryHeadset: Float?,
+    val isLeftPodCharging: Boolean?,
+    val isRightPodCharging: Boolean?,
+    val isCaseCharging: Boolean?,
+    val isHeadsetBeingCharged: Boolean?,
+    val ancMode: AapSetting.AncMode.Value?,
+    val pendingAncMode: AapSetting.AncMode.Value?,
+)
+
+private fun PodDevice.toWidgetKey(): WidgetDeviceKey = WidgetDeviceKey(
+    profileId = profileId,
+    model = model,
+    batteryLeft = batteryLeft,
+    batteryRight = batteryRight,
+    batteryCase = batteryCase,
+    batteryHeadset = batteryHeadset,
+    isLeftPodCharging = isLeftPodCharging,
+    isRightPodCharging = isRightPodCharging,
+    isCaseCharging = isCaseCharging,
+    isHeadsetBeingCharged = isHeadsetBeingCharged,
+    ancMode = ancMode?.current,
+    pendingAncMode = pendingAncMode,
+)

--- a/app/src/main/java/eu/darken/capod/App.kt
+++ b/app/src/main/java/eu/darken/capod/App.kt
@@ -17,13 +17,11 @@ import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.ui.widget.WidgetManager
+import eu.darken.capod.main.ui.widget.toWidgetKey
 import eu.darken.capod.monitor.core.DeviceMonitor
-import eu.darken.capod.monitor.core.PodDevice
 
 import eu.darken.capod.monitor.core.devicesWithProfiles
 
-import eu.darken.capod.pods.core.apple.PodModel
-import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.launchIn
@@ -99,33 +97,3 @@ open class App : Application() {
         }
     }
 }
-
-private data class WidgetDeviceKey(
-    val profileId: String?,
-    val model: PodModel,
-    val batteryLeft: Float?,
-    val batteryRight: Float?,
-    val batteryCase: Float?,
-    val batteryHeadset: Float?,
-    val isLeftPodCharging: Boolean?,
-    val isRightPodCharging: Boolean?,
-    val isCaseCharging: Boolean?,
-    val isHeadsetBeingCharged: Boolean?,
-    val ancMode: AapSetting.AncMode.Value?,
-    val pendingAncMode: AapSetting.AncMode.Value?,
-)
-
-private fun PodDevice.toWidgetKey(): WidgetDeviceKey = WidgetDeviceKey(
-    profileId = profileId,
-    model = model,
-    batteryLeft = batteryLeft,
-    batteryRight = batteryRight,
-    batteryCase = batteryCase,
-    batteryHeadset = batteryHeadset,
-    isLeftPodCharging = isLeftPodCharging,
-    isRightPodCharging = isRightPodCharging,
-    isCaseCharging = isCaseCharging,
-    isHeadsetBeingCharged = isHeadsetBeingCharged,
-    ancMode = ancMode?.current,
-    pendingAncMode = pendingAncMode,
-)

--- a/app/src/main/java/eu/darken/capod/common/flow/FlowExtensions.kt
+++ b/app/src/main/java/eu/darken/capod/common/flow/FlowExtensions.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.shareIn
@@ -54,7 +53,6 @@ fun <T> Flow<T>.takeUntilAfter(predicate: suspend (T) -> Boolean) = transformWhi
 
 fun <T> Flow<T>.setupCommonEventHandlers(tag: String, identifier: () -> String) = this
     .onStart { log(tag, VERBOSE) { "${identifier()}.onStart()" } }
-    .onEach { log(tag, VERBOSE) { "${identifier()}.onEach(): $it" } }
     .onCompletion { log(tag, VERBOSE) { "${identifier()}.onCompletion()" } }
     .catch {
         if (it.hasCause(CancellationException::class)) {

--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetDeviceKey.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetDeviceKey.kt
@@ -1,0 +1,40 @@
+package eu.darken.capod.main.ui.widget
+
+import eu.darken.capod.monitor.core.PodDevice
+import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
+
+/**
+ * Snapshot of the [PodDevice] fields that affect widget rendering. Used to
+ * gate widget refreshes so RSSI / reliability / scan-counter churn doesn't
+ * cause a refresh on every BLE advertisement.
+ */
+internal data class WidgetDeviceKey(
+    val profileId: String?,
+    val model: PodModel,
+    val batteryLeft: Float?,
+    val batteryRight: Float?,
+    val batteryCase: Float?,
+    val batteryHeadset: Float?,
+    val isLeftPodCharging: Boolean?,
+    val isRightPodCharging: Boolean?,
+    val isCaseCharging: Boolean?,
+    val isHeadsetBeingCharged: Boolean?,
+    val ancMode: AapSetting.AncMode.Value?,
+    val pendingAncMode: AapSetting.AncMode.Value?,
+)
+
+internal fun PodDevice.toWidgetKey(): WidgetDeviceKey = WidgetDeviceKey(
+    profileId = profileId,
+    model = model,
+    batteryLeft = batteryLeft,
+    batteryRight = batteryRight,
+    batteryCase = batteryCase,
+    batteryHeadset = batteryHeadset,
+    isLeftPodCharging = isLeftPodCharging,
+    isRightPodCharging = isRightPodCharging,
+    isCaseCharging = isCaseCharging,
+    isHeadsetBeingCharged = isHeadsetBeingCharged,
+    ancMode = ancMode?.current,
+    pendingAncMode = pendingAncMode,
+)

--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetManager.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetManager.kt
@@ -3,9 +3,6 @@ package eu.darken.capod.main.ui.widget
 import android.content.Context
 import androidx.glance.appwidget.updateAll
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
-import eu.darken.capod.common.debug.logging.log
-import eu.darken.capod.common.debug.logging.logTag
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,12 +13,7 @@ class WidgetManager @Inject constructor(
 ) {
 
     suspend fun refreshWidgets() {
-        log(TAG, VERBOSE) { "refreshWidgets()" }
         BatteryGlanceWidget().updateAll(context)
         AncGlanceWidget().updateAll(context)
-    }
-
-    companion object {
-        val TAG = logTag("Widget", "Manager")
     }
 }

--- a/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetSettings.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/widget/WidgetSettings.kt
@@ -36,12 +36,8 @@ class WidgetSettings @Inject constructor(
         }
     }
 
-    fun getWidgetProfile(widgetId: Int): ProfileId? {
-        val profileId = runBlocking {
-            dataStore.data.first()[stringPreferencesKey(getWidgetProfileKey(widgetId))]
-        }
-        log(TAG, VERBOSE) { "getWidgetProfile(widgetId=$widgetId) = $profileId" }
-        return profileId
+    fun getWidgetProfile(widgetId: Int): ProfileId? = runBlocking {
+        dataStore.data.first()[stringPreferencesKey(getWidgetProfileKey(widgetId))]
     }
 
     fun removeWidget(widgetId: Int) {

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -11,6 +11,7 @@ import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.capod.common.bluetooth.BluetoothAddress
 import eu.darken.capod.common.bluetooth.BluetoothDevice2
 import eu.darken.capod.common.bluetooth.BluetoothManager2
 import eu.darken.capod.common.coroutine.DispatcherProvider
@@ -35,6 +36,7 @@ import eu.darken.capod.monitor.core.primaryDevice
 import eu.darken.capod.monitor.ui.MonitorNotifications
 import eu.darken.capod.pods.core.apple.PodModel
 import eu.darken.capod.pods.core.apple.aap.AapConnectionManager
+import eu.darken.capod.pods.core.apple.aap.AapPodState
 import eu.darken.capod.profiles.core.DeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfilesRepo
 import eu.darken.capod.reaction.core.autoconnect.AutoConnect
@@ -49,6 +51,7 @@ import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -225,31 +228,19 @@ class MonitorService : Service() {
                         profilesRepo.profiles,
                         bluetoothManager.connectedDevices,
                         aapConnectionManager.allStates,
-                    ) { monitorMode, profiles, connectedDevices, aapStates ->
-                        listOf(monitorMode, profiles, connectedDevices, aapStates)
+                    ) { mode, profiles, devices, aapStates ->
+                        buildMonitorModeState(mode, profiles, devices, aapStates)
                     }
                 }
             }
+            .distinctUntilChanged()
             .setupCommonEventHandlers(TAG) { "MonitorMode" }
-            .flatMapLatest { arguments ->
-                val monitorMode = arguments[0] as MonitorMode
+            .flatMapLatest { state ->
+                log(TAG) { "Monitor mode: ${state.mode}" }
+                log(TAG) { "connectedAddresses: ${state.connectedAddresses}" }
+                log(TAG) { "knownAddresses: ${state.knownAddresses}" }
 
-                @Suppress("UNCHECKED_CAST")
-                val profiles = arguments[1] as List<DeviceProfile>
-
-                @Suppress("UNCHECKED_CAST")
-                val devices = arguments[2] as Collection<BluetoothDevice2>
-
-                @Suppress("UNCHECKED_CAST")
-                val aapStates = arguments[3] as Map<*, *>
-
-                val connectedAddresses = devices.map { it.address }.toSet()
-                val knownAddresses = profiles.mapNotNull { it.address }.toSet()
-                log(TAG) { "Monitor mode: $monitorMode" }
-                log(TAG) { "connectedAddresses: $connectedAddresses" }
-                log(TAG) { "knownAddresses: $knownAddresses" }
-
-                when (monitorMode) {
+                when (state.mode) {
                     MonitorMode.MANUAL -> flow<Unit> {
                         monitorScope.coroutineContext.cancelChildren()
                     }
@@ -257,11 +248,11 @@ class MonitorService : Service() {
                     MonitorMode.ALWAYS -> emptyFlow()
                     MonitorMode.AUTOMATIC -> flow {
                         when {
-                            profiles.isEmpty() && devices.isNotEmpty() -> {
+                            !state.hasProfiles && state.connectedAddresses.isNotEmpty() -> {
                                 log(TAG, WARN) { "Main device address not set, staying alive while any is connected" }
                             }
 
-                            knownAddresses.any { it in connectedAddresses } || aapStates.isNotEmpty() -> {
+                            state.knownAddresses.any { it in state.connectedAddresses } || state.hasAapSession -> {
                                 log(TAG) { "A device is connected, aborting any timeout." }
                             }
 
@@ -346,6 +337,27 @@ class MonitorService : Service() {
         }
     }
 }
+
+internal data class MonitorModeState(
+    val mode: MonitorMode,
+    val hasProfiles: Boolean,
+    val knownAddresses: Set<BluetoothAddress>,
+    val connectedAddresses: Set<BluetoothAddress>,
+    val hasAapSession: Boolean,
+)
+
+internal fun buildMonitorModeState(
+    mode: MonitorMode,
+    profiles: List<DeviceProfile>,
+    devices: Collection<BluetoothDevice2>,
+    aapStates: Map<BluetoothAddress, AapPodState>,
+): MonitorModeState = MonitorModeState(
+    mode = mode,
+    hasProfiles = profiles.isNotEmpty(),
+    knownAddresses = profiles.mapNotNull { it.address }.toSet(),
+    connectedAddresses = devices.map { it.address }.toSet(),
+    hasAapSession = aapStates.isNotEmpty(),
+)
 
 private data class NotificationDeviceKey(
     val profileId: String?,

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/AppleFactory.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/AppleFactory.kt
@@ -2,6 +2,7 @@ package eu.darken.capod.pods.core.apple.ble
 
 import eu.darken.capod.common.bluetooth.BleScanResult
 import eu.darken.capod.common.bluetooth.logSummary
+import eu.darken.capod.common.bluetooth.redactedForLogs
 import eu.darken.capod.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
@@ -119,7 +120,7 @@ class AppleFactory @Inject constructor(
             }
         }
 
-        factory.create(
+        val device = factory.create(
             scanResult = scanResult,
             payload = payload,
             meta = ApplePods.AppleMeta(
@@ -127,6 +128,18 @@ class AppleFactory @Inject constructor(
                 profile = profile,
             ),
         )
+
+        log(TAG, DEBUG) {
+            val rawHex = scanResult.manufacturerSpecificData.entries.joinToString("; ") { (id, bytes) ->
+                "$id:${bytes.joinToString(" ") { "%02X".format(it.toInt() and 0xFF) }}"
+            }
+            val publicHex = payload.public.data.joinToString(" ") { "%02X".format(it.toInt()) }
+            val privateHex = payload.private?.data?.joinToString(" ") { "%02X".format(it.toInt()) } ?: "-"
+            "Apple decoded: model=${device.model}, addr=${scanResult.address.redactedForLogs()}, " +
+                "irkMatch=$isIrkMatch, raw=[$rawHex], public=[$publicHex], private=[$privateHex]"
+        }
+
+        device
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/PodFactory.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/PodFactory.kt
@@ -3,7 +3,6 @@ package eu.darken.capod.pods.core.apple.ble
 import dagger.Reusable
 import eu.darken.capod.common.bluetooth.BleScanResult
 import eu.darken.capod.common.bluetooth.logSummary
-import eu.darken.capod.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
@@ -26,7 +25,7 @@ class PodFactory @Inject constructor(
             device = unknownFactory.create(scanResult)
         }
 
-        log(TAG, DEBUG) { "Pod created: ${device.logSummary()}" }
+        log(TAG, VERBOSE) { "Pod created: ${device.logSummary()}" }
         return Result(scanResult = scanResult, device = device)
     }
 

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/protocol/ProximityMessage.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/protocol/ProximityMessage.kt
@@ -37,14 +37,14 @@ data class ProximityMessage(
                 log(
                     TAG,
                     Logging.Priority.ERROR
-                ) { "Failed to decrypt $message with ${key.toByteString()}\n${e.asLog()}" }
+                ) { "Failed to decrypt $message\n${e.asLog()}" }
                 null
             }
 
             log(
                 TAG,
                 Logging.Priority.VERBOSE
-            ) { "Decrypted $message with ${key.toByteString()} to ${decryptedData?.toByteString()}" }
+            ) { "Decrypted $message to ${decryptedData?.toByteString()}" }
 
             if (decryptedData == null || decryptedData.size != 16) return null
 

--- a/app/src/main/java/eu/darken/capod/profiles/core/AppleDeviceProfile.kt
+++ b/app/src/main/java/eu/darken/capod/profiles/core/AppleDeviceProfile.kt
@@ -55,4 +55,19 @@ data class AppleDeviceProfile(
             showPopUpOnCaseOpen = showPopUpOnCaseOpen,
             showPopUpOnConnection = showPopUpOnConnection,
         )
+
+    override fun toString(): String = "AppleDeviceProfile(" +
+        "id=$id, label=$label, priority=$priority, model=$model, " +
+        "minimumSignalQuality=$minimumSignalQuality, " +
+        "identityKey=${if (identityKey == null) "null" else "<redacted>"}, " +
+        "encryptionKey=${if (encryptionKey == null) "null" else "<redacted>"}, " +
+        "address=$address, autoPause=$autoPause, autoPlay=$autoPlay, " +
+        "onePodMode=$onePodMode, autoConnect=$autoConnect, " +
+        "autoConnectCondition=$autoConnectCondition, " +
+        "showPopUpOnCaseOpen=$showPopUpOnCaseOpen, " +
+        "showPopUpOnConnection=$showPopUpOnConnection, " +
+        "learnedAllowOffEnabled=$learnedAllowOffEnabled, " +
+        "lastRequestedListeningModeCycleMask=$lastRequestedListeningModeCycleMask, " +
+        "stemActions=$stemActions" +
+        ")"
 }

--- a/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorModeStateTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorModeStateTest.kt
@@ -1,0 +1,181 @@
+package eu.darken.capod.monitor.core.worker
+
+import eu.darken.capod.common.bluetooth.BluetoothAddress
+import eu.darken.capod.common.bluetooth.BluetoothDevice2
+import eu.darken.capod.main.core.MonitorMode
+import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.aap.AapPodState
+import eu.darken.capod.profiles.core.AppleDeviceProfile
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class MonitorModeStateTest : BaseTest() {
+
+    private val addressA: BluetoothAddress = "AA:BB:CC:DD:EE:01"
+    private val addressB: BluetoothAddress = "AA:BB:CC:DD:EE:02"
+
+    private val profileA = AppleDeviceProfile(
+        label = "AirPods A",
+        model = PodModel.AIRPODS_PRO2_USBC,
+        address = addressA,
+    )
+    private val profileB = AppleDeviceProfile(
+        label = "AirPods B",
+        model = PodModel.AIRPODS_PRO2_USBC,
+        address = addressB,
+    )
+    private val noAddressProfile = AppleDeviceProfile(
+        label = "Profile no address",
+        model = PodModel.AIRPODS_PRO2_USBC,
+        address = null,
+    )
+
+    private val aapStateA = AapPodState(
+        connectionState = AapPodState.ConnectionState.READY,
+        lastMessageAt = Instant.parse("2026-04-25T12:00:00Z"),
+    )
+
+    private fun mockDevice(addr: BluetoothAddress): BluetoothDevice2 = mockk {
+        every { address } returns addr
+    }
+
+    @Test
+    fun `empty profiles - hasProfiles false and addresses empty`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = emptyList(),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        state.hasProfiles shouldBe false
+        state.knownAddresses shouldBe emptySet()
+        state.connectedAddresses shouldBe emptySet()
+        state.hasAapSession shouldBe false
+        state.mode shouldBe MonitorMode.AUTOMATIC
+    }
+
+    @Test
+    fun `profile with valid address - hasProfiles true and address present`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(profileA),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        state.hasProfiles shouldBe true
+        state.knownAddresses shouldBe setOf(addressA)
+    }
+
+    @Test
+    fun `profile with null address - hasProfiles true but knownAddresses empty`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(noAddressProfile),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        state.hasProfiles shouldBe true
+        state.knownAddresses shouldBe emptySet()
+    }
+
+    @Test
+    fun `mixed profiles - hasProfiles true and only addressed profile contributes`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(profileA, noAddressProfile),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        state.hasProfiles shouldBe true
+        state.knownAddresses shouldBe setOf(addressA)
+    }
+
+    @Test
+    fun `connectedDevices addresses derived from BluetoothDevice2 address`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = emptyList(),
+            devices = listOf(mockDevice(addressA), mockDevice(addressB)),
+            aapStates = emptyMap(),
+        )
+        state.connectedAddresses shouldBe setOf(addressA, addressB)
+    }
+
+    @Test
+    fun `aapStates non-empty - hasAapSession true`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = emptyList(),
+            devices = emptyList(),
+            aapStates = mapOf(addressA to aapStateA),
+        )
+        state.hasAapSession shouldBe true
+    }
+
+    @Test
+    fun `aapStates empty - hasAapSession false`() {
+        val state = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = emptyList(),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        state.hasAapSession shouldBe false
+    }
+
+    @Test
+    fun `equal inputs produce equal states - data class equality enables distinctUntilChanged`() {
+        val first = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(profileA, profileB),
+            devices = listOf(mockDevice(addressA)),
+            aapStates = mapOf(addressA to aapStateA),
+        )
+        val second = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(profileA, profileB),
+            devices = listOf(mockDevice(addressA)),
+            aapStates = mapOf(addressA to aapStateA),
+        )
+        first shouldBe second
+    }
+
+    @Test
+    fun `reordered profile list with same addresses produces equal knownAddresses`() {
+        val first = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(profileA, profileB),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        val second = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = listOf(profileB, profileA),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        first.knownAddresses shouldBe second.knownAddresses
+        first shouldBe second
+    }
+
+    @Test
+    fun `mode change produces unequal states`() {
+        val auto = buildMonitorModeState(
+            mode = MonitorMode.AUTOMATIC,
+            profiles = emptyList(),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        val manual = buildMonitorModeState(
+            mode = MonitorMode.MANUAL,
+            profiles = emptyList(),
+            devices = emptyList(),
+            aapStates = emptyMap(),
+        )
+        (auto == manual) shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

Reduces debug log volume during normal operation and stops two paths from leaking AirPods pairing secrets into logs.

No user-facing functional change. The behavioral changes are all in what gets written to logcat / the support-bundle file logger.

## Technical Context

- **Privacy: encryption keys no longer logged.** `AppleDeviceProfile`'s auto-generated `toString` embedded the IRK and the proximity-payload AES key as raw byte arrays. Any `PodDevice.toString()` (logged from numerous flow observers) cascaded those into logs and into support bundles. Overrode `AppleDeviceProfile.toString` to redact the two key fields. Same issue in `ProximityMessage.Decrypter` — both its success and failure logs printed the encryption key as a hex string per-advertisement. Stripped the key from those two log strings.
- **Volume: per-emission flow logger removed.** `setupCommonEventHandlers` (used by 25+ flow chains) wrapped every emission with `.onEach { log("$identifier.onEach(): $it") }`. For chains emitting `PodDevice` (BlePodMonitor, popUpCase) this dumped 4–5 KB of nested `toString` per advertisement. Removed the per-emission line; `onStart` / `onCompletion` / cancellation / error logging stays. Call sites that genuinely need per-emission visibility can add an inline `.onEach { log… }` with whatever content makes sense for that flow.
- **Volume: MonitorService state block re-evaluated on every upstream emission.** Now keyed on a typed `MonitorModeState` snapshot (mode, address sets, profile/AAP-session presence) and gated by `distinctUntilChanged`. `hasProfiles` is carried separately because an empty profile list and a list of profiles with `address == null` would otherwise both produce an empty address set despite taking different downstream branches.
- **Volume: PodFactory "Pod created" downgraded to VERBOSE.** Fires per BLE advertisement (multiple per second per nearby device); only RSSI / reliability change between adjacent emissions.
- **Redundancy: dropped two paired noise logs.** `WidgetManager.refreshWidgets()` is always preceded by an explanatory log at the call site (App.kt's "Main device changed" / "Pro status changed"); the inner log was pure echo. `WidgetSettings.getWidgetProfile()` logged on every read of an unchanged value — pure getter spam.
- **AAP `Setting: X = Y [was: Y]` re-emission noise** was considered and deliberately not gated: the AAP engine optimistically updates state when the app sends a setting command, so a naive `value == previous` downgrade would also silence the device's confirmation of user-initiated changes. Per project memory, AAP protocol data must stay logged anyway.
- **`LogCatLogger` and `FileLogger` write every priority.** Level downgrades only help logcat viewers that filter by level — they do NOT shrink the support-bundle file logs. Only the `distinctUntilChanged` gate and the removed per-emission log actually shrink file-log volume.
- **Test coverage:** `MonitorService` and `PodFactory` had no direct unit tests. Extracted the new `MonitorModeState` derivation into a pure `buildMonitorModeState` and added `MonitorModeStateTest` covering the empty / null-address / mixed profile cases, address derivation from `BluetoothDevice2`, AAP session flag, and data-class equality (the property `distinctUntilChanged` relies on).
