### PR TITLE
General: Update app translations

### DIFF
--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Agtergrond-deursigtigheid</string>
     <string name="widget_config_show_device_label">Wys toestelnaam</string>
     <string name="widget_config_reset_label">Stel terug na standaarde</string>
+    <string name="widget_config_preview_resize_hint">U kan die widget vergroot of verklein nadat u dit op u tuisskerm geplaas het.</string>
     <string name="widget_config_custom_label">Aangepas</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Donker</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Dit is \'n onbekende toestel, maar dit gebruik \'n soortgelyke boodskapformaat. Kom ons voeg ondersteuning daarvoor by, kontak my :)</string>
     <string name="pods_none_label_short">Geen toestel</string>
     <string name="pods_charging_label">Laai</string>
+    <string name="pods_charging_optimized_label">Geoptimaliseer</string>
     <string name="pods_inear_label">In oor</string>
     <string name="pods_microphone_label">Mikrofoon</string>
     <string name="anc_mode_off">Af</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-toestelaanduiding</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Vervaardiger</string>
+    <string name="device_settings_info_hardware_label">Hardeware</string>
     <string name="device_settings_info_serial_label">Serienommer</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Hangende Firmware</string>
     <string name="device_settings_info_build_label">Bou</string>
     <string name="device_settings_info_left_serial_label">Linker Pod Serienommer</string>
     <string name="device_settings_info_right_serial_label">Regter Pod Serienommer</string>
+    <string name="device_settings_info_left_bonded_label">Links Gekoppel</string>
+    <string name="device_settings_info_right_bonded_label">Regs Gekoppel</string>
     <string name="device_settings_info_details_label">Toestelbesonderhede</string>
     <string name="device_settings_info_details_action">Wys toestelbesonderhede</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Hierdie toestel is naby maar nie aan hierdie foon gekoppel nie. Koppel om toegang tot instellings en beheer te verkry.</string>
     <string name="device_settings_not_connected_connect_action">Koppel</string>
     <string name="device_settings_not_connected_open_settings_action">Maak Bluetooth-instellings oop</string>
+    <string name="device_settings_not_nearby_label">Toestel nie naby nie</string>
+    <string name="device_settings_not_nearby_description">Instellings is slegs beskikbaar wanneer hierdie toestel naby is en aan jou foon gekoppel is.</string>
     <string name="device_settings_aap_unavailable_label">Gevorderde instellings nie beskikbaar nie</string>
     <string name="device_settings_aap_unavailable_description">Gevorderde AirPods-instellings vereis \'n Bluetooth-kenmerk wat nie op hierdie foon beskikbaar is nie. Dit kan deur \'n toekomstige Android-opdatering van jou toestelvervaardiger opgelos word.</string>
+    <string name="device_settings_aap_unavailable_action">Bekyk verenigbaarheidsnaspeurder</string>
     <string name="device_settings_category_sound_label">Klank</string>
     <string name="device_settings_category_controls_label">Beheer</string>
     <string name="device_settings_nc_one_airpod_label">ANC met een pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkel druk om mikrofoon te demp</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbel druk om oproep te beëindig</string>
     <string name="device_settings_open_cd">Maak toestel-instellings oop</string>
+    <string name="overview_card_missing_paired_device">Hierdie profiel het geen gekoppelde Bluetooth-toestel nie.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Mikrofoon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Laat Af toe as \'n kiesbare geraasbeheermodus. Wanneer gedeaktiveer, slaan stingels Af oor tydens siklus.</string>
     <string name="device_settings_sleep_detection_label">Slaapopsporing</string>
     <string name="device_settings_sleep_detection_description">Pauses oudio outomaties wanneer jy aan die slaap raak</string>
+    <string name="reaction_sleep_channel_label">Slaapopsporing</string>
+    <string name="reaction_sleep_notification_title">Gepauseer deur Slaapopsporing</string>
+    <string name="reaction_sleep_notification_text">%1$s het aangemeld dat jy aan die slaap geraak het, so jou musiek is gepauseer. Jy kan dit in die toestelinstellings deaktiveer.</string>
     <string name="device_settings_rename_label">Hernoem</string>
     <string name="device_settings_rename_hint">Toestelnaam</string>
     <string name="device_settings_rename_confirm">Hernoem</string>
@@ -491,10 +504,14 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-instellings</string>
     <string name="device_settings_send_failed">Kon nie instelling toepas nie: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Af-modus is nie op hierdie toestel geaktiveer nie. Aktiveer \"Laat Af-modus toe\" onder Geraasbeheersing.</string>
+    <string name="device_settings_category_battery_label">Batterij</string>
+    <string name="device_settings_charge_cap_label">Geoptimaliseerde Laailimiet</string>
+    <string name="device_settings_charge_cap_description">Leer jou roetine en laat laai rondom 80%% pouseer om batteryleeftyd te verleng, en vul die dopjes aan voordat jy hulle waarskynlik sal gebruik.</string>
+    <string name="device_settings_charge_cap_rejected_message">Geoptimaliseerde Laailimiet kon nie verander word nie. Dit is \'n eksperimentele funksie — meld asseblief as dit aanhou misluk.</string>
     <string name="device_settings_category_connections_label">Gekoppelde toestelle</string>
     <string name="device_settings_connected_devices_description">Ander toestelle wat tans aan hierdie AirPods gekoppel is</string>
     <string name="device_settings_connected_device_label">Toestel %d</string>
-    <string name="device_settings_connected_device_call">In \’n oproep</string>
+    <string name="device_settings_connected_device_call">In ’n oproep</string>
     <string name="device_settings_connected_device_media">Speel media</string>
     <string name="device_settings_noise_control_label">Geraasbeheer</string>
     <string name="device_settings_eq_label">Egaliseerder</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">የዳራ ግልጽነት</string>
     <string name="widget_config_show_device_label">የመሳሪያ ስም አሳይ</string>
     <string name="widget_config_reset_label">ወደ ነባሪ መመለስ</string>
+    <string name="widget_config_preview_resize_hint">ዊጄቱን በዋናው ስክሪን ላይ ካስቀመጡት በኋላ መጠኑን መቀየር ይችላሉ።</string>
     <string name="widget_config_custom_label">ብጁ</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">ጨለማ</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">ይህ ያልታወቀ መሣሪያ ነው ግን ተመሳሳይ የመልዕክት ቅርጸት ይጠቀማል። ድጋፍ እንጨምርለት፣ ያግኙኝ :)</string>
     <string name="pods_none_label_short">ምንም መሣሪያ የለም</string>
     <string name="pods_charging_label">በመሙላት ላይ</string>
+    <string name="pods_charging_optimized_label">ተመቻችቷል</string>
     <string name="pods_inear_label">በጆሮ ውስጥ</string>
     <string name="pods_microphone_label">ማይክሮፎን</string>
     <string name="anc_mode_off">ጠፍቷል</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">የብሉቱዝ መሳሪያ ስያሜ</string>
     <string name="device_settings_info_model_label">ሞዴል</string>
     <string name="device_settings_info_manufacturer_label">አምራች</string>
+    <string name="device_settings_info_hardware_label">ሃርድዌር</string>
     <string name="device_settings_info_serial_label">ተከታታይ ቁጥር</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">ወደ ላይ ለሚጫን ፈርምዌር</string>
     <string name="device_settings_info_build_label">ግንባታ</string>
     <string name="device_settings_info_left_serial_label">የግራ ፖድ ተከታታይ ቅጥር</string>
     <string name="device_settings_info_right_serial_label">የቀኝ ፖድ ተከታታይ ቅጥር</string>
+    <string name="device_settings_info_left_bonded_label">ግራ ተያይዟል</string>
+    <string name="device_settings_info_right_bonded_label">ቀኝ ተያይዟል</string>
     <string name="device_settings_info_details_label">የመሳሪያ ዝርዝሮች</string>
     <string name="device_settings_info_details_action">የመሳሪያ ዝርዝሮችን አሳይ</string>
     <string name="device_settings_info_status_label">ሁኔታ</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">ይህ መሣሪያ አቅራቢያ አለ ነገር ግን ከዚህ ስልክ ጋር አልተገናኘም። ቅንብሮችን እና መቆጣጠሪያዎችን ለማግኘት ያገናኙ።</string>
     <string name="device_settings_not_connected_connect_action">ያገናኙ</string>
     <string name="device_settings_not_connected_open_settings_action">የብሉቱዝ ቅንብሮችን ይክፈቱ</string>
+    <string name="device_settings_not_nearby_label">መሣሪያው ቅርብ አይደለም</string>
+    <string name="device_settings_not_nearby_description">ቅንብሮቹ የሚገኙት ይህ መሣሪያ ቅርብ ሆኖ ከስልክዎ ጋር ሲገናኝ ብቻ ነው።</string>
     <string name="device_settings_aap_unavailable_label">የላቁ ቅንብሮች አይገኙም</string>
     <string name="device_settings_aap_unavailable_description">የላቀ AirPods ቅንብሮች በዚህ ስለክ ላይ የማይገኝ የብሉቱዝ ባህሪ ይፈልጋሉ። ይህ ከወደፊቱ ከመሳሪያ አምራችዎ የሚመጣ የAndroid ዝማኔ ሊፈታ ይችላል።</string>
+    <string name="device_settings_aap_unavailable_action">የተኳሃኝነት ተከታይ ይመልከቱ</string>
     <string name="device_settings_category_sound_label">ድምፅ</string>
     <string name="device_settings_category_controls_label">መቀጣጣሪያዎች</string>
     <string name="device_settings_nc_one_airpod_label">ANC በአንድ ፖድ</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ማይክሮፎኑን ለማጥፈት አንድ ጊዜ ጀን</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ጥሪን ለመጨረስ ሁለት ጊዜ ጀን</string>
     <string name="device_settings_open_cd">የመሣሪያ ቅንብሮችን ክፈት</string>
+    <string name="overview_card_missing_paired_device">ይህ መገለጫ የጋራ ብሉቱዝ መሳሪያ የለውም።</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">አጠቃላይ</string>
     <string name="device_settings_microphone_mode_label">ማይክሮፎን</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">ጠፍን እንደ ሊመረጥ የሚችል የጫጫታ ቁጥጥር ሁኔታ ፍቀድ። ሲሰናከል፣ ቀንዶቹ ዑደት ሲያደርጉ ጠፍን ይዝለሉ።</string>
     <string name="device_settings_sleep_detection_label">እንቅልፍ ማወቃያ</string>
     <string name="device_settings_sleep_detection_description">ሲተኝ ድምጹን ራስ-ሰር አቁም</string>
+    <string name="reaction_sleep_channel_label">የእንቅልፍ ማወቂያ</string>
+    <string name="reaction_sleep_notification_title">በእንቅልፍ ማወቂያ ምክንያት ታግዷል</string>
+    <string name="reaction_sleep_notification_text">%1$s እርስዎ ተኝተዋል ብሎ ዘገበ፣ ስለዚህ ሙዚቃዎ ተቋርጧል። ይህን በመሣሪያ ቅንብሮች ውስጥ ማሰናከል ይችላሉ።</string>
     <string name="device_settings_rename_label">ስም ቀይር</string>
     <string name="device_settings_rename_hint">የመሣሪያ ስም</string>
     <string name="device_settings_rename_confirm">ስም ቀይር</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">የ Bluetooth ቅንብሮች</string>
     <string name="device_settings_send_failed">ቅንብሩን መተግበር አልተቻለም: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">ጠፍ ሁኔታ በዚህ መሳሪያ ላይ አልነቃም። \"ጠፍ ሁኔታን ፍቀድ\" በጫጫታ ቁጥጥር ስር አንቃ።</string>
+    <string name="device_settings_category_battery_label">ባትሪ</string>
+    <string name="device_settings_charge_cap_label">ተመቻችቶ የሚቆጠር የኃይል ወሰን</string>
+    <string name="device_settings_charge_cap_description">የእርስዎን ልምድ ተምሮ የባትሪ ሕይወት ለማሳደግ ወደ 80%% ሲደርስ ኤሌክትሪኩን ያቆማል፣ ሊጠቀሟቸው ከመሆናቸው በፊት ድብዳቤ ኮዳቹን ሙሉ ይሞላቸዋል።</string>
+    <string name="device_settings_charge_cap_rejected_message">ተመቻችቶ የሚቆጠር የኃይል ወሰን ሊቀየር አልቻለም። ይህ የሙከራ ባህሪ ነው — አሁንም ቢሆን ካልሰራ እባክዎ ሪፖርት ያድርጉ።</string>
     <string name="device_settings_category_connections_label">የተገናኙ መሣሪያዎች</string>
     <string name="device_settings_connected_devices_description">አሁን ለእነዚህ AirPods የተገናኙ ሌሎች መሣሪያዎች</string>
     <string name="device_settings_connected_device_label">መሣሪያ %d</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">شفافية الخلفية</string>
     <string name="widget_config_show_device_label">إظهار اسم الجهاز</string>
     <string name="widget_config_reset_label">إعادة تعيين إلى الإعدادات الافتراضية</string>
+    <string name="widget_config_preview_resize_hint">يمكنك تغيير حجم الأداة بعد وضعها على شاشتك الرئيسية.</string>
     <string name="widget_config_custom_label">مخصص</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">مظلم</string>
@@ -258,6 +259,7 @@
     <string name="pods_unknown_contact_dev">هذا جهاز غير معروف، لكنه يستخدم تنسيق رسائل مشابهًا. دعونا نضيف دعمًا له، تواصل معي :)</string>
     <string name="pods_none_label_short">لا يوجد جهاز</string>
     <string name="pods_charging_label">جارٍ الشحن</string>
+    <string name="pods_charging_optimized_label">محسَّن</string>
     <string name="pods_inear_label">في الأذن</string>
     <string name="pods_microphone_label">الميكروفون</string>
     <string name="anc_mode_off">إيقاف</string>
@@ -427,11 +429,15 @@
     <string name="device_settings_info_bt_name_label">تسمية جهاز البلوتوث</string>
     <string name="device_settings_info_model_label">الطراز</string>
     <string name="device_settings_info_manufacturer_label">الشركة المصنّعة</string>
+    <string name="device_settings_info_hardware_label">الجهاز</string>
     <string name="device_settings_info_serial_label">الرقم التسلسلي</string>
     <string name="device_settings_info_firmware_label">البرنامج الثابت</string>
+    <string name="device_settings_info_firmware_pending_label">البرنامج الثابت المعلق</string>
     <string name="device_settings_info_build_label">الإصدار</string>
     <string name="device_settings_info_left_serial_label">الرقم التسلسلي للسماعة اليسرى</string>
     <string name="device_settings_info_right_serial_label">الرقم التسلسلي للسماعة اليمنى</string>
+    <string name="device_settings_info_left_bonded_label">اليسار مقترن</string>
+    <string name="device_settings_info_right_bonded_label">اليمين مقترن</string>
     <string name="device_settings_info_details_label">تفاصيل الجهاز</string>
     <string name="device_settings_info_details_action">عرض تفاصيل الجهاز</string>
     <string name="device_settings_info_status_label">الحالة</string>
@@ -441,8 +447,11 @@
     <string name="device_settings_not_connected_description">هذا الجهاز قريب لكنه غير متصل بهذا الهاتف. اتصل للوصول إلى الإعدادات والعناصر.</string>
     <string name="device_settings_not_connected_connect_action">اتصال</string>
     <string name="device_settings_not_connected_open_settings_action">فتح إعدادات البلوتوث</string>
+    <string name="device_settings_not_nearby_label">الجهاز غير قريب</string>
+    <string name="device_settings_not_nearby_description">الإعدادات متاحة فقط عندما يكون هذا الجهاز قريبًا ومتصلًا بهاتفك.</string>
     <string name="device_settings_aap_unavailable_label">الإعدادات المتقدمة غير متاحة</string>
     <string name="device_settings_aap_unavailable_description">تتطلب إعدادات AirPods المتقدمة ميزة بلوتوث غير متاحة على هذا الهاتف. قد يتم حل هذا بتحديث Android مستقبلي من الشركة المصنّعة لجهازك.</string>
+    <string name="device_settings_aap_unavailable_action">عرض متتبع التوافق</string>
     <string name="device_settings_category_sound_label">الصوت</string>
     <string name="device_settings_category_controls_label">عناصر التحكم</string>
     <string name="device_settings_nc_one_airpod_label">إلغاء ضوضاء نشط مع سماعة واحدة</string>
@@ -480,6 +489,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ضغطة واحدة لكتم صوت الميكروفون</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ضغطة مزدوجة لإنهاء المكالمة</string>
     <string name="device_settings_open_cd">فتح إعدادات الجهاز</string>
+    <string name="overview_card_missing_paired_device">هذا الملف الشخصي لا يحتوي على جهاز بلوتوث مقترن.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عام</string>
     <string name="device_settings_microphone_mode_label">ميكروفون</string>
@@ -502,6 +512,9 @@
     <string name="device_settings_allow_off_description">السماح بوضع إيقاف كوضع تحكم قابل للتحديد في الضوضاء. عند التعطيل، تتجاوز الذراعان وضع إيقاف أثناء الدوران.</string>
     <string name="device_settings_sleep_detection_label">اكتشاف النوم</string>
     <string name="device_settings_sleep_detection_description">إيقاف الصوت تلقائيًا عند النوم</string>
+    <string name="reaction_sleep_channel_label">اكتشاف النوم</string>
+    <string name="reaction_sleep_notification_title">تم الإيقاف المؤقت بواسطة اكتشاف النوم</string>
+    <string name="reaction_sleep_notification_text">%1$s أفاد بأنك نمت، لذا تم إيقاف موسيقاك مؤقتًا. يمكنك تعطيل هذا في إعدادات الجهاز.</string>
     <string name="device_settings_rename_label">إعادة تسمية</string>
     <string name="device_settings_rename_hint">اسم الجهاز</string>
     <string name="device_settings_rename_confirm">إعادة تسمية</string>
@@ -511,6 +524,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">إعدادات البلوتوث</string>
     <string name="device_settings_send_failed">تعذّر تطبيق الإعداد: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">وضع إيقاف غير مفعّل على هذا الجهاز. فعّل \"السماح بوضع إيقاف\" ضمن التحكم في الضوضاء.</string>
+    <string name="device_settings_category_battery_label">البطارية</string>
+    <string name="device_settings_charge_cap_label">حد الشحن المحسَّن</string>
+    <string name="device_settings_charge_cap_description">يتعلم روتينك ويوقف الشحن مؤقتًا عند حوالي 80%% لإطالة عمر البطارية، مع شحن السماعات بالكامل قبل استخدامك المتوقع لها.</string>
+    <string name="device_settings_charge_cap_rejected_message">تعذّر تغيير حد الشحن المحسَّن. هذه ميزة تجريبية — يرجى الإبلاغ إذا استمر الفشل.</string>
     <string name="device_settings_category_connections_label">الأجهزة المتصلة</string>
     <string name="device_settings_connected_devices_description">الأجهزة الأخرى المتصلة حاليًا بهذه AirPods</string>
     <string name="device_settings_connected_device_label">الجهاز %d</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Fon şəffaflığı</string>
     <string name="widget_config_show_device_label">Cihaz adını göstər</string>
     <string name="widget_config_reset_label">Varsayılan ayarlara sıfırla</string>
+    <string name="widget_config_preview_resize_hint">Vidceti ana ekranınıza yerləşdirdikdən sonra ölçüsünü dəyişə bilərsiniz.</string>
     <string name="widget_config_custom_label">Fərdi</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tünd</string>
@@ -233,7 +234,7 @@
     <string name="pods_dual_left_label">Sol qulaqlıq</string>
     <string name="pods_dual_right_label">Sağ qulaqlıq</string>
     <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">S</string>
+    <string name="pods_dual_right_short_label">SĚ</string>
     <string name="pods_case_label">Qutu</string>
     <string name="battery_unavailable_label">Batareya məlumatı yoxdur</string>
     <string name="pods_case_status_open_label">Açıq</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Bu naməlum bir cihazdır, lakin oxşar mesaj formatından istifadə edir. Onun üçün dəstək əlavə edək, mənimlə əlaqə saxlayın :)</string>
     <string name="pods_none_label_short">Cihaz yoxdur</string>
     <string name="pods_charging_label">Şarj olunur</string>
+    <string name="pods_charging_optimized_label">Optimallaşdırılmış</string>
     <string name="pods_inear_label">Qulaqda</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Söndür</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth Cihaz Etiketə</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">İstehsalcı</string>
+    <string name="device_settings_info_hardware_label">Aparat</string>
     <string name="device_settings_info_serial_label">Seriya Nömrəsi</string>
     <string name="device_settings_info_firmware_label">Proqram təminı</string>
+    <string name="device_settings_info_firmware_pending_label">Gözləmədə olan proqram təminatı</string>
     <string name="device_settings_info_build_label">Yazılım versiyası</string>
     <string name="device_settings_info_left_serial_label">Sol Qulaqcıq Seriya Nömrəsi</string>
     <string name="device_settings_info_right_serial_label">Sağ Qulaqcıq Seriya Nömrəsi</string>
+    <string name="device_settings_info_left_bonded_label">Sol cütləşdirilmiş</string>
+    <string name="device_settings_info_right_bonded_label">Sağ cütləşdirilmiş</string>
     <string name="device_settings_info_details_label">Cihaz Ǝtraflı Məlumatları</string>
     <string name="device_settings_info_details_action">Cihaz təfsilatlarını göstər</string>
     <string name="device_settings_info_status_label">Vəziyyət</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Bu cihaz yaxında yerləşir, lakin bu telefona bağlı deyil. Parametrlərə və idarəetməyə daxil olmaq üçün qoşulun.</string>
     <string name="device_settings_not_connected_connect_action">Qoşul</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth Parametrlərini Aç</string>
+    <string name="device_settings_not_nearby_label">Cihaz yaxında deyil</string>
+    <string name="device_settings_not_nearby_description">Parametrlər yalnız bu cihaz yaxında olduqda və telefonunuza qoşulduqda mövcuddur.</string>
     <string name="device_settings_aap_unavailable_label">Ətraflı parametrlər əlçatmazdır</string>
     <string name="device_settings_aap_unavailable_description">Qabaqcıl AirPods parametrləri bu telefondan əldati olunan Bluetooth funksiyasını tələb edir. Bu problem cihaz istehsalcınızdan gələcək Android yenilməsi ilə həll oluna bilər.</string>
+    <string name="device_settings_aap_unavailable_action">Uyğunluq izləyicisinə baxın</string>
     <string name="device_settings_category_sound_label">Səs</string>
     <string name="device_settings_category_controls_label">İdarəetmələr</string>
     <string name="device_settings_nc_one_airpod_label">Tək qulaqcıqla ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Mikrofonu susdurmağ üçün bir dəfə basın</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Zəngi bitirmək üçün iki dəfə basın</string>
     <string name="device_settings_open_cd">Cihaz parametrlərini açın</string>
+    <string name="overview_card_missing_paired_device">Bu profilin cütləşdirilmiş Bluetooth cihazı yoxdur.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ümumi</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Söndürmə rejiminin səs-küy nəzarətində seçilə bilməsinə icazə ver. Deaktiv edildçə, gövə dövr kəsindi Söndürməni atlayar.</string>
     <string name="device_settings_sleep_detection_label">Yuxu Aşkarlama</string>
     <string name="device_settings_sleep_detection_description">Yuxuya getdikdə audionu avtomatik dayandırın</string>
+    <string name="reaction_sleep_channel_label">Yuxu Aşkarlaması</string>
+    <string name="reaction_sleep_notification_title">Yuxu Aşkarlaması ilə dayandırıldı</string>
+    <string name="reaction_sleep_notification_text">%1$s sizin yuxuya getdiyinizi bildirdi, buna görə musiqiniz dayandırıldı. Bunu cihaz parametrlərindən söndürə bilərsiniz.</string>
     <string name="device_settings_rename_label">Adı dəyişdirin</string>
     <string name="device_settings_rename_hint">Cihaz adı</string>
     <string name="device_settings_rename_confirm">Adı dəyişdirin</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth Parametrləri</string>
     <string name="device_settings_send_failed">Parametr tətbiq edilə bilmədi: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Söndürmə rejimi bu cihazda aktiv deyil. Səs-Küy Nəzarəti altında \"Söndürmə rejiminə icazə ver\" seçimini aktiv edin.</string>
+    <string name="device_settings_category_battery_label">Batareya</string>
+    <string name="device_settings_charge_cap_label">Optimallaşdırılmış Şarj Həddi</string>
+    <string name="device_settings_charge_cap_description">Batareya ömrünü uzatmaq üçün rutininizi öyrənir və şarjı təxminən 80%%-də dayandırır, qulluqlardan istifadə etməzdən əvvəl onları şarj edir.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimallaşdırılmış Şarj Həddini dəyişdirmək mümkün olmadı. Bu eksperimental bir xüsusiyyətdir — davam edərsə xahiş edirik bildirin.</string>
     <string name="device_settings_category_connections_label">Bağlı Cihazlar</string>
     <string name="device_settings_connected_devices_description">Bu AirPodlara hal-hazırda bağlı olan digər cihazlar</string>
     <string name="device_settings_connected_device_label">Cihaz %d</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Прозрачнасць фона</string>
     <string name="widget_config_show_device_label">Паказаць назву прылады</string>
     <string name="widget_config_reset_label">Скінуць да змаўчання</string>
+    <string name="widget_config_preview_resize_hint">Вы можаце змяніць памер віджэта пасля размяшчэння яго на галоўным экране.</string>
     <string name="widget_config_custom_label">Адвольны</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Цёмны</string>
@@ -254,6 +255,7 @@
     <string name="pods_unknown_contact_dev">Гэта невядомая прылада, але яна выкарыстоўвае падобны фармат паведамленняў. Давайце дадамо яе падтрымку, звяжыцеся са мной :)</string>
     <string name="pods_none_label_short">Няма прылады</string>
     <string name="pods_charging_label">Зарадка</string>
+    <string name="pods_charging_optimized_label">Аптымізавана</string>
     <string name="pods_inear_label">У вуху</string>
     <string name="pods_microphone_label">Мікрафон</string>
     <string name="anc_mode_off">Выкл</string>
@@ -417,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">Назва Bluetooth-прылады</string>
     <string name="device_settings_info_model_label">Мадэль</string>
     <string name="device_settings_info_manufacturer_label">Вытворца</string>
+    <string name="device_settings_info_hardware_label">Абсталяванне</string>
     <string name="device_settings_info_serial_label">Серыйны нумар</string>
     <string name="device_settings_info_firmware_label">Прашыўка</string>
+    <string name="device_settings_info_firmware_pending_label">Прашыўка ў чарзе</string>
     <string name="device_settings_info_build_label">Зборка</string>
     <string name="device_settings_info_left_serial_label">Сэрыйны нумар левага навушніка</string>
     <string name="device_settings_info_right_serial_label">Сэрыйны нумар правага навушніка</string>
+    <string name="device_settings_info_left_bonded_label">Левы спалучаны</string>
+    <string name="device_settings_info_right_bonded_label">Правы спалучаны</string>
     <string name="device_settings_info_details_label">Дэталі прылады</string>
     <string name="device_settings_info_details_action">Паказаць дэталі прылады</string>
     <string name="device_settings_info_status_label">Стан</string>
@@ -431,8 +437,11 @@
     <string name="device_settings_not_connected_description">Гэта прылада знаходзіцца побач, але не падключана да гэтага тэлефона. Падключыцеся, каб атрымаць доступ да налад і кіравання.</string>
     <string name="device_settings_not_connected_connect_action">Падключыцца</string>
     <string name="device_settings_not_connected_open_settings_action">Адкрыць налады Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Прылада не паблізу</string>
+    <string name="device_settings_not_nearby_description">Налады даступныя толькі тады, калі гэтая прылада знаходзіцца паблізу і падключана да вашага тэлефона.</string>
     <string name="device_settings_aap_unavailable_label">Пашыраныя налады недаступныя</string>
     <string name="device_settings_aap_unavailable_description">Пашыраныя налады AirPods патрабуюць функцыі Bluetooth, якая недаступная на гэтым тэлефоне. Гэта можа быць вырашана будучым абнаўленнем Android ад вытворцы вашай прылады.</string>
+    <string name="device_settings_aap_unavailable_action">Праглядзець трэкер сумяшчальнасці</string>
     <string name="device_settings_category_sound_label">Гук</string>
     <string name="device_settings_category_controls_label">Кіраванне</string>
     <string name="device_settings_nc_one_airpod_label">ANC з адным навушнікам</string>
@@ -470,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Аднаразовы націск для адключэння мікрафона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двайны націск для завяршэння выкліку</string>
     <string name="device_settings_open_cd">Адкрыць налады прылады</string>
+    <string name="overview_card_missing_paired_device">З гэтым профілем не сапалучана прылада Bluetooth.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Агульныя</string>
     <string name="device_settings_microphone_mode_label">Мікрафон</string>
@@ -492,6 +502,9 @@
     <string name="device_settings_allow_off_description">Дазволіць рэжым «Выкл» як выбіральны рэжым кіравання шумам. Калі адключана, ножкі прапускаюць «Выкл» пры цыкле.</string>
     <string name="device_settings_sleep_detection_label">Выяўленне сну</string>
     <string name="device_settings_sleep_detection_description">Аўтаматычна ставіць аўдыё на паўзу, калі вы засынаеце</string>
+    <string name="reaction_sleep_channel_label">Выяўленне сну</string>
+    <string name="reaction_sleep_notification_title">Прыпынена функцыяй выяўлення сну</string>
+    <string name="reaction_sleep_notification_text">%1$s паведаміла, што вы заснулі, таму музыка была прыпынена. Вы можаце адключыць гэта ў наладах прылады.</string>
     <string name="device_settings_rename_label">Перайменаваць</string>
     <string name="device_settings_rename_hint">Назва прылады</string>
     <string name="device_settings_rename_confirm">Перайменаваць</string>
@@ -501,6 +514,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Налады Bluetooth</string>
     <string name="device_settings_send_failed">Не ўдалося прымяніць налады: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Рэжым «Выкл» не ўключаны на гэтай прыладзе. Уключыце «Дазволіць рэжым Выкл» ў раздзеле «Кіраванне шумам».</string>
+    <string name="device_settings_category_battery_label">Акумулятар</string>
+    <string name="device_settings_charge_cap_label">Аптымізаваная мяжа зарадкі</string>
+    <string name="device_settings_charge_cap_description">Вывучае ваш распарадак і прыпыняе зарадку каля 80%%, каб падоўжыць тэрмін службы акумулятара, дазараджаючы наўшпількі перад тым, як вы, верагодна, скарыстаецеся імі.</string>
+    <string name="device_settings_charge_cap_rejected_message">Аптымізаваную мяжу зарадкі не ўдалося змяніць. Гэта эксперыментальная функцыя — калі ласка, паведамляйце, калі яна ўвесь час не спрацоўвае.</string>
     <string name="device_settings_category_connections_label">Падключаныя прылады</string>
     <string name="device_settings_connected_devices_description">Іншыя прылады, якія цяпер падключаны да гэтых AirPods</string>
     <string name="device_settings_connected_device_label">Прылада %d</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Прозрачност на фона</string>
     <string name="widget_config_show_device_label">Показване на името на устройството</string>
     <string name="widget_config_reset_label">Възстановяване на стандартните настройки</string>
+    <string name="widget_config_preview_resize_hint">Можете да преоразмерите джаджата, след като я поставите на началния си екран.</string>
     <string name="widget_config_custom_label">Персонализирано</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Тъмно</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Това е неизвестно устройство, но използва подобен формат на съобщения. Нека добавим поддръжка за него, свържете се с мен :)</string>
     <string name="pods_none_label_short">Няма устройство</string>
     <string name="pods_charging_label">Зареждане</string>
+    <string name="pods_charging_optimized_label">Оптимизирано</string>
     <string name="pods_inear_label">В ухото</string>
     <string name="pods_microphone_label">Микрофон</string>
     <string name="anc_mode_off">Изкл.</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth етикет на устройство</string>
     <string name="device_settings_info_model_label">Модел</string>
     <string name="device_settings_info_manufacturer_label">Производител</string>
+    <string name="device_settings_info_hardware_label">Хардуер</string>
     <string name="device_settings_info_serial_label">Сериен номер</string>
     <string name="device_settings_info_firmware_label">Фърмуер</string>
+    <string name="device_settings_info_firmware_pending_label">Изчакващ фърмуер</string>
     <string name="device_settings_info_build_label">Версия</string>
     <string name="device_settings_info_left_serial_label">Сериен номер на левия под</string>
     <string name="device_settings_info_right_serial_label">Сериен номер на десния под</string>
+    <string name="device_settings_info_left_bonded_label">Ляво сдвоено</string>
+    <string name="device_settings_info_right_bonded_label">Дясно сдвоено</string>
     <string name="device_settings_info_details_label">Подробности за устройството</string>
     <string name="device_settings_info_details_action">Покажи подробности за устройството</string>
     <string name="device_settings_info_status_label">Статус</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Устройството е наблизо, но не е свързано с този телефон. Свържете се, за да получите достъп до настройките и управлението.</string>
     <string name="device_settings_not_connected_connect_action">Свържи се</string>
     <string name="device_settings_not_connected_open_settings_action">Отвори настройките на Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Устройството не е наблизо</string>
+    <string name="device_settings_not_nearby_description">Настройките са налични само когато устройството е наблизо и свързано с телефона ви.</string>
     <string name="device_settings_aap_unavailable_label">Разширените настройки не са налични</string>
     <string name="device_settings_aap_unavailable_description">Разширените настройки на AirPods изискват Bluetooth функция, която не е налична на този телефон. Това може да бъде разрешено от бъдеща актуализация на Android от производителя на вашето устройство.</string>
+    <string name="device_settings_aap_unavailable_action">Вижте проследяването на съвместимостта</string>
     <string name="device_settings_category_sound_label">Звук</string>
     <string name="device_settings_category_controls_label">Управление</string>
     <string name="device_settings_nc_one_airpod_label">ANC с един под</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Едно натискане за заглушаване на микрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двойно натискане за прекратяване на разговора</string>
     <string name="device_settings_open_cd">Отворете настройките на устройството</string>
+    <string name="overview_card_missing_paired_device">Този профил няма сдвоено Bluetooth устройство.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Общи</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Разрешава Изключено като избираем режим за контрол на шума. Когато е деактивирано, стъблата пропускат Изключено при циклиране.</string>
     <string name="device_settings_sleep_detection_label">Разпознаване на сън</string>
     <string name="device_settings_sleep_detection_description">Автоматично поставя звука на пауза, когато заспите</string>
+    <string name="reaction_sleep_channel_label">Откриване на сън</string>
+    <string name="reaction_sleep_notification_title">Поставено на пауза от Откриване на сън</string>
+    <string name="reaction_sleep_notification_text">%1$s откри, че сте заспали, затова музиката ви беше поставена на пауза. Можете да деактивирате това в настройките на устройството.</string>
     <string name="device_settings_rename_label">Преименуване</string>
     <string name="device_settings_rename_hint">Наименование на устройството</string>
     <string name="device_settings_rename_confirm">Преименуване</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth настройки</string>
     <string name="device_settings_send_failed">Неуспешно прилагане на настройката: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Режимът Изключено не е активиран на това устройство. Активирайте \"Разрешаване на режим Изключено\" в Контрол на шума.</string>
+    <string name="device_settings_category_battery_label">Батерия</string>
+    <string name="device_settings_charge_cap_label">Оптимизиран лимит за зареждане</string>
+    <string name="device_settings_charge_cap_description">Научава ежедневието ви и спира зареждането около 80%%, за да удължи живота на батерията, като напълно зарежда слушалките преди да е вероятно да ги използвате.</string>
+    <string name="device_settings_charge_cap_rejected_message">Оптимизираният лимит за зареждане не можа да бъде променен. Това е експериментална функция — моля, докладвайте ако продължава да се проваля.</string>
     <string name="device_settings_category_connections_label">Свързани устройства</string>
     <string name="device_settings_connected_devices_description">Другите устройства, свързани в момента към тези AirPods</string>
     <string name="device_settings_connected_device_label">Устройство %d</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">পটভূমি স্বচ্ছতা</string>
     <string name="widget_config_show_device_label">ডিভাইসের নাম দেখান</string>
     <string name="widget_config_reset_label">ডিফল্টে পুনরায় সেট করুন</string>
+    <string name="widget_config_preview_resize_hint">আপনি হোম স্ক্রিনে রাখার পরে উইজেটটি পুনরায় আকার দিতে পারবেন।</string>
     <string name="widget_config_custom_label">কাস্টম</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">গাঢ়</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">এটি একটি অজানা ডিভাইস, তবে এটি অনুরূপ বার্তা বিন্যাস ব্যবহার করছে। চলুন এর জন্য সমর্থন যোগ করি, আমার সাথে যোগাযোগ করুন :)</string>
     <string name="pods_none_label_short">কোনো ডিভাইস নেই</string>
     <string name="pods_charging_label">চার্জ হচ্ছে</string>
+    <string name="pods_charging_optimized_label">অপ্টিমাইজড</string>
     <string name="pods_inear_label">কানে</string>
     <string name="pods_microphone_label">মাইক্রোফোন</string>
     <string name="anc_mode_off">বন্ধ</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">ব্লুটুথ ডিভাইস লেবেল</string>
     <string name="device_settings_info_model_label">মডেল</string>
     <string name="device_settings_info_manufacturer_label">প্রস্তুতকারক</string>
+    <string name="device_settings_info_hardware_label">হার্ডওয়্যার</string>
     <string name="device_settings_info_serial_label">সিরিয়াল নম্বর</string>
     <string name="device_settings_info_firmware_label">ফার্মওয়্যার</string>
+    <string name="device_settings_info_firmware_pending_label">বিচারাধীন ফার্মওয়্যার</string>
     <string name="device_settings_info_build_label">বিল্ড</string>
     <string name="device_settings_info_left_serial_label">বাম পড সিরিয়াল</string>
     <string name="device_settings_info_right_serial_label">ডান পড সিরিয়াল</string>
+    <string name="device_settings_info_left_bonded_label">বাম পেয়ার করা</string>
+    <string name="device_settings_info_right_bonded_label">ডান পেয়ার করা</string>
     <string name="device_settings_info_details_label">ডিভাইস বিস্তারিত</string>
     <string name="device_settings_info_details_action">ডিভাইস বিস্তারিত দেখুন</string>
     <string name="device_settings_info_status_label">স্ট্যাটাস</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">এই ডিভাইসটি কাছাকাছি আছে কিন্তু এই ফোনে সংযুক্ত নয়। সেটিংস এবং নিয়ন্ত্রণে প্রবেশ করতে সংযুক্ত করুন।</string>
     <string name="device_settings_not_connected_connect_action">সংযুক্ত করুন</string>
     <string name="device_settings_not_connected_open_settings_action">ব্লুটুথ সেটিংস খুলুন</string>
+    <string name="device_settings_not_nearby_label">ডিভাইস কাছাকাছি নেই</string>
+    <string name="device_settings_not_nearby_description">সেটিংস শুধুমাত্র তখনই পাওয়া যাবে যখন এই ডিভাইসটি কাছাকাছি থাকবে এবং আপনার ফোনের সাথে সংযুক্ত থাকবে।</string>
     <string name="device_settings_aap_unavailable_label">উন্নত সেটিংস অনুপলব্ধ</string>
     <string name="device_settings_aap_unavailable_description">উন্নত AirPods সেটিংসের জন্য একটি ব্লুটুথ ফিচার প্রয়োজন যা এই ফোনে উপলব্ধ নয়। এটি আপনার ডিভাইস প্রস্তুতকারকের ভবিষ্যৎ Android আপডেট দ্বারা সমাধান হতে পারে।</string>
+    <string name="device_settings_aap_unavailable_action">সামঞ্জস্যতা ট্র্যাকার দেখুন</string>
     <string name="device_settings_category_sound_label">শব্দ</string>
     <string name="device_settings_category_controls_label">নিয়ন্ত্রণ</string>
     <string name="device_settings_nc_one_airpod_label">একটি পড দিয়ে ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">মাইক্রোফোন মিউট করতে একবার চাপুন</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">কল শেষ করতে দুবার চাপুন</string>
     <string name="device_settings_open_cd">ডিভাইস সেটিংস খুলুন</string>
+    <string name="overview_card_missing_paired_device">এই প্রোফাইলে কোনো পেয়ার করা ব্লুটুথ ডিভাইস নেই।</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">সাধারণ</string>
     <string name="device_settings_microphone_mode_label">মাইক্রোফোন</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">অফকে একটি নির্বাচনযোগ্য নয়েজ কন্ট্রোল মোড হিসেবে অনুমতি দিন। অক্ষম থাকলে, স্টেম সাইক্লিং করার সময় অফ এড়িয়ে যায়।</string>
     <string name="device_settings_sleep_detection_label">ঘুম শনাক্তি</string>
     <string name="device_settings_sleep_detection_description">ঘুমিয়ে পড়লে স্বয়ংক্রিয়ভাবে অডিও বিরত করুন</string>
+    <string name="reaction_sleep_channel_label">ঘুম শনাক্তকরণ</string>
+    <string name="reaction_sleep_notification_title">ঘুম শনাক্তকরণ দ্বারা বিরতি দেওয়া হয়েছে</string>
+    <string name="reaction_sleep_notification_text">%1$s জানিয়েছে আপনি ঘুমিয়ে পড়েছেন, তাই আপনার সঙ্গীত বিরতি দেওয়া হয়েছে। আপনি ডিভাইস সেটিংসে এটি নিষ্ক্রিয় করতে পারেন।</string>
     <string name="device_settings_rename_label">নাম বদলান</string>
     <string name="device_settings_rename_hint">ডিভাইসের নাম</string>
     <string name="device_settings_rename_confirm">নাম বদলান</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ব্লুটুথ সেটিংস</string>
     <string name="device_settings_send_failed">সেটিং প্রয়োগ করা যায়নি: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">এই ডিভাইসে অফ মোড সক্রিয় নেই। নয়েজ কন্ট্রোলের অধীনে \"অফ মোড অনুমতি দিন\" সক্রিয় করুন।</string>
+    <string name="device_settings_category_battery_label">ব্যাটারি</string>
+    <string name="device_settings_charge_cap_label">অপ্টিমাইজড চার্জ সীমা</string>
+    <string name="device_settings_charge_cap_description">আপনার রুটিন শিখে ব্যাটারি জীবন বাড়াতে প্রায় ৮0%% এ চার্জ বিরতি রাখে, আপনি ব্যবহার করার আগে পডসগুলি পূর্ণ চার্জ করে দেয়।</string>
+    <string name="device_settings_charge_cap_rejected_message">অপ্টিমাইজড চার্জ সীমা পরিবর্তন করা যায়নি। এটি একটি প্রযোগমূলক বৈশিষ্ট্য — বারবার ব্যর্থ হলে দয়া করে জানান।</string>
     <string name="device_settings_category_connections_label">সংযুক্ত ডিভাইসগুলো</string>
     <string name="device_settings_connected_devices_description">এই AirPodsডে বর্তমানে সংযুক্ত অন্যান্য ডিভাইস</string>
     <string name="device_settings_connected_device_label">ডিভাইস %d</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparència del fons</string>
     <string name="widget_config_show_device_label">Mostra el nom del dispositiu</string>
     <string name="widget_config_reset_label">Restaura els valors per defecte</string>
+    <string name="widget_config_preview_resize_hint">Podeu canviar la mida del giny després de col·locar-lo a la pantalla d\'inici.</string>
     <string name="widget_config_custom_label">Personalitzat</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Fosc</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Aquest és un dispositiu desconegut, però utilitza un format de missatge similar. Anem a fer-lo compatible, contacteu amb mi :)</string>
     <string name="pods_none_label_short">Cap dispositiu</string>
     <string name="pods_charging_label">Carregant</string>
+    <string name="pods_charging_optimized_label">Optimitzada</string>
     <string name="pods_inear_label">A l\'orella</string>
     <string name="pods_microphone_label">Micròfon</string>
     <string name="anc_mode_off">Desactivat</string>
@@ -292,7 +294,7 @@
     <string name="profiles_delete_action">Elimina</string>
     <string name="profiles_basic_info_title">Informació del dispositiu</string>
     <string name="profiles_basic_info_description">Configureu el nom del dispositiu, el model i l\'emparellament Bluetooth opcional.</string>
-    <string name="profiles_signal_quality_title">Qualitat de senyal mínima</string>
+    <string name="profiles_signal_quality_title">Qualitat de senyal màxima</string>
     <string name="profiles_signal_quality_description">Només es detecten dispositius amb una intensitat de senyal superior a aquest llindar. Els valors més baixos augmenten el rang de detecció, però poden causar falsos positius. No configureu aquest valor massa alt: la recepció Bluetooth generalment és deficient i varia segons la distància i els obstacles.</string>
     <string name="profiles_identitykey_label">Clau d\'identitat</string>
     <string name="profilessettings_maindevice_identitykey_description">La clau de resolució d\'identitat (IRK) del dispositiu ajuda al CAPod a identificar-lo entre els dispositius propers.</string>
@@ -394,7 +396,7 @@
     <string name="support_contact_send_action">Obre l\'aplicació de correu</string>
     <string name="support_contact_no_email_app">No s\'ha trobat cap aplicació de correu en aquest dispositiu.</string>
     <string name="support_contact_debuglog_delete_title">Voleu suprimir el registre de depuració?</string>
-    <string name="support_contact_debuglog_delete_message">Aquest registre de depuració se suprimirà permanentment.</string>
+    <string name="support_contact_debuglog_delete_message">Aquest registre de depuració se suprimrirà permanentment.</string>
     <!-- Post-share confirmation -->
     <string name="support_debuglog_sent_title">S\'ha enviat el registre?</string>
     <string name="support_debuglog_sent_message">El registre de depuració s\'ha enviat correctament? El registre s\'eliminarà.</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etiqueta del dispositiu Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Fabricant</string>
+    <string name="device_settings_info_hardware_label">Maquinari</string>
     <string name="device_settings_info_serial_label">Número de sèrie</string>
     <string name="device_settings_info_firmware_label">Microprogramari</string>
+    <string name="device_settings_info_firmware_pending_label">Microprogramari pendent</string>
     <string name="device_settings_info_build_label">Compilació</string>
     <string name="device_settings_info_left_serial_label">Número de sèrie de l\'auricular esquerre</string>
     <string name="device_settings_info_right_serial_label">Número de sèrie de l\'auricular dret</string>
+    <string name="device_settings_info_left_bonded_label">Esquerre vinculat</string>
+    <string name="device_settings_info_right_bonded_label">Dret vinculat</string>
     <string name="device_settings_info_details_label">Detalls del dispositiu</string>
     <string name="device_settings_info_details_action">Mostra els detalls del dispositiu</string>
     <string name="device_settings_info_status_label">Estat</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Aquest dispositiu és a prop però no està connectat a aquest telèfon. Connecteu-lo per accedir a la configuració i als controls.</string>
     <string name="device_settings_not_connected_connect_action">Connecta</string>
     <string name="device_settings_not_connected_open_settings_action">Obre la configuració del Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositiu no proper</string>
+    <string name="device_settings_not_nearby_description">La configuració només està disponible quan aquest dispositiu està a prop i connectat al telèfon.</string>
     <string name="device_settings_aap_unavailable_label">Configuració avançada no disponible</string>
     <string name="device_settings_aap_unavailable_description">La configuració avançada dels AirPods requereix una funció de Bluetooth que no està disponible en aquest telèfon. Pot ser que una actualització futura d\'Android del fabricant del dispositiu ho resolgui.</string>
+    <string name="device_settings_aap_unavailable_action">Mostra el rastrejador de compatibilitat</string>
     <string name="device_settings_category_sound_label">So</string>
     <string name="device_settings_category_controls_label">Controls</string>
     <string name="device_settings_nc_one_airpod_label">ANC amb un sol auricular</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Un sol toc per silenciar el micròfon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Doble toc per acabar la trucada</string>
     <string name="device_settings_open_cd">Obre la configuració del dispositiu</string>
+    <string name="overview_card_missing_paired_device">Aquest perfil no té cap dispositiu Bluetooth emparellat.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micròfon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permet l\'opció Desactivat com a mode de control de soroll seleccionable. Quan està desactivat, les pliques ometen l\'opció Desactivat durant el cicle.</string>
     <string name="device_settings_sleep_detection_label">Detecció del son</string>
     <string name="device_settings_sleep_detection_description">Pausa automàticament l\'àudio quan us adormiu</string>
+    <string name="reaction_sleep_channel_label">Detecció del son</string>
+    <string name="reaction_sleep_notification_title">Pausat per la detecció del son</string>
+    <string name="reaction_sleep_notification_text">%1$s ha informat que us heu adormit, de manera que la vostra música s\'ha posat en pausa. Podeu desactivar-ho a la configuració del dispositiu.</string>
     <string name="device_settings_rename_label">Canvia el nom</string>
     <string name="device_settings_rename_hint">Nom del dispositiu</string>
     <string name="device_settings_rename_confirm">Canvia el nom</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Configuració del Bluetooth</string>
     <string name="device_settings_send_failed">No s\'ha pogut aplicar la configuració: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">El mode Desactivat no esta habilitat en aquest dispositiu. Activeu l\'opció «Permet el mode desactivat» al Control de soroll.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Límit de càrrega optimitzat</string>
+    <string name="device_settings_charge_cap_description">Aprèn la vostra rutina i pausa la càrrega al voltant del 80%% per allargar la vida de la bateria i completa la càrrega dels auriculars abans que els necessiteu.</string>
+    <string name="device_settings_charge_cap_rejected_message">No s\'ha pogut canviar el límit de càrrega optimitzat. Aquesta és una funció experimental; informeu si continua fallant.</string>
     <string name="device_settings_category_connections_label">Dispositius connectats</string>
     <string name="device_settings_connected_devices_description">Altres dispositius connectats ara a aquests AirPods</string>
     <string name="device_settings_connected_device_label">Dispositiu %d</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -26,7 +26,7 @@
     <string name="upgrade_benefit_popups">Vyskakovací okno při otevření a připojení</string>
     <string name="upgrade_benefit_widgets">Widgety domovské obrazovky</string>
     <string name="upgrade_benefit_device_settings">Pokročilá nastavení zařízení</string>
-    <string name="upgrade_benefit_device_controls">Ovládání zařízení &#8212; hluk, stonky &amp; více</string>
+    <string name="upgrade_benefit_device_controls">Ovládací prvky zařízení &#8212; šum, okolní hluk a další</string>
     <string name="upgrade_benefit_support">Podpořit vývojáře</string>
     <string name="upgrade_benefit_disclaimer">Dostupnost funkcí závisí na vašich sluchátkách a zařízení.</string>
     <string name="upgrade_screen_options_description">Stejné funkce, různé ceny. Předplatné zahrnuje bezplatnou zkušební dobu a lze jej kdykoli zrušit.</string>
@@ -82,10 +82,10 @@
     <string name="settings_popup_connected_label">Zobrazit vyskakovací okno při připojení</string>
     <string name="settings_popup_connected_description">Zobrazit vyskakovací okno při prvním připojení zařízení.</string>
     <string name="settings_popup_info_not_in_app">Vyskakovací okna jsou zobrazována pouze tehdy, když nejste v aplikaci.</string>
-    <string name="settings_popup_warning_manual_mode">Vyskakovací okna vyžadují, aby monitor běžel. Váš režim monitoru je nastaven na „Když je aplikace otevřena“, což zastaví monitor, když aplikaci opustíte.</string>
+    <string name="settings_popup_warning_manual_mode">Vyskakovací okna vyžadují, aby monitor běžel. Váš režim monitoru je nastaven na \"Když je aplikace otevřena\", což zastaví monitor, když aplikaci opustíte.</string>
     <string name="general_fix_it_action">Opravit</string>
     <string name="device_settings_experimental_title">Experimentální funkce</string>
-    <string name="device_settings_experimental_description">Tato funkce ještě nebyla testována na všech zařízeních. Pokud něco nefunguje správně, otevřete prosím problém s protokolem ladění.</string>
+    <string name="device_settings_experimental_description">Tato funkce ještě nebyla testována na všech zařízeních. Pokud něco nefunguje správně, nahlaste problém s logem ladění.</string>
     <string name="device_settings_experimental_action">Otevřít sledovač problémů</string>
     <string name="notification_channel_device_status_label">Stav zařízení</string>
     <string name="notification_channel_device_status_connected_label">Připojené zařízení</string>
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Průhlednost pozadí</string>
     <string name="widget_config_show_device_label">Zobrazit název zařízení</string>
     <string name="widget_config_reset_label">Obnovit výchozí nastavení</string>
+    <string name="widget_config_preview_resize_hint">Velikost widgetu můžete změnit po jeho umístění na domovskou obrazovku.</string>
     <string name="widget_config_custom_label">Vlastní</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tmavá</string>
@@ -191,7 +192,7 @@
     <string name="overview_nomaindevice_label">Není nakonfigurováno žádné zařízení</string>
     <string name="overview_nomaindevice_description">Nakonfigurujte zařízení tak, aby začalo sledovat stav baterie a aktivujte další funkce.</string>
     <string name="overview_bluetooth_disabled_icon_cd">Bluetooth vypnuto, otevřít nastavení</string>
-    <string name="overview_bluetooth_nearby_icon_cd">Zařízení v blízkosti, otevřít nastavení Bluetooth</string>
+    <string name="overview_bluetooth_nearby_icon_cd">Zařízení v blízkösti, otevřít nastavení Bluetooth</string>
     <string name="overview_bluetooth_connected_icon_cd">Zařízení připojeno, otevřít nastavení Bluetooth</string>
     <string name="overview_bluetooth_disabled_label">Bluetooth je vypnuto</string>
     <string name="overview_bluetooth_disabled_description">Bluetooth je vypnuto, zapněte jej ;)</string>
@@ -205,10 +206,10 @@
         <item quantity="other">%d zařízení bez odpovídajícího profilu</item>
     </plurals>
     <plurals name="overview_more_devices_upgrade">
-        <item quantity="one">o %d zařízení více</item>
-        <item quantity="few">o %d zařízení více</item>
-        <item quantity="many">o %d zařízení více</item>
-        <item quantity="other">o %d zařízení více</item>
+        <item quantity="one">%d další zařízení</item>
+        <item quantity="few">%d další zařízení</item>
+        <item quantity="many">%d dalších zařízení</item>
+        <item quantity="other">%d dalších zařízení</item>
     </plurals>
     <string name="permission_bluetooth_connect_label">Připojení Bluetooth</string>
     <string name="permission_bluetooth_connect_description">Tato aplikace vyžaduje oprávnění \"připojení Bluetooth\" pro interakci se spárovanými zařízeními a zahájení připojení.</string>
@@ -254,6 +255,7 @@
     <string name="pods_unknown_contact_dev">Jedná se o neznámé zařízení, ale používá podobný formát zprávy. Přidejme pro něj podporu. Kontaktujte mě :)</string>
     <string name="pods_none_label_short">Žádné zařízení</string>
     <string name="pods_charging_label">Nabíjení</string>
+    <string name="pods_charging_optimized_label">Optimalizováno</string>
     <string name="pods_inear_label">V uchu</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Vypnuto</string>
@@ -266,7 +268,7 @@
     <string name="signal_badge_key_encrypted_cd">Šifrované připojení</string>
     <string name="signal_badge_aap_cd">Přímé připojení aktivní</string>
     <string name="signal_indicator_bars_cd">Síla signálu: %1$d ze 4 dílků</string>
-    <string name="signal_indicator_disconnected_cd">Signál: odpojen</string>
+    <string name="signal_indicator_disconnected_cd">Signál: odpojeno</string>
     <string name="pods_yours">Vaše</string>
     <string name="headset_being_worn_label">Používá se</string>
     <string name="headset_not_being_worn_label">Nepoužíváno</string>
@@ -417,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">Název zařízení Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Výrobce</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Sériové číslo</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Čekající firmware</string>
     <string name="device_settings_info_build_label">Sestavení</string>
     <string name="device_settings_info_left_serial_label">Sériové číslo levého sluchátka</string>
     <string name="device_settings_info_right_serial_label">Sériové číslo pravého sluchátka</string>
+    <string name="device_settings_info_left_bonded_label">Levá spárována</string>
+    <string name="device_settings_info_right_bonded_label">Pravá spárována</string>
     <string name="device_settings_info_details_label">Detaily zařízení</string>
     <string name="device_settings_info_details_action">Zobrazit detaily zařízení</string>
     <string name="device_settings_info_status_label">Stav</string>
@@ -431,8 +437,11 @@
     <string name="device_settings_not_connected_description">Toto zařízení je v dosahu, ale není připojeno k tomuto telefonu. Připojte se pro přístup k nastavení a ovládacím prvkům.</string>
     <string name="device_settings_not_connected_connect_action">Připojit</string>
     <string name="device_settings_not_connected_open_settings_action">Otevřít nastavení Bluetooth</string>
-    <string name="device_settings_aap_unavailable_label">Rozšířená nastavení nedostupná</string>
+    <string name="device_settings_not_nearby_label">Zařízení není v blízkosti</string>
+    <string name="device_settings_not_nearby_description">Nastavení jsou dostupná pouze tehdy, když je toto zařízení v blízkosti a připojeno k vašemu telefonu.</string>
+    <string name="device_settings_aap_unavailable_label">Pokročilá nastavení nedostupná</string>
     <string name="device_settings_aap_unavailable_description">Pokročilá nastavení AirPods vyžadují funkci Bluetooth, která není na tomto telefonu dostupná. To může být vyřešeno budoucí aktualizací Androidu od výrobce vašeho zařízení.</string>
+    <string name="device_settings_aap_unavailable_action">Zobrazit sledování kompatibility</string>
     <string name="device_settings_category_sound_label">Zvuk</string>
     <string name="device_settings_category_controls_label">Ovládání</string>
     <string name="device_settings_nc_one_airpod_label">ANC s jedním sluchátkem</string>
@@ -440,7 +449,7 @@
     <string name="device_settings_personalized_volume_label">Personalizovaná hlasitost</string>
     <string name="device_settings_personalized_volume_description">Upravit hlasitost médií na základě prostředí</string>
     <string name="device_settings_conversation_awareness_description">Snížit hlasitost médií a utlumit hluk, když k vám někdo mluví</string>
-    <string name="device_settings_tone_volume_label">Hlasitost zvěnkě</string>
+    <string name="device_settings_tone_volume_label">Hlasitost zvonění</string>
     <string name="device_settings_tone_volume_description">Hlasitost potvrzení a vyzvánění</string>
     <string name="device_settings_adaptive_noise_label">Adaptivní potlačení hluku</string>
     <string name="device_settings_adaptive_noise_description">Kolik okolního hluku je propouštěno</string>
@@ -470,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Jednorázový stisk pro ztlumení mikrofonu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojitý stisk pro ukončení hovoru</string>
     <string name="device_settings_open_cd">Otevřít nastavení zařízení</string>
+    <string name="overview_card_missing_paired_device">Tento profil nemá spárované zařízení Bluetooth.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Obecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -492,6 +502,9 @@
     <string name="device_settings_allow_off_description">Povolit Vypnuto jako volitelný režim kontroly hluku. Pokud je zakázáno, stopky při cyklování přeskočí Vypnuto.</string>
     <string name="device_settings_sleep_detection_label">Detekce spánku</string>
     <string name="device_settings_sleep_detection_description">Automaticky pozastavit zvuk, když usnete</string>
+    <string name="reaction_sleep_channel_label">Detekce spánku</string>
+    <string name="reaction_sleep_notification_title">Pozastaveno detekcí spánku</string>
+    <string name="reaction_sleep_notification_text">%1$s oznámil, že jste usnuli, takže vaše hudba byla pozastavena. Toto můžete vypnout v nastavení zařízení.</string>
     <string name="device_settings_rename_label">Přejmenovat</string>
     <string name="device_settings_rename_hint">Název zařízení</string>
     <string name="device_settings_rename_confirm">Přejmenovat</string>
@@ -501,13 +514,17 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Nastavení Bluetooth</string>
     <string name="device_settings_send_failed">Nastavení nelze použít: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Režim Vypnuto není na tomto zařízení povolen. Povolte „Povolit režim Vypnuto“ v části Kontrola hluku.</string>
+    <string name="device_settings_category_battery_label">Baterie</string>
+    <string name="device_settings_charge_cap_label">Optimalizovaný limit nabíjení</string>
+    <string name="device_settings_charge_cap_description">Naučí se vaše návyky a pozastaví nabíjení přibližně na 80 %%, aby prodloužilo životnost baterie, a dobíjí sluchátka těsně před jejich použitím.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimalizovaný limit nabíjení nepšel změnit. Jde o experimentalní funkci — prosím nahláste, pokud to nefunguje opakovaně.</string>
     <string name="device_settings_category_connections_label">Připojená zařízení</string>
     <string name="device_settings_connected_devices_description">Další zařízení aktuálně připojená k těmto AirPods</string>
     <string name="device_settings_connected_device_label">Zařízení %d</string>
     <string name="device_settings_connected_device_call">Probíhá hovor</string>
     <string name="device_settings_connected_device_media">Přehrává média</string>
     <string name="device_settings_noise_control_label">Ovládání zvuku</string>
-    <string name="device_settings_eq_label">Ekvualizér</string>
+    <string name="device_settings_eq_label">Ekvalizér</string>
     <!-- Press Controls -->
     <string name="press_controls_title">Ovládání stisku</string>
     <string name="press_controls_nav_description">Nastavte chování stisku a přiřaďte stisky k akcím</string>
@@ -518,13 +535,13 @@
     <string name="press_controls_long_press">Dlouhý stisk</string>
     <string name="press_controls_long_press_anc_cycle_info">Přiřazení akce dlouhého stisku také zakáže cyklování režimů Kontroly hluku (např. Potlačení hluku, Transparentnost) stisknutím a podržením AirPods.</string>
     <string name="press_controls_mappings_section_title">Mapování stisku</string>
-    <string name="press_controls_left">Levý</string>
-    <string name="press_controls_right">Pravý</string>
+    <string name="press_controls_left">Levé</string>
+    <string name="press_controls_right">Pravé</string>
     <string name="press_action_none">Výchozí</string>
     <string name="press_action_no_action">Žádná akce</string>
     <string name="press_action_play_pause">Přehrát/Pozastavit</string>
-    <string name="press_action_next_track">Další stopa</string>
-    <string name="press_action_previous_track">Předchozí stopa</string>
+    <string name="press_action_next_track">Další skladba</string>
+    <string name="press_action_previous_track">Předchozí skladba</string>
     <string name="press_action_volume_up">Hlasitost nahoru</string>
     <string name="press_action_volume_down">Hlasitost dolů</string>
     <string name="press_action_mute_toggle">Ztlumit hudbu</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Baggrundsgennemsigtighed</string>
     <string name="widget_config_show_device_label">Vis enhedsnavn</string>
     <string name="widget_config_reset_label">Nulstil til standard</string>
+    <string name="widget_config_preview_resize_hint">Du kan ændre størrelsen på widgetten, efter du har placeret den på din startskærm.</string>
     <string name="widget_config_custom_label">Brugerdefineret</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Mørk</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Dette er en ukendt enhed, men den bruger et lignende meddelelsesformat. Lad os tilføje understøttelse for den, kontakt mig :)</string>
     <string name="pods_none_label_short">Ingen enhed</string>
     <string name="pods_charging_label">Oplader</string>
+    <string name="pods_charging_optimized_label">Optimeret</string>
     <string name="pods_inear_label">I øret</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Fra</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-enhedsnavn</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producent</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Serienummer</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Afventende firmware</string>
     <string name="device_settings_info_build_label">Version</string>
     <string name="device_settings_info_left_serial_label">Venstre pod-serienummer</string>
     <string name="device_settings_info_right_serial_label">Højre pod-serienummer</string>
+    <string name="device_settings_info_left_bonded_label">Venstre parret</string>
+    <string name="device_settings_info_right_bonded_label">Højre parret</string>
     <string name="device_settings_info_details_label">Enhedsdetaljer</string>
     <string name="device_settings_info_details_action">Vis enhedsdetaljer</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Denne enhed er i nærheden, men ikke forbundet til denne telefon. Opret forbindelse for at få adgang til indstillinger og kontrolfunktioner.</string>
     <string name="device_settings_not_connected_connect_action">Opret forbindelse</string>
     <string name="device_settings_not_connected_open_settings_action">Åbn Bluetooth-indstillinger</string>
+    <string name="device_settings_not_nearby_label">Enhed ikke i nærheden</string>
+    <string name="device_settings_not_nearby_description">Indstillinger er kun tilgængelige, når denne enhed er i nærheden og tilsluttet din telefon.</string>
     <string name="device_settings_aap_unavailable_label">Avancerede indstillinger er ikke tilgængelige</string>
     <string name="device_settings_aap_unavailable_description">Avancerede AirPods-indstillinger kræver en Bluetooth-funktion, der ikke er tilgængelig på denne telefon. Dette kan muligvis løses af en fremtidig Android-opdatering fra din enhedsproducent.</string>
+    <string name="device_settings_aap_unavailable_action">Se kompatibilitetssporing</string>
     <string name="device_settings_category_sound_label">Lyd</string>
     <string name="device_settings_category_controls_label">Betjeninger</string>
     <string name="device_settings_nc_one_airpod_label">ANC med én pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkelt tryk for at slå mikrofon fra</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dobbelt tryk for at afslutte opkald</string>
     <string name="device_settings_open_cd">Åbn enhedsindstillinger</string>
+    <string name="overview_card_missing_paired_device">Denne profil har ingen parret Bluetooth-enhed.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Tillad Slukket som en valgbar støjkontrol-tilstand. Når deaktiveret, springer stammer Slukket over under cyklus.</string>
     <string name="device_settings_sleep_detection_label">Søvnregistrering</string>
     <string name="device_settings_sleep_detection_description">Sæt automatisk lyd på pause når du falder i søvn</string>
+    <string name="reaction_sleep_channel_label">Søvnregistrering</string>
+    <string name="reaction_sleep_notification_title">Sat på pause af søvnregistrering</string>
+    <string name="reaction_sleep_notification_text">%1$s registrerede, at du faldt i søvn, så din musik blev sat på pause. Du kan deaktivere dette i enhedsindstillingerne.</string>
     <string name="device_settings_rename_label">Omdøb</string>
     <string name="device_settings_rename_hint">Enhedsnavn</string>
     <string name="device_settings_rename_confirm">Omdøb</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-indstillinger</string>
     <string name="device_settings_send_failed">Kunne ikke anvende indstilling: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Slukket-tilstand er ikke aktiveret på denne enhed. Aktivér \"Tillad Slukket-tilstand\" under Støjkontrol.</string>
+    <string name="device_settings_category_battery_label">Batteri</string>
+    <string name="device_settings_charge_cap_label">Optimeret opladningsgrænse</string>
+    <string name="device_settings_charge_cap_description">Lær din rutine og sæt opladningen på pause ved ca. 80%% for at forlænge batterilevetiden, og top pods op, inden du sandsynligvis skal bruge dem.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimeret opladningsgrænse kunne ikke ændres. Dette er en eksperimentel funktion — rapporter venligst, hvis det bliver ved med at fejle.</string>
     <string name="device_settings_category_connections_label">Tilsluttede enheder</string>
     <string name="device_settings_connected_devices_description">Andre enheder der i øjeblikket er tilsluttet disse AirPods</string>
     <string name="device_settings_connected_device_label">Enhed %d</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Hintergrundtransparenz</string>
     <string name="widget_config_show_device_label">Gerätenamen anzeigen</string>
     <string name="widget_config_reset_label">Auf Standardwerte zurücksetzen</string>
+    <string name="widget_config_preview_resize_hint">Du kannst die Widget-Größe anpassen, nachdem du es auf deinem Startbildschirm platziert hast.</string>
     <string name="widget_config_custom_label">Benutzerdefiniert</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Dunkel</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Dies ist ein unbekanntes Gerät, aber es verwendet ein ähnliches Nachrichtenformat. Lass uns Unterstützung dafür hinzufügen, kontaktiere mich :)</string>
     <string name="pods_none_label_short">Kein Gerät</string>
     <string name="pods_charging_label">Laden</string>
+    <string name="pods_charging_optimized_label">Optimiert</string>
     <string name="pods_inear_label">Im Ohr</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Aus</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-Gerätebezeichnung</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Hersteller</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Seriennummer</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Ausstehende Firmware</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Seriennummer linker Pod</string>
     <string name="device_settings_info_right_serial_label">Seriennummer rechter Pod</string>
+    <string name="device_settings_info_left_bonded_label">Links gekoppelt</string>
+    <string name="device_settings_info_right_bonded_label">Rechts gekoppelt</string>
     <string name="device_settings_info_details_label">Gerätedetails</string>
     <string name="device_settings_info_details_action">Gerätedetails anzeigen</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Dieses Gerät ist in der Nähe, aber nicht mit diesem Telefon verbunden. Verbinden, um auf Einstellungen und Steuerungen zuzugreifen.</string>
     <string name="device_settings_not_connected_connect_action">Verbinden</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth-Einstellungen öffnen</string>
+    <string name="device_settings_not_nearby_label">Gerät nicht in der Nähe</string>
+    <string name="device_settings_not_nearby_description">Einstellungen sind nur verfügbar, wenn dieses Gerät in der Nähe und mit deinem Telefon verbunden ist.</string>
     <string name="device_settings_aap_unavailable_label">Erweiterte Einstellungen nicht verfügbar</string>
     <string name="device_settings_aap_unavailable_description">Erweiterte AirPods-Einstellungen erfordern eine Bluetooth-Funktion, die auf diesem Telefon nicht verfügbar ist. Dies könnte durch ein zukünftiges Android-Update deines Geräteherstellers behoben werden.</string>
+    <string name="device_settings_aap_unavailable_action">Kompatibilitätsliste anzeigen</string>
     <string name="device_settings_category_sound_label">Ton</string>
     <string name="device_settings_category_controls_label">Steuerung</string>
     <string name="device_settings_nc_one_airpod_label">ANC mit einem Pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Einmaliges Drücken zum Stummschalten des Mikrofons</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Zweimaliges Drücken zum Beenden des Anrufs</string>
     <string name="device_settings_open_cd">Geräteeinstellungen öffnen</string>
+    <string name="overview_card_missing_paired_device">Dieses Profil hat kein gekoppeltes Bluetooth-Gerät.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Allgemein</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Aus als auswählbaren Geräuschsteuerungsmodus erlauben. Wenn deaktiviert, überspringen die Stiele den Aus-Modus beim Durchschalten.</string>
     <string name="device_settings_sleep_detection_label">Schlaferkennung</string>
     <string name="device_settings_sleep_detection_description">Audio automatisch pausieren, wenn du einschläfst</string>
+    <string name="reaction_sleep_channel_label">Schlaferkennung</string>
+    <string name="reaction_sleep_notification_title">Pausiert durch Schlafmodus-Erkennung</string>
+    <string name="reaction_sleep_notification_text">%1$s hat erkannt, dass du eingeschlafen bist, daher wurde deine Musik pausiert. Du kannst dies in den Geräteeinstellungen deaktivieren.</string>
     <string name="device_settings_rename_label">Umbenennen</string>
     <string name="device_settings_rename_hint">Gerätename</string>
     <string name="device_settings_rename_confirm">Umbenennen</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-Einstellungen</string>
     <string name="device_settings_send_failed">Einstellung konnte nicht angewendet werden: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Der Aus-Modus ist auf diesem Gerät nicht aktiviert. Aktiviere „Aus-Modus erlauben“ unter Geräuschsteuerung.</string>
+    <string name="device_settings_category_battery_label">Akku</string>
+    <string name="device_settings_charge_cap_label">Optimiertes Ladelimit</string>
+    <string name="device_settings_charge_cap_description">Lernt deine Routine und pausiert das Laden bei ca. 80%%, um die Akkulebensdauer zu verlängern, und lädt die Pods vor der wahrscheinlichen Nutzung voll auf.</string>
+    <string name="device_settings_charge_cap_rejected_message">Das optimierte Ladelimit konnte nicht geändert werden. Dies ist eine experimentelle Funktion – bitte melde es, wenn es weiterhin fehlschlägt.</string>
     <string name="device_settings_category_connections_label">Verbundene Geräte</string>
     <string name="device_settings_connected_devices_description">Andere Geräte, die derzeit mit diesen AirPods verbunden sind</string>
     <string name="device_settings_connected_device_label">Gerät %d</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Διαφάνεια φόντου</string>
     <string name="widget_config_show_device_label">Εμφάνιση ονόματος συσκευής</string>
     <string name="widget_config_reset_label">Επαναφορά στις προεπιλογές</string>
+    <string name="widget_config_preview_resize_hint">Μπορείτε να αλλάξετε το μέγεθος του widget αφού το τοποθετήσετε στην αρχική οθόνη σας.</string>
     <string name="widget_config_custom_label">Προσαρμοσμένη</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Σκοτεινό</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Αυτή είναι μια άγνωστη συσκευή, αλλά χρησιμοποιεί παρόμοια μορφή μηνύματος. Ας προσθέσουμε υποστήριξη γι\' αυτήν, επικοινωνήστε μαζί μου :)</string>
     <string name="pods_none_label_short">Καμία συσκευή</string>
     <string name="pods_charging_label">Φόρτιση</string>
+    <string name="pods_charging_optimized_label">Βελτιστοποιημένη</string>
     <string name="pods_inear_label">Στο αυτί</string>
     <string name="pods_microphone_label">Μικρόφωνο</string>
     <string name="anc_mode_off">Απενεργοποιημένο</string>
@@ -304,7 +306,7 @@
     <string name="profiles_key_expected_format">Αναμενόμενη μορφή: %1$s</string>
     <string name="profiles_key_status_configured">Διαμορφωμένο</string>
     <string name="profiles_key_status_not_set">Μη ορισμένο</string>
-    <string name="profiles_signal_quality_min_label">Απενεργοποιημένο</string>
+    <string name="profiles_signal_quality_min_label">Απενεργο</string>
     <string name="profiles_signal_quality_max_label">Αυστηρό</string>
     <string name="profiles_priority_hint">Η σειρά των προφίλ καθορίζει την προτεραιότητα. Σύρετε τα προφίλ για αναδιάταξη - τα προφίλ υψηλότερα στη λίστα έχουν προτεραιότητα όταν ταιριάζουν πολλαπλές συσκευές.</string>
     <!-- Theme Mode -->
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Ετικέτα Συσκευής Bluetooth</string>
     <string name="device_settings_info_model_label">Μοντέλο</string>
     <string name="device_settings_info_manufacturer_label">Κατασκευαστής</string>
+    <string name="device_settings_info_hardware_label">Υλικό</string>
     <string name="device_settings_info_serial_label">Σειριακός Αριθμός</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Εκκρεμές Firmware</string>
     <string name="device_settings_info_build_label">Έκδοση</string>
     <string name="device_settings_info_left_serial_label">Σειριακός Αριθμός Αριστερού Pod</string>
     <string name="device_settings_info_right_serial_label">Σειριακός Αριθμός Δεξιού Pod</string>
+    <string name="device_settings_info_left_bonded_label">Αριστερό Συζευγμένο</string>
+    <string name="device_settings_info_right_bonded_label">Δεξί Συζευγμένο</string>
     <string name="device_settings_info_details_label">Λεπτομέρειες Συσκευής</string>
     <string name="device_settings_info_details_action">Εμφάνιση λεπτομερειών συσκευής</string>
     <string name="device_settings_info_status_label">Κατάσταση</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Αυτή η συσκευή είναι κοντά αλλά δεν είναι συνδεδεμένη σε αυτό το τηλέφωνο. Συνδεθείτε για πρόσβαση στις ρυθμίσεις και τις επιλογές ελέγχου.</string>
     <string name="device_settings_not_connected_connect_action">Σύνδεση</string>
     <string name="device_settings_not_connected_open_settings_action">Άνοιγμα Ρυθμίσεων Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Η συσκευή δεν βρίσκεται κοντά</string>
+    <string name="device_settings_not_nearby_description">Οι ρυθμίσεις είναι διαθέσιμες μόνο όταν αυτή η συσκευή βρίσκεται κοντά και είναι συνδεδεμένη στο τηλέφωνό σας.</string>
     <string name="device_settings_aap_unavailable_label">Οι προηγμένες ρυθμίσεις δεν είναι διαθέσιμες</string>
     <string name="device_settings_aap_unavailable_description">Οι προηγμένες ρυθμίσεις AirPods απαιτούν λειτουργία Bluetooth που δεν είναι διαθέσιμη σε αυτό το τηλέφωνο. Αυτό μπορεί να επιλυθεί με μελλοντική ενημέρωση Android από τον κατασκευαστή της συσκευής σας.</string>
+    <string name="device_settings_aap_unavailable_action">Προβολή εργαλείου παρακολούθησης συμβατότητας</string>
     <string name="device_settings_category_sound_label">Ήχος</string>
     <string name="device_settings_category_controls_label">Χειριστήρια</string>
     <string name="device_settings_nc_one_airpod_label">ANC με ένα pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Μία πίεση για σίγαση μικροφώνου</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Διπλή πίεση για τερματισμό κλήσης</string>
     <string name="device_settings_open_cd">Άνοιγμα ρυθμίσεων συσκευής</string>
+    <string name="overview_card_missing_paired_device">Αυτό το προφίλ δεν έχει συζευγμένη συσκευή Bluetooth.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Γενικά</string>
     <string name="device_settings_microphone_mode_label">Μικρόφωνο</string>
@@ -480,8 +490,11 @@
     <string name="device_settings_listening_mode_cycle_adaptive">Προσαρμοστικό</string>
     <string name="device_settings_allow_off_label">Να επιτρέπεται η λειτουργία Απενεργοποίησης</string>
     <string name="device_settings_allow_off_description">Να επιτρέπεται η Απενεργοποίηση ως επιλέξιμη λειτουργία ελέγχου θορύβου. Όταν είναι απενεργοποιημένη, τα στελέχη παραλείπουν την Απενεργοποίηση κατά τον κύκλο.</string>
-    <string name="device_settings_sleep_detection_label">Ανίχνευση ύπνου</string>
+    <string name="device_settings_sleep_detection_label">Ανίχνευση ΍πνου</string>
     <string name="device_settings_sleep_detection_description">Αυτόματη παύση ήχου όταν αποκοιμηθείτε</string>
+    <string name="reaction_sleep_channel_label">Ανίχνευση Ύπνου</string>
+    <string name="reaction_sleep_notification_title">Σε παύση από την Ανίχνευση Ύπνου</string>
+    <string name="reaction_sleep_notification_text">%1$s ανέφερε ότι αποκοιμηθήκατε, οπότε η μουσική σας τέθηκε σε παύση. Μπορείτε να το απενεργοποιήσετε στις ρυθμίσεις συσκευής.</string>
     <string name="device_settings_rename_label">Μετονομασία</string>
     <string name="device_settings_rename_hint">Όνομα συσκευής</string>
     <string name="device_settings_rename_confirm">Μετονομασία</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Ρυθμίσεις Bluetooth</string>
     <string name="device_settings_send_failed">Δεν ήταν δυνατή η εφαρμογή ρύθμισης: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Η λειτουργία Απενεργοποίησης δεν είναι ενεργοποιημένη σε αυτή τη συσκευή. Ενεργοποιήστε «Να επιτρέπεται η λειτουργία Απενεργοποίησης» στον Έλεγχο Θορύβου.</string>
+    <string name="device_settings_category_battery_label">Μπαταρία</string>
+    <string name="device_settings_charge_cap_label">Βελτιστοποιημένο Όριο Φόρτισης</string>
+    <string name="device_settings_charge_cap_description">Μαθαίνει τη ρουτίνα σας και διακόπτει τη φόρτιση γύρω στο 80%% για να παρατείνει τη διάρκεια ζωής της μπαταρίας, φορτίζοντας πλήρως τα pods πριν τα χρησιμοποιήσετε.</string>
+    <string name="device_settings_charge_cap_rejected_message">Δεν ήταν δυνατή η αλλαγή του Βελτιστοποιημένου Ορίου Φόρτισης. Αυτό είναι πειραματικό χαρακτηριστικό — παρακαλώ αναφέρετε αν συνεχίσει να αποτυγχάνει.</string>
     <string name="device_settings_category_connections_label">Συνδεδεμένες Συσκευές</string>
     <string name="device_settings_connected_devices_description">Άλλες συσκευές που είναι συνδεδεμένες στα AirPods αυτή τη στιγμή</string>
     <string name="device_settings_connected_device_label">Συσκευή %d</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparencia de fondo</string>
     <string name="widget_config_show_device_label">Mostrar nombre del dispositivo</string>
     <string name="widget_config_reset_label">Restablecer valores predeterminados</string>
+    <string name="widget_config_preview_resize_hint">Podés redimensionar el widget después de colocarlo en tu pantalla de inicio.</string>
     <string name="widget_config_custom_label">Personalizado</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Oscuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Es un dispositivo desconocido, pero está utilizando un formato similar. Añadamos soporte para ello, contáctame :)</string>
     <string name="pods_none_label_short">Sin dispositivo</string>
     <string name="pods_charging_label">Cargando</string>
+    <string name="pods_charging_optimized_label">Optimizado</string>
     <string name="pods_inear_label">En el oído</string>
     <string name="pods_microphone_label">Micrófono</string>
     <string name="anc_mode_off">Desactivado</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Nombre de dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Número de serie</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware pendiente</string>
     <string name="device_settings_info_build_label">Compilación</string>
     <string name="device_settings_info_left_serial_label">Número de serie del auricular izquierdo</string>
     <string name="device_settings_info_right_serial_label">Número de serie del auricular derecho</string>
+    <string name="device_settings_info_left_bonded_label">Izquierdo vinculado</string>
+    <string name="device_settings_info_right_bonded_label">Derecho vinculado</string>
     <string name="device_settings_info_details_label">Detalles del dispositivo</string>
     <string name="device_settings_info_details_action">Mostrar detalles del dispositivo</string>
     <string name="device_settings_info_status_label">Estado</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Este dispositivo está cerca pero no conectado a este teléfono. Conectate para acceder a la configuración y los controles.</string>
     <string name="device_settings_not_connected_connect_action">Conectar</string>
     <string name="device_settings_not_connected_open_settings_action">Abrir ajustes de Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo no está cerca</string>
+    <string name="device_settings_not_nearby_description">La configuración solo está disponible cuando este dispositivo está cerca y conectado a tu teléfono.</string>
     <string name="device_settings_aap_unavailable_label">Configuración avanzada no disponible</string>
     <string name="device_settings_aap_unavailable_description">La configuración avanzada de AirPods requiere una función de Bluetooth que no está disponible en este teléfono. Esto puede resolverse con una futura actualización de Android del fabricante de tu dispositivo.</string>
+    <string name="device_settings_aap_unavailable_action">Ver rastreador de compatibilidad</string>
     <string name="device_settings_category_sound_label">Sonido</string>
     <string name="device_settings_category_controls_label">Controles</string>
     <string name="device_settings_nc_one_airpod_label">ANC con un solo auricular</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pulsación simple para silenciar el micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Doble pulsación para finalizar la llamada</string>
     <string name="device_settings_open_cd">Abrir configuración del dispositivo</string>
+    <string name="overview_card_missing_paired_device">Este perfil no tiene ningún dispositivo Bluetooth emparejado.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permitió Desactivado como modo de control de ruido seleccionable. Cuando está deshabilitado, los tallos omiten Desactivado al ciclar.</string>
     <string name="device_settings_sleep_detection_label">Detección de sueño</string>
     <string name="device_settings_sleep_detection_description">Pausar automáticamente el audio cuando te quedas dormido</string>
+    <string name="reaction_sleep_channel_label">Detección de sueño</string>
+    <string name="reaction_sleep_notification_title">Pausado por Detección de sueño</string>
+    <string name="reaction_sleep_notification_text">%1$s informó que te quedaste dormido, por lo que tu música fue pausada. Podés desactivar esto en la configuración del dispositivo.</string>
     <string name="device_settings_rename_label">Renombrar</string>
     <string name="device_settings_rename_hint">Nombre del dispositivo</string>
     <string name="device_settings_rename_confirm">Renombrar</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Ajustes de Bluetooth</string>
     <string name="device_settings_send_failed">No se pudo aplicar la configuración: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">El modo Desactivado no está habilitado en este dispositivo. Activá \"Permitir modo Desactivado\" en Control de ruido.</string>
+    <string name="device_settings_category_battery_label">Batería</string>
+    <string name="device_settings_charge_cap_label">Límite de carga optimizado</string>
+    <string name="device_settings_charge_cap_description">Aprende tu rutina y pausa la carga alrededor del 80%% para prolongar la vida de la batería, terminando de cargar los auriculares antes de que sea probable que los uses.</string>
+    <string name="device_settings_charge_cap_rejected_message">No se pudo cambiar el Límite de carga optimizado. Esta es una función experimental — informá si sigue fallando.</string>
     <string name="device_settings_category_connections_label">Dispositivos conectados</string>
     <string name="device_settings_connected_devices_description">Otros dispositivos actualmente conectados a estos AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparencia de fondo</string>
     <string name="widget_config_show_device_label">Mostrar nombre del dispositivo</string>
     <string name="widget_config_reset_label">Restablecer predeterminados</string>
+    <string name="widget_config_preview_resize_hint">Puedes cambiar el tamaño del widget después de colocarlo en tu pantalla de inicio.</string>
     <string name="widget_config_custom_label">Personalizado</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Oscuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Es un dispositivo desconocido, pero está utilizando un formato similar. Añadamos soporte para ello, contáctame :)</string>
     <string name="pods_none_label_short">Sin dispositivo</string>
     <string name="pods_charging_label">Cargando</string>
+    <string name="pods_charging_optimized_label">Optimizado</string>
     <string name="pods_inear_label">En el oído</string>
     <string name="pods_microphone_label">Micrófono</string>
     <string name="anc_mode_off">Apagado</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etiqueta del dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Número de serie</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware pendiente</string>
     <string name="device_settings_info_build_label">Compilación</string>
     <string name="device_settings_info_left_serial_label">Número de serie del auricular izquierdo</string>
     <string name="device_settings_info_right_serial_label">Número de serie del auricular derecho</string>
+    <string name="device_settings_info_left_bonded_label">Izquierdo vinculado</string>
+    <string name="device_settings_info_right_bonded_label">Derecho vinculado</string>
     <string name="device_settings_info_details_label">Detalles del dispositivo</string>
     <string name="device_settings_info_details_action">Mostrar detalles del dispositivo</string>
     <string name="device_settings_info_status_label">Estado</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Este dispositivo está cerca pero no conectado a este teléfono. Conéctalo para acceder a la configuración y controles.</string>
     <string name="device_settings_not_connected_connect_action">Conectar</string>
     <string name="device_settings_not_connected_open_settings_action">Abrir ajustes de Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo no está cerca</string>
+    <string name="device_settings_not_nearby_description">La configuración solo está disponible cuando este dispositivo está cerca y conectado a tu teléfono.</string>
     <string name="device_settings_aap_unavailable_label">Configuración avanzada no disponible</string>
     <string name="device_settings_aap_unavailable_description">La configuración avanzada de AirPods requiere una función de Bluetooth que no está disponible en este teléfono. Esto podría resolverse con una futura actualización de Android de tu fabricante.</string>
+    <string name="device_settings_aap_unavailable_action">Ver rastreador de compatibilidad</string>
     <string name="device_settings_category_sound_label">Sonido</string>
     <string name="device_settings_category_controls_label">Controles</string>
     <string name="device_settings_nc_one_airpod_label">ANC con un solo auricular</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pulsación simple para silenciar el micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pulsación doble para terminar la llamada</string>
     <string name="device_settings_open_cd">Abrir ajustes del dispositivo</string>
+    <string name="overview_card_missing_paired_device">Este perfil no tiene ningún dispositivo Bluetooth vinculado.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permitir Apagado como modo de control de ruido seleccionable. Cuando está desactivado, los tallos omiten Apagado al ciclar.</string>
     <string name="device_settings_sleep_detection_label">Detección de sueño</string>
     <string name="device_settings_sleep_detection_description">Pausar automáticamente el audio cuando te quedas dormido</string>
+    <string name="reaction_sleep_channel_label">Detección de sueño</string>
+    <string name="reaction_sleep_notification_title">Pausado por detección de sueño</string>
+    <string name="reaction_sleep_notification_text">%1$s detectó que te quedaste dormido, por lo que tu música fue pausada. Puedes desactivar esto en la configuración del dispositivo.</string>
     <string name="device_settings_rename_label">Renombrar</string>
     <string name="device_settings_rename_hint">Nombre del dispositivo</string>
     <string name="device_settings_rename_confirm">Renombrar</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Ajustes de Bluetooth</string>
     <string name="device_settings_send_failed">No se pudo aplicar la configuración: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">El modo Apagado no está habilitado en este dispositivo. Activa \"Permitir modo Apagado\" en Control de ruido.</string>
+    <string name="device_settings_category_battery_label">Batería</string>
+    <string name="device_settings_charge_cap_label">Límite de carga optimizado</string>
+    <string name="device_settings_charge_cap_description">Aprende tu rutina y pausa la carga alrededor del 80%% para prolongar la vida útil de la batería, cargando los pods antes de que los uses.</string>
+    <string name="device_settings_charge_cap_rejected_message">No se pudo cambiar el límite de carga optimizado. Esta es una función experimental — por favor repórtalo si sigue fallando.</string>
     <string name="device_settings_category_connections_label">Dispositivos conectados</string>
     <string name="device_settings_connected_devices_description">Otros dispositivos actualmente conectados a estos AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparencia del fondo</string>
     <string name="widget_config_show_device_label">Mostrar el nombre del dispositivo</string>
     <string name="widget_config_reset_label">Restaurar los valores predeterminados</string>
+    <string name="widget_config_preview_resize_hint">Puedes cambiar el tamaño del widget después de colocarlo en la pantalla de inicio.</string>
     <string name="widget_config_custom_label">Personalizado</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Oscuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Es un dispositivo desconocido, pero está utilizando un formato similar. Añadamos soporte para ello, contáctame :)</string>
     <string name="pods_none_label_short">Sin dispositivo</string>
     <string name="pods_charging_label">Cargando</string>
+    <string name="pods_charging_optimized_label">Optimizado</string>
     <string name="pods_inear_label">En el oído</string>
     <string name="pods_microphone_label">Micrófono</string>
     <string name="anc_mode_off">Desactivado</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etiqueta del dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Número de serie</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware pendiente</string>
     <string name="device_settings_info_build_label">Versión</string>
     <string name="device_settings_info_left_serial_label">Número de serie del auricular izquierdo</string>
     <string name="device_settings_info_right_serial_label">Número de serie del auricular derecho</string>
+    <string name="device_settings_info_left_bonded_label">Izquierdo vinculado</string>
+    <string name="device_settings_info_right_bonded_label">Derecho vinculado</string>
     <string name="device_settings_info_details_label">Detalles del dispositivo</string>
     <string name="device_settings_info_details_action">Mostrar detalles del dispositivo</string>
     <string name="device_settings_info_status_label">Estado</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Este dispositivo está cerca pero no conectado a este teléfono. Conéctalo para acceder a los ajustes y controles.</string>
     <string name="device_settings_not_connected_connect_action">Conectar</string>
     <string name="device_settings_not_connected_open_settings_action">Abrir ajustes de Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo no cercano</string>
+    <string name="device_settings_not_nearby_description">La configuración solo está disponible cuando este dispositivo está cerca y conectado a tu teléfono.</string>
     <string name="device_settings_aap_unavailable_label">Ajustes avanzados no disponibles</string>
     <string name="device_settings_aap_unavailable_description">La configuración avanzada de AirPods requiere una función Bluetooth que no está disponible en este teléfono. Esto podría resolverse con una futura actualización de Android del fabricante de tu dispositivo.</string>
+    <string name="device_settings_aap_unavailable_action">Ver rastreador de compatibilidad</string>
     <string name="device_settings_category_sound_label">Sonido</string>
     <string name="device_settings_category_controls_label">Controles</string>
     <string name="device_settings_nc_one_airpod_label">ANC con un solo auricular</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pulsación simple para silenciar el micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Doble pulsación para finalizar llamada</string>
     <string name="device_settings_open_cd">Abrir configuración del dispositivo</string>
+    <string name="overview_card_missing_paired_device">Este perfil no tiene ningún dispositivo Bluetooth emparejado.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permite el modo Desactivado como modo de control de ruido seleccionable. Cuando está deshabilitado, el tallo omite Desactivado al ciclar.</string>
     <string name="device_settings_sleep_detection_label">Detección de sueño</string>
     <string name="device_settings_sleep_detection_description">Pausar el audio automáticamente cuando te quedes dormido</string>
+    <string name="reaction_sleep_channel_label">Detección de sueño</string>
+    <string name="reaction_sleep_notification_title">Pausado por detección de sueño</string>
+    <string name="reaction_sleep_notification_text">%1$s informó que te quedaste dormido, por lo que tu música fue pausada. Puedes desactivar esto en la configuración del dispositivo.</string>
     <string name="device_settings_rename_label">Renombrar</string>
     <string name="device_settings_rename_hint">Nombre del dispositivo</string>
     <string name="device_settings_rename_confirm">Renombrar</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Ajustes de Bluetooth</string>
     <string name="device_settings_send_failed">No se pudo aplicar el ajuste: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">El modo Desactivado no está habilitado en este dispositivo. Activa \"Permitir modo Desactivado\" en Control de ruido.</string>
+    <string name="device_settings_category_battery_label">Batería</string>
+    <string name="device_settings_charge_cap_label">Límite de carga optimizado</string>
+    <string name="device_settings_charge_cap_description">Aprende tu rutina y pausa la carga alrededor del 80%% para alargar la vida de la batería, completando la carga de los auriculares antes de que vayas a usarlos.</string>
+    <string name="device_settings_charge_cap_rejected_message">No se pudo cambiar el límite de carga optimizado. Es una función experimental; informe si sigue fallando.</string>
     <string name="device_settings_category_connections_label">Dispositivos conectados</string>
     <string name="device_settings_connected_devices_description">Otros dispositivos conectados actualmente a estos AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -62,7 +62,7 @@
     <string name="settings_signal_minimum_description">Väikseim signaali kvaliteet, mis seade peab omama, et seda peetaks teie omaks.</string>
     <string name="settings_autoconnect_label">Automaatne ühendamine</string>
     <string name="settings_autoconnect_description">Kui Android ei ühendu ise, saame seda taotleda. See lülitab jälgimisrežiimi sisse alatiseks.</string>
-    <string name="settings_autoconnect_info_android12">Automaatne ühendus tugineb süsteemifunktsioonile, mida Android 12 ja uuemad versioonid piiravad. See ei pruugi teie seadmel toimida.</string>
+    <string name="settings_autoconnect_info_android12">Iseühenduvus tugineb süsteemivõimalusele, mida Android 12 ja uuemad versioonid piiravad. See ei pruugi teie seadmel toimida.</string>
     <string name="settings_autoconnect_condition_label">Automaatse ühendamise tingimus</string>
     <string name="settings_autoconnect_condition_description">Millal võime üritada ühendada teie seadet?</string>
     <string name="settings_devices_label">Seadmed</string>
@@ -76,7 +76,7 @@
     <string name="settings_compat_offloaded_batching_disabled_title">Keela riistvara rühmitamine</string>
     <string name="settings_compat_offloaded_batching_disabled_summary">Keelake süsteemil rühmitada kogutud andmeid madalama energiatarbimisega Bluetoothi kohta enne meile saatmist.</string>
     <string name="settings_onepod_mode_label">Ühe klapi režiim</string>
-    <string name="settings_onepod_mode_description">Automaatne esitus/paus ja automaatühendus reageerivad ühele kõrvaklapile, mitte ei nõua mõlemat.</string>
+    <string name="settings_onepod_mode_description">Automaatne esitus/paus ja iseühenduvus reageerivad ühele kõrvaklapile, mitte ei nõua mõlemat.</string>
     <string name="settings_popup_caseopen_label">Näita kaane hüpikakent</string>
     <string name="settings_popup_caseopen_description">Seadme kaane avamisel näita hüpikakent (katsetamisel).</string>
     <string name="settings_popup_connected_label">Näita ühenduse hüpikakent</string>
@@ -84,8 +84,8 @@
     <string name="settings_popup_info_not_in_app">Hüpikaknad kuvatakse ainult siis, kui sa pole rakenduses.</string>
     <string name="settings_popup_warning_manual_mode">Hüpikaknad nõuavad monitori töötamist. Monitori režiim on seatud „Kui rakendus on avatud“, mis peatab monitori, kui rakendusest lahkud.</string>
     <string name="general_fix_it_action">Paranda</string>
-    <string name="device_settings_experimental_title">Eksperimentaalne funktsioon</string>
-    <string name="device_settings_experimental_description">Seda funktsiooni ei ole kõigil seadmetel veel testitud. Kui midagi ei tööta korrektselt, avage probleem koos silumislogi failiga.</string>
+    <string name="device_settings_experimental_title">Katsetamisel</string>
+    <string name="device_settings_experimental_description">Seda pole kõigil seadmetel veel katsetatud. Kui midagi ei toimi õigesti, avage probleem koos silumislogi failiga.</string>
     <string name="device_settings_experimental_action">Ava probleemide jälgija</string>
     <string name="notification_channel_device_status_label">Seadme olek</string>
     <string name="notification_channel_device_status_connected_label">Ühendatud seade</string>
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Tausta läbipaistvus</string>
     <string name="widget_config_show_device_label">Kuva seadme nimi</string>
     <string name="widget_config_reset_label">Lähtesta vaikeseadistused</string>
+    <string name="widget_config_preview_resize_hint">Pärast vidina asetamist avaekraanile saate muuta selle suurust.</string>
     <string name="widget_config_custom_label">Kohandatud</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tume</string>
@@ -190,9 +191,9 @@
     <string name="general_manage_devices_action">Halda seadmeid</string>
     <string name="overview_nomaindevice_label">Seadistatud seadmed puuduvad</string>
     <string name="overview_nomaindevice_description">Aku taseme jälgimiseks ja lisavõimaluste lubamiseks seadistage oma seade.</string>
-    <string name="overview_bluetooth_disabled_icon_cd">Bluetooth on keelatud, ava seaded</string>
-    <string name="overview_bluetooth_nearby_icon_cd">Seade on lähedal, ava Bluetoothi seaded</string>
-    <string name="overview_bluetooth_connected_icon_cd">Seade on ühendatud, ava Bluetoothi seaded</string>
+    <string name="overview_bluetooth_disabled_icon_cd">Bluetooth on keelatud, avage seaded</string>
+    <string name="overview_bluetooth_nearby_icon_cd">Seade on lähedal, avage Bluetoothi seaded</string>
+    <string name="overview_bluetooth_connected_icon_cd">Seade on ühendatud, avage Bluetoothi seaded</string>
     <string name="overview_bluetooth_disabled_label">Bluetooth on välja lülitatud</string>
     <string name="overview_bluetooth_disabled_description">Bluetooth on keelatud, lubage see ;)</string>
     <string name="overview_monitoring_active_label">Seadmete jälgimine</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">See on tundmatu seade, mis kasutab sarnast teatevormingut. Las ma muudan selle ühilduvaks, selleks võta minuga ühendust :)</string>
     <string name="pods_none_label_short">Puudub seade</string>
     <string name="pods_charging_label">Laeb</string>
+    <string name="pods_charging_optimized_label">Optimeeritud</string>
     <string name="pods_inear_label">Kõrvas</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Väljas</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetoothi seadme silt</string>
     <string name="device_settings_info_model_label">Mudel</string>
     <string name="device_settings_info_manufacturer_label">Tootja</string>
+    <string name="device_settings_info_hardware_label">Riistvara</string>
     <string name="device_settings_info_serial_label">Seerianumber</string>
     <string name="device_settings_info_firmware_label">Püsivara</string>
+    <string name="device_settings_info_firmware_pending_label">Ootel püsivara</string>
     <string name="device_settings_info_build_label">Versioon</string>
     <string name="device_settings_info_left_serial_label">Vasaku kõrvaklapiosa seerianumber</string>
     <string name="device_settings_info_right_serial_label">Parema kõrvaklapiosa seerianumber</string>
+    <string name="device_settings_info_left_bonded_label">Vasak seotud</string>
+    <string name="device_settings_info_right_bonded_label">Parem seotud</string>
     <string name="device_settings_info_details_label">Seadme andmed</string>
     <string name="device_settings_info_details_action">Kuva seadme andmed</string>
     <string name="device_settings_info_status_label">Olek</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">See seade on lähedal, kuid pole selle telefoniga ühendatud. Seadete ja juhtelementide kasutamiseks ühendage seade.</string>
     <string name="device_settings_not_connected_connect_action">Ühenda</string>
     <string name="device_settings_not_connected_open_settings_action">Ava Bluetoothi seaded</string>
+    <string name="device_settings_not_nearby_label">Seade on kaugel</string>
+    <string name="device_settings_not_nearby_description">Seaded on saadaval ainult siis, kui see seade on lähedal ja teie telefoniga ühendatud.</string>
     <string name="device_settings_aap_unavailable_label">Täpsemad seaded pole saadaval</string>
-    <string name="device_settings_aap_unavailable_description">Täpsemad AirPodsi seaded nõuavad Bluetoothi funktsiooni, mis pole sellel telefonis saadaval. See võib laheneda teie seadme tootja tulevase Androidi värskendusega.</string>
+    <string name="device_settings_aap_unavailable_description">Täpsemad AirPodsi seaded nõuavad Bluetoothi, mis pole selles telefonis saadaval. See võib laheneda teie seadme tootja tulevase Androidi värskendusega.</string>
+    <string name="device_settings_aap_unavailable_action">Kuva ühilduvuse jälgija</string>
     <string name="device_settings_category_sound_label">Heli</string>
     <string name="device_settings_category_controls_label">Juhtnupud</string>
     <string name="device_settings_nc_one_airpod_label">ANC ühe kõrvaklapiosaga</string>
@@ -434,7 +443,7 @@
     <string name="device_settings_tone_volume_description">Kinnitushelide ja helinate helitugevus</string>
     <string name="device_settings_adaptive_noise_label">Kohanduva heli müra</string>
     <string name="device_settings_adaptive_noise_description">Kui palju keskkonna müra läbi lastakse</string>
-    <string name="device_settings_adaptive_noise_requires_adaptive">Nõuab kohanduva mürakontrolli</string>
+    <string name="device_settings_adaptive_noise_requires_adaptive">Nõuab kohanduvat mürakontrolli</string>
     <string name="device_settings_pending_info">Muudatused jõustuvad, kui AirPodsid on kõrvades</string>
     <string name="device_settings_press_speed_label">Vajutuse kiirus</string>
     <string name="device_settings_press_speed_description">Kui kiiresti pead vajutama mitme vajutuse žestide jaoks</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Ühe vajutusega vaigista mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Kahe vajutusega lõpeta kõne</string>
     <string name="device_settings_open_cd">Ava seadme seaded</string>
+    <string name="overview_card_missing_paired_device">Sellel profiilil puudub seotud Bluetoothi seade.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Üldine</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -473,15 +483,18 @@
     <string name="device_settings_listening_mode_cycle_dialog_title">Kohandage pikalt vajutamise tsüklit</string>
     <string name="device_settings_listening_mode_cycle_summary_helper">Kasutatakse varretikku hoides ja kiirvalijas</string>
     <string name="device_settings_listening_mode_cycle_summary_helper_override">Kasutatakse kiirvalijas. Kohandatud varretiku pika vajutuse toiming asendab AirPodside tsüklimise.</string>
-    <string name="device_settings_listening_mode_cycle_minimum">Vähemalt 2 režiimi peab jääma lubatust.</string>
+    <string name="device_settings_listening_mode_cycle_minimum">Vähemalt 2 režiimi peab jääma lubatuks.</string>
     <string name="device_settings_listening_mode_cycle_off">Väljas</string>
     <string name="device_settings_listening_mode_cycle_anc">Mürasummutus</string>
     <string name="device_settings_listening_mode_cycle_transparency">Läbipaistvus</string>
     <string name="device_settings_listening_mode_cycle_adaptive">Kohanduv</string>
     <string name="device_settings_allow_off_label">Luba väljalülitatuse režiim</string>
-    <string name="device_settings_allow_off_description">Luba Välja valikuna mürakontrolli režiimis. Kui keelatud, jätavad varretikud tsüklimise ajal Välja vahele.</string>
+    <string name="device_settings_allow_off_description">Luba „Väljas“ valik mürakontrolli režiimis. Kui keelatud, jätavad varretikud tsüklimise ajal „Väljas“ vahele.</string>
     <string name="device_settings_sleep_detection_label">Une tuvastamine</string>
     <string name="device_settings_sleep_detection_description">Heli vaigistub, kui jääd magama</string>
+    <string name="reaction_sleep_channel_label">Une tuvastamine</string>
+    <string name="reaction_sleep_notification_title">Uinumise tõttu peatatud</string>
+    <string name="reaction_sleep_notification_text">%1$s teatas, et uinusite, seega muusika vaikis. Saate selle seadme seadetes keelata.</string>
     <string name="device_settings_rename_label">Nimeta ümber</string>
     <string name="device_settings_rename_hint">Seadme nimi</string>
     <string name="device_settings_rename_confirm">Nimeta ümber</string>
@@ -490,7 +503,11 @@
     <string name="device_settings_rename_system_unavailable">Android ei lubanud meil seadet siin ümber nimetada. Bluetoothi seadetes nime uuendamiseks nimetage see seal ümber või siduge seade uuesti.</string>
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetoothi seaded</string>
     <string name="device_settings_send_failed">Seadet ei saanud rakendada: %1$s</string>
-    <string name="device_settings_anc_off_rejected_message">Väljas režiim ei ole sellel seadmel lubatud. Lubage \"Luba väljalülitatuse režiim\" mürakontrolli all.</string>
+    <string name="device_settings_anc_off_rejected_message">Väljas-režiim pole sellel seadmel lubatud. Lubage „Luba väljalülitatuse režiim“ mürakontrolli all.</string>
+    <string name="device_settings_category_battery_label">Aku</string>
+    <string name="device_settings_charge_cap_label">Optimeeritud laadimispiirang</string>
+    <string name="device_settings_charge_cap_description">Õpib kasutamisharjumusest ja peatab laadimise umbes 80%% juures, et pikendada aku kasutusiga, laadides kuularid täis enne, kui neid tõenäoliselt kasutate.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimeeritud laadimispiirangut ei saanud muuta. Seda katsetatakse — teavitage, kui see ikka nurjub.</string>
     <string name="device_settings_category_connections_label">Ühendatud seadmed</string>
     <string name="device_settings_connected_devices_description">Muud seadmed, mis on hetkel nende AirPodidega ühendatud</string>
     <string name="device_settings_connected_device_label">Seade %d</string>
@@ -501,7 +518,7 @@
     <!-- Press Controls -->
     <string name="press_controls_title">Vajutuse juhtelemendid</string>
     <string name="press_controls_nav_description">Häälesta vajutuskäitumist ja mäaarake vajutustele toimingud</string>
-    <string name="press_controls_description">Häälesta, kuidas vajutused tuvastatakse, valige kõnenuppu käitumine ja määrake vajutustele toimingud. Määratud toimingud kehtivad ainult sellele seadmele ja lasevad rakendusel vajutuse vahele võtta, mitte AirPodsidel seda looduslikult käsitseda.</string>
+    <string name="press_controls_description">Häälestage, kuidas vajutused tuvastatakse, valige kõnenuppu käitumine ja määrake vajutustele toimingud. Määratud toimingud kehtivad ainult sellele seadmele ja lasevad rakendusel vajutust mõjutada, mitte AirPodsidel seda käsitseda.</string>
     <string name="press_controls_single_press">Üks vajutus</string>
     <string name="press_controls_double_press">Kaks vajutust</string>
     <string name="press_controls_triple_press">Kolm vajutust</string>
@@ -512,18 +529,18 @@
     <string name="press_controls_right">Parem</string>
     <string name="press_action_none">Tavaline</string>
     <string name="press_action_no_action">Toiming puudub</string>
-    <string name="press_action_play_pause">Esita/Peata</string>
+    <string name="press_action_play_pause">Esita/peata</string>
     <string name="press_action_next_track">Järgmine lugu</string>
     <string name="press_action_previous_track">Eelmine lugu</string>
     <string name="press_action_volume_up">Valjemaks</string>
     <string name="press_action_volume_down">Vaiksemaks</string>
     <string name="press_action_mute_toggle">Vaigista muusika</string>
     <string name="press_action_stop">Peata</string>
-    <string name="press_action_fast_forward">Kiirkelleramine</string>
+    <string name="press_action_fast_forward">Kiirkerimine</string>
     <string name="press_action_rewind">Tagasikerimine</string>
     <string name="press_action_cycle_anc">Mürakontrolli tsükkel</string>
     <string name="press_action_toggle_anc_transparency">Vaheta läbipaistvust</string>
     <string name="press_controls_reset_label">Taasta tavaseadistused</string>
-    <string name="press_controls_reset_confirm_message">Lähestada kõik vajutuse vastendused vaikeväärtustele?</string>
+    <string name="press_controls_reset_confirm_message">Lähestada kõik vajutuse vastendused tavaväärtustele?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Ava vajutuse juhtelemendid</string>
 </resources>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Atzeko planoaren gardentasuna</string>
     <string name="widget_config_show_device_label">Gailuaren izena erakutsi</string>
     <string name="widget_config_reset_label">Berriro lehenespenera berrezarri</string>
+    <string name="widget_config_preview_resize_hint">Widgeta tamainaz alda dezakezu hasierako pantailan jarri ondoren.</string>
     <string name="widget_config_custom_label">Pertsonalizatua</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Iluna</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Gailu ezezagun bat da, baina mezu-formatu berdina erabiltzen du. Gehitu dezagun euskarria, jarri nirekin harremanetan :)</string>
     <string name="pods_none_label_short">Gailurik ez</string>
     <string name="pods_charging_label">Kargatzen</string>
+    <string name="pods_charging_optimized_label">Optimizatua</string>
     <string name="pods_inear_label">Belarrian</string>
     <string name="pods_microphone_label">Mikrofonoa</string>
     <string name="anc_mode_off">Itzalita</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth gailuaren etiketa</string>
     <string name="device_settings_info_model_label">Modeloa</string>
     <string name="device_settings_info_manufacturer_label">Fabrikatzailea</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Serie-zenbakia</string>
     <string name="device_settings_info_firmware_label">Firmware-a</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware Zain</string>
     <string name="device_settings_info_build_label">Eraikuntza</string>
     <string name="device_settings_info_left_serial_label">Ezkerreko pod-aren seriea</string>
     <string name="device_settings_info_right_serial_label">Eskuineko pod-aren seriea</string>
+    <string name="device_settings_info_left_bonded_label">Ezkerra Lotuta</string>
+    <string name="device_settings_info_right_bonded_label">Eskuina Lotuta</string>
     <string name="device_settings_info_details_label">Gailuaren xehetasunak</string>
     <string name="device_settings_info_details_action">Erakutsi gailuaren xehetasunak</string>
     <string name="device_settings_info_status_label">Egoera</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Gailu hau gertu dago baina ez dago telefono honetara konektatuta. Konektatu ezarpenak eta kontrolak atzitzeko.</string>
     <string name="device_settings_not_connected_connect_action">Konektatu</string>
     <string name="device_settings_not_connected_open_settings_action">Ireki Bluetooth Ezarpenak</string>
+    <string name="device_settings_not_nearby_label">Gailua ez dago inguruan</string>
+    <string name="device_settings_not_nearby_description">Ezarpenak eskuragarri daude soilik gailu hau inguruan dagoenean eta zure telefonora konektatuta dagoenean.</string>
     <string name="device_settings_aap_unavailable_label">Ezarpen aurreratuak ez daude erabilgarri</string>
     <string name="device_settings_aap_unavailable_description">AirPods ezarpen aurreratuek telefono honetan erabilgarri ez dagoen Bluetooth funtzio bat behar dute. Baliteke etorkizuneko Android eguneraketa batek konpontzea, zure gailuaren fabrikatzailearen eskutik.</string>
+    <string name="device_settings_aap_unavailable_action">Ikusi bateragarritasun jarraipena</string>
     <string name="device_settings_category_sound_label">Soinua</string>
     <string name="device_settings_category_controls_label">Kontrolak</string>
     <string name="device_settings_nc_one_airpod_label">ANC pod batekin</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Sakapen bakar bat mikrofonoa mututzeko</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Bikoitz sakatu deia amaitzeko</string>
     <string name="device_settings_open_cd">Ireki gailuaren ezarpenak</string>
+    <string name="overview_card_missing_paired_device">Profil honek ez du Bluetooth gailurik parekaturik.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Orokorra</string>
     <string name="device_settings_microphone_mode_label">Mikrofonoa</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Onartu Itzali zarata-kontrolaren modu aukeragarri gisa. Desgaitutakoan, zuztarrak Itzali saltatzen du zikloaren bitartean.</string>
     <string name="device_settings_sleep_detection_label">Lo-detekzioa</string>
     <string name="device_settings_sleep_detection_description">Pausatu audioa automatikoki lo geratzen zarenean</string>
+    <string name="reaction_sleep_channel_label">Lo Detekzioa</string>
+    <string name="reaction_sleep_notification_title">Lo Detekzioak Pausatuta</string>
+    <string name="reaction_sleep_notification_text">%1$s-ek jakinarazi du lo geratu zarela, eta musikak pausatu egin zen. Gailu-ezarpenetan desgaitu dezakezu.</string>
     <string name="device_settings_rename_label">Berrizendatu</string>
     <string name="device_settings_rename_hint">Gailuaren izena</string>
     <string name="device_settings_rename_confirm">Berrizendatu</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth ezarpenak</string>
     <string name="device_settings_send_failed">Ezin izan da ezarpena aplikatu: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Itzali modua ez dago aktibatuta gailu honetan. Gaitu \"Baimendu Itzali modua\" Zarata Kontrolen atalean.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Karga Muga Optimizatua</string>
+    <string name="device_settings_charge_cap_description">Zure errutina ikasi eta karga %% 80 inguruan pausatu bateriaren bizitza luzatzeko, podak erabiltzeko prest utziz.</string>
+    <string name="device_settings_charge_cap_rejected_message">Karga Muga Optimizatua ezin izan da aldatu. Funtzio esperimentala da — jakinarazi huts egiten jarraitzen badu.</string>
     <string name="device_settings_category_connections_label">Konektatutako gailuak</string>
     <string name="device_settings_connected_devices_description">AirPod hauetara konektatuta dauden beste gailuak</string>
     <string name="device_settings_connected_device_label">%d. gailua</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">شفافیت پس‌زمینه</string>
     <string name="widget_config_show_device_label">نمایش نام دستگاه</string>
     <string name="widget_config_reset_label">بازنشانی به مقادیر پیش‌فرض</string>
+    <string name="widget_config_preview_resize_hint">می‌توانید پس از قرار دادن ویجت روی صفحه اصلی، اندازه آن را تغییر دهید.</string>
     <string name="widget_config_custom_label">سفارشی</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">تیره</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">این یک دستگاه ناشناخته است، اما از فرمت پیام مشابهی استفاده می‌کند. بیایید پشتیبانی از آن را اضافه کنیم، با من تماس بگیرید :)</string>
     <string name="pods_none_label_short">بدون دستگاه</string>
     <string name="pods_charging_label">در حال شارژ</string>
+    <string name="pods_charging_optimized_label">بهینه‌شده</string>
     <string name="pods_inear_label">در گوش</string>
     <string name="pods_microphone_label">میکروفون</string>
     <string name="anc_mode_off">خاموش</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">برچسب دستگاه بلوتوث</string>
     <string name="device_settings_info_model_label">مدل</string>
     <string name="device_settings_info_manufacturer_label">سازنده</string>
+    <string name="device_settings_info_hardware_label">سخت‌افزار</string>
     <string name="device_settings_info_serial_label">شماره سریال</string>
     <string name="device_settings_info_firmware_label">سیستم‌افزار</string>
+    <string name="device_settings_info_firmware_pending_label">فریمور در انتظار</string>
     <string name="device_settings_info_build_label">بیلد</string>
     <string name="device_settings_info_left_serial_label">شماره سریال پاد چپ</string>
     <string name="device_settings_info_right_serial_label">شماره سریال پاد راست</string>
+    <string name="device_settings_info_left_bonded_label">چپ متصل</string>
+    <string name="device_settings_info_right_bonded_label">راست متصل</string>
     <string name="device_settings_info_details_label">جزئیات دستگاه</string>
     <string name="device_settings_info_details_action">نمایش جزئیات دستگاه</string>
     <string name="device_settings_info_status_label">وضعیت</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">این دستگاه در نزدیکی است اما به این گوشی متصل نیست. برای دسترسی به تنظیمات و کنترل‌ها، متصل شوید.</string>
     <string name="device_settings_not_connected_connect_action">اتصال</string>
     <string name="device_settings_not_connected_open_settings_action">باز کردن تنظیمات بلوتوث</string>
+    <string name="device_settings_not_nearby_label">دستگاه در نزدیکی نیست</string>
+    <string name="device_settings_not_nearby_description">تنظیمات فقط زمانی در دسترس هستند که این دستگاه در نزدیکی باشد و به تلفن شما متصل باشد.</string>
     <string name="device_settings_aap_unavailable_label">تنظیمات پیشرفته در دسترس نیست</string>
     <string name="device_settings_aap_unavailable_description">تنظیمات پیشرفته AirPods به یک ویژگی بلوتوثی نیاز دارند که در این تلفن در دسترس نیست. ممکن است با یک بروزرسانی آینده اندروید از سازنده دستگاه شما این مشکل حل شود.</string>
+    <string name="device_settings_aap_unavailable_action">مشاهده ردیاب سازگاری</string>
     <string name="device_settings_category_sound_label">صدا</string>
     <string name="device_settings_category_controls_label">کنترل‌ها</string>
     <string name="device_settings_nc_one_airpod_label">ANC با یک پاد</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">یک‌بار فشار برای بی‌صدا کردن میکروفون</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">دوبار فشار برای پایان دادن تماس</string>
     <string name="device_settings_open_cd">باز کردن تنظیمات دستگاه</string>
+    <string name="overview_card_missing_paired_device">این پروفایل هیچ دستگاه بلوتوثی جفت‌شده‌ای ندارد.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">میکروفون</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">اجازه دادن به حالت خاموش به عنوان یک حالت قابل انتخاب کنترل نویز. وقتی غیرفعال است، ساقه‌ها هنگام چرخش از حالت خاموش رد می‌شوند.</string>
     <string name="device_settings_sleep_detection_label">تشخیص خواب</string>
     <string name="device_settings_sleep_detection_description">به‌طور خودکار صدا را مکث کن هنگامی که به خواب می‌روید</string>
+    <string name="reaction_sleep_channel_label">تشخیص خواب</string>
+    <string name="reaction_sleep_notification_title">توسط تشخیص خواب متوقف شد</string>
+    <string name="reaction_sleep_notification_text">%1$s گزارش داد که به خواب رفتید، بنابراین موسیقی شما متوقف شد. می‌توانید این را در تنظیمات دستگاه غیرفعال کنید.</string>
     <string name="device_settings_rename_label">تغییر نام</string>
     <string name="device_settings_rename_hint">نام دستگاه</string>
     <string name="device_settings_rename_confirm">تغییر نام</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">تنظیمات بلوتوث</string>
     <string name="device_settings_send_failed">نمی‌توان تنظیمات را اعمال کرد: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">حالت خاموش روی این دستگاه فعال نیست. «اجازه دادن به حالت خاموش» را در کنترل نویز فعال کنید.</string>
+    <string name="device_settings_category_battery_label">باتری</string>
+    <string name="device_settings_charge_cap_label">محدودیت شارژ بهینه</string>
+    <string name="device_settings_charge_cap_description">روتین شما را یاد می‌گیرد و شارژ را در حدود ۸۰%% متوقف می‌کند تا عمر باتری افزایش یابد و پادها را قبل از زمانی که احتمالاً از آن‌ها استفاده می‌کنید شارژ کامل می‌کند.</string>
+    <string name="device_settings_charge_cap_rejected_message">محدودیت شارژ بهینه قابل تغییر نبود. این یک ویژگی آزمایشی است — لطفاً در صورت ادامه خرابی گزارش دهید.</string>
     <string name="device_settings_category_connections_label">دستگاه‌های متصل</string>
     <string name="device_settings_connected_devices_description">دستگاه‌های دیگری که در حال حاضر به این AirPods متصل هستند</string>
     <string name="device_settings_connected_device_label">دستگاه %d</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Taustan läpinäkyvyys</string>
     <string name="widget_config_show_device_label">Näytä laitteen nimi</string>
     <string name="widget_config_reset_label">Palauta oletusasetukset</string>
+    <string name="widget_config_preview_resize_hint">Voit muuttaa widgetin kokoa sen asettamisen jälkeen aloitusnäytöllä.</string>
     <string name="widget_config_custom_label">Mukautettu</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tumma</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Tämä on tuntematon laite, mutta se käyttää samanlaista viestimuotoa. Lisätään sille tuki, ota yhteyttä :)</string>
     <string name="pods_none_label_short">Ei laitetta</string>
     <string name="pods_charging_label">Latautuu</string>
+    <string name="pods_charging_optimized_label">Optimoitu</string>
     <string name="pods_inear_label">Korvassa</string>
     <string name="pods_microphone_label">Mikrofoni</string>
     <string name="anc_mode_off">Pois</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-laitteen nimi</string>
     <string name="device_settings_info_model_label">Malli</string>
     <string name="device_settings_info_manufacturer_label">Valmistaja</string>
+    <string name="device_settings_info_hardware_label">Laitteisto</string>
     <string name="device_settings_info_serial_label">Sarjanumero</string>
     <string name="device_settings_info_firmware_label">Laiteohjelmisto</string>
+    <string name="device_settings_info_firmware_pending_label">Odottava laiteohjelmisto</string>
     <string name="device_settings_info_build_label">Versio</string>
     <string name="device_settings_info_left_serial_label">Vasemman kuulokkeen sarjanumero</string>
     <string name="device_settings_info_right_serial_label">Oikean kuulokkeen sarjanumero</string>
+    <string name="device_settings_info_left_bonded_label">Vasen yhdistetty</string>
+    <string name="device_settings_info_right_bonded_label">Oikea yhdistetty</string>
     <string name="device_settings_info_details_label">Laitteen tiedot</string>
     <string name="device_settings_info_details_action">Näytä laitteen tiedot</string>
     <string name="device_settings_info_status_label">Tila</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Tämä laite on lähellä, mutta ei yhdistettynä tähän puhelimeen. Yhdistä päästäksesi asetuksiin ja säätimiin.</string>
     <string name="device_settings_not_connected_connect_action">Yhdistä</string>
     <string name="device_settings_not_connected_open_settings_action">Avaa Bluetooth-asetukset</string>
+    <string name="device_settings_not_nearby_label">Laite ei ole lähellä</string>
+    <string name="device_settings_not_nearby_description">Asetukset ovat käytettävissä vain, kun tämä laite on lähellä ja yhdistettynä puhelimeesi.</string>
     <string name="device_settings_aap_unavailable_label">Lisäasetukset eivät ole käytettävissä</string>
     <string name="device_settings_aap_unavailable_description">AirPods-lisäasetukset vaativat Bluetooth-ominaisuuden, joka ei ole saatavilla tässä puhelimessa. Laitteen valmistajan tuleva Android-päivitys saattaa ratkaista tämän.</string>
+    <string name="device_settings_aap_unavailable_action">Katso yhteensopivuusseuranta</string>
     <string name="device_settings_category_sound_label">Ääni</string>
     <string name="device_settings_category_controls_label">Säätimet</string>
     <string name="device_settings_nc_one_airpod_label">ANC yhdellä kuulokkeella</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Yksinkertainen painallus mykistää mikrofonin</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Kaksoispainallus lopettaa puhelun</string>
     <string name="device_settings_open_cd">Avaa laiteasetukset</string>
+    <string name="overview_card_missing_paired_device">Tällä profiililla ei ole yhdistettyä Bluetooth-laitetta.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Yleiset</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Salli Pois valittavaksi melunhallintatilaksi. Kun poistettu käytöstä, varret ohittavat Pois-tilan kierrossa.</string>
     <string name="device_settings_sleep_detection_label">Unitunnistus</string>
     <string name="device_settings_sleep_detection_description">Pysäytä ääni automaattisesti, kun nukahdat</string>
+    <string name="reaction_sleep_channel_label">Unitunnistus</string>
+    <string name="reaction_sleep_notification_title">Unitunnistus keskeytti toiston</string>
+    <string name="reaction_sleep_notification_text">%1$s havaitsi sinun nukahtaneen, joten musiikkisi keskeytettiin. Voit poistaa tämän käytöstä laiteasetuksista.</string>
     <string name="device_settings_rename_label">Nimeä uudelleen</string>
     <string name="device_settings_rename_hint">Laitteen nimi</string>
     <string name="device_settings_rename_confirm">Nimeä uudelleen</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-asetukset</string>
     <string name="device_settings_send_failed">Asetusta ei voitu ottaa käyttöön: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Pois-tila ei ole käytössä tässä laitteessa. Ota käyttöön \"Salli Pois-tila\" Melunhallinnassa.</string>
+    <string name="device_settings_category_battery_label">Akku</string>
+    <string name="device_settings_charge_cap_label">Optimoitu latausraja</string>
+    <string name="device_settings_charge_cap_description">Oppii rutiinisi ja keskeyttää lataamisen noin 80 %%:iin akkukeston pidentämiseksi, täydentäen kuulokkeet ennen todennäköistä käyttöä.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimoitua latausrajaa ei voitu muuttaa. Tämä on kokeellinen ominaisuus – ilmoita asiasta, jos ongelma toistuu.</string>
     <string name="device_settings_category_connections_label">Yhdistetyt laitteet</string>
     <string name="device_settings_connected_devices_description">Muut laitteet, jotka ovat tällä hetkellä yhdistetty näihin AirPodeihin</string>
     <string name="device_settings_connected_device_label">Laite %d</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparency ng background</string>
     <string name="widget_config_show_device_label">Ipakita ang pangalan ng device</string>
     <string name="widget_config_reset_label">I-reset sa mga default</string>
+    <string name="widget_config_preview_resize_hint">Maaari mong baguhin ang laki ng widget pagkatapos ilagay ito sa iyong home screen.</string>
     <string name="widget_config_custom_label">Pasadyang</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Madilim</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Ito ay isang hindi kilalang device, ngunit gumagamit ito ng katulad na format ng mensahe. Magdagdag tayo ng suporta para dito, kontakin mo ako :)</string>
     <string name="pods_none_label_short">Walang device</string>
     <string name="pods_charging_label">Nagcha-charge</string>
+    <string name="pods_charging_optimized_label">Na-optimize</string>
     <string name="pods_inear_label">Nasa tainga</string>
     <string name="pods_microphone_label">Mikropono</string>
     <string name="anc_mode_off">Naka-off</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Label ng Bluetooth Device</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Tagagawa</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Serial Number</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Nakabinbing Firmware</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Serial ng Kaliwang Pod</string>
     <string name="device_settings_info_right_serial_label">Serial ng Kanang Pod</string>
+    <string name="device_settings_info_left_bonded_label">Kaliwang Naka-bond</string>
+    <string name="device_settings_info_right_bonded_label">Kanang Naka-bond</string>
     <string name="device_settings_info_details_label">Mga Detalye ng Device</string>
     <string name="device_settings_info_details_action">Ipakita ang mga detalye ng device</string>
     <string name="device_settings_info_status_label">Katayuan</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Ang device na ito ay malapit ngunit hindi nakakonekta sa teleponong ito. Kumonekta para ma-access ang mga setting at kontrol.</string>
     <string name="device_settings_not_connected_connect_action">Kumonekta</string>
     <string name="device_settings_not_connected_open_settings_action">Buksan ang Mga Setting ng Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Hindi malapit ang device</string>
+    <string name="device_settings_not_nearby_description">Ang mga setting ay available lamang kapag ang device na ito ay malapit at nakakonekta sa iyong telepono.</string>
     <string name="device_settings_aap_unavailable_label">Hindi available ang mga advanced na setting</string>
     <string name="device_settings_aap_unavailable_description">Ang mga advanced na setting ng AirPods ay nangangailangan ng Bluetooth na tampok na hindi available sa teleponong ito. Maaaring malutas ito ng isang hinaharap na Android update mula sa tagagawa ng iyong device.</string>
+    <string name="device_settings_aap_unavailable_action">Tingnan ang compatibility tracker</string>
     <string name="device_settings_category_sound_label">Tunog</string>
     <string name="device_settings_category_controls_label">Mga Kontrol</string>
     <string name="device_settings_nc_one_airpod_label">ANC na may isang pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Isang pindutin para i-mute ang mikropono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dalawang pindutin para tapusin ang tawag</string>
     <string name="device_settings_open_cd">Buksan ang mga setting ng device</string>
+    <string name="overview_card_missing_paired_device">Ang profile na ito ay walang naipares na Bluetooth device.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Pangkalahatan</string>
     <string name="device_settings_microphone_mode_label">Mikropono</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Payagan ang Off bilang mapipiling noise control mode. Kapag naka-disable, nilalaktawan ng mga stem ang Off habang nagcy-cycle.</string>
     <string name="device_settings_sleep_detection_label">Sleep Detection</string>
     <string name="device_settings_sleep_detection_description">Awtomatikong i-pause ang audio kapag nakatulog ka</string>
+    <string name="reaction_sleep_channel_label">Pagtuklas ng Pagtulog</string>
+    <string name="reaction_sleep_notification_title">Naka-pause ng Pagtuklas ng Pagtulog</string>
+    <string name="reaction_sleep_notification_text">Naiulat ng %1$s na nakatulog ka, kaya na-pause ang iyong musika. Maaari mong i-disable ito sa mga setting ng device.</string>
     <string name="device_settings_rename_label">Palitan ang Pangalan</string>
     <string name="device_settings_rename_hint">Pangalan ng device</string>
     <string name="device_settings_rename_confirm">Palitan ang Pangalan</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Mga Setting ng Bluetooth</string>
     <string name="device_settings_send_failed">Hindi ma-apply ang setting: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Hindi naka-enable ang Off mode sa device na ito. I-enable ang \"Payagan ang Off mode\" sa ilalim ng Noise Control.</string>
+    <string name="device_settings_category_battery_label">Baterya</string>
+    <string name="device_settings_charge_cap_label">Na-optimize na Limitasyon ng Pagsisingilin</string>
+    <string name="device_settings_charge_cap_description">Matuto ng iyong gawain at i-pause ang pagsisingilin sa paligid ng 80%% upang mapahaba ang buhay ng baterya, sinisisingilin ang mga pods bago mo pa malamang gamitin ang mga ito.</string>
+    <string name="device_settings_charge_cap_rejected_message">Hindi mabago ang Na-optimize na Limitasyon ng Pagsisingilin. Ito ay isang eksperimental na feature — mangyaring iulat kung patuloy itong nabibigo.</string>
     <string name="device_settings_category_connections_label">Mga Nakakonektang Device</string>
     <string name="device_settings_connected_devices_description">Iba pang mga device na kasalukuyang nakakonekta sa mga AirPods na ito</string>
     <string name="device_settings_connected_device_label">Device %d</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparence de l\'arrière-plan</string>
     <string name="widget_config_show_device_label">Afficher le nom de l’appareil</string>
     <string name="widget_config_reset_label">Rétablir les valeurs par défaut</string>
+    <string name="widget_config_preview_resize_hint">Vous pouvez redimensionner le widget après l\'avoir placé sur votre écran d\'accueil.</string>
     <string name="widget_config_custom_label">Personnalisée</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Sombre</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Cet appareil est inconnu, mais il utilise un format de message semblable. Prenons-le en charge, contactez-moi :)</string>
     <string name="pods_none_label_short">Aucun appareil</string>
     <string name="pods_charging_label">En charge</string>
+    <string name="pods_charging_optimized_label">Optimisé</string>
     <string name="pods_inear_label">Porté</string>
     <string name="pods_microphone_label">Microphone</string>
     <string name="anc_mode_off">Désactivé</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Étiquette de l’appareil Bluetooth</string>
     <string name="device_settings_info_model_label">Modèle</string>
     <string name="device_settings_info_manufacturer_label">Fabricant</string>
+    <string name="device_settings_info_hardware_label">Matériel</string>
     <string name="device_settings_info_serial_label">Numéro de série</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware en attente</string>
     <string name="device_settings_info_build_label">Version</string>
     <string name="device_settings_info_left_serial_label">Numéro de série de l’écouteur gauche</string>
     <string name="device_settings_info_right_serial_label">Numéro de série de l’écouteur droit</string>
+    <string name="device_settings_info_left_bonded_label">Gauche appairé</string>
+    <string name="device_settings_info_right_bonded_label">Droite appairée</string>
     <string name="device_settings_info_details_label">Détails de l’appareil</string>
     <string name="device_settings_info_details_action">Afficher les détails de l’appareil</string>
     <string name="device_settings_info_status_label">État</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Cet appareil est à proximité mais n\'est pas connecté à ce téléphone. Connectez-vous pour accéder aux paramètres et aux commandes.</string>
     <string name="device_settings_not_connected_connect_action">Connecter</string>
     <string name="device_settings_not_connected_open_settings_action">Ouvrir les paramètres Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Appareil non à proximité</string>
+    <string name="device_settings_not_nearby_description">Les paramètres ne sont disponibles que lorsque cet appareil est à proximité et connecté à votre téléphone.</string>
     <string name="device_settings_aap_unavailable_label">Paramètres avancés indisponibles</string>
     <string name="device_settings_aap_unavailable_description">Les paramètres avancés des AirPods nécessitent une fonctionnalité Bluetooth qui n’est pas disponible sur ce téléphone. Cela pourrait être résolu par une future mise à jour Android de votre fabricant d’appareil.</string>
+    <string name="device_settings_aap_unavailable_action">Voir le suivi de compatibilité</string>
     <string name="device_settings_category_sound_label">Son</string>
     <string name="device_settings_category_controls_label">Contrôles</string>
     <string name="device_settings_nc_one_airpod_label">ANC avec un seul écouteur</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Appui simple pour couper le microphone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Double appui pour terminer l’appel</string>
     <string name="device_settings_open_cd">Ouvrir les paramètres de l’appareil</string>
+    <string name="overview_card_missing_paired_device">Ce profil n\'a aucun appareil Bluetooth associé.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Général</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Autoriser Désactivé comme mode de contrôle du bruit sélectionnable. Lorsque désactivé, les tiges ignorent Désactivé lors du cycle.</string>
     <string name="device_settings_sleep_detection_label">Détection du sommeil</string>
     <string name="device_settings_sleep_detection_description">Mettre automatiquement en pause l’audio quand vous vous endormez</string>
+    <string name="reaction_sleep_channel_label">Détection du sommeil</string>
+    <string name="reaction_sleep_notification_title">Mis en pause par la détection du sommeil</string>
+    <string name="reaction_sleep_notification_text">%1$s a détecté que vous vous êtes endormi, votre musique a donc été mise en pause. Vous pouvez désactiver cela dans les paramètres de l\'appareil.</string>
     <string name="device_settings_rename_label">Renommer</string>
     <string name="device_settings_rename_hint">Nom de l’appareil</string>
     <string name="device_settings_rename_confirm">Renommer</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Paramètres Bluetooth</string>
     <string name="device_settings_send_failed">Impossible d\'appliquer le paramètre : %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Le mode Désactivé n’est pas activé sur cet appareil. Activez « Autoriser le mode Désactivé » sous Contrôle du bruit.</string>
+    <string name="device_settings_category_battery_label">Batterie</string>
+    <string name="device_settings_charge_cap_label">Limite de charge optimisée</string>
+    <string name="device_settings_charge_cap_description">Apprend votre routine et met la charge en pause autour de 80 %% pour prolonger la durée de vie de la batterie, en rechargeant les écouteurs avant que vous soyez susceptible de les utiliser.</string>
+    <string name="device_settings_charge_cap_rejected_message">La limite de charge optimisée n’a pas pu être modifiée. Il s’agit d’une fonctionnalité expérimentale — veuillez signaler le problème si cela continue à échouer.</string>
     <string name="device_settings_category_connections_label">Appareils connectés</string>
     <string name="device_settings_connected_devices_description">Autres appareils actuellement connectés à ces AirPods</string>
     <string name="device_settings_connected_device_label">Appareil %d</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparencia de fondo</string>
     <string name="widget_config_show_device_label">Mostrar nome do dispositivo</string>
     <string name="widget_config_reset_label">Restablecer aos valores predeterminados</string>
+    <string name="widget_config_preview_resize_hint">Podes cambiar o tamaño do widget despois de colocalo na pantalla de inicio.</string>
     <string name="widget_config_custom_label">Personalizado</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Escuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Este é un dispositivo descoñecido, pero está a usar un formato de mensaxe similar. Engadamos compatibilidade para el, contacta comigo :)</string>
     <string name="pods_none_label_short">Sen dispositivo</string>
     <string name="pods_charging_label">Cargando</string>
+    <string name="pods_charging_optimized_label">Optimizado</string>
     <string name="pods_inear_label">No oído</string>
     <string name="pods_microphone_label">Micrófono</string>
     <string name="anc_mode_off">Desactivado</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etiqueta do dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Número de serie</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware pendente</string>
     <string name="device_settings_info_build_label">Compilación</string>
     <string name="device_settings_info_left_serial_label">Número de serie do auricular esquerdo</string>
     <string name="device_settings_info_right_serial_label">Número de serie do auricular dereito</string>
+    <string name="device_settings_info_left_bonded_label">Esquerdo vinculado</string>
+    <string name="device_settings_info_right_bonded_label">Dereito vinculado</string>
     <string name="device_settings_info_details_label">Detalles do dispositivo</string>
     <string name="device_settings_info_details_action">Mostrar detalles do dispositivo</string>
     <string name="device_settings_info_status_label">Estado</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Este dispositivo está preto pero non está conectado a este teléfono. Conéctao para acceder á configuración e aos controis.</string>
     <string name="device_settings_not_connected_connect_action">Conectar</string>
     <string name="device_settings_not_connected_open_settings_action">Abrir a configuración de Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo non preto</string>
+    <string name="device_settings_not_nearby_description">A configuración só está dispoñible cando este dispositivo está preto e conectado ao teu teléfono.</string>
     <string name="device_settings_aap_unavailable_label">Configuración avanzada non dispoñible</string>
     <string name="device_settings_aap_unavailable_description">A configuración avanzada dos AirPods require unha función de Bluetooth que non está dispoñible neste teléfono. Isto pode resolverse cunha futura actualización de Android do fabricante do teu dispositivo.</string>
+    <string name="device_settings_aap_unavailable_action">Ver rastrexador de compatibilidade</string>
     <string name="device_settings_category_sound_label">Son</string>
     <string name="device_settings_category_controls_label">Controis</string>
     <string name="device_settings_nc_one_airpod_label">ANC cun só auricular</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Prema unha vez para silenciar o micrófono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Prema dúas veces para finalizar a chamada</string>
     <string name="device_settings_open_cd">Abrir a configuración do dispositivo</string>
+    <string name="overview_card_missing_paired_device">Este perfil non ten ningún dispositivo Bluetooth emparellado.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Xeral</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permite o modo Desactivado como modo de control de ruído seleccionable. Cando está desactivado, os tallos omiten Desactivado durante o ciclo.</string>
     <string name="device_settings_sleep_detection_label">Detección do sono</string>
     <string name="device_settings_sleep_detection_description">Pausar o audio automaticamente cando te quedas durmído</string>
+    <string name="reaction_sleep_channel_label">Detección de sono</string>
+    <string name="reaction_sleep_notification_title">Pausado pola detección de sono</string>
+    <string name="reaction_sleep_notification_text">%1$s detectou que te durmiches, polo que a túa música foi pausada. Podes desactivar isto na configuración do dispositivo.</string>
     <string name="device_settings_rename_label">Renomear</string>
     <string name="device_settings_rename_hint">Nome do dispositivo</string>
     <string name="device_settings_rename_confirm">Renomear</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Configuración de Bluetooth</string>
     <string name="device_settings_send_failed">Non se puido aplicar a configuración: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">O modo Desactivado non está habilitado neste dispositivo. Activa «Permitir o modo Desactivado» en Control de ruído.</string>
+    <string name="device_settings_category_battery_label">Batería</string>
+    <string name="device_settings_charge_cap_label">Límite de carga optimizado</string>
+    <string name="device_settings_charge_cap_description">Aprende a túa rutina e pausa a carga arredor do 80%% para prolongar a vida da batería, cargando os auriculares antes de que os vaias usar.</string>
+    <string name="device_settings_charge_cap_rejected_message">Non se puido cambiar o límite de carga optimizado. Esta é unha función experimental; infórmanos se segue fallando.</string>
     <string name="device_settings_category_connections_label">Dispositivos conectados</string>
     <string name="device_settings_connected_devices_description">Outros dispositivos conectados actualmente a estes AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">पृष्ठभूमि पारदर्शिता</string>
     <string name="widget_config_show_device_label">डिवाइस का नाम दिखाएं</string>
     <string name="widget_config_reset_label">डिफ़ॉल्ट पर रीसेट करें</string>
+    <string name="widget_config_preview_resize_hint">आप होम स्क्रीन पर रखने के बाद विजेट का आकार बदल सकते हैं।</string>
     <string name="widget_config_custom_label">कस्टम</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">गहरा</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">यह एक अज्ञात डिवाइस है, लेकिन यह समान संदेश प्रारूप का उपयोग कर रहा है। इसके लिए समर्थन जोड़ते हैं, मुझसे संपर्क करें :)</string>
     <string name="pods_none_label_short">कोई डिवाइस नहीं</string>
     <string name="pods_charging_label">चार्ज हो रहा है</string>
+    <string name="pods_charging_optimized_label">अनुकूलित</string>
     <string name="pods_inear_label">कान में</string>
     <string name="pods_microphone_label">माइक्रोफ़ोन</string>
     <string name="anc_mode_off">बंद</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth डिवाइस लेबल</string>
     <string name="device_settings_info_model_label">मॉडल</string>
     <string name="device_settings_info_manufacturer_label">निर्माता</string>
+    <string name="device_settings_info_hardware_label">हार्डवेयर</string>
     <string name="device_settings_info_serial_label">सीरियल नंबर</string>
     <string name="device_settings_info_firmware_label">फर्मवेयर</string>
+    <string name="device_settings_info_firmware_pending_label">लंबित फर्मवेयर</string>
     <string name="device_settings_info_build_label">बिल्ड</string>
     <string name="device_settings_info_left_serial_label">बाएं पॉड का सीरियल नंबर</string>
     <string name="device_settings_info_right_serial_label">दाएं पॉड का सीरियल नंबर</string>
+    <string name="device_settings_info_left_bonded_label">बायाँ युग्मित</string>
+    <string name="device_settings_info_right_bonded_label">दायाँ युग्मित</string>
     <string name="device_settings_info_details_label">डिवाइस विवरण</string>
     <string name="device_settings_info_details_action">डिवाइस विवरण दिखाएं</string>
     <string name="device_settings_info_status_label">स्थिति</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">यह डिवाइस पास में है लेकिन इस फ़ोन से कनेक्ट नहीं है। सेटिंग्स और नियंत्रण तक पहुंचने के लिए कनेक्ट करें।</string>
     <string name="device_settings_not_connected_connect_action">कनेक्ट करें</string>
     <string name="device_settings_not_connected_open_settings_action">ब्लूटूथ सेटिंग्स खोलें</string>
+    <string name="device_settings_not_nearby_label">डिवाइस पास में नहीं है</string>
+    <string name="device_settings_not_nearby_description">सेटिंग्स केवल तभी उपलब्ध होती हैं जब यह डिवाइस आपके फ़ोन के पास और उससे कनेक्ट हो।</string>
     <string name="device_settings_aap_unavailable_label">उन्नत सेटिंग्स अनुपलब्ध</string>
     <string name="device_settings_aap_unavailable_description">उन्नत AirPods सेटिंग के लिए Bluetooth फ़ीचर की आवश्यकता है जो इस फ़ोन पर उपलब्ध नहीं है। आपके डिवाइस निर्माता के भविष्य के Android अपडेट से यह समस्या हल हो सकती है।</string>
+    <string name="device_settings_aap_unavailable_action">संगतता ट्रैकर देखें</string>
     <string name="device_settings_category_sound_label">ध्वनि</string>
     <string name="device_settings_category_controls_label">नियंत्रण</string>
     <string name="device_settings_nc_one_airpod_label">एक पॉड के साथ ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">माइक्रोफ़ोन म्यूट करने के लिए एक बार दबाएं</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कॉल समाप्त करने के लिए दो बार दबाएं</string>
     <string name="device_settings_open_cd">डिवाइस सेटिंग्स खोलें</string>
+    <string name="overview_card_missing_paired_device">इस प्रोफ़ाइल में कोई पेयर किया गया Bluetooth डिवाइस नहीं है।</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफ़ोन</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Off को चयनयोग्य शोर नियंत्रण मोड के रूप में अनुमति दें। अक्षम होने पर, स्टेम साइकिल करते समय Off को छोड़ देते हैं।</string>
     <string name="device_settings_sleep_detection_label">नींद पहचान</string>
     <string name="device_settings_sleep_detection_description">सोने पर स्वचालित रूप से ऑडियो रोकें</string>
+    <string name="reaction_sleep_channel_label">नींद का पता लगाना</string>
+    <string name="reaction_sleep_notification_title">नींद का पता लगाने से रोका गया</string>
+    <string name="reaction_sleep_notification_text">%1$s ने बताया कि आप सो गए, इसलिए आपका संगीत रोक दिया गया। आप इसे डिवाइस सेटिंग्स में बंद कर सकते हैं।</string>
     <string name="device_settings_rename_label">नाम बदलें</string>
     <string name="device_settings_rename_hint">डिवाइस का नाम</string>
     <string name="device_settings_rename_confirm">नाम बदलें</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ब्लूटूथ सेटिंग्स</string>
     <string name="device_settings_send_failed">सेटिंग लागू नहीं हो सकी: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">इस डिवाइस पर Off मोड सक्षम नहीं है। शोर नियंत्रण के अंतर्गत \"ऑफ मोड अनुमति दें\" सक्षम करें।</string>
+    <string name="device_settings_category_battery_label">बैटरी</string>
+    <string name="device_settings_charge_cap_label">अनुकूलित चार्ज सीमा</string>
+    <string name="device_settings_charge_cap_description">आपकी दिनचर्या सीखें और बैटरी जीवन बढ़ाने के लिए लगभग 80%% पर चार्जिंग रोकें, इस्तेमाल से पहले पॉड्स को पूरी तरह चार्ज करें।</string>
+    <string name="device_settings_charge_cap_rejected_message">अनुकूलित चार्ज सीमा नहीं बदली जा सकी। यह एक प्रायोगिक सुविधा है — अगर यह बार-बार विफल होती रहे तो कृपया रिपोर्ट करें।</string>
     <string name="device_settings_category_connections_label">कनेक्टेड डिवाइस</string>
     <string name="device_settings_connected_devices_description">इन AirPods से वर्तमान में कनेक्टेड अन्य डिवाइस</string>
     <string name="device_settings_connected_device_label">डिवाइस %d</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Prozirnost pozadine</string>
     <string name="widget_config_show_device_label">Prikaži naziv uređaja</string>
     <string name="widget_config_reset_label">Vrati na zadane vrijednosti</string>
+    <string name="widget_config_preview_resize_hint">Možete promijeniti veličinu widgeta nakon što ga postavite na početni zaslon.</string>
     <string name="widget_config_custom_label">Prilagođeno</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tamno</string>
@@ -252,6 +253,7 @@
     <string name="pods_unknown_contact_dev">Ovo je nepoznat uređaj, ali koristi sličan format poruka. Dodajmo podršku za njega, kontaktirajte me :)</string>
     <string name="pods_none_label_short">Nema uređaja</string>
     <string name="pods_charging_label">Punjenje</string>
+    <string name="pods_charging_optimized_label">Optimizirano</string>
     <string name="pods_inear_label">U uhu</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Isključeno</string>
@@ -412,11 +414,15 @@
     <string name="device_settings_info_bt_name_label">Oznaka Bluetooth uređaja</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Proizvođač</string>
+    <string name="device_settings_info_hardware_label">Hardver</string>
     <string name="device_settings_info_serial_label">Serijski broj</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmver na čekanju</string>
     <string name="device_settings_info_build_label">Verzija</string>
     <string name="device_settings_info_left_serial_label">Serijski broj lijevog poda</string>
     <string name="device_settings_info_right_serial_label">Serijski broj desnog poda</string>
+    <string name="device_settings_info_left_bonded_label">Lijevo vezano</string>
+    <string name="device_settings_info_right_bonded_label">Desno vezano</string>
     <string name="device_settings_info_details_label">Detalji uređaja</string>
     <string name="device_settings_info_details_action">Prikaži detalje uređaja</string>
     <string name="device_settings_info_status_label">Stanje</string>
@@ -426,8 +432,11 @@
     <string name="device_settings_not_connected_description">Ovaj uređaj je u blizini, ali nije povezan s ovim telefonom. Povežite se za pristup postavkama i upravljačkim elementima.</string>
     <string name="device_settings_not_connected_connect_action">Poveži</string>
     <string name="device_settings_not_connected_open_settings_action">Otvori Bluetooth postavke</string>
+    <string name="device_settings_not_nearby_label">Uređaj nije u blizini</string>
+    <string name="device_settings_not_nearby_description">Postavke su dostupne samo kada je ovaj uređaj u blizini i spojen na vaš telefon.</string>
     <string name="device_settings_aap_unavailable_label">Napredne postavke nedostupne</string>
     <string name="device_settings_aap_unavailable_description">Napredne AirPods postavke zahtijevaju Bluetooth značajku koja nije dostupna na ovom telefonu. To može biti riješeno budućim Android ažuriranjem vašeg proizvođača uređaja.</string>
+    <string name="device_settings_aap_unavailable_action">Pogledajte tracker kompatibilnosti</string>
     <string name="device_settings_category_sound_label">Zvuk</string>
     <string name="device_settings_category_controls_label">Kontrole</string>
     <string name="device_settings_nc_one_airpod_label">ANC s jednim podom</string>
@@ -465,6 +474,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Jedan pritisak za isključivanje mikrofona</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvostruki pritisak za završetak poziva</string>
     <string name="device_settings_open_cd">Otvori postavke uređaja</string>
+    <string name="overview_card_missing_paired_device">Ovaj profil nema uparenog Bluetooth uređaja.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Općenito</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -487,6 +497,9 @@
     <string name="device_settings_allow_off_description">Dozvoli Isključeno kao odabrani način kontrole buke. Kada je onemogućeno, stabljike preskakovanjem Isključeno pri cikliranju.</string>
     <string name="device_settings_sleep_detection_label">Detekcija sna</string>
     <string name="device_settings_sleep_detection_description">Automatski pauziraj zvuk kad zaspite</string>
+    <string name="reaction_sleep_channel_label">Otkrivanje spavanja</string>
+    <string name="reaction_sleep_notification_title">Pauzirano otkrivanjem spavanja</string>
+    <string name="reaction_sleep_notification_text">%1$s je prijavio da ste zaspali, pa je vaša glazba pauzirana. Možete to onemogućiti u postavkama uređaja.</string>
     <string name="device_settings_rename_label">Preimenuj</string>
     <string name="device_settings_rename_hint">Naziv uređaja</string>
     <string name="device_settings_rename_confirm">Preimenuj</string>
@@ -496,6 +509,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth postavke</string>
     <string name="device_settings_send_failed">Nije moguće primijeniti postavku: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Način rada Isključeno nije omogućen na ovom uređaju. Omogućite \"Dozvoli način rada Isključeno\" pod Kontrola buke.</string>
+    <string name="device_settings_category_battery_label">Baterija</string>
+    <string name="device_settings_charge_cap_label">Optimizirano ograničenje punjenja</string>
+    <string name="device_settings_charge_cap_description">Nauči vašu rutinu i pauzira punjenje oko 80%% kako bi produžilo vijek trajanja baterije, dopunjujući slušalice prije nego što ćete ih vjerojatno koristiti.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimizirano ograničenje punjenja nije se moglo promijeniti. Ovo je eksperimentalna značajka — molimo prijavite ako se nastavlja neuspješno.</string>
     <string name="device_settings_category_connections_label">Povezani uređaji</string>
     <string name="device_settings_connected_devices_description">Drugi uređaji koji su trenutno spojeni na ove AirPodove</string>
     <string name="device_settings_connected_device_label">Uređaj %d</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Háttér átlátszósága</string>
     <string name="widget_config_show_device_label">Eszköznév megjelenítése</string>
     <string name="widget_config_reset_label">Alapértékek visszaállítása</string>
+    <string name="widget_config_preview_resize_hint">A widgetet átméretezheted, miután elhelyezted a kezdőképernyőn.</string>
     <string name="widget_config_custom_label">Egyéni</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Sötét</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Ez egy ismeretlen eszköz, de hasonló üzenetformátumot használ. Adjunk hozzá támogatást, lépjen kapcsolatba velem :)</string>
     <string name="pods_none_label_short">Nincs eszköz</string>
     <string name="pods_charging_label">Töltés</string>
+    <string name="pods_charging_optimized_label">Optimalizált</string>
     <string name="pods_inear_label">Fülben</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Ki</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-eszköz neve</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Gyártó</string>
+    <string name="device_settings_info_hardware_label">Hardver</string>
     <string name="device_settings_info_serial_label">Sorozatszám</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Függőben lévő firmware</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Bal fülhallgató sorozatszáma</string>
     <string name="device_settings_info_right_serial_label">Jobb fülhallgató sorozatszáma</string>
+    <string name="device_settings_info_left_bonded_label">Bal fülhallgató párosítva</string>
+    <string name="device_settings_info_right_bonded_label">Jobb fülhallgató párosítva</string>
     <string name="device_settings_info_details_label">Eszköz részletei</string>
     <string name="device_settings_info_details_action">Eszköz részleteinek megjelenítése</string>
     <string name="device_settings_info_status_label">Állapot</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Ez az eszköz a közelben van, de nincs csatlakoztatva ehhez a telefonhoz. Csatlakozzon a beállítások és vezérlők eléréséhez.</string>
     <string name="device_settings_not_connected_connect_action">Csatlakozás</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth beállítások megnyitása</string>
+    <string name="device_settings_not_nearby_label">Az eszköz nincs a közelben</string>
+    <string name="device_settings_not_nearby_description">A beállítások csak akkor érhetők el, ha az eszköz a közelben van és csatlakoztatva van a telefonodhoz.</string>
     <string name="device_settings_aap_unavailable_label">Speciális beállítások nem elérhetők</string>
     <string name="device_settings_aap_unavailable_description">A speciális AirPods beállításokhoz olyan Bluetooth-funkció szükséges, amely nem érhető el ezen a telefonon. Ez megoldódhat a készülékgyártó jövőbeli Android-frissítésével.</string>
+    <string name="device_settings_aap_unavailable_action">Kompatibilitási lista megtekintése</string>
     <string name="device_settings_category_sound_label">Hang</string>
     <string name="device_settings_category_controls_label">Vezérlők</string>
     <string name="device_settings_nc_one_airpod_label">ANC egyetlen fülhallgatóval</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Egyszeri nyomás a mikrofon némításához</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dupla nyomás a hívás befejezéséhez</string>
     <string name="device_settings_open_cd">Eszközbeállítások megnyitása</string>
+    <string name="overview_card_missing_paired_device">Ehhez a profilhoz nincs párosított Bluetooth-eszköz.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Általános</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">A Ki mód engedélyezése választható zajvezérlési módként. Ha le van tiltva, a szárak kihagyják a Ki módot a ciklizálás során.</string>
     <string name="device_settings_sleep_detection_label">Alvásérzékelés</string>
     <string name="device_settings_sleep_detection_description">Audíó automatikus szüneteltetéseelalváskor</string>
+    <string name="reaction_sleep_channel_label">Alvásérzékelés</string>
+    <string name="reaction_sleep_notification_title">Az alvásérzékelés által szüneteltetve</string>
+    <string name="reaction_sleep_notification_text">%1$s jelezte, hogy elaludtál, ezért a zene szünetelt. Ezt a készülék beállításaiban kapcsolhatod ki.</string>
     <string name="device_settings_rename_label">Átnevézés</string>
     <string name="device_settings_rename_hint">Eszköz neve</string>
     <string name="device_settings_rename_confirm">Átnevézés</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-beállítások</string>
     <string name="device_settings_send_failed">Nem sikerült alkalmazni a beállítást: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">A Ki mód nincs engedélyezve ezen az eszközön. Engedélyezd a \"Ki mód engedélyezése\" opciót a Zajvezérlés alatt.</string>
+    <string name="device_settings_category_battery_label">Akkumulátor</string>
+    <string name="device_settings_charge_cap_label">Optimalizált töltési limit</string>
+    <string name="device_settings_charge_cap_description">Megtanulja a szokásaidat, és kb. 80%%-nál szünetelteti a töltést az akkumulátor élettartalmának megnyújtásához, majd befejezi a töltést, mielőtt valószínűleg használni szeretnéd.</string>
+    <string name="device_settings_charge_cap_rejected_message">Az optimalizált töltési limit módosítása nem sikerült. Ez egy kísérleti funkció — kérjük, jelezd, ha továbbra is hibás marad.</string>
     <string name="device_settings_category_connections_label">Csatlakoztatott eszközök</string>
     <string name="device_settings_connected_devices_description">Más eszközök, amelyek jelenleg csatlakoznak ezekhez az AirPodokhoz</string>
     <string name="device_settings_connected_device_label">%d. eszköz</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Ֆոնի թափանցիկություն</string>
     <string name="widget_config_show_device_label">Ցուցադրել սարքի անունը</string>
     <string name="widget_config_reset_label">Վերականգնել լռելյալը</string>
+    <string name="widget_config_preview_resize_hint">Դուք կարող եք փոխել վիջեթի չափը այն ձեր գլխավոր էկրանին տեղադրելուց հետո:</string>
     <string name="widget_config_custom_label">Հատուկ</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Մութ</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Սա անհայտ սարք է, բայց այն օգտագործում է նմանատիպ հաղորդագրության ձևաչափ։ Եկեք ավելացնենք աջակցություն դրա համար, կապվեք ինձ հետ :)</string>
     <string name="pods_none_label_short">Սարք չկա</string>
     <string name="pods_charging_label">Լիցքավորվում է</string>
+    <string name="pods_charging_optimized_label">Օպտիմիզացված</string>
     <string name="pods_inear_label">Ականջում է</string>
     <string name="pods_microphone_label">Բարձրախոս</string>
     <string name="anc_mode_off">Անջատ</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth սարքի անուն</string>
     <string name="device_settings_info_model_label">Մոդել</string>
     <string name="device_settings_info_manufacturer_label">Արտադրող</string>
+    <string name="device_settings_info_hardware_label">Ապարատ</string>
     <string name="device_settings_info_serial_label">Սերիական համար</string>
     <string name="device_settings_info_firmware_label">Ծրագրաշար</string>
+    <string name="device_settings_info_firmware_pending_label">Սպասվող որոնվածային ծրագիր</string>
     <string name="device_settings_info_build_label">Կառուցվածք</string>
     <string name="device_settings_info_left_serial_label">Ձախ ականջակալի սերիա</string>
     <string name="device_settings_info_right_serial_label">Աջ ականջակալի սերիա</string>
+    <string name="device_settings_info_left_bonded_label">Ձախ կապակցված</string>
+    <string name="device_settings_info_right_bonded_label">Աջ կապակցված</string>
     <string name="device_settings_info_details_label">Սարքի մանրամասները</string>
     <string name="device_settings_info_details_action">Ցուցադրել սարքի մանրամասները</string>
     <string name="device_settings_info_status_label">Կարգավիճակ</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Սարքը մոտ է, սակայն կապված չէ այս հեռախոսին։ Կապվեք՝ կարգավորումներն ու կառավարումները մուտք գործելու համար։</string>
     <string name="device_settings_not_connected_connect_action">Կապվել</string>
     <string name="device_settings_not_connected_open_settings_action">Բացել Bluetooth-ի կարգավորումները</string>
+    <string name="device_settings_not_nearby_label">Սարքը մոտակայքում չէ</string>
+    <string name="device_settings_not_nearby_description">Կարգավորումները հասանելի են միայն այն դեպքում, երբ այս սարքը մոտակայքում է և միացած ձեր հեռախոսին։</string>
     <string name="device_settings_aap_unavailable_label">Ընդլայնված կարգաբերումներն անհասանելի են</string>
     <string name="device_settings_aap_unavailable_description">AirPods-ի առաջադեմ կարգավորումները պահանջում են Bluetooth հատկություն, որը հասանելի չէ այս հեռախոսին: Այս կարգը կարող է լուծվել ձեր սարքի արտադրողի Android-ի ապագա թարմացմամբ:</string>
+    <string name="device_settings_aap_unavailable_action">Դիտել համատեղելիության հետագծիչը</string>
     <string name="device_settings_category_sound_label">Ձայն</string>
     <string name="device_settings_category_controls_label">Կառավարում</string>
     <string name="device_settings_nc_one_airpod_label">ANC մեկ ականջակալով</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Մեկ սեղմում խոսափոնը անձայնեցնելու համար</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Կրկնակի սեղմում զանգը ավարտելու համար</string>
     <string name="device_settings_open_cd">Բացել սառքի կառավարումները</string>
+    <string name="overview_card_missing_paired_device">Այս պրոֆիլը չունի զուգակցված Bluetooth սարք:</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ընդհանուր</string>
     <string name="device_settings_microphone_mode_label">Խոսափող</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Թույլատրել Անջատ-ը որպես ընտրովի աղմուկի կառավարման ռեժիմ: Անջատելու դեպքում կառուները շրջանի ժամանակ բաց են թողնում Անջատ-ը:</string>
     <string name="device_settings_sleep_detection_label">Քնի հայտնաբերում</string>
     <string name="device_settings_sleep_detection_description">Ավտոմատ կասեցնել ձայնը, երբ քնում եք</string>
+    <string name="reaction_sleep_channel_label">Քնի հայտնաբերում</string>
+    <string name="reaction_sleep_notification_title">Դադարեցված Քնի հայտնաբերման կողմից</string>
+    <string name="reaction_sleep_notification_text">%1$s-ը հայտնել է, որ դուք քնեցիք, ուստի ձեր երաժշտությունը դադարեցվեց։ Դուք կարող եք անջատել սա սարքի կարգավորումներում։</string>
     <string name="device_settings_rename_label">Փոխել անունը</string>
     <string name="device_settings_rename_hint">Սառքի անուն</string>
     <string name="device_settings_rename_confirm">Փոխել անունը</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth կարգաբերումներ</string>
     <string name="device_settings_send_failed">Չհաջողվեց կիրառել կարգավորումը՝ %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Անջատ ռեժիմը հասանելի չէ այս սարքին: Միացրեք «Թույլատրել Անջատ ռեժիմը» Աղմուկի կառավարման բաժնում:</string>
+    <string name="device_settings_category_battery_label">Մարտկոց</string>
+    <string name="device_settings_charge_cap_label">Լիցքի օպտիմիզացված սահման</string>
+    <string name="device_settings_charge_cap_description">Սովորեք ձեր ռեժիմը և դադարեցրեք լիցքավորումը մոտ 80%%-ի դեպքում՝ մարտկոցի ծառայության ժամկետը երկարացնելու համար՝ pods-երը լիցքավորելով նախքան դրանք օգտագործելը։</string>
+    <string name="device_settings_charge_cap_rejected_message">Լիցքի օպտիմիզացված սահմանը հնարավոր չեղավ փոխել։ Սա փորձարարական հատկություն է — խնդրում ենք հայտնել, եթե այն շարունակի ձախողվել։</string>
     <string name="device_settings_category_connections_label">Կապլված սառքեր</string>
     <string name="device_settings_connected_devices_description">Այլ սառքերը, որոնք կապլված են խի AirPods-ին</string>
     <string name="device_settings_connected_device_label">Սառք %d</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparansi latar belakang</string>
     <string name="widget_config_show_device_label">Tampilkan nama perangkat</string>
     <string name="widget_config_reset_label">Atur ulang ke default</string>
+    <string name="widget_config_preview_resize_hint">Anda dapat mengubah ukuran widget setelah menempatkannya di layar beranda.</string>
     <string name="widget_config_custom_label">Kustom</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Gelap</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">Ini adalah perangkat yang tidak dikenal, tetapi menggunakan format pesan yang serupa. Mari tambahkan dukungannya, hubungi saya :)</string>
     <string name="pods_none_label_short">Tidak ada perangkat</string>
     <string name="pods_charging_label">Mengisi daya</string>
+    <string name="pods_charging_optimized_label">Dioptimalkan</string>
     <string name="pods_inear_label">Di telinga</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Nonaktif</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">Label Perangkat Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Produsen</string>
+    <string name="device_settings_info_hardware_label">Perangkat Keras</string>
     <string name="device_settings_info_serial_label">Nomor Seri</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware Tertunda</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Nomor Seri Pod Kiri</string>
     <string name="device_settings_info_right_serial_label">Nomor Seri Pod Kanan</string>
+    <string name="device_settings_info_left_bonded_label">Kiri Terhubung</string>
+    <string name="device_settings_info_right_bonded_label">Kanan Terhubung</string>
     <string name="device_settings_info_details_label">Detail Perangkat</string>
     <string name="device_settings_info_details_action">Tampilkan detail perangkat</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">Perangkat ini ada di dekat sini tetapi tidak terhubung ke ponsel ini. Hubungkan untuk mengakses pengaturan dan kontrol.</string>
     <string name="device_settings_not_connected_connect_action">Hubungkan</string>
     <string name="device_settings_not_connected_open_settings_action">Buka Pengaturan Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Perangkat tidak di dekatnya</string>
+    <string name="device_settings_not_nearby_description">Pengaturan hanya tersedia saat perangkat ini berada di dekatnya dan terhubung ke ponsel Anda.</string>
     <string name="device_settings_aap_unavailable_label">Pengaturan lanjutan tidak tersedia</string>
     <string name="device_settings_aap_unavailable_description">Pengaturan AirPods lanjutan memerlukan fitur Bluetooth yang tidak tersedia di ponsel ini. Masalah ini mungkin akan diselesaikan oleh pembaruan Android dari produsen perangkat Anda di masa mendatang.</string>
+    <string name="device_settings_aap_unavailable_action">Lihat pelacak kompatibilitas</string>
     <string name="device_settings_category_sound_label">Suara</string>
     <string name="device_settings_category_controls_label">Kontrol</string>
     <string name="device_settings_nc_one_airpod_label">ANC dengan satu pod</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Tekan sekali untuk membisukan mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tekan dua kali untuk mengakhiri panggilan</string>
     <string name="device_settings_open_cd">Buka pengaturan perangkat</string>
+    <string name="overview_card_missing_paired_device">Profil ini tidak memiliki Perangkat Bluetooth yang dipasangkan.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">Izinkan Mati sebagai mode kontrol kebisingan yang dapat dipilih. Jika dinonaktifkan, stem melewati Mati saat bersiklus.</string>
     <string name="device_settings_sleep_detection_label">Deteksi Tidur</string>
     <string name="device_settings_sleep_detection_description">Otomatis jeda audio saat Anda tertidur</string>
+    <string name="reaction_sleep_channel_label">Deteksi Tidur</string>
+    <string name="reaction_sleep_notification_title">Dijeda oleh Deteksi Tidur</string>
+    <string name="reaction_sleep_notification_text">%1$s mendeteksi Anda tertidur, sehingga musik Anda dijeda. Anda dapat menonaktifkan ini di pengaturan perangkat.</string>
     <string name="device_settings_rename_label">Ganti Nama</string>
     <string name="device_settings_rename_hint">Nama perangkat</string>
     <string name="device_settings_rename_confirm">Ganti Nama</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Pengaturan Bluetooth</string>
     <string name="device_settings_send_failed">Tidak dapat menerapkan pengaturan: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Mode Mati tidak diaktifkan di perangkat ini. Aktifkan \"Izinkan mode Mati\" di bawah Kontrol Kebisingan.</string>
+    <string name="device_settings_category_battery_label">Baterai</string>
+    <string name="device_settings_charge_cap_label">Batas Pengisian Teroptimasi</string>
+    <string name="device_settings_charge_cap_description">Mempelajari rutinitas Anda dan menjeda pengisian sekitar 80%% untuk memperpanjang masa pakai baterai, mengisi pod sebelum Anda kemungkinan menggunakannya.</string>
+    <string name="device_settings_charge_cap_rejected_message">Batas Pengisian Teroptimasi tidak dapat diubah. Ini adalah fitur eksperimental — laporkan jika terus gagal.</string>
     <string name="device_settings_category_connections_label">Perangkat Terhubung</string>
     <string name="device_settings_connected_devices_description">Perangkat lain yang saat ini terhubung ke AirPods ini</string>
     <string name="device_settings_connected_device_label">Perangkat %d</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Gagnsæi bakgrunns</string>
     <string name="widget_config_show_device_label">Sýna heiti tækis</string>
     <string name="widget_config_reset_label">Endurstilla sjálfgildi</string>
+    <string name="widget_config_preview_resize_hint">Þú getur breytt stærð græjunnar eftir að þú hefur sett hana á heimaskjáinn þinn.</string>
     <string name="widget_config_custom_label">Sérsniðið</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Dökkt</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Þetta er óþekkt tæki, en það notar svipað skilaboðasnið. Bætum við stuðningi fyrir það, hafðu samband :)</string>
     <string name="pods_none_label_short">Ekkert tæki</string>
     <string name="pods_charging_label">Hleður</string>
+    <string name="pods_charging_optimized_label">Fínstillt</string>
     <string name="pods_inear_label">Í eyra</string>
     <string name="pods_microphone_label">Hljóðnemi</string>
     <string name="anc_mode_off">Slökkt</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-tækjaheiti</string>
     <string name="device_settings_info_model_label">Líkan</string>
     <string name="device_settings_info_manufacturer_label">Framleiðandi</string>
+    <string name="device_settings_info_hardware_label">Vélbúnaður</string>
     <string name="device_settings_info_serial_label">Raðnúmer</string>
     <string name="device_settings_info_firmware_label">Hugbúnnaður</string>
+    <string name="device_settings_info_firmware_pending_label">Hugbúnaðaruppfærsla í bið</string>
     <string name="device_settings_info_build_label">Útgáfa</string>
     <string name="device_settings_info_left_serial_label">Raðnúmer vinstri hlustunarpípu</string>
     <string name="device_settings_info_right_serial_label">Raðnúmer hægri hlustunarpípu</string>
+    <string name="device_settings_info_left_bonded_label">Vinstri tengd</string>
+    <string name="device_settings_info_right_bonded_label">Hægri tengd</string>
     <string name="device_settings_info_details_label">Tækjaupplýsingar</string>
     <string name="device_settings_info_details_action">Sýna tækjaupplýsingar</string>
     <string name="device_settings_info_status_label">Staða</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Þetta tæki er í nágrenninu en er ekki tengt þessum síma. Tengdu til að fá aðgang að stillingum og stjórnun.</string>
     <string name="device_settings_not_connected_connect_action">Tengja</string>
     <string name="device_settings_not_connected_open_settings_action">Opna Bluetooth stillingar</string>
+    <string name="device_settings_not_nearby_label">Tækið ekki í nágrenninu</string>
+    <string name="device_settings_not_nearby_description">Stillingar eru aðeins tiltækar þegar þetta tæki er í nágrenninu og tengt við símann þinn.</string>
     <string name="device_settings_aap_unavailable_label">Ítarlegar stillingar ekki tiltækar</string>
     <string name="device_settings_aap_unavailable_description">Ítarlegar AirPods-stillingar krefjast Bluetooth-eiginleika sem er ekki tiltækur á þessum síma. Þetta gæti lagast með framtiðaruppfærslu Android frá framleiðanda tækisins þíns.</string>
+    <string name="device_settings_aap_unavailable_action">Skoða samhæfnirakara</string>
     <string name="device_settings_category_sound_label">Hljóð</string>
     <string name="device_settings_category_controls_label">Stýring</string>
     <string name="device_settings_nc_one_airpod_label">ANC með einni hlustunarpípu</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Eitt þrýsting til að þagga hátalara</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tvöföld þrýsting til að ljúka simátali</string>
     <string name="device_settings_open_cd">Opna tæki stillingar</string>
+    <string name="overview_card_missing_paired_device">Þetta snið á sér ekkert tengt Bluetooth-tæki.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Álmennt</string>
     <string name="device_settings_microphone_mode_label">Hljóðnemi</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Leyfa Af sem valanlega hljóðstýringunarstillingu. Þegar slökt er á þessu sleppir stillingarpinninn Af í hringrás.</string>
     <string name="device_settings_sleep_detection_label">Svefngreining</string>
     <string name="device_settings_sleep_detection_description">Gera hljóð hljóðlegt sjálfvirkt þá sem þu sofnar</string>
+    <string name="reaction_sleep_channel_label">Svefngreining</string>
+    <string name="reaction_sleep_notification_title">Gert hlé af svefngreiningu</string>
+    <string name="reaction_sleep_notification_text">%1$s greindi að þú sefur, þannig var tónlistin sett í hlé. Þú getur slökkt á þessu í tækjastillingum.</string>
     <string name="device_settings_rename_label">Endurskíra</string>
     <string name="device_settings_rename_hint">Nafn tækis</string>
     <string name="device_settings_rename_confirm">Endurskíra</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-stillingar</string>
     <string name="device_settings_send_failed">Gat ekki beitt stillingu: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Af-stilling er ekki virk á þessu tæki. Virkjaðu „Af-stilling leyfist“ undir Hljóðstýring.</string>
+    <string name="device_settings_category_battery_label">Rafhlaða</string>
+    <string name="device_settings_charge_cap_label">Fínstillt hleðslutakmark</string>
+    <string name="device_settings_charge_cap_description">Lærir venjur þínar og hleyðir að 80%% til að lengja líftíma rafhlöðunnar, og lokar hleðslunni áður en þú notar þær.</string>
+    <string name="device_settings_charge_cap_rejected_message">Fínstilltu hleðslutakmarkið gat ekki verið breytt. Þetta er tilraunaeiginleiki — vinsamlegast tilkynntu ef hann heldur áfram að mistakast.</string>
     <string name="device_settings_category_connections_label">Tengd tæki</string>
     <string name="device_settings_connected_devices_description">Onnur tæki sem eru tengd við þessa AirPods</string>
     <string name="device_settings_connected_device_label">Tæki %d</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Trasparenza sfondo</string>
     <string name="widget_config_show_device_label">Mostra nome dispositivo</string>
     <string name="widget_config_reset_label">Ripristina predefiniti</string>
+    <string name="widget_config_preview_resize_hint">Puoi ridimensionare il widget dopo averlo posizionato sulla schermata Home.</string>
     <string name="widget_config_custom_label">Personalizzato</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Scuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Questo è un dispositivo sconosciuto, ma utilizza un formato di messaggio simile. Aggiungiamo il supporto, contattami :)</string>
     <string name="pods_none_label_short">Nessun dispositivo</string>
     <string name="pods_charging_label">In carica</string>
+    <string name="pods_charging_optimized_label">Ottimizzato</string>
     <string name="pods_inear_label">Nell\'orecchio</string>
     <string name="pods_microphone_label">Microfono</string>
     <string name="anc_mode_off">Spento</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etichetta dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modello</string>
     <string name="device_settings_info_manufacturer_label">Produttore</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Numero di serie</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware in attesa</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Seriale pod sinistro</string>
     <string name="device_settings_info_right_serial_label">Seriale pod destro</string>
+    <string name="device_settings_info_left_bonded_label">Sinistra associata</string>
+    <string name="device_settings_info_right_bonded_label">Destra associata</string>
     <string name="device_settings_info_details_label">Dettagli dispositivo</string>
     <string name="device_settings_info_details_action">Mostra dettagli dispositivo</string>
     <string name="device_settings_info_status_label">Stato</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Questo dispositivo è nelle vicinanze ma non è connesso a questo telefono. Connettiti per accedere alle impostazioni e ai controlli.</string>
     <string name="device_settings_not_connected_connect_action">Connetti</string>
     <string name="device_settings_not_connected_open_settings_action">Apri Impostazioni Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo non nelle vicinanze</string>
+    <string name="device_settings_not_nearby_description">Le impostazioni sono disponibili solo quando questo dispositivo è nelle vicinanze e connesso al tuo telefono.</string>
     <string name="device_settings_aap_unavailable_label">Impostazioni avanzate non disponibili</string>
     <string name="device_settings_aap_unavailable_description">Le impostazioni avanzate degli AirPods richiedono una funzione Bluetooth non disponibile su questo telefono. Potrebbe essere risolta con un futuro aggiornamento Android da parte del produttore del dispositivo.</string>
+    <string name="device_settings_aap_unavailable_action">Visualizza il tracker di compatibilità</string>
     <string name="device_settings_category_sound_label">Audio</string>
     <string name="device_settings_category_controls_label">Controlli</string>
     <string name="device_settings_nc_one_airpod_label">ANC con un solo pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Premere una volta per disattivare il microfono</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Premere due volte per terminare la chiamata</string>
     <string name="device_settings_open_cd">Apri impostazioni dispositivo</string>
+    <string name="overview_card_missing_paired_device">Questo profilo non ha nessun dispositivo Bluetooth associato.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfono</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Consenti Off come modalità di controllo del rumore selezionabile. Se disabilitato, i gambi saltano Off durante il ciclo.</string>
     <string name="device_settings_sleep_detection_label">Rilevamento sonno</string>
     <string name="device_settings_sleep_detection_description">Metti automaticamente in pausa l’audio quando ti addormenti</string>
+    <string name="reaction_sleep_channel_label">Rilevamento del sonno</string>
+    <string name="reaction_sleep_notification_title">In pausa per Rilevamento del sonno</string>
+    <string name="reaction_sleep_notification_text">%1$s ha rilevato che ti sei addormentato/a, quindi la musica è stata messa in pausa. Puoi disabilitarlo nelle impostazioni del dispositivo.</string>
     <string name="device_settings_rename_label">Rinomina</string>
     <string name="device_settings_rename_hint">Nome dispositivo</string>
     <string name="device_settings_rename_confirm">Rinomina</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Impostazioni Bluetooth</string>
     <string name="device_settings_send_failed">Impossibile applicare l\'impostazione: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">La modalità Off non è abilitata su questo dispositivo. Abilita \"Consenti modalità Off\" sotto Controllo del rumore.</string>
+    <string name="device_settings_category_battery_label">Batteria</string>
+    <string name="device_settings_charge_cap_label">Limite di carica ottimizzato</string>
+    <string name="device_settings_charge_cap_description">Impara la tua routine e metti in pausa la ricarica intorno all\'80%% per prolungare la durata della batteria, completando la carica degli auricolari prima che tu li utilizzi.</string>
+    <string name="device_settings_charge_cap_rejected_message">Il limite di carica ottimizzato non è stato modificato. Si tratta di una funzionalità sperimentale — segnala il problema se continua a non funzionare.</string>
     <string name="device_settings_category_connections_label">Dispositivi connessi</string>
     <string name="device_settings_connected_devices_description">Altri dispositivi attualmente connessi a questi AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">שקיפות רקע</string>
     <string name="widget_config_show_device_label">הצג שם התקן</string>
     <string name="widget_config_reset_label">אפס לברירות המחדל</string>
+    <string name="widget_config_preview_resize_hint">ניתן לשנות את גודל הווידג\'ט לאחר הצבתו על מסך הבית שלך.</string>
     <string name="widget_config_custom_label">מותאם אישית</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">כהה</string>
@@ -204,6 +205,12 @@
         <item quantity="many">%d מכשירים ללא פרופיל תואם</item>
         <item quantity="other">%d מכשירים ללא פרופיל תואם</item>
     </plurals>
+    <plurals name="overview_more_devices_upgrade">
+        <item quantity="one">התקן %d נוסף</item>
+        <item quantity="two">%d התקנים נוספים</item>
+        <item quantity="many">%d התקנים נוספים</item>
+        <item quantity="other">%d התקנים נוספים</item>
+    </plurals>
     <string name="permission_bluetooth_connect_label">חיבור Bluetooth</string>
     <string name="permission_bluetooth_connect_description">אפליקציה זו דורשת הרשאת \"חיבור Bluetooth\" כדי לתקשר עם מכשירים מותאמים וליזום חיבורים.</string>
     <string name="permission_bluetooth_scan_label">סריקת Bluetooth</string>
@@ -248,6 +255,7 @@
     <string name="pods_unknown_contact_dev">זהו מכשיר לא ידוע, אך הוא משתמש בפורמט הודעות דומה. בואו נוסיף תמיכה בו, צרו איתי קשר :)</string>
     <string name="pods_none_label_short">אין מכשיר</string>
     <string name="pods_charging_label">טעינה</string>
+    <string name="pods_charging_optimized_label">מותאם</string>
     <string name="pods_inear_label">באוזן</string>
     <string name="pods_microphone_label">מיקרופון</string>
     <string name="anc_mode_off">כבוי</string>
@@ -411,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">תווית התקן בלוטות\'</string>
     <string name="device_settings_info_model_label">דגם</string>
     <string name="device_settings_info_manufacturer_label">יצרן</string>
+    <string name="device_settings_info_hardware_label">חומרה</string>
     <string name="device_settings_info_serial_label">מספר סריאלי</string>
     <string name="device_settings_info_firmware_label">קושחאר</string>
+    <string name="device_settings_info_firmware_pending_label">קושחה ממתינה</string>
     <string name="device_settings_info_build_label">גרסה</string>
     <string name="device_settings_info_left_serial_label">מספר סידורי שמאל</string>
     <string name="device_settings_info_right_serial_label">מספר סידורי ימין</string>
+    <string name="device_settings_info_left_bonded_label">שמאל מחובר</string>
+    <string name="device_settings_info_right_bonded_label">ימין מחובר</string>
     <string name="device_settings_info_details_label">פרטי התקן</string>
     <string name="device_settings_info_details_action">הצג פרטי התקן</string>
     <string name="device_settings_info_status_label">מצב</string>
@@ -425,8 +437,11 @@
     <string name="device_settings_not_connected_description">המכשיר בקרבת מקום אך אינו מחובר לטלפון זה. התחבר כדי לגשת להגדרות ופקדים.</string>
     <string name="device_settings_not_connected_connect_action">התחבר</string>
     <string name="device_settings_not_connected_open_settings_action">פתח הגדרות Bluetooth</string>
+    <string name="device_settings_not_nearby_label">המכשיר אינו בקרבת מקום</string>
+    <string name="device_settings_not_nearby_description">ההגדרות זמינות רק כאשר המכשיר נמצא בקרבת מקום ומחובר לטלפון שלך.</string>
     <string name="device_settings_aap_unavailable_label">הגדרות מתקדמות אינן זמינות</string>
     <string name="device_settings_aap_unavailable_description">הגדרות AirPods מתקדמות דורשות תכונת בלוטות\' שאינה זמינה בטלפון זה. ייתכן שיש לכך פתרון בעדכון אנדרואיד עתידי מיצרן המכשיר.</string>
+    <string name="device_settings_aap_unavailable_action">צפה במעקב תאימות</string>
     <string name="device_settings_category_sound_label">צליל</string>
     <string name="device_settings_category_controls_label">בקרות</string>
     <string name="device_settings_nc_one_airpod_label">ANC עם אוזנייה אחת</string>
@@ -464,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">לחיצה אחת להשתקת מיקרופון</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">לחיצה כפולה לסיום שיחה</string>
     <string name="device_settings_open_cd">פתח הגדרות מכשיר</string>
+    <string name="overview_card_missing_paired_device">לפרופיל זה אין התקן Bluetooth מקושר.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">כללי</string>
     <string name="device_settings_microphone_mode_label">מיקרופון</string>
@@ -486,6 +502,9 @@
     <string name="device_settings_allow_off_description">אפשר כבוי כמצב בקרת רעש ניתן לבחירה. כאשר מבוטל, הגבעולים דולגים על כבוי במהלך המחזור.</string>
     <string name="device_settings_sleep_detection_label">זיהוי שינה</string>
     <string name="device_settings_sleep_detection_description">השהית שמע אוטומטית כשאתה נרדם</string>
+    <string name="reaction_sleep_channel_label">זיהוי שינה</string>
+    <string name="reaction_sleep_notification_title">הושהה על ידי זיהוי שינה</string>
+    <string name="reaction_sleep_notification_text">%1$s דיווח שנרדמת, לכן המוזיקה הושהתה. ניתן להשבית זאת בהגדרות המכשיר.</string>
     <string name="device_settings_rename_label">שנה שם</string>
     <string name="device_settings_rename_hint">שם המכשיר</string>
     <string name="device_settings_rename_confirm">שנה שם</string>
@@ -495,6 +514,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">הגדרות Bluetooth</string>
     <string name="device_settings_send_failed">לא ניתן היה להחיל את ההגדרה: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">מצב כבוי אינו מופעל במכשיר זה. הפעל את \"אפשר מצב כבוי\" תחת בקרת רעש.</string>
+    <string name="device_settings_category_battery_label">סוללה</string>
+    <string name="device_settings_charge_cap_label">מגבלת טעינה מותאמת</string>
+    <string name="device_settings_charge_cap_description">לומד את השגרה שלך ומשהה את הטעינה סביב 80%% כדי להאריך את חיי הסוללה, ומשלים את הטעינה לפני שסביר שתשתמש בהם.</string>
+    <string name="device_settings_charge_cap_rejected_message">לא ניתן לשנות את מגבלת הטעינה המותאמת. זוהי תכונה ניסיונית — אנא דווח אם היא ממשיכה להיכשל.</string>
     <string name="device_settings_category_connections_label">מכשירים מחוברים</string>
     <string name="device_settings_connected_devices_description">מכשירים אחרים המחוברים כעת ל-AirPods אלו</string>
     <string name="device_settings_connected_device_label">מכשיר %d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">背景の透明度</string>
     <string name="widget_config_show_device_label">デバイス名を表示</string>
     <string name="widget_config_reset_label">デフォルトにリセット</string>
+    <string name="widget_config_preview_resize_hint">ホーム画面に配置した後、ウィジェットのサイズを変更できます。</string>
     <string name="widget_config_custom_label">カスタム</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">ダーク</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">これは不明なデバイスですが、似たメッセージ形式を使用しています。サポートを追加しましょう。連絡してください :)</string>
     <string name="pods_none_label_short">デバイスなし</string>
     <string name="pods_charging_label">充電中</string>
+    <string name="pods_charging_optimized_label">最適化済み</string>
     <string name="pods_inear_label">装着中</string>
     <string name="pods_microphone_label">マイク</string>
     <string name="anc_mode_off">オフ</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">Bluetoothデバイスラベル</string>
     <string name="device_settings_info_model_label">モデル</string>
     <string name="device_settings_info_manufacturer_label">メーカー</string>
+    <string name="device_settings_info_hardware_label">ハードウェア</string>
     <string name="device_settings_info_serial_label">シリアル番号</string>
     <string name="device_settings_info_firmware_label">ファームウェア</string>
+    <string name="device_settings_info_firmware_pending_label">保留中のファームウェア</string>
     <string name="device_settings_info_build_label">ビルド</string>
     <string name="device_settings_info_left_serial_label">左ポッドのシリアル</string>
     <string name="device_settings_info_right_serial_label">右ポッドのシリアル</string>
+    <string name="device_settings_info_left_bonded_label">左ボンド済み</string>
+    <string name="device_settings_info_right_bonded_label">右ボンド済み</string>
     <string name="device_settings_info_details_label">デバイス詳細</string>
     <string name="device_settings_info_details_action">デバイス詳細を表示</string>
     <string name="device_settings_info_status_label">状態</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">このデバイスは近くにありますが、このスマートフォンに接続されていません。設定と操作にアクセスするには接続してください。</string>
     <string name="device_settings_not_connected_connect_action">接続</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth設定を開く</string>
+    <string name="device_settings_not_nearby_label">デバイスが近くにありません</string>
+    <string name="device_settings_not_nearby_description">設定は、このデバイスが近くにあり、スマートフォンに接続されている場合にのみ利用可能です。</string>
     <string name="device_settings_aap_unavailable_label">詳細設定を利用できません</string>
     <string name="device_settings_aap_unavailable_description">高度なAirPods設定には、このスマートフォンで利用できないBluetooth機能が必要です。デバイスメーカーからの将来のAndroidアップデートで解決される可能性があります。</string>
+    <string name="device_settings_aap_unavailable_action">互換性トラッカーを表示</string>
     <string name="device_settings_category_sound_label">サウンド</string>
     <string name="device_settings_category_controls_label">コントロール</string>
     <string name="device_settings_nc_one_airpod_label">1つのポッドでANC</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">シングルプレスでマイクをミュート</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ダブルプレスで通話を終了</string>
     <string name="device_settings_open_cd">デバイス設定を開く</string>
+    <string name="overview_card_missing_paired_device">このプロファイルにはペアリングされたBluetoothデバイスがありません。</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">マイク</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">ノイズコントロールの選択能なモードとしてオフを許可します。無効の場合、ステムのサイクル中にオフがスキップされます。</string>
     <string name="device_settings_sleep_detection_label">睡眠検知</string>
     <string name="device_settings_sleep_detection_description">眠りに就いたときに自動的にオーディオを一時停止</string>
+    <string name="reaction_sleep_channel_label">睡眠検出</string>
+    <string name="reaction_sleep_notification_title">睡眠検出によって一時停止されました</string>
+    <string name="reaction_sleep_notification_text">%1$s が眠りについたことを検出したため、音楽が一時停止されました。デバイス設定で無効にできます。</string>
     <string name="device_settings_rename_label">名前を変更</string>
     <string name="device_settings_rename_hint">デバイス名</string>
     <string name="device_settings_rename_confirm">名前を変更</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth設定</string>
     <string name="device_settings_send_failed">設定を適用できませんでした: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">オフモードはこのデバイスで有効になっていません。「ノイズコントロール」で「オフモードを許可」を有効にしてください。</string>
+    <string name="device_settings_category_battery_label">バッテリー</string>
+    <string name="device_settings_charge_cap_label">最適化された充電上限</string>
+    <string name="device_settings_charge_cap_description">あなたのルーティンを学習し、バッテリー寿命を延ばすために80%%前後で充電を一時停止し、使用する直前にイヤポッドを満充電にします。</string>
+    <string name="device_settings_charge_cap_rejected_message">最適化された充電上限を変更できませんでした。これは実験的な機能です。引き続き失敗する場合は報告してください。</string>
     <string name="device_settings_category_connections_label">接続済みデバイス</string>
     <string name="device_settings_connected_devices_description">このAirPodsに現在接続中のその他のデバイス</string>
     <string name="device_settings_connected_device_label">デバイス %d</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">ფონის გამჭვირვალობა</string>
     <string name="widget_config_show_device_label">მოწყობილობის სახელის ჩვენება</string>
     <string name="widget_config_reset_label">დაბრუნება ნაგულისხმებ პარამეტრებზე</string>
+    <string name="widget_config_preview_resize_hint">ვიჯეტის ზომის შეცვლა შესაძლებელია მთავარ ეკრანზე განთავსების შემდეგ.</string>
     <string name="widget_config_custom_label">მორგებული</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">მუქი</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">ეს უცნობი მოწყობილობაა, მაგრამ იყენებს მსგავს შეტყობინების ფორმატს. მოდით, მხარდაჭერა დავამატოთ, დამიკავშირდით :)</string>
     <string name="pods_none_label_short">მოწყობილობა არ არის</string>
     <string name="pods_charging_label">იტენება</string>
+    <string name="pods_charging_optimized_label">ოპტიმიზებული</string>
     <string name="pods_inear_label">ყურშია</string>
     <string name="pods_microphone_label">მიკროფონი</string>
     <string name="anc_mode_off">გამორთული</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth მოწყობილობის სახელი</string>
     <string name="device_settings_info_model_label">მოდელი</string>
     <string name="device_settings_info_manufacturer_label">მწარმოებელი</string>
+    <string name="device_settings_info_hardware_label">აპარატურა</string>
     <string name="device_settings_info_serial_label">სერიული ნომერი</string>
     <string name="device_settings_info_firmware_label">პროგრამული უზრუნველყოფა</string>
+    <string name="device_settings_info_firmware_pending_label">მომლოდინე პროგრამული უზრუნველყოფა</string>
     <string name="device_settings_info_build_label">ბილდი</string>
     <string name="device_settings_info_left_serial_label">მარცხენა Pod-ის სერიალური</string>
     <string name="device_settings_info_right_serial_label">მარჯვენა Pod-ის სერიალური</string>
+    <string name="device_settings_info_left_bonded_label">მარცხენა დაწყვილებული</string>
+    <string name="device_settings_info_right_bonded_label">მარჯვენა დაწყვილებული</string>
     <string name="device_settings_info_details_label">მოწყობილობის დეტალურები</string>
     <string name="device_settings_info_details_action">მოწყობილობის დეტალურების ჩვენება</string>
     <string name="device_settings_info_status_label">სტატუსი</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">ეს მოწყობილობა ახლოსაა, მაგრამ ამ ტელეფონთან არ არის დაკავშირებული. დაუკავშირდით პარამეტრებსა და კონტროლებზე წვდომისათვის.</string>
     <string name="device_settings_not_connected_connect_action">დაკავშირება</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth პარამეტრების გახსნა</string>
+    <string name="device_settings_not_nearby_label">მოწყობილობა ახლოს არ არის</string>
+    <string name="device_settings_not_nearby_description">პარამეტრები მხოლოდ მაშინ არის ხელმისაწვდომი, როდესაც ეს მოწყობილობა ახლოსაა და დაკავშირებულია თქვენს ტელეფონთან.</string>
     <string name="device_settings_aap_unavailable_label">გაფართოებული პარამეტრები მიუწვდომელია</string>
     <string name="device_settings_aap_unavailable_description">AirPods-ის გაფართოებული პარამეტრები საჭიროებს Bluetooth-ის ფუნქციას, რომელიც არ არის ხელმისაყოფლო ამ ტელეფონზე. შესაძლოა ეს აღმოიფხვეს თქვენი მოწყობილობის Android-ის მომავალი განახლებით.</string>
+    <string name="device_settings_aap_unavailable_action">თავსებადობის ტრეკერის ნახვა</string>
     <string name="device_settings_category_sound_label">ხმა</string>
     <string name="device_settings_category_controls_label">კონტროლები</string>
     <string name="device_settings_nc_one_airpod_label">ANC ერთი pod-ისაან</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ერთხელ დაჭერით მიკროფონის დადუმება</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ორჯერ დაჭერით ზარის დასრულება</string>
     <string name="device_settings_open_cd">მოწყობილობის პარამეტრების გახსნა</string>
+    <string name="overview_card_missing_paired_device">ამ პროფილს არ აქვს დაწყვილებული Bluetooth მოწყობილობა.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ზოგადი</string>
     <string name="device_settings_microphone_mode_label">მიკროფონი</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">დაშვას Off საირჩიე ხმაურის კონტროლის რეჟიმად. გათიშვისას, stems გადაინაცვლებს Off-ს ციკლურისას.</string>
     <string name="device_settings_sleep_detection_label">ძილის დეტექცია</string>
     <string name="device_settings_sleep_detection_description">ავტომატურად შეაჩერე აუდიო, როდესაც ჩაიძინებ</string>
+    <string name="reaction_sleep_channel_label">ძილის გამოვლენა</string>
+    <string name="reaction_sleep_notification_title">შეჩერებულია ძილის გამოვლენის მიერ</string>
+    <string name="reaction_sleep_notification_text">%1$s-მ დააფიქსირა, რომ ჩაეძინათ, ამიტომ მუსიკა შეჩერდა. ამის გათიშვა შეგიძლიათ მოწყობილობის პარამეტრებში.</string>
     <string name="device_settings_rename_label">გადარქმევა</string>
     <string name="device_settings_rename_hint">მოწყობილობის სახელი</string>
     <string name="device_settings_rename_confirm">გადარქმევა</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth პარამეტრები</string>
     <string name="device_settings_send_failed">პარამეტრის გამოყენება ვერ მოხერხდა: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Off რეჟიმი არ არის აქტიური ამ მოწყობილობაზე. აღვისეთ \"Off რეჟიმის დაშვება\" Noise Control-ში.</string>
+    <string name="device_settings_category_battery_label">ბატარეა</string>
+    <string name="device_settings_charge_cap_label">ოპტიმიზებული დამუხტვის ლიმიტი</string>
+    <string name="device_settings_charge_cap_description">ისწავლის თქვენს რუტინას და შეაჩერებს დამუხტვას დაახლოებით 80%%-ზე ბატარეის სიცოცხლის გასახანგრძლივებლად, პოდებს დამუხტავს სრულად სავარაუდო გამოყენებამდე.</string>
+    <string name="device_settings_charge_cap_rejected_message">ოპტიმიზებული დამუხტვის ლიმიტის შეცვლა ვერ მოხერხდა. ეს ექსპერიმენტული ფუნქციაა — გთხოვთ, შეგვატყობინოთ, თუ პრობლემა გრძელდება.</string>
     <string name="device_settings_category_connections_label">დაკავშირებული მოწყობილობები</string>
     <string name="device_settings_connected_devices_description">სხვა მოწყობილობები, რომლებიც ამჟამად ამ აირპოდს-თან არის დაკავშირებული</string>
     <string name="device_settings_connected_device_label">მოწყობილობა %d</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">ភាពថ្លាផ្ទៃខាងក្រោយ</string>
     <string name="widget_config_show_device_label">បង្ហាញឈ្មោះឧបករណ៍</string>
     <string name="widget_config_reset_label">កំណត់ឡើងវិញទៅលម្អិតដើម</string>
+    <string name="widget_config_preview_resize_hint">អ្នកអាចប្តូរទំហំ widget បន្ទាប់ពីដាក់វានៅលើអេក្រង់ដើមរបស់អ្នក។</string>
     <string name="widget_config_custom_label">ផ្ទាល់ខ្លួន</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">ងងឹត</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">នេះជាឧបករណ៍មិនស្គាល់ ប៉ុន្តែវាកំពុងប្រើទម្រង់សារស្រដៀងគ្នា។ សូមបន្ថែមការគាំទ្រសម្រាប់វា ទាក់ទងមកខ្ញុំ :)</string>
     <string name="pods_none_label_short">គ្មានឧបករណ៍</string>
     <string name="pods_charging_label">កំពុងសាក</string>
+    <string name="pods_charging_optimized_label">បានបង្កើនប្រសិទ្ធភាព</string>
     <string name="pods_inear_label">ក្នុងត្រចៀក</string>
     <string name="pods_microphone_label">មីក្រូហ្វូន</string>
     <string name="anc_mode_off">បិទ</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">ស្លាកឧបករណ៍ Bluetooth</string>
     <string name="device_settings_info_model_label">គំរូ</string>
     <string name="device_settings_info_manufacturer_label">ក្រុមហ៊ុនផលិត</string>
+    <string name="device_settings_info_hardware_label">ផ្នែករឹង</string>
     <string name="device_settings_info_serial_label">លើខស្អីរី</string>
     <string name="device_settings_info_firmware_label">កំណែ Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">កម្មវិធីបង្កប់រង់ចាំ</string>
     <string name="device_settings_info_build_label">កំណែ</string>
     <string name="device_settings_info_left_serial_label">លើខស៊ើរី Pod ខាងឆ្វេង</string>
     <string name="device_settings_info_right_serial_label">លើខស៊ើរី Pod ខាងស្តាំ</string>
+    <string name="device_settings_info_left_bonded_label">ខាងឆ្វេងបានភ្ជាប់</string>
+    <string name="device_settings_info_right_bonded_label">ខាងស្តាំបានភ្ជាប់</string>
     <string name="device_settings_info_details_label">ព័ត៌មានលម័អិតឧបករណ៍</string>
     <string name="device_settings_info_details_action">បង់ហាញព័ត៌មានលម័អិតឧបករណ៍</string>
     <string name="device_settings_info_status_label">ស្ថានភាព</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">ឧបករណ៍នេះនៅជិតប៉ុន្តែមិនបានតភ្ជាប់ទៅទូរស័ព្ទនេះទេ។ ភ្ជាប់ដើម្បីចូលប្រើការកំណត់និងការគ្រប់គ្រង។</string>
     <string name="device_settings_not_connected_connect_action">ភ្ជាប់</string>
     <string name="device_settings_not_connected_open_settings_action">បើកការកំណត់ Bluetooth</string>
+    <string name="device_settings_not_nearby_label">ឧបករណ៍មិននៅជិតទេ</string>
+    <string name="device_settings_not_nearby_description">ការកំណត់មានតែនៅពេលឧបករណ៍នេះនៅជិត ហើយបានភ្ជាប់ទៅទូរស័ព្ទរបស់អ្នក។</string>
     <string name="device_settings_aap_unavailable_label">ការកំណត់កម្រិតខ្ពស់មិនអាចប្រើបាន</string>
     <string name="device_settings_aap_unavailable_description">ការកំណត់ AirPods កម្រិតខ្ពស់តម្រូវឱ្យមានមុខងារ Bluetooth ដែលមិនអាចប្រើបានលើទូរស័ភ្ទនេះ។ ករណីនេះប្រហែលជាត្រូវបានដោះស្រួលដោយការអាប់ដើត Android នាពេលអនាគតពីក្រុមហ៊ុនផលិតឧបករណ៍របស់អ្នក។</string>
+    <string name="device_settings_aap_unavailable_action">មើលឧបករណ៍តាមដានភាពឆបគ្នា</string>
     <string name="device_settings_category_sound_label">សំឡេង</string>
     <string name="device_settings_category_controls_label">ការគ្រប់គ្រង</string>
     <string name="device_settings_nc_one_airpod_label">ANC ជាមួយ pod មួយ</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ចុចម្តងដើម្បិបិតមីក្រូហ្វូន</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ចុចពីរដងដើម្បិបញ្ចប់ការហឹល</string>
     <string name="device_settings_open_cd">បើកការកំណត់ឧបករណ៍</string>
+    <string name="overview_card_missing_paired_device">គម្រោងនេះមិនមានឧបករណ៍ Bluetooth ដែលបានផ្គូផ្គងទេ។</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ជាទូទៅ</string>
     <string name="device_settings_microphone_mode_label">ไมโครโฟน</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">អនុញ្ញាត Off ជារបឰបគ្រប់គ្រងសំឡេងរំខានដែលអាចជ្រើររើសបាន។ នៅពេលបិទ stems នឹងរំលង Off ខណែពេលកំពុងប្តូរ។</string>
     <string name="device_settings_sleep_detection_label">ការរកៃើញការដេក</string>
     <string name="device_settings_sleep_detection_description">ផ្អាកអូឌីយ័ឡដោយស្វ័យប្រវត្តិពេលអ្នកដេកលក់</string>
+    <string name="reaction_sleep_channel_label">ការរកឃើញការគេង</string>
+    <string name="reaction_sleep_notification_title">ផ្អាកដោយការរកឃើញការគេង</string>
+    <string name="reaction_sleep_notification_text">%1$s រាយការណ៍ថាអ្នកគេងលក់ ដូច្នេះតន្ត្រីរបស់អ្នកត្រូវបានផ្អាក។ អ្នកអាចបិទមុខងារនេះបានក្នុងការកំណត់ឧបករណ៍។</string>
     <string name="device_settings_rename_label">ប្តូរៀម្អោះ</string>
     <string name="device_settings_rename_hint">ៀម្អោះឧបករណ៍</string>
     <string name="device_settings_rename_confirm">ប្តូរៀម្អោះ</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ការកំណត់ Bluetooth</string>
     <string name="device_settings_send_failed">មិនអាចអនុវត្តការកំណត់: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">របឰប Off មិនបានបើកនៅលើឧបករណ៍នេះ។ បើក \"អនុញ្ញាតរបឰប Off\" ក្របម Noise Control។</string>
+    <string name="device_settings_category_battery_label">ថ្មី</string>
+    <string name="device_settings_charge_cap_label">កំណត់ការសាកថ្មប្រសិទ្ធភាព</string>
+    <string name="device_settings_charge_cap_description">រៀនទម្លាប់របស់អ្នក ហើយផ្អាកការសាកប្រហែល 80%% ដើម្បីពន្យារអាយុថ្ម ដោយបំពេញ pods មុនពេលអ្នកទំនងនឹងប្រើពួកវា។</string>
+    <string name="device_settings_charge_cap_rejected_message">មិនអាចផ្លាស់ប្តូរ​កំណត់ការសាកថ្មប្រសិទ្ធភាពបានទេ។ នេះជាមុខងារពិសោធន៍ — សូមរាយការណ៍ប្រសិនបើវានៅតែបរាជ័យ។</string>
     <string name="device_settings_category_connections_label">ឧបករណ៍ភ្ជាប់</string>
     <string name="device_settings_connected_devices_description">ឧបករណ៍ផ្សេទៀតដែលបានភ្ជាប់ទៅ AirPods តាំនេះ</string>
     <string name="device_settings_connected_device_label">ឧបករណ៍ %d</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -26,7 +26,7 @@
     <string name="upgrade_benefit_popups">Popup dema vekirina qutiyê &amp; girêdanê</string>
     <string name="upgrade_benefit_widgets">Widgetên ekrana malê</string>
     <string name="upgrade_benefit_device_settings">Mîhengen pêşkertî yên cîhazê</string>
-    <string name="upgrade_benefit_device_controls">Kontrolên cîhazê &#8212; deng, stûn &amp; zêdetir</string>
+    <string name="upgrade_benefit_device_controls">Kontrolên cîhazê &#8212; deng, stûn &amp; zªtir</string>
     <string name="upgrade_benefit_support">Pêşdebir piştgirî bike</string>
     <string name="upgrade_benefit_disclaimer">Hebûna taybet mendêyê bi kulaklîkên we û amûrê ve girêdayî ye.</string>
     <string name="upgrade_screen_options_description">Heman taybetmendî, bihayên cûda. Abonê ceribandineke belaş vedihewîne û her dem dikare were betal kirin.</string>
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Zelabûna paşxistê</string>
     <string name="widget_config_show_device_label">Navê cihazê nîşan bide</string>
     <string name="widget_config_reset_label">Vegere bergûzariyên niyşê</string>
+    <string name="widget_config_preview_resize_hint">Tu dikarî pêvekê piştî danîna wê li ser ekrana xwe ya malê guhêrbikî.</string>
     <string name="widget_config_custom_label">Xweser</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tarî</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Ev amûrek nenas e, lê formata peyamên wekhev bikar tîne. Ka em piştgiriyê lê zêde bikin, bi min re têkilî daynin :)</string>
     <string name="pods_none_label_short">Tu amûr tune</string>
     <string name="pods_charging_label">Tê şarjkirin</string>
+    <string name="pods_charging_optimized_label">Xweşkirî</string>
     <string name="pods_inear_label">Di guhê de</string>
     <string name="pods_microphone_label">Mîkrofon</string>
     <string name="anc_mode_off">Vemirandî</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Navê Amûra Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Çêker</string>
+    <string name="device_settings_info_hardware_label">Donanî</string>
     <string name="device_settings_info_serial_label">Jimara Rêzî</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Nermalava Benda</string>
     <string name="device_settings_info_build_label">Avakirin</string>
     <string name="device_settings_info_left_serial_label">Serî ya Pod Çep</string>
     <string name="device_settings_info_right_serial_label">Serî ya Pod Rast</string>
+    <string name="device_settings_info_left_bonded_label">Çepê Girêdayî</string>
+    <string name="device_settings_info_right_bonded_label">Rastê Girêdayî</string>
     <string name="device_settings_info_details_label">Hûrguliyîn Amûrê</string>
     <string name="device_settings_info_details_action">Hûrguliyîn amûrê nîşan bide</string>
     <string name="device_settings_info_status_label">Rewş</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Ev cîhaz li nêzîkê ye lê bi vê têlefonê ve girêdayî nine. Girêde da bigihîjî mîheng û kontrolan.</string>
     <string name="device_settings_not_connected_connect_action">Girêde</string>
     <string name="device_settings_not_connected_open_settings_action">Mîhengên Bluetooth veke</string>
+    <string name="device_settings_not_nearby_label">Amûr li nêzîkê nîne</string>
+    <string name="device_settings_not_nearby_description">Mîheng tenê dema ku ev amûr li nêzîkê be û bi têlefona we ve girêdayî be tê peyda kirin.</string>
     <string name="device_settings_aap_unavailable_label">Mîhengên pêşkeftî nepeyda ne</string>
     <string name="device_settings_aap_unavailable_description">Mêhengîn pêşkeftî yîn AirPods taybetmendiyek Bluetooth hewce dike ku li ser vê têlefonê berdest nêne. Ev dibe ku bi nûvekirina pêşerojê ya Android ji çêkerê amûra we were çareserkirin.</string>
+    <string name="device_settings_aap_unavailable_action">Şopnerê lihevhatinê bibîne</string>
     <string name="device_settings_category_sound_label">Deng</string>
     <string name="device_settings_category_controls_label">Kontrol</string>
     <string name="device_settings_nc_one_airpod_label">ANC bi yek pod</string>
@@ -451,15 +460,16 @@
     <string name="device_settings_volume_swipe_length_label">Dema Rawestana Kaşkirina Dengê</string>
     <string name="device_settings_volume_swipe_length_description">Ji bo pêşîlêgirtina guherandina dengê ya bê mebest, hilbijêre çiqas li bendê bimînî di navbera kaşkirinan de.</string>
     <string name="device_settings_volume_swipe_length_default">Xwerû</string>
-    <string name="device_settings_volume_swipe_length_longer">Dirêjtir</string>
+    <string name="device_settings_volume_swipe_length_longer">Dirªjtir</string>
     <string name="device_settings_volume_swipe_length_longest">Herî Dirêj</string>
     <string name="device_settings_end_call_mute_mic_label">Kontrolên Bangê</string>
-    <string name="device_settings_end_call_mute_mic_description">Hilbijêre ku pêtina stûnê di dema bangên çi dike</string>
+    <string name="device_settings_end_call_mute_mic_description">Hilbijêre ku pªtina stûnê di dema bangên çi dike</string>
     <string name="device_settings_end_call_mute_mic_option_a_title">Yek pêtin ji bo bidawîkirina bangê</string>
     <string name="device_settings_end_call_mute_mic_option_a_subtitle">Du pêtin ji bo bîdengkirina mîkrofonê</string>
     <string name="device_settings_end_call_mute_mic_option_b_title">Yek pêtin ji bo bîdengkirina mîkrofonê</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Du pêtin ji bo bidawîkirina bangê</string>
     <string name="device_settings_open_cd">Mîhengên cîhazê veke</string>
+    <string name="overview_card_missing_paired_device">Ev profîl ti amûrek Bluetooth-ê ya hevgirtî tune.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Giştî</string>
     <string name="device_settings_microphone_mode_label">Mîkrofon</string>
@@ -481,7 +491,10 @@
     <string name="device_settings_allow_off_label">Destûrê bide Moda Venebûnê</string>
     <string name="device_settings_allow_off_description">Destûrê bide Venebûn wekî moda kontrola dengê ya bijartbar. Dema neçalak e, stem dema çerxkirinê Venebûn derbas dike.</string>
     <string name="device_settings_sleep_detection_label">Tespîtkirina Xewê</string>
-    <string name="device_settings_sleep_detection_description">Dema ku dikevî xewê, dengê medyayê bixweber rawes têne</string>
+    <string name="device_settings_sleep_detection_description">Dema ku dikªvî xewê, dengê medyayê bixweber rawes têne</string>
+    <string name="reaction_sleep_channel_label">Tespîtkirina Xewê</string>
+    <string name="reaction_sleep_notification_title">Ji hêla Tespîtkirina Xewê ve hate rawestandin</string>
+    <string name="reaction_sleep_notification_text">%1$s ragihand ku hûn xew çûn, ji ber vê yekê muzîka we hate rawestandin. Hûn dikarin vê di mîhengên amûrê de neçalak bikin.</string>
     <string name="device_settings_rename_label">Navnivisîn</string>
     <string name="device_settings_rename_hint">Navê cîhazê</string>
     <string name="device_settings_rename_confirm">Navnivisîn</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Mîhengên Bluetooth</string>
     <string name="device_settings_send_failed">Mîheng nehate sepandin: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Moda Venebûn li ser vê amûrê neçalak e. \"Destûrê bide Moda Venebûnê\" di bin Kontrola Dengê de çalak bike.</string>
+    <string name="device_settings_category_battery_label">Batarya</string>
+    <string name="device_settings_charge_cap_label">Sînorê Şandina Xweşkirî</string>
+    <string name="device_settings_charge_cap_description">Rutîna we hîn bike û şandina bataryayê li dora 80%% rawestîne da ku heyama bataryayê dirêj bike, podên we berî ku hûn wan bikar bînin tijî bike.</string>
+    <string name="device_settings_charge_cap_rejected_message">Sînorê Şandina Xweşkirî nehat guhêrtin. Ev taybetmendiyek ceribandinê ye — ji kerema xwe raporte bikin eger ew têk diçe.</string>
     <string name="device_settings_category_connections_label">Amûrên Girêdayî</string>
     <string name="device_settings_connected_devices_description">Amûrên din ên niha bi van AirPods girêdayî</string>
     <string name="device_settings_connected_device_label">Amûr %d</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">ಹಿನ್ನೆಲೆ ಪಾರದರ್ಶಕತೆ</string>
     <string name="widget_config_show_device_label">ಸಾಧನ ಹೆಸರು ತೋರಿಸಿ</string>
     <string name="widget_config_reset_label">ಪೂರ್ವನಿರ್ಧಾರಿತಕ್ಕೆ ಮರುಹೊಂದಿಸಿ</string>
+    <string name="widget_config_preview_resize_hint">ನಿಮ್ಮ ಹೋಮ್ ಸ್ಕ್ರೀನ್‌ನಲ್ಲಿ ವಿಜೆಟ್ ಇಟ್ಟ ನಂತರ ನೀವು ಅದನ್ನು ಮರುಗಾತ್ರಗೊಳಿಸಬಹುದು.</string>
     <string name="widget_config_custom_label">ಕಸ್ಟಮ್</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">ಗಾಢ</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">ಇದು ಅಜ್ಞಾತ ಸಾಧನವಾಗಿದೆ, ಆದರೆ ಇದು ಇದೇ ರೀತಿಯ ಸಂದೇಶ ಸ್ವರೂಪವನ್ನು ಬಳಸುತ್ತಿದೆ. ಇದಕ್ಕೆ ಬೆಂಬಲವನ್ನು ಸೇರಿಸೋಣ, ನನ್ನನ್ನು ಸಂಪರ್ಕಿಸಿ :)</string>
     <string name="pods_none_label_short">ಸಾಧನವಿಲ್ಲ</string>
     <string name="pods_charging_label">ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ</string>
+    <string name="pods_charging_optimized_label">ಆಪ್ಟಿಮೈಸ್ ಮಾಡಲಾಗಿದೆ</string>
     <string name="pods_inear_label">ಕಿವಿಯಲ್ಲಿ</string>
     <string name="pods_microphone_label">ಮೈಕ್ರೋಫೋನ್</string>
     <string name="anc_mode_off">ಆಫ್</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">ಬ್ಲೂಟೂತ್ ಸಾಧನ ಲೇಬಲ್</string>
     <string name="device_settings_info_model_label">ಮಾದರಿ</string>
     <string name="device_settings_info_manufacturer_label">ತಯಾರಕ</string>
+    <string name="device_settings_info_hardware_label">ಹಾರ್ಡ್‌ವೇರ್</string>
     <string name="device_settings_info_serial_label">ಸಿರಿಯಲ್ ಸಂಖ್ಯೆ</string>
     <string name="device_settings_info_firmware_label">ಫರ್ಮ್ವೆಯರ್</string>
+    <string name="device_settings_info_firmware_pending_label">ಬಾಕಿ ಇರುವ ಫರ್ಮ್‌ವೇರ್</string>
     <string name="device_settings_info_build_label">ಬಿಲ್ಡ್</string>
     <string name="device_settings_info_left_serial_label">ಎಡ ಪಾಡ್ ಸೀರಿಯಲ್</string>
     <string name="device_settings_info_right_serial_label">ಬಲ ಪಾಡ್ ಸೀರಿಯಲ್</string>
+    <string name="device_settings_info_left_bonded_label">ಎಡ ಬಂಧಿತ</string>
+    <string name="device_settings_info_right_bonded_label">ಬಲ ಬಂಧಿತ</string>
     <string name="device_settings_info_details_label">ಸಾಧನ ವಿವರಗಳು</string>
     <string name="device_settings_info_details_action">ಸಾಧನ ವಿವರಗಳನ್ನು ತೋರಿಸಿ</string>
     <string name="device_settings_info_status_label">ಸ್ಥಿತಿ</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">ಈ ಸಾಧನವು ಹತ್ತಿರದಲ್ಲಿದೆ ಆದರೆ ಈ ಫೋನ್‌ಗೆ ಸಂಪರ್ಕಿಸಲಾಗಿಲ್ಲ. ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಮತ್ತು ನಿಯಂತ್ರಣಗಳನ್ನು ಪ್ರವೇಶಿಸಲು ಸಂಪರ್ಕಿಸಿ.</string>
     <string name="device_settings_not_connected_connect_action">ಸಂಪರ್ಕಿಸಿ</string>
     <string name="device_settings_not_connected_open_settings_action">ಬ್ಲೂಟೂತ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ</string>
+    <string name="device_settings_not_nearby_label">ಸಾಧನ ಹತ್ತಿರದಲ್ಲಿಲ್ಲ</string>
+    <string name="device_settings_not_nearby_description">ಈ ಸಾಧನ ಹತ್ತಿರದಲ್ಲಿದ್ದು ನಿಮ್ಮ ಫೋನ್‌ಗೆ ಸಂಪರ್ಕಿತವಾಗಿರುವಾಗ ಮಾತ್ರ ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಲಭ್ಯವಿರುತ್ತವೆ.</string>
     <string name="device_settings_aap_unavailable_label">ಸುಧಾರಿತ ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಲಭ್ಯವಿಲ್ಲ</string>
     <string name="device_settings_aap_unavailable_description">ಸುಧಾರಿತ AirPods ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗೆ ಈ ಫೋನ್‌ನಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲದ ಬ್ಲೂಟೂತ್ ವೈಶಿಷ್ಟ್ಯ ಅಗತ್ಯವಿದೆ. ನಿಮ್ಮ ಸಾಧನ ತಯಾರಕರ ಮುಂದಿನ Android ನವೀಕರಣದಿಂದ ಇದನ್ನು ಪರಿಹರಿಸಬಹುದು.</string>
+    <string name="device_settings_aap_unavailable_action">ಹೊಂದಾಣಿಕೆ ಟ್ರ್ಯಾಕರ್ ವೀಕ್ಷಿಸಿ</string>
     <string name="device_settings_category_sound_label">ಶಬ್ದ</string>
     <string name="device_settings_category_controls_label">ನಿಯಂತ್ರಣಗಳು</string>
     <string name="device_settings_nc_one_airpod_label">ಒಂದು ಪಾಡ್‌ನೊಂದಿಗೆ ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ಮೈಕ್ ಮ್ಯೂಟ್ ಮಾಡಲು ಒಂದು ಬಾರಿ ಬಗೆ ದಲ್ಲಿಸಿ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ಕರೆ ಮುಗಿಸಲು ಎರಡು ಬಾರಿ ಬಗೆ ದಲ್ಲಿಸಿ</string>
     <string name="device_settings_open_cd">ಸಾಧನ ಸೆಟ್ಟಿಂಗ್ಸ್ ತೆರೆಯಿರಿ</string>
+    <string name="overview_card_missing_paired_device">ಈ ಪ್ರೊಫೈಲ್‌ಗೆ ಯಾವುದೇ ಜೋಡಿಸಲಾದ ಬ್ಲೂಟೂತ್ ಸಾಧನವಿಲ್ಲ.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ಸಾಮಾನ್ಯ</string>
     <string name="device_settings_microphone_mode_label">ಮೈಕ್ರೊಫೋನ್</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">ಆಫ್ ಅನ್ನು ಆಯ್ಕೆ ಮಾಡಬಹುದಾದ ಶಬ್ದ ನಿಯಂತ್ರಣ ಮೋಡ್ ಆಗಿ ಅನುಮತಿಸಿ. ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿದಾಗ, ಸೈಕ್ಲಿಂಗ್ ಮಾಡುವಾಗ ಸ್ಟೆಮ್‌ಗಳು ಆಫ್ ಅನ್ನು ಬಿಟ್ಟುಬಿಡುತ್ತವೆ.</string>
     <string name="device_settings_sleep_detection_label">ನಿದ್ದೆ ಪತ್ತೆ</string>
     <string name="device_settings_sleep_detection_description">ನಿಮ್ಮಗೆ ನಿದ್ದೆ ಬಂದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆಡಿಯೋ ನಿಲ್ಲಿಸಿ</string>
+    <string name="reaction_sleep_channel_label">ನಿದ್ರೆ ಪತ್ತೆ</string>
+    <string name="reaction_sleep_notification_title">ನಿದ್ರೆ ಪತ್ತೆಯಿಂದ ವಿರಾಮಗೊಂಡಿದೆ</string>
+    <string name="reaction_sleep_notification_text">%1$s ನೀವು ನಿದ್ರಿಸಿದಿರಿ ಎಂದು ತಿಳಿಸಿದೆ, ಆದ್ದರಿಂದ ನಿಮ್ಮ ಸಂಗೀತವನ್ನು ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ. ಸಾಧನ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಇದನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಬಹುದು.</string>
     <string name="device_settings_rename_label">ಮರುಹೆಸರಿಸಿ</string>
     <string name="device_settings_rename_hint">ಸಾಧನ ಹೆಸರು</string>
     <string name="device_settings_rename_confirm">ಮರುಹೆಸರಿಸಿ</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ಬ್ಲೂಟೂತ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು</string>
     <string name="device_settings_send_failed">ಸೆಟ್ಟಿಂಗ್ ಅನ್ವಯಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">ಈ ಸಾಧನದಲ್ಲಿ ಆಫ್ ಮೋಡ್ ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿಲ್ಲ. ಶಬ್ದ ನಿಯಂತ್ರಣ ಅಡಿಯಲ್ಲಿ \"ಆಫ್ ಮೋಡ್ ಅನುಮತಿಸಿ\" ಸಕ್ರಿಯಗೊಳಿಸಿ.</string>
+    <string name="device_settings_category_battery_label">ಬ್ಯಾಟರಿ</string>
+    <string name="device_settings_charge_cap_label">ಆಪ್ಟಿಮೈಸ್ಡ್ ಚಾರ್ಜ್ ಮಿತಿ</string>
+    <string name="device_settings_charge_cap_description">ನಿಮ್ಮ ದಿನಚರಿಯನ್ನು ಕಲಿತು 80%% ಸಮೀಪ ಚಾರ್ಜಿಂಗ್ ವಿರಾಮಗೊಳಿಸಿ ಬ್ಯಾಟರಿ ಆಯಸ್ಸು ವಿಸ್ತರಿಸುತ್ತದೆ, ನೀವು ಬಳಸುವ ಮೊದಲು ಪಾಡ್‌ಗಳನ್ನು ತುಂಬಿಸುತ್ತದೆ.</string>
+    <string name="device_settings_charge_cap_rejected_message">ಆಪ್ಟಿಮೈಸ್ಡ್ ಚಾರ್ಜ್ ಮಿತಿಯನ್ನು ಬದಲಾಯಿಸಲಾಗಲಿಲ್ಲ. ಇದು ಪ್ರಾಯೋಗಿಕ ವೈಶಿಷ್ಟ್ಯ — ಇದು ವಿಫಲವಾಗುತ್ತಲೇ ಇದ್ದರೆ ದಯವಿಟ್ಟು ವರದಿ ಮಾಡಿ.</string>
     <string name="device_settings_category_connections_label">ಸಂಪರ್ಕಿತ ಸಾಧನಗಳು</string>
     <string name="device_settings_connected_devices_description">ಈ AirPods ಗೆ ಪ್ರಸ್ತುತ ಸಂಪರ್ಕಿತ ಇತರ ಸಾಧನಗಳು</string>
     <string name="device_settings_connected_device_label">ಸಾಧನ %d</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">배경 투명도</string>
     <string name="widget_config_show_device_label">기기 이름 표시</string>
     <string name="widget_config_reset_label">기본값으로 재설정</string>
+    <string name="widget_config_preview_resize_hint">홈 화면에 위젯을 배치한 후 크기를 조절할 수 있습니다.</string>
     <string name="widget_config_custom_label">사용자 정의</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">어두움</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">알 수 없는 기기이나 비슷한 형식으로 정보를 보내는 기기인 것 같습니다. 제게 알려주시면 앱에 해당 기기 지원을 추가해 드릴게요 :)</string>
     <string name="pods_none_label_short">기기 없음</string>
     <string name="pods_charging_label">충전 중</string>
+    <string name="pods_charging_optimized_label">최적화됨</string>
     <string name="pods_inear_label">착용 중</string>
     <string name="pods_microphone_label">마이크</string>
     <string name="anc_mode_off">끄기</string>
@@ -404,11 +406,15 @@
     <string name="device_settings_info_bt_name_label">블루투스 기기 레이블</string>
     <string name="device_settings_info_model_label">모델</string>
     <string name="device_settings_info_manufacturer_label">제조사</string>
+    <string name="device_settings_info_hardware_label">하드웨어</string>
     <string name="device_settings_info_serial_label">시리얼 번호</string>
     <string name="device_settings_info_firmware_label">펌웨어</string>
+    <string name="device_settings_info_firmware_pending_label">대기 중인 펌웨어</string>
     <string name="device_settings_info_build_label">빌드</string>
     <string name="device_settings_info_left_serial_label">왼쪽 이어팟 일련번호</string>
     <string name="device_settings_info_right_serial_label">오른쪽 이어팟 일련번호</string>
+    <string name="device_settings_info_left_bonded_label">왼쪽 연결됨</string>
+    <string name="device_settings_info_right_bonded_label">오른쪽 연결됨</string>
     <string name="device_settings_info_details_label">기기 세부정보</string>
     <string name="device_settings_info_details_action">기기 세부정보 보기</string>
     <string name="device_settings_info_status_label">상태</string>
@@ -418,8 +424,11 @@
     <string name="device_settings_not_connected_description">이 기기가 근처에 있지만 이 휴대폰에 연결되어 있지 않습니다. 설정과 제어에 접근하려면 연결하세요.</string>
     <string name="device_settings_not_connected_connect_action">연결</string>
     <string name="device_settings_not_connected_open_settings_action">블루투스 설정 열기</string>
+    <string name="device_settings_not_nearby_label">기기가 근처에 없음</string>
+    <string name="device_settings_not_nearby_description">이 기기가 근처에 있고 휴대폰에 연결되어 있을 때만 설정을 사용할 수 있습니다.</string>
     <string name="device_settings_aap_unavailable_label">고급 설정 사용 불가</string>
     <string name="device_settings_aap_unavailable_description">고급 AirPods 설정은 이 휴대전화에서 사용할 수 없는 블루투스 기능이 필요합니다. 이는 기기 제조사의 향후 Android 업데이트로 해결될 수 있습니다.</string>
+    <string name="device_settings_aap_unavailable_action">호환성 추적기 보기</string>
     <string name="device_settings_category_sound_label">사운드</string>
     <string name="device_settings_category_controls_label">제어</string>
     <string name="device_settings_nc_one_airpod_label">단일 이어팟으로 ANC 사용</string>
@@ -457,6 +466,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">한 번 눌러 마이크 음소거</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">두 번 눌러 통화 종료</string>
     <string name="device_settings_open_cd">기기 설정 열기</string>
+    <string name="overview_card_missing_paired_device">이 프로필에는 페어링된 Bluetooth 기기가 없습니다.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">일반</string>
     <string name="device_settings_microphone_mode_label">마이크</string>
@@ -479,6 +489,9 @@
     <string name="device_settings_allow_off_description">Off를 선택 가능한 소음 제어 모드로 허용합니다. 비활성화되면 스템이 순환 중 Off를 건너마앙니다.</string>
     <string name="device_settings_sleep_detection_label">수면 감지</string>
     <string name="device_settings_sleep_detection_description">잠들면 자동으로 오디오 일시 정지</string>
+    <string name="reaction_sleep_channel_label">수면 감지</string>
+    <string name="reaction_sleep_notification_title">수면 감지로 일시 정지됨</string>
+    <string name="reaction_sleep_notification_text">%1$s에서 잠든 것을 감지하여 음악이 일시 정지되었습니다. 기기 설정에서 이 기능을 비활성화할 수 있습니다.</string>
     <string name="device_settings_rename_label">이름 바꾸기</string>
     <string name="device_settings_rename_hint">기기 이름</string>
     <string name="device_settings_rename_confirm">이름 바꾸기</string>
@@ -488,6 +501,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">블루투스 설정</string>
     <string name="device_settings_send_failed">설정을 적용할 수 없습니다: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">이 기기에서 Off 모드가 활성화되어 있지 않습니다. 소음 제어 아래의 \"오프 모드 허용\"을 활성화하세요.</string>
+    <string name="device_settings_category_battery_label">배터리</string>
+    <string name="device_settings_charge_cap_label">최적화된 충전 한도</string>
+    <string name="device_settings_charge_cap_description">사용 패턴을 학습하여 배터리 수명 연장을 위해 충전을 약 80%%에서 일시 중지하고, 사용하기 전에 충전을 완료합니다.</string>
+    <string name="device_settings_charge_cap_rejected_message">최적화된 충전 한도를 변경할 수 없습니다. 이 기능은 실험적 기능입니다. 계속 실패하면 신고해 주세요.</string>
     <string name="device_settings_category_connections_label">연결된 기기</string>
     <string name="device_settings_connected_devices_description">현재 이 AirPods에 연결된 다른 기기</string>
     <string name="device_settings_connected_device_label">기기 %d</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Фондун тунуктугу</string>
     <string name="widget_config_show_device_label">Түзүлмөнүн атын көрсөтүү</string>
     <string name="widget_config_reset_label">Демейки параметрлерге өндөрүү</string>
+    <string name="widget_config_preview_resize_hint">Виджетти башкы экранга жайгаштыргандан кийин, анын өлчөмүн өзгөртө аласыз.</string>
     <string name="widget_config_custom_label">Ыңгайлаштырылган</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Караңгы</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Бул белгисиз түзмөк, бирок окшош билдирүү форматын колдонот. Аны колдоого кошолу, мени менен байланышыңыз :)</string>
     <string name="pods_none_label_short">Түзмөк жок</string>
     <string name="pods_charging_label">Кубатталууда</string>
+    <string name="pods_charging_optimized_label">Оптималдаштырылган</string>
     <string name="pods_inear_label">Кулакта</string>
     <string name="pods_microphone_label">Микрофон</string>
     <string name="anc_mode_off">Өчүк</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth түзмөгүнүн аталышы</string>
     <string name="device_settings_info_model_label">Модель</string>
     <string name="device_settings_info_manufacturer_label">Өнүмчү</string>
+    <string name="device_settings_info_hardware_label">Аппараттык камсыздоо</string>
     <string name="device_settings_info_serial_label">Сериялык номер</string>
     <string name="device_settings_info_firmware_label">Микробагдарлама</string>
+    <string name="device_settings_info_firmware_pending_label">Күтүүдөгү микропрограмма</string>
     <string name="device_settings_info_build_label">Версия</string>
     <string name="device_settings_info_left_serial_label">Сол гарнитуранын сериал номери</string>
     <string name="device_settings_info_right_serial_label">Оң гарнитуранын сериал номери</string>
+    <string name="device_settings_info_left_bonded_label">Сол жакка байланган</string>
+    <string name="device_settings_info_right_bonded_label">Оң жакка байланган</string>
     <string name="device_settings_info_details_label">Түзмөк деталдары</string>
     <string name="device_settings_info_details_action">Түзмөк деталдарын көрсөтүү</string>
     <string name="device_settings_info_status_label">Абалы</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Бул түзмөк жакын жерде, бирок бул телефонго туташпаган. Орнотууларга жана башкарууга кирүү үчүн туташыңыз.</string>
     <string name="device_settings_not_connected_connect_action">Туташуу</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth орнотууларын ачуу</string>
+    <string name="device_settings_not_nearby_label">Түзмөк жакын жерде эмес</string>
+    <string name="device_settings_not_nearby_description">Жөндөөлөр бул түзмөк жакын жерде жана телефонуңузга туташканда гана жеткиликтүү.</string>
     <string name="device_settings_aap_unavailable_label">Өнүккөн жөндөөлөр жеткиликсиз</string>
     <string name="device_settings_aap_unavailable_description">AirPodsтын кеңейтилген жөндөөлөрү Bluetooth функциясын талап кылат, бул телефондо жетишсиз. Бул түзмөгүңүздүн Android жаңыртылуусу аркылуу менен чечилиши мүмкүн.</string>
+    <string name="device_settings_aap_unavailable_action">Шайкештик трекерин көрүү</string>
     <string name="device_settings_category_sound_label">Үн</string>
     <string name="device_settings_category_controls_label">Башкаруу</string>
     <string name="device_settings_nc_one_airpod_label">Бир гарнитура менен ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Микрофонду өчүрүү үчүн бир жолу басыңыз</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Чалууну аяктоо үчүн эки жолу басыңыз</string>
     <string name="device_settings_open_cd">Түзмөк жөндөөлөрүн ачуу</string>
+    <string name="overview_card_missing_paired_device">Бул профилде жупталган Bluetooth түзмөгү жок.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Жалпы</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Өчүрүктү шуум башкаруу режими ретинде тандалууга жол беріңиз. Өчүрүлгөндө, стержендер цикл жүрүшүндө Өчүрүкты өткөрүп өтөшөт.</string>
     <string name="device_settings_sleep_detection_label">Уйку аныктоо</string>
     <string name="device_settings_sleep_detection_description">Уйкуга кеткенде аудиону автоматтык түрдө токтотуу</string>
+    <string name="reaction_sleep_channel_label">Уйку аныктоо</string>
+    <string name="reaction_sleep_notification_title">Уйку аныктоо аркылуу токтотулду</string>
+    <string name="reaction_sleep_notification_text">%1$s сиздин уктап калганыңызды аныктады, ошондуктан музыкаңыз токтотулду. Муну түзмөк жөндөөлөрүнөн өчүрсөңүз болот.</string>
     <string name="device_settings_rename_label">Ат өзгөртүү</string>
     <string name="device_settings_rename_hint">Түзмөк аты</string>
     <string name="device_settings_rename_confirm">Ат өзгөртүү</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth Жөндөөлөрү</string>
     <string name="device_settings_send_failed">Орнотууну колдонуу мүмкүн болгон жок: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Өчүрүк режими бул түзмөктө косулган жок. Шуум Башкаруунун астында \"Өчүрүк режиміне жол берүү\"дү косуңуз.</string>
+    <string name="device_settings_category_battery_label">Батарея</string>
+    <string name="device_settings_charge_cap_label">Оптималдаштырылган кубаттоо чеги</string>
+    <string name="device_settings_charge_cap_description">Батарея өмүрүн узартуу үчүн адатыңызды үйрөнүп, кубаттоону болжол менен 80%% деңгээлинде токтотот жана аларды колдонуудан мурун кайра кубаттайт.</string>
+    <string name="device_settings_charge_cap_rejected_message">Оптималдаштырылган кубаттоо чегин өзгөртүү мүмкүн болгон жок. Бул эксперименттик функция — эгер ал иштебей жатса, кабарлаңыз.</string>
     <string name="device_settings_category_connections_label">Туташкан түзмөктөр</string>
     <string name="device_settings_connected_devices_description">Учурда бул AirPods туташкан башка түзмөктөр</string>
     <string name="device_settings_connected_device_label">%d-түзмөк</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">ຄວາມໂປ່ງໃສພື້ນຫຼັງ</string>
     <string name="widget_config_show_device_label">ສະແດງຊື່ອຸປະກອນ</string>
     <string name="widget_config_reset_label">ຣີເຊັດເປັນຄ່າເລີ່ມຕົ້ນ</string>
+    <string name="widget_config_preview_resize_hint">ທ່ານສາມາດປັບຂະໜາດ widget ຫຼັງຈາກວາງມັນໄວ້ໃນໜ້າຈໍຫຼັກຂອງທ່ານ.</string>
     <string name="widget_config_custom_label">ກຳນົດເອງ</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">ມືດ</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">ນີ້ແມ່ນອຸປະກອນທີ່ບໍ່ຮູ້ຈັກ, ແຕ່ມັນໃຊ້ຮູບແບບຂໍ້ຄວາມທີ່ຄ້າຍຄືກັນ. ມາເພີ່ມການຮອງຮັບ, ຕິດຕໍ່ຂ້ອຍ :)</string>
     <string name="pods_none_label_short">ບໍ່ມີອຸປະກອນ</string>
     <string name="pods_charging_label">ກຳລັງສາກ</string>
+    <string name="pods_charging_optimized_label">ປັບປຸງແລ້ວ</string>
     <string name="pods_inear_label">ໃນຫູ</string>
     <string name="pods_microphone_label">ໄມໂຄຣໂຟນ</string>
     <string name="anc_mode_off">ປິດ</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">ຊື່ອຸປະກອນ Bluetooth</string>
     <string name="device_settings_info_model_label">ລຸ້ນ</string>
     <string name="device_settings_info_manufacturer_label">ຜູ້ຜະລິດ</string>
+    <string name="device_settings_info_hardware_label">ຮາດແວ</string>
     <string name="device_settings_info_serial_label">ຫມາຍເລກຫຼ່ວນ</string>
     <string name="device_settings_info_firmware_label">ເຟີມເວີກ</string>
+    <string name="device_settings_info_firmware_pending_label">ເຟີມແວທີ່ລໍຖ້າ</string>
     <string name="device_settings_info_build_label">ບິລດ</string>
     <string name="device_settings_info_left_serial_label">ໝາຍເລກ Pod ຊ້າຍ</string>
     <string name="device_settings_info_right_serial_label">ໝາຍເລກ Pod ຂວາ</string>
+    <string name="device_settings_info_left_bonded_label">ຊ້າຍໄດ້ຜູກມັດ</string>
+    <string name="device_settings_info_right_bonded_label">ຂວາໄດ້ຜູກມັດ</string>
     <string name="device_settings_info_details_label">ຂໍ້ມູນອຸປະກອນ</string>
     <string name="device_settings_info_details_action">ສະແດງຂໍ້ມູນອຸປະກອນ</string>
     <string name="device_settings_info_status_label">ສົຖະນະ</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">ອຸປະກອນນີ້ຢູ່ໃກ້ແຕ່ຍັງບໍ່ໄດ້ເຊື່ອມຕໍ່ກັບໂທລະສັບນີ້. ເຊື່ອມຕໍ່ເພື່ອເຂົ້າເຖິງການຕັ້ງຄ່າ ແລະ ການຄວບຄຸມ.</string>
     <string name="device_settings_not_connected_connect_action">ເຊື່ອມຕໍ່</string>
     <string name="device_settings_not_connected_open_settings_action">ເປີດການຕັ້ງຄ່າ Bluetooth</string>
+    <string name="device_settings_not_nearby_label">ອຸປະກອນບໍ່ຢູ່ໃກ້</string>
+    <string name="device_settings_not_nearby_description">ການຕັ້ງຄ່າສາມາດໃຊ້ໄດ້ເຊິ່ງອຸປະກອນນີ້ຢູ່ໃກ້ ​ແລະ ເຊື່ອມຕໍ່ກັບໂທລະສັບຂອງທ່ານ.</string>
     <string name="device_settings_aap_unavailable_label">ການຕັ້ງຄ່າຂັ້ນສູງບໍ່ສາມາດໃຊ້ໄດ້</string>
     <string name="device_settings_aap_unavailable_description">ການຕັ້ງຄ່າ AirPods ຂັ້ນສູງຕ້ອງການຟີເຈີ Bluetooth ທີ່ບໍ່ສາມາດໃຊ້ງານໄດ້ໃນໂທລະສັບນີ້. ອາດຈະໄດ້ຮັບການແກ້ໄຂໂດຍການອັບເດດ Android ໃນອະນາຄົດຈາກຜູ້ຜະລິດອຸປະກອນຂອງທ່ານ.</string>
+    <string name="device_settings_aap_unavailable_action">ເບິ່ງຕົວຕິດຕາມຄວາມເຂົ້າກັນໄດ້</string>
     <string name="device_settings_category_sound_label">ເສີງ</string>
     <string name="device_settings_category_controls_label">ການຄວບຄຸມ</string>
     <string name="device_settings_nc_one_airpod_label">ANC ດ້ວຍ pod ດຽວ</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">ກດໄວໝິ່ວໝິ່ວເພື່ອປິດເສີງໄມຂອບພາກ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ກດສອງຄັ້ງເພື່ອວາງສາຍການເຈຮາ</string>
     <string name="device_settings_open_cd">ເປີດການຕັ້ງຄ່າອຸປະກອນ</string>
+    <string name="overview_card_missing_paired_device">ໂປຣໄຟລ໌ນີ້ບໍ່ມີອຸປະກອນ Bluetooth ທີ່ຈັບຄູ່ໄວ້.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ທົ່ວໄປ</string>
     <string name="device_settings_microphone_mode_label">ໄມໂຄຣໂຟນ</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">ອະນຸຍາດໂໝດປິດເປັນໂໝດຄວບຄຸມສຽງລົບກວນທີ່ເລືອກໄດ້. ເມື່ອປິດໃຊ້ງານ, stems ຂ້າມ Off ໃນການແວ່ນວງ.</string>
     <string name="device_settings_sleep_detection_label">ການຕຣວຈຈັບການນອນ</string>
     <string name="device_settings_sleep_detection_description">ພ଱ກເສີງອັດຕະໂນມັດເມື່ອທ່ານຫລັບ</string>
+    <string name="reaction_sleep_channel_label">ການກວດຈັບການນອນ</string>
+    <string name="reaction_sleep_notification_title">ຢຸດຊົ່ວຄາວໂດຍການກວດຈັບການນອນ</string>
+    <string name="reaction_sleep_notification_text">%1$s ລາຍງານວ່າທ່ານຫຼັບໄປ, ດັ່ງນັ້ນດົນຕີຂອງທ່ານໄດ້ຖືກຢຸດຊົ່ວຄາວ. ທ່ານສາມາດປິດການໃຊ້ງານນີ້ໄດ້ໃນການຕັ້ງຄ່າອຸປະກອນ.</string>
     <string name="device_settings_rename_label">ເປລີ່ຊື່</string>
     <string name="device_settings_rename_hint">ຊື່ອຸປະກອນ</string>
     <string name="device_settings_rename_confirm">ເປລີ່ຊື່</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ການຕັ້ງຄ່າ Bluetooth</string>
     <string name="device_settings_send_failed">ບໍ່ສາມາດໃຊ້ການຕັ້ງຄ່າ: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">ໂໝດປິດບໍ່ໄດ້ເຮັດວຽກໃນອຸປະກອນນີ້. ເຮັດວຽກ \"ອະນຸຍາດໂໝດປິດ\" ເທິງໃຕ້ ການຄວບຄຸມສຽງລົບກວນ.</string>
+    <string name="device_settings_category_battery_label">ແບດເຕີລີ</string>
+    <string name="device_settings_charge_cap_label">ຈຳກັດການສາກທີ່ປັບປຸງແລ້ວ</string>
+    <string name="device_settings_charge_cap_description">ຮຽນຮູ້ການເຮັດວຽກປົກກະຕິຂອງທ່ານ ແລະ ຢຸດການສາກໄຟລອບ 80%% ເພື່ອຍືດອາຍຸການໃຊ້ງານແບດເຕີລີ, ໂດຍເຕີມຈົນເຕັມກ່ອນທີ່ທ່ານຈະໃຊ້ງານ.</string>
+    <string name="device_settings_charge_cap_rejected_message">ຈຳກັດການສາກທີ່ປັບປຸງແລ້ວບໍ່ສາມາດປ່ຽນໄດ້. ນີ້ເປັນຄຸນສົມບັດທົດລອງ — ກະລຸນາລາຍງານຖ້າຍັງລົ້ມເຫຼວຕໍ່ໄປ.</string>
     <string name="device_settings_category_connections_label">ອຸປະກອນທີ່ເຊື່ອມຕໍ່</string>
     <string name="device_settings_connected_devices_description">ອຸປະກອນອື່ນທີ່ເຊື່ອມຕໍ່ກັບ AirPods ນີ້ໃນຂະນີ້</string>
     <string name="device_settings_connected_device_label">ອຸປະກອນ %d</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Fono permatomumas</string>
     <string name="widget_config_show_device_label">Rodyti įrenginio pavadinimą</string>
     <string name="widget_config_reset_label">Atstatyti į numatytuosius nustatymus</string>
+    <string name="widget_config_preview_resize_hint">Galite keisti valdiklio dydį po to, kai jį įdėsite į pagrindinį ekraną.</string>
     <string name="widget_config_custom_label">Pasirinktinis</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tamsi</string>
@@ -254,6 +255,7 @@
     <string name="pods_unknown_contact_dev">Tai nežinomas įrenginys, bet jis naudoja panašų žinučių formatą. Pridėkime jo palaikymą, susisiekite su manimi :)</string>
     <string name="pods_none_label_short">Nėra įrenginio</string>
     <string name="pods_charging_label">Kraunama</string>
+    <string name="pods_charging_optimized_label">Optimizuota</string>
     <string name="pods_inear_label">Ausyje</string>
     <string name="pods_microphone_label">Mikrofonas</string>
     <string name="anc_mode_off">Išjungta</string>
@@ -417,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth įrenginio žnyma</string>
     <string name="device_settings_info_model_label">Modelis</string>
     <string name="device_settings_info_manufacturer_label">Gamintojas</string>
+    <string name="device_settings_info_hardware_label">Aparatinė įranga</string>
     <string name="device_settings_info_serial_label">Serijos numeris</string>
     <string name="device_settings_info_firmware_label">Programinė įranga</string>
+    <string name="device_settings_info_firmware_pending_label">Laukiama programinė įranga</string>
     <string name="device_settings_info_build_label">Versija</string>
     <string name="device_settings_info_left_serial_label">Kairės ausinuko serijos numeris</string>
     <string name="device_settings_info_right_serial_label">Dešiniojo ausinuko serijos numeris</string>
+    <string name="device_settings_info_left_bonded_label">Kairė susieta</string>
+    <string name="device_settings_info_right_bonded_label">Dešinė susieta</string>
     <string name="device_settings_info_details_label">Įrenginio informacija</string>
     <string name="device_settings_info_details_action">Rodyti įrenginio informaciją</string>
     <string name="device_settings_info_status_label">Būsena</string>
@@ -431,8 +437,11 @@
     <string name="device_settings_not_connected_description">Šis įrenginys yra netoliese, bet neprisijungęs prie šio telefono. Prisijunkite, kad pasiektumėte nustatymus ir valdiklius.</string>
     <string name="device_settings_not_connected_connect_action">Prisijungti</string>
     <string name="device_settings_not_connected_open_settings_action">Atidaryti Bluetooth nustatymus</string>
+    <string name="device_settings_not_nearby_label">Įrenginys netoliese</string>
+    <string name="device_settings_not_nearby_description">Nustatymai pasiekiami tik tada, kai šis įrenginys yra netoliese ir prijungtas prie jūsų telefono.</string>
     <string name="device_settings_aap_unavailable_label">Isplestiniai nustatymai nepasiekiami</string>
     <string name="device_settings_aap_unavailable_description">Išplėstinės AirPods nuostatos reikalauja Bluetooth funkcijos, kuri šiame telefone neprieinama. Tai gali būti išspręsta būsimo Android atnaujinimo, kuriam jūsų įrenginio gamintojas pateiks.</string>
+    <string name="device_settings_aap_unavailable_action">Peržiūrėti suderinamumo stebyklą</string>
     <string name="device_settings_category_sound_label">Garsas</string>
     <string name="device_settings_category_controls_label">Valdikliai</string>
     <string name="device_settings_nc_one_airpod_label">ANC su vienu ausinuku</string>
@@ -470,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Vienas paspaudimas nutildyti mikrofoną</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvigubas paspaudimas baigia skambučį</string>
     <string name="device_settings_open_cd">Atidaryti įrenginio nustatymus</string>
+    <string name="overview_card_missing_paired_device">Šis profilis neturi susieto „Bluetooth“ įrenginio.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Bendrieji</string>
     <string name="device_settings_microphone_mode_label">Mikrofonas</string>
@@ -492,6 +502,9 @@
     <string name="device_settings_allow_off_description">Leisti išjungimo režimą kaip pasirinktamą triukšmo valdymo režimą. Kai išjungta, kąteliai praleidžia išjungimo režimą cikluodami.</string>
     <string name="device_settings_sleep_detection_label">Miego aptikimas</string>
     <string name="device_settings_sleep_detection_description">Automatiškai pristabdyti garsą, kai užmiegat</string>
+    <string name="reaction_sleep_channel_label">Miego aptikimas</string>
+    <string name="reaction_sleep_notification_title">Pristabdyta miego aptikimo</string>
+    <string name="reaction_sleep_notification_text">%1$s pranešė, kad užmigote, todėl jūsų muzika buvo pristabdyta. Tai galite išjungti įrenginio nustatymuose.</string>
     <string name="device_settings_rename_label">Pervadinti</string>
     <string name="device_settings_rename_hint">Ĭrenginio pavadinimas</string>
     <string name="device_settings_rename_confirm">Pervadinti</string>
@@ -501,6 +514,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth nustatymai</string>
     <string name="device_settings_send_failed">Nepavyko pritaikyti nustatymo: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Išjungimo režimas nėra įjungtas šiame įrenginyje. Įjunkite \"Leisti išjungimo režimą\" skiltyje Triukšmo valdymas.</string>
+    <string name="device_settings_category_battery_label">Baterija</string>
+    <string name="device_settings_charge_cap_label">Optimizuotas įkrovimo limitas</string>
+    <string name="device_settings_charge_cap_description">Išmokite savo rutiną ir stabdykite įkrovimą ties 80%%, kad prailgintumėte baterijos tarnavimo laiką – ausinukai bus viškai įkrauti prieš tai, kai tikėtinai juos naudosite.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimizuoto įkrovimo limito nepavyko pakeisti. Tai eksperimentinė funkcija – praneškite, jei ji toliau neveikia.</string>
     <string name="device_settings_category_connections_label">Prijungti įrenginiai</string>
     <string name="device_settings_connected_devices_description">Kiti šiuo metu prijungti prie šių AirPods įrenginiai</string>
     <string name="device_settings_connected_device_label">Ĭrenginys %d</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Fona caursspīdīgums</string>
     <string name="widget_config_show_device_label">Rādīt ierīces nosaukumu</string>
     <string name="widget_config_reset_label">Atiestatīt noklusējumos</string>
+    <string name="widget_config_preview_resize_hint">Varat mainīt logrīka izmēru pēc tā novietošanas sākumekrānā.</string>
     <string name="widget_config_custom_label">Pielāgots</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tumšs</string>
@@ -252,6 +253,7 @@
     <string name="pods_unknown_contact_dev">Šī ir nezināma ierīce, bet tā izmanto līdzīgu ziņojumu formātu. Pievienosim tai atbalstu, sazinieties ar mani :)</string>
     <string name="pods_none_label_short">Nav ierīces</string>
     <string name="pods_charging_label">Uzlāde</string>
+    <string name="pods_charging_optimized_label">Optimizēts</string>
     <string name="pods_inear_label">Ausī</string>
     <string name="pods_microphone_label">Mikrofons</string>
     <string name="anc_mode_off">Izslēgts</string>
@@ -412,11 +414,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth ierīces nosaukums</string>
     <string name="device_settings_info_model_label">Modelis</string>
     <string name="device_settings_info_manufacturer_label">Ražotājs</string>
+    <string name="device_settings_info_hardware_label">Aparatūra</string>
     <string name="device_settings_info_serial_label">Sērijas numurs</string>
     <string name="device_settings_info_firmware_label">Programmatūra</string>
+    <string name="device_settings_info_firmware_pending_label">Gaidošā programmaparatūra</string>
     <string name="device_settings_info_build_label">Versija</string>
     <string name="device_settings_info_left_serial_label">Kreisās austiņas sērijas numurs</string>
     <string name="device_settings_info_right_serial_label">Labās austiņas sērijas numurs</string>
+    <string name="device_settings_info_left_bonded_label">Kreisais savienots</string>
+    <string name="device_settings_info_right_bonded_label">Labais savienots</string>
     <string name="device_settings_info_details_label">Ierīces informācija</string>
     <string name="device_settings_info_details_action">Rādīt ierīces informāciju</string>
     <string name="device_settings_info_status_label">Stāvoklis</string>
@@ -426,8 +432,11 @@
     <string name="device_settings_not_connected_description">Šī ierīce ir tuvumā, bet nav savienota ar šo tālruni. Savienojieties, lai piekļūtu iestatījumiem un vadīklām.</string>
     <string name="device_settings_not_connected_connect_action">Savienot</string>
     <string name="device_settings_not_connected_open_settings_action">Atvērt Bluetooth iestatījumus</string>
+    <string name="device_settings_not_nearby_label">Ierīce nav tuvumā</string>
+    <string name="device_settings_not_nearby_description">Iestatījumi ir pieejami tikai tad, kad šī ierīce ir tuvumā un savienota ar jūsu tālruni.</string>
     <string name="device_settings_aap_unavailable_label">Papildu iestatījumi nav pieejami</string>
     <string name="device_settings_aap_unavailable_description">Papildu AirPods iestatījumi prasa Bluetooth funkciju, kas nav pieejama šajā tālrunī. To var novērst nākamais Android atjauninājums no jūsu ierīces ražotāja.</string>
+    <string name="device_settings_aap_unavailable_action">Skatīt saderības izsekotāju</string>
     <string name="device_settings_category_sound_label">Skaņa</string>
     <string name="device_settings_category_controls_label">Vadīklēšana</string>
     <string name="device_settings_nc_one_airpod_label">ANC ar vienu austiņu</string>
@@ -465,6 +474,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Vienu reizi nospiežot, islēdz mikrofonu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Divas reizes nospiežot, beidz zvanu</string>
     <string name="device_settings_open_cd">Atvērt ierīces iestatījumus</string>
+    <string name="overview_card_missing_paired_device">Šim profilam nav savienota Bluetooth ierīce.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Vispārīgi</string>
     <string name="device_settings_microphone_mode_label">Mikrofons</string>
@@ -487,6 +497,9 @@
     <string name="device_settings_allow_off_description">Atļaut Izslēgts kā izvēlamu trokšņu kontroles režīmu. Ja atspējots, kāti izslēgšanas režīmu izlaiž ciklā.</string>
     <string name="device_settings_sleep_detection_label">Miega noteikšana</string>
     <string name="device_settings_sleep_detection_description">Automātiski apturēt audio, kad aizmiegat</string>
+    <string name="reaction_sleep_channel_label">Miega noteikšana</string>
+    <string name="reaction_sleep_notification_title">Apturēts ar miega noteikšanu</string>
+    <string name="reaction_sleep_notification_text">%1$s ziņoja, ka jūs aizmigsāt, tāpēc mūzika tika pauzēta. To var atspējot ierīces iestatījumos.</string>
     <string name="device_settings_rename_label">Pārdēvēt</string>
     <string name="device_settings_rename_hint">Ierīces nosaukums</string>
     <string name="device_settings_rename_confirm">Pārdēvēt</string>
@@ -496,6 +509,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth iestatījumi</string>
     <string name="device_settings_send_failed">Nevarēja piemērot iestatījumu: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Izslēgšanas režīms nav iespējots šajā ierīcē. Iespējojiet „Atļaut izslēgšanas režīmu“ sadalā Trokšņu kontrole.</string>
+    <string name="device_settings_category_battery_label">Akumulators</string>
+    <string name="device_settings_charge_cap_label">Optimizēts uzņēmšanas limits</string>
+    <string name="device_settings_charge_cap_description">Iemacās jūsu ikdienas rutbu un aptur uzņēmšanu ap 80%%, lai pagarinātu akumulatora kalpošanas laiku, uzņemot aussāgļus pilnbīdi, pirms jūs tos drīzāk izmantosīt.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimizēto uzņēmšanas limitu nevarēja mainīt. Šī ir ekspeimentāla funkcija — lūdzu ziņojiet, ja tā turpinās neizdeveties.</string>
     <string name="device_settings_category_connections_label">Pievienotās ierīces</string>
     <string name="device_settings_connected_devices_description">Citas ierīces, kas pašlaik ir savienotas ar šiem AirPods</string>
     <string name="device_settings_connected_device_label">Ierīce %d</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Транспарентност на позадина</string>
     <string name="widget_config_show_device_label">Прикажи име на уред</string>
     <string name="widget_config_reset_label">Врати на стандардни</string>
+    <string name="widget_config_preview_resize_hint">Можете да го промените големината на виџетот откако ќе го поставите на почетниот екран.</string>
     <string name="widget_config_custom_label">Прилагодено</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Темно</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Ова е непознат уред, но користи сличен формат на пораки. Ајде да додадеме поддршка за него, контактирајте ме :)</string>
     <string name="pods_none_label_short">Нема уред</string>
     <string name="pods_charging_label">Се полни</string>
+    <string name="pods_charging_optimized_label">Оптимизирано</string>
     <string name="pods_inear_label">Во уво</string>
     <string name="pods_microphone_label">Микрофон</string>
     <string name="anc_mode_off">Исклучено</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Назив на Блуетут уред</string>
     <string name="device_settings_info_model_label">Модел</string>
     <string name="device_settings_info_manufacturer_label">Производител</string>
+    <string name="device_settings_info_hardware_label">Хардвер</string>
     <string name="device_settings_info_serial_label">Сериски број</string>
     <string name="device_settings_info_firmware_label">Фирмвер</string>
+    <string name="device_settings_info_firmware_pending_label">Фирмвер на чекање</string>
     <string name="device_settings_info_build_label">Изградба</string>
     <string name="device_settings_info_left_serial_label">Сериски број на левиот слушалец</string>
     <string name="device_settings_info_right_serial_label">Сериски број на десниот слушалец</string>
+    <string name="device_settings_info_left_bonded_label">Лево поврзано</string>
+    <string name="device_settings_info_right_bonded_label">Десно поврзано</string>
     <string name="device_settings_info_details_label">Детали за уредот</string>
     <string name="device_settings_info_details_action">Покажи детали за уредот</string>
     <string name="device_settings_info_status_label">Статус</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Овој уред е во близина, но не е поврзан со овој телефон. Поврзете се за да пристапите до поставките и контролите.</string>
     <string name="device_settings_not_connected_connect_action">Поврзи се</string>
     <string name="device_settings_not_connected_open_settings_action">Отвори Bluetooth поставки</string>
+    <string name="device_settings_not_nearby_label">Уредот не е во близина</string>
+    <string name="device_settings_not_nearby_description">Поставките се достапни само кога овој уред е во близина и поврзан со вашиот телефон.</string>
     <string name="device_settings_aap_unavailable_label">Напредните поставки се недостапни</string>
     <string name="device_settings_aap_unavailable_description">Напредните поставки за AirPods бараат функција на Блуетут која не е достапна на овој телефон. Ова може да се реши со идно будно ажурирање на Android од производителот на вашиот уред.</string>
+    <string name="device_settings_aap_unavailable_action">Прегледај тракер за компатибилност</string>
     <string name="device_settings_category_sound_label">Звук</string>
     <string name="device_settings_category_controls_label">Контроли</string>
     <string name="device_settings_nc_one_airpod_label">ANC со еден слушалец</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Едно притискање за исклучување на микрофонот</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двојно притискање за прекинување на повикот</string>
     <string name="device_settings_open_cd">Отворете ги поставките на уредот</string>
+    <string name="overview_card_missing_paired_device">Овој профил нема спарен Bluetooth уред.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Генерално</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -479,9 +489,12 @@
     <string name="device_settings_listening_mode_cycle_transparency">Транспарентност</string>
     <string name="device_settings_listening_mode_cycle_adaptive">Адаптивно</string>
     <string name="device_settings_allow_off_label">Дозволете режим Исклучено</string>
-    <string name="device_settings_allow_off_description">Дозволете Исклучено како изборлив режим на контрола на бучава. Кога е исклучено, дршките го прескочуваат Исклучено додека преминуваат.</string>
+    <string name="device_settings_allow_off_description">Дозволете Исклучено како изборлив режим на контрола на бучава. Кога е исклучено, дршките го прескочуваат ܿсклучено додека преминуваат.</string>
     <string name="device_settings_sleep_detection_label">Откривање сон</string>
     <string name="device_settings_sleep_detection_description">Автоматски паузирање на звукот кога заспиете</string>
+    <string name="reaction_sleep_channel_label">Детекција на спиење</string>
+    <string name="reaction_sleep_notification_title">Паузирано од Детекција на спиење</string>
+    <string name="reaction_sleep_notification_text">%1$s пријави дека заспавте, па вашата музика беше паузирана. Ова можете да го оневозможите во поставките за уредот.</string>
     <string name="device_settings_rename_label">Преименување</string>
     <string name="device_settings_rename_hint">Име на уредот</string>
     <string name="device_settings_rename_confirm">Преименување</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth поставки</string>
     <string name="device_settings_send_failed">Не може да се примени поставката: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Режимот Исклучено не е вклучен на овој уред. Вклучете \"Дозволете режим Исклучено\" под Контрола на бучава.</string>
+    <string name="device_settings_category_battery_label">Батерија</string>
+    <string name="device_settings_charge_cap_label">Оптимизирана граница на полнење</string>
+    <string name="device_settings_charge_cap_description">Учи ја вашата рутина и паузира полнење околу 80%% за да го продолжи животниот век на батеријата, доливајќи ги слушалките пред да ги користите.</string>
+    <string name="device_settings_charge_cap_rejected_message">Оптимизираната граница на полнење не можеше да се промени. Ова е експериментална функција — ве молиме пријавете ако продолжи да не работи.</string>
     <string name="device_settings_category_connections_label">Поврзани уреди</string>
     <string name="device_settings_connected_devices_description">Други уреди што во моментов се поврзани на овие AirPods</string>
     <string name="device_settings_connected_device_label">Уред %d</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">പശ്ചാത്തല സ്വച്ഛത</string>
     <string name="widget_config_show_device_label">ഉപകരണത്തിന്റെ പേര് കാണിക്കുക</string>
     <string name="widget_config_reset_label">ഡിഫോള്‍ട്ടിലേക്ക് പുനഃസജ്ജമാക്കുക</string>
+    <string name="widget_config_preview_resize_hint">ഹോം സ്ക്രീനിൽ വിജറ്റ് വെച്ചതിനുശേഷം നിങ്ങൾക്ക് അതിന്റെ വലുപ്പം മാറ്റാൻ കഴിയും.</string>
     <string name="widget_config_custom_label">കസ്റ്റം</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">ഗാഢം</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">ഇത് ഒരു അജ്ഞാത ഉപകരണമാണ്, പക്ഷേ ഇത് സമാനമായ സന്ദേശ ഫോർമാറ്റ് ഉപയോഗിക്കുന്നു. ഇതിനുള്ള പിന്തുണ ചേർക്കാം, എന്നെ ബന്ധപ്പെടുക :)</string>
     <string name="pods_none_label_short">ഉപകരണമില്ല</string>
     <string name="pods_charging_label">ചാർജ് ചെയ്യുന്നു</string>
+    <string name="pods_charging_optimized_label">ഒപ്റ്റിമൈസ് ചെയ്തത്</string>
     <string name="pods_inear_label">ചെവിയിൽ</string>
     <string name="pods_microphone_label">മൈക്രോഫോൺ</string>
     <string name="anc_mode_off">ഓഫ്</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">ബ്ലൂടൂത്ത് ഡിവൈസ് ലേബൽ</string>
     <string name="device_settings_info_model_label">മോഡൽ</string>
     <string name="device_settings_info_manufacturer_label">നിർമ്മാതാവ്</string>
+    <string name="device_settings_info_hardware_label">ഹാർഡ്‌വെയർ</string>
     <string name="device_settings_info_serial_label">സീരിയൽ നമ്പർ</string>
     <string name="device_settings_info_firmware_label">ഫേംവെയർ</string>
+    <string name="device_settings_info_firmware_pending_label">തീർച്ചയാകാത്ത ഫേംവെയർ</string>
     <string name="device_settings_info_build_label">ബിൽഡ്</string>
     <string name="device_settings_info_left_serial_label">ഇടതു പോഡ് സീരിയൽ</string>
     <string name="device_settings_info_right_serial_label">വലതു പോഡ് സീരിയൽ</string>
+    <string name="device_settings_info_left_bonded_label">ഇടത് ബോണ്ട് ചെയ്തത്</string>
+    <string name="device_settings_info_right_bonded_label">വലത് ബോണ്ട് ചെയ്തത്</string>
     <string name="device_settings_info_details_label">ഡിവൈസ് വിവരങ്ങൾ</string>
     <string name="device_settings_info_details_action">ഡിവൈസ് വിവരങ്ങൾ കാണിക്കുക</string>
     <string name="device_settings_info_status_label">നില</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">ഈ ഉപകരണം സമീപത്താണ്, പക്ഷേ ഈ ഫോണുമായി കണക്റ്റ് ചെയ്തിട്ടില്ല. ക്രമീകരണങ്ങളും നിയന്ത്രണങ്ങളും ആക്‌സസ് ചെയ്യാൻ കണക്റ്റ് ചെയ്യുക.</string>
     <string name="device_settings_not_connected_connect_action">കണക്റ്റ് ചെയ്യുക</string>
     <string name="device_settings_not_connected_open_settings_action">ബ്ലൂടൂത്ത് ക്രമീകരണങ്ങൾ തുറക്കുക</string>
+    <string name="device_settings_not_nearby_label">ഉപകരണം അടുത്തില്ല</string>
+    <string name="device_settings_not_nearby_description">ഈ ഉപകരണം അടുത്തും നിങ്ങളുടെ ഫോണുമായി ബന്ധിപ്പിച്ചിരിക്കുമ്പോൾ മാത്രമേ ക്രമീകരണങ്ങൾ ലഭ്യമാകൂ.</string>
     <string name="device_settings_aap_unavailable_label">വിപുലമായ ക്രമീകരണങ്ങൾ ലഭ്യമല്ല</string>
     <string name="device_settings_aap_unavailable_description">വിന്ന്യാസപ്പെട്ട എയർപോഡ്സ് ക്രമീകരണങ്ങൾക്ക് ഈ ഫോണിൽ ലഭ്യമല്ലാത്ത ഒരു ബ്ലൂടൂത്ത് സവിശേഷത ആവശ്യമാണ്. നിങ്ങളുടെ ഡിവൈസ് നിർമാതാവിൽ നിന്നുള്ള ഭാവി ആന്ഡ്രോയ്ഡ് അപ്ടൊഡേറ്റ് വഴി ഇത് പരിഹരിക്കുന്ന സാധ്യതയുണ്ട്.</string>
+    <string name="device_settings_aap_unavailable_action">അനുയോജ്യതാ ട്രാക്കർ കാണുക</string>
     <string name="device_settings_category_sound_label">ശബ്ദം</string>
     <string name="device_settings_category_controls_label">നിയന്ത്രണങ്ങൾ</string>
     <string name="device_settings_nc_one_airpod_label">ഒരു പോഡ് ഉപയോഗിച്ചുള്ള ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">മൈക്രോഫോൻ മ്യൂട്ട് ചെയ്യാൻ ഒറ്റ അമർത്തൽ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">കോൾ അവസാനിപ്പിക്കാൻ ഇരട്ട അമർത്തൽ</string>
     <string name="device_settings_open_cd">ഉപകരണ ക്രമീകരണങ്ങൾ തുറക്കുക</string>
+    <string name="overview_card_missing_paired_device">ഈ പ്രൊഫൈലിൽ ജോടിയാക്കിയ ബ്ലൂടൂത്ത് ഉപകരണം ഇല്ല.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">പൊതുവായ</string>
     <string name="device_settings_microphone_mode_label">മൈക്രോഫോൺ</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Off-നെ തിരഞ്ഞെടുക്കാവുന്ന ശബ്ദ നിയന്ത്രണ മോഡായി അനുവദിക്കുക. പ്രപ്തമാക്കിയില്ലെങ്കിൽ, സൈക്കിൾ ചെയ്യുമ്പോൾ സ്റ്റെംകൾ Off അവിടെയ് കടന്നു പോകും.</string>
     <string name="device_settings_sleep_detection_label">ഉറക്ക ഡിറ്റക്ഷൻ</string>
     <string name="device_settings_sleep_detection_description">നിങ്ങൾ ഉറങ്ങുമ്പോൾ ഓഡിയോ ഓട്ടോമാറ്റിക്കായി താൽക്കാലികമായി നിർത്തുക</string>
+    <string name="reaction_sleep_channel_label">ഉറക്ക കണ്ടെത്തൽ</string>
+    <string name="reaction_sleep_notification_title">ഉറക്ക കണ്ടെത്തൽ മൂലം താൽക്കാലികമായി നിർത്തി</string>
+    <string name="reaction_sleep_notification_text">%1$s നിങ്ങൾ ഉറങ്ങിപ്പോയതായി റിപ്പോർട്ട് ചെയ്തതിനാൽ സംഗീതം താൽക്കാലികമായി നിർത്തി. ഉപകരണ ക്രമീകരണങ്ങളിൽ ഇത് പ്രവർത്തനരഹിതമാക്കാം.</string>
     <string name="device_settings_rename_label">പുനർനാമകരണം ചെയ്യുക</string>
     <string name="device_settings_rename_hint">ഉപകരണ നാമം</string>
     <string name="device_settings_rename_confirm">പുനർനാമകരണം ചെയ്യുക</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ബ്ലൂടൂത്ത് ക്രമീകരണങ്ങൾ</string>
     <string name="device_settings_send_failed">ക്രമീകരണം പ്രയോഗിക്കാൻ കഴിഞ്ഞില്ല: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">ഈ ഡിവൈസിൽ Off മോഡ് പ്രപ്തമാക്കിയിട്ടില്ല. ശബ്ദ നിയന്ത്രണത്തിനു കീഴിലുള്ള \"ഇസ്ലാമിക Off മോഡ്\" പ്രപ്തമാക്കുക.</string>
+    <string name="device_settings_category_battery_label">ബാറ്ററി</string>
+    <string name="device_settings_charge_cap_label">ഒപ്റ്റിമൈസ്ഡ് ചാർജ് പരിധി</string>
+    <string name="device_settings_charge_cap_description">നിങ്ങളുടെ ദിനചര്യ പഠിച്ച് ബാറ്ററി ആയുസ്സ് വർദ്ധിപ്പിക്കാൻ 80%% ഓളം ചാർജ്ജിംഗ് താൽക്കാലികമായി നിർത്തി, ഉപയോഗിക്കാൻ സാധ്യതയുള്ളതിന് മുമ്പ് പോഡ്‌സ് ടോപ്പ് ഓഫ് ചെയ്യും.</string>
+    <string name="device_settings_charge_cap_rejected_message">ഒപ്റ്റിമൈസ്ഡ് ചാർജ് പരിധി മാറ്റാൻ കഴിഞ്ഞില്ല. ഇത് ഒരു പരീക്ഷണാത്മക സവിശേഷതയാണ് — തുടർച്ചയായി പരാജയപ്പെടുകയാണെങ്കിൽ ദയവായി റിപ്പോർട്ട് ചെയ്യുക.</string>
     <string name="device_settings_category_connections_label">ബന്ധിപ്പിച്ച ഉപകരണങ്ങൾ</string>
     <string name="device_settings_connected_devices_description">നിലവിൽ ഈ AirPods-മായി ബന്ധിപ്പിച്ചിരിക്കുന്ന മറ്റ് ഉപകരണങ്ങൾ</string>
     <string name="device_settings_connected_device_label">ഉപകരണം %d</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Фоны тунгалаг байдал</string>
     <string name="widget_config_show_device_label">Төхөөрөмжийн нэрийг харуулах</string>
     <string name="widget_config_reset_label">Анхны утга руу сэргээх</string>
+    <string name="widget_config_preview_resize_hint">Та виджетийг нүүр дэлгэцэндээ байрлуулсны дараа хэмжээг нь өөрчилж болно.</string>
     <string name="widget_config_custom_label">Нэмэлт</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Сүүдэр</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Энэ нь тодорхойгүй төхөөрөмж боловч ижил төстэй мессежийн формат ашиглаж байна. Дэмжлэг нэмье, надтай холбоо барина уу :)</string>
     <string name="pods_none_label_short">Төхөөрөмж алга</string>
     <string name="pods_charging_label">Цэнэглэж байна</string>
+    <string name="pods_charging_optimized_label">Оновсон</string>
     <string name="pods_inear_label">Чихэнд</string>
     <string name="pods_microphone_label">Микрофон</string>
     <string name="anc_mode_off">Унтраалттай</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth төхөөрөмжийн нэр</string>
     <string name="device_settings_info_model_label">Загвар</string>
     <string name="device_settings_info_manufacturer_label">Үйлдвэрлэгч</string>
+    <string name="device_settings_info_hardware_label">Техник хангамж</string>
     <string name="device_settings_info_serial_label">Серийн дугаар</string>
     <string name="device_settings_info_firmware_label">Програм хангамж</string>
+    <string name="device_settings_info_firmware_pending_label">Хүлээгдэж буй програм хангамж</string>
     <string name="device_settings_info_build_label">Бүтээц</string>
     <string name="device_settings_info_left_serial_label">Зүүн чихэвчийн серийн дугаар</string>
     <string name="device_settings_info_right_serial_label">Баруун чихэвчийн серийн дугаар</string>
+    <string name="device_settings_info_left_bonded_label">Зүүн холбосон</string>
+    <string name="device_settings_info_right_bonded_label">Баруун холбосон</string>
     <string name="device_settings_info_details_label">Төхөөрөмжийн дэлгэрэнгүй мэдээлэл</string>
     <string name="device_settings_info_details_action">Төхөөрөмжийн дэлгэрэнгүй мэдээлэл үзэх</string>
     <string name="device_settings_info_status_label">Төлөв</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Энэ төхөөрөмж ойролцоо байгаа боловч энэ утастай холбогдоогүй байна. Тохиргоо болон удирдлагад хандахын тулд холбогдоно уу.</string>
     <string name="device_settings_not_connected_connect_action">Холбогдох</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth тохиргоог нээх</string>
+    <string name="device_settings_not_nearby_label">Төхөөрөмж ойролцоо байхгүй</string>
+    <string name="device_settings_not_nearby_description">Тохиргоо нь энэ төхөөрөмж ойролцоо байж, таны утастай холбогдсон үед л боломжтой.</string>
     <string name="device_settings_aap_unavailable_label">Нарийвчилсан тохиргоо боломжгүй</string>
     <string name="device_settings_aap_unavailable_description">Өннө AirPods тохиргоо энэ утасны утасны Bluetooth функций шаардаг. Таны утасны Android шинэчлэлтийн шинэчлэлт ирээдэнд энэ асуудал шийдвэрлэгдэж боломж тайлбыр.</string>
+    <string name="device_settings_aap_unavailable_action">Нийцтэй байдлын хянагчийг үзэх</string>
     <string name="device_settings_category_sound_label">Дуу</string>
     <string name="device_settings_category_controls_label">Удирдлага</string>
     <string name="device_settings_nc_one_airpod_label">Нэг чихэвчтэй ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Микрофоныг хаахын тулд нэг дарна уу</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Дуудлага дуусгахын тулд хоёр дарна уу</string>
     <string name="device_settings_open_cd">Төхөөрөмжийн тохиргоо нээх</string>
+    <string name="overview_card_missing_paired_device">Энэ профайл нь хосолсон Bluetooth төхөөрөмжгүй байна.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ерөнхий</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Унтарсаныг сонгох шуугайн хяналтын горим болгохыг зөвшөөрө. Идэвхгүй бол, ширхүүд циклэх үед унтарсаныг алгасана.</string>
     <string name="device_settings_sleep_detection_label">Нойр илрүүлэх</string>
     <string name="device_settings_sleep_detection_description">Унтахад аудиог автоматаар зогсох</string>
+    <string name="reaction_sleep_channel_label">Нойрны мэдрэгч</string>
+    <string name="reaction_sleep_notification_title">Нойрны мэдрэгчээр түр зогссон</string>
+    <string name="reaction_sleep_notification_text">%1$s таныг унтаж байна гэж мэдээллэсэн тул хөгжим нь түр зогссон. Үүнийг төхөөрөмжийн тохиргооноос идэвхгүй болгож болно.</string>
     <string name="device_settings_rename_label">Нэр өөрчлөх</string>
     <string name="device_settings_rename_hint">Төхөөрөмжийн нэр</string>
     <string name="device_settings_rename_confirm">Нэр өөрчлөх</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth тохиргоо</string>
     <string name="device_settings_send_failed">Тохиргоог хэрэгжүүлэх боломжгүй: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Энэ төхөөрөмж дээр унтарсан горим идэвхгүй байна. Шуугайн Хяналт хэсэгт \"Allow Off mode\" гэснээсийг идэвхүүлээ.</string>
+    <string name="device_settings_category_battery_label">Батарей</string>
+    <string name="device_settings_charge_cap_label">Оновсон цэнэглэлтийн хязгаар</string>
+    <string name="device_settings_charge_cap_description">Таны дутмийг судлаж, батарейны ашиглалтын хугацааг уртасгахын тулд цэнэглэлтийг 80%%-ийн үед түр зогсоож, ашиглах магадлалтай үеэс өмнө дуусгана.</string>
+    <string name="device_settings_charge_cap_rejected_message">Оновсон цэнэглэлтийн хязгаарыг өөрчлөх боломжгүй байна. Энэ бол туршилтын функц — байнга алдаа гарвал мэдэгдэнэ үү.</string>
     <string name="device_settings_category_connections_label">Холбогдсон төхөөрөмжүүд</string>
     <string name="device_settings_connected_devices_description">Одоогоор эдгээр AirPods-д холбогдсон бусад төхөөрөмжүүд</string>
     <string name="device_settings_connected_device_label">Төхөөрөмж %d</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">पार्श्वभूमी पारदर्शकता</string>
     <string name="widget_config_show_device_label">डिव्हाइस नाव दाखवा</string>
     <string name="widget_config_reset_label">डिफॉल्टवर रीसेट करा</string>
+    <string name="widget_config_preview_resize_hint">तुम्ही विजेट तुमच्या होम स्क्रीनवर ठेवल्यानंतर त्याचा आकार बदलू शकता.</string>
     <string name="widget_config_custom_label">कस्टम</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">गाढ</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">हे एक अज्ञात डिव्हाइस आहे, पण ते समान संदेश स्वरूप वापरत आहे. चला यासाठी समर्थन जोडूया, माझ्याशी संपर्क साधा :)</string>
     <string name="pods_none_label_short">डिव्हाइस नाही</string>
     <string name="pods_charging_label">चार्ज होत आहे</string>
+    <string name="pods_charging_optimized_label">अनुकूलित</string>
     <string name="pods_inear_label">कानात</string>
     <string name="pods_microphone_label">मायक्रोफोन</string>
     <string name="anc_mode_off">बंद</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">ब्लूटूथ डिव्हाइस लेबल</string>
     <string name="device_settings_info_model_label">मॉडेल</string>
     <string name="device_settings_info_manufacturer_label">निर्माता</string>
+    <string name="device_settings_info_hardware_label">हार्डवेअर</string>
     <string name="device_settings_info_serial_label">सीरियल नंबर</string>
     <string name="device_settings_info_firmware_label">फर्मवेअर</string>
+    <string name="device_settings_info_firmware_pending_label">प्रलंबित फर्मवेअर</string>
     <string name="device_settings_info_build_label">बिल्ड</string>
     <string name="device_settings_info_left_serial_label">डाव्या पॉडचा सीरियल</string>
     <string name="device_settings_info_right_serial_label">उजव्या पॉडचा सीरियल</string>
+    <string name="device_settings_info_left_bonded_label">डावे बाँडेड</string>
+    <string name="device_settings_info_right_bonded_label">उजवे बाँडेड</string>
     <string name="device_settings_info_details_label">डिव्हाइस तपशिल</string>
     <string name="device_settings_info_details_action">डिव्हाइस तपशिल दाखवा</string>
     <string name="device_settings_info_status_label">स्थिती</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">हे डिव्हाइस जवळ आहे पण या फोनशी कनेक्ट केलेले नाही. सेटिंग्ज आणि नियंत्रणे ॲक्सेस करण्यासाठी कनेक्ट करा.</string>
     <string name="device_settings_not_connected_connect_action">कनेक्ट करा</string>
     <string name="device_settings_not_connected_open_settings_action">ब्लूटूथ सेटिंग्ज उघडा</string>
+    <string name="device_settings_not_nearby_label">डिव्हाइस जवळ नाही</string>
+    <string name="device_settings_not_nearby_description">सेटिंग्ज केवळ तेव्हाच उपलब्ध आहेत जेव्हा हे डिव्हाइस जवळ असेल आणि तुमच्या फोनशी कनेक्ट केलेले असेल.</string>
     <string name="device_settings_aap_unavailable_label">प्रगत सेटिंग्ज उपलब्ध नाहीत</string>
     <string name="device_settings_aap_unavailable_description">प्रगत AirPods सेटिंग्जसाठी एक ब्लूटूथ वैशिष्ट्य आवश्यक आहे जे या फोनवर उपलब्ध नाही. हे तुमच्या डिव्हाइस निर्मात्याकडून भविष्यातील Android अद्यतनाद्वारे सोडवले जाउ शकते.</string>
+    <string name="device_settings_aap_unavailable_action">सुसंगतता ट्रॅकर पाहा</string>
     <string name="device_settings_category_sound_label">ध्वनी</string>
     <string name="device_settings_category_controls_label">नियंत्रणे</string>
     <string name="device_settings_nc_one_airpod_label">एका पॉडसह ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">मायक्रोफोन म्यूट करण्यासाठी एकदा दाबा</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कॉल संपवण्यासाठी दोनदा दाबा</string>
     <string name="device_settings_open_cd">डिव्हाइस सेटिंग्ज उघडा</string>
+    <string name="overview_card_missing_paired_device">या प्रोफाइलशी कोणतेही Bluetooth डिव्हाइस जोडलेले नाही.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">मायक्रोफोन</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">ऑफला निवडण्यायोग्य आवाज नियंत्रण मोड म्हणून परवानगी द्या. अक्षम केल्यावर, सायक्लिंग करताना स्टेम ऑफ वगळतात.</string>
     <string name="device_settings_sleep_detection_label">झोप शोध</string>
     <string name="device_settings_sleep_detection_description">झोपल्यावर आपोआप ऑडिओ थांबवा</string>
+    <string name="reaction_sleep_channel_label">झोप शोध</string>
+    <string name="reaction_sleep_notification_title">झोप शोधाने थांबवले</string>
+    <string name="reaction_sleep_notification_text">%1$s ने नोंदवले की तुम्ही झोपी गेलात, त्यामुळे तुमचे संगीत थांबवले गेले. तुम्ही डिव्हाइस सेटिंग्जमध्ये हे अक्षम करू शकता.</string>
     <string name="device_settings_rename_label">नाव बदला</string>
     <string name="device_settings_rename_hint">डिव्हाइसचे नाव</string>
     <string name="device_settings_rename_confirm">नाव बदला</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth सेटिंग्ज</string>
     <string name="device_settings_send_failed">सेटिंग लागू करता आली नाही: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">या डिव्हाइसवर ऑफ मोड सक्षम नाही. ध्वनी नियंत्रणाखाली “ऑफ मोड परवानगी द्या” सक्षम करा.</string>
+    <string name="device_settings_category_battery_label">बॅटरी</string>
+    <string name="device_settings_charge_cap_label">अनुकूलित चार्ज मर्यादा</string>
+    <string name="device_settings_charge_cap_description">तुमची दिनचर्या शिका आणि बॅटरी आयुष्य वाढवण्यासाठी सुमारे 80%% वर चार्जिंग थांबवा, वापरण्यापूर्वी पॉड्स पूर्ण चार्ज करा.</string>
+    <string name="device_settings_charge_cap_rejected_message">अनुकूलित चार्ज मर्यादा बदलता आली नाही. हे एक प्रायोगिक वैशिष्ट्य आहे — जर ते वारंवार अयशस्वी होत असेल तर कृपया नोंदवा.</string>
     <string name="device_settings_category_connections_label">जोडलेली डिव्हाइस</string>
     <string name="device_settings_connected_devices_description">सध्या या AirPods शी जोडलेली इतर डिव्हाइस</string>
     <string name="device_settings_connected_device_label">डिव्हाइस %d</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Ketelusan latar belakang</string>
     <string name="widget_config_show_device_label">Tampilkan nama peranti</string>
     <string name="widget_config_reset_label">Tetapkan semula ke nilai lalai</string>
+    <string name="widget_config_preview_resize_hint">Anda boleh mengubah saiz widget selepas meletakkannya pada skrin utama anda.</string>
     <string name="widget_config_custom_label">Tersuai</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Gelap</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">Ini adalah peranti yang tidak dikenali, tetapi ia menggunakan format mesej yang serupa. Mari tambah sokongan untuknya, hubungi saya :)</string>
     <string name="pods_none_label_short">Tiada peranti</string>
     <string name="pods_charging_label">Mengecas</string>
+    <string name="pods_charging_optimized_label">Dioptimumkan</string>
     <string name="pods_inear_label">Dalam telinga</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Mati</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">Label Peranti Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Pengilang</string>
+    <string name="device_settings_info_hardware_label">Perkakasan</string>
     <string name="device_settings_info_serial_label">Nombor Siri</string>
     <string name="device_settings_info_firmware_label">Perisian Tegar</string>
+    <string name="device_settings_info_firmware_pending_label">Perisian Tegar Tertunda</string>
     <string name="device_settings_info_build_label">Binaan</string>
     <string name="device_settings_info_left_serial_label">Nombor Siri Pod Kiri</string>
     <string name="device_settings_info_right_serial_label">Nombor Siri Pod Kanan</string>
+    <string name="device_settings_info_left_bonded_label">Kiri Terikat</string>
+    <string name="device_settings_info_right_bonded_label">Kanan Terikat</string>
     <string name="device_settings_info_details_label">Butiran Peranti</string>
     <string name="device_settings_info_details_action">Tunjuk butiran peranti</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">Peranti ini berhampiran tetapi tidak bersambung dengan telefon ini. Sambung untuk mengakses tetapan dan kawalan.</string>
     <string name="device_settings_not_connected_connect_action">Sambung</string>
     <string name="device_settings_not_connected_open_settings_action">Buka Tetapan Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Peranti tidak berdekatan</string>
+    <string name="device_settings_not_nearby_description">Tetapan hanya tersedia apabila peranti ini berdekatan dan disambungkan ke telefon anda.</string>
     <string name="device_settings_aap_unavailable_label">Tetapan lanjutan tidak tersedia</string>
     <string name="device_settings_aap_unavailable_description">Tetapan AirPods lanjutan memerlukan ciri Bluetooth yang tidak tersedia pada telefon ini. Ini mungkin diselesaikan oleh kemas kini Android pada masa hadapan daripada pengilang peranti anda.</string>
+    <string name="device_settings_aap_unavailable_action">Lihat penjejak keserasian</string>
     <string name="device_settings_category_sound_label">Bunyi</string>
     <string name="device_settings_category_controls_label">Kawalan</string>
     <string name="device_settings_nc_one_airpod_label">ANC dengan satu pod</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Tekan sekali untuk redam mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tekan dua kali untuk tamatkan panggilan</string>
     <string name="device_settings_open_cd">Buka tetapan peranti</string>
+    <string name="overview_card_missing_paired_device">Profil ini tiada peranti Bluetooth yang dipasangkan.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">Benarkan Mati sebagai mod kawalan hingar yang boleh dipilih. Apabila dilumpuhkan, batang melangkau Mati semasa kitaran.</string>
     <string name="device_settings_sleep_detection_label">Pengesanan Tidur</string>
     <string name="device_settings_sleep_detection_description">Jeda audio secara automatik apabila anda tertidur</string>
+    <string name="reaction_sleep_channel_label">Pengesanan Tidur</string>
+    <string name="reaction_sleep_notification_title">Dijeda oleh Pengesanan Tidur</string>
+    <string name="reaction_sleep_notification_text">%1$s melaporkan anda tertidur, jadi muzik anda telah dijeda. Anda boleh melumpuhkan ini dalam tetapan peranti.</string>
     <string name="device_settings_rename_label">Namakan Semula</string>
     <string name="device_settings_rename_hint">Nama peranti</string>
     <string name="device_settings_rename_confirm">Namakan Semula</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Tetapan Bluetooth</string>
     <string name="device_settings_send_failed">Tidak dapat menggunakan tetapan: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Mod Mati tidak diaktifkan pada peranti ini. Aktifkan \"Benarkan mod Mati\" di bawah Kawalan Hingar.</string>
+    <string name="device_settings_category_battery_label">Bateri</string>
+    <string name="device_settings_charge_cap_label">Had Cas Dioptimumkan</string>
+    <string name="device_settings_charge_cap_description">Pelajari rutin anda dan jeda pengecasan sekitar 80%% untuk melanjutkan hayat bateri, mengisi semula pod sebelum anda berkemungkinan menggunakannya.</string>
+    <string name="device_settings_charge_cap_rejected_message">Had Cas Dioptimumkan tidak dapat diubah. Ini adalah ciri eksperimen — sila laporkan jika ia terus gagal.</string>
     <string name="device_settings_category_connections_label">Peranti Disambung</string>
     <string name="device_settings_connected_devices_description">Peranti lain yang kini disambungkan ke AirPods ini</string>
     <string name="device_settings_connected_device_label">Peranti %d</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">နောက်ခံ ခွဲခြားမှု</string>
     <string name="widget_config_show_device_label">စက်ပစ္စည်း အမည် ပြသရန်</string>
     <string name="widget_config_reset_label">ပုံမှန်သို့ ပြန်လည်ချိန်ညှိသည်</string>
+    <string name="widget_config_preview_resize_hint">သင့် ပင်မစခရင်တွင် widget ချထားပြီးနောက် ၎င်းကို အရွယ်အစား ပြောင်းလဲနိုင်သည်။</string>
     <string name="widget_config_custom_label">အလိုအလျောက်</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">အမှောင်</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">ဤသည်မှာ မသိသောစက်ပစ္စည်းဖြစ်သော်လည်း ၎င်းသည် အလားတူမက်ဆေ့ချ်ပုံစံကိုအသုံးပြုနေသည်။ ၎င်းအတွက် ပံ့ပိုးမှုထည့်သွင်းကြပါစို့၊ ကျွန်ုပ်ကို ဆက်သွယ်ပါ :)</string>
     <string name="pods_none_label_short">စက်ပစ္စည်းမရှိပါ</string>
     <string name="pods_charging_label">အားသွင်းနေသည်</string>
+    <string name="pods_charging_optimized_label">အကောင်းဆုံးဖြစ်အောင်ပြုလုပ်ထားသည်</string>
     <string name="pods_inear_label">နားထဲတွင်</string>
     <string name="pods_microphone_label">မိုက်ခရိုဖုန်း</string>
     <string name="anc_mode_off">ပိတ်</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth ကိရိယာ အညွှန်း</string>
     <string name="device_settings_info_model_label">မော်ဒယ်</string>
     <string name="device_settings_info_manufacturer_label">ထုတ်လုပ်သူ</string>
+    <string name="device_settings_info_hardware_label">ဟာ့ဒ်ဝဲ</string>
     <string name="device_settings_info_serial_label">စီရီရယ်နံပါတ်</string>
     <string name="device_settings_info_firmware_label">ဖာမ်ဝဲ</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware လာမည်</string>
     <string name="device_settings_info_build_label">တည်ဆောက်မှု</string>
     <string name="device_settings_info_left_serial_label">ဘေးဘက် Pod စီရီရယ်နံပါတ်</string>
     <string name="device_settings_info_right_serial_label">ညာဘက် Pod စီရီရယ်နံပါတ်</string>
+    <string name="device_settings_info_left_bonded_label">ဘယ်ဘက် ချိတ်ဆက်ထားသည်</string>
+    <string name="device_settings_info_right_bonded_label">ညာဘက် ချိတ်ဆက်ထားသည်</string>
     <string name="device_settings_info_details_label">ကိရိယာ အသေးစိတ်</string>
     <string name="device_settings_info_details_action">ကိရိယာ အသေးစိတ်ကို ပြသပါ</string>
     <string name="device_settings_info_status_label">အခြေအနေ</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">ဤစက်ပစ္စည်းသည် နီးကပ်ရာတွင် ရှိသော်လည်း ဤဖုန်းနှင့် ချိတ်ဆက်မထားပါ။ ဆက်တင်နှင့် ထိန်းချုပ်မှုများကို ဝင်ရောက်ရန် ချိတ်ဆက်ပါ။</string>
     <string name="device_settings_not_connected_connect_action">ချိတ်ဆက်ပါ</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth ဆက်တင်ဖွင့်ပါ</string>
+    <string name="device_settings_not_nearby_label">စက်ပစ္စည်း မနီးစပ်ဘူး</string>
+    <string name="device_settings_not_nearby_description">ဤစက်ပစ္စည်း နီးစပ်ပြီး သင့်ဖုန်းနှင့် ချိတ်ဆက်ထားသောအခါမှသာ ဆက်တင်များကို ရနိုင်သည်။</string>
     <string name="device_settings_aap_unavailable_label">အဆင့်မြင့်ဆက်တင်များ မရရှိနိုင်ပါ</string>
     <string name="device_settings_aap_unavailable_description">အဆင့်မြင့် AirPods ဆက်တင်များသည် ဤဖုန်းတွင် မရနိုင်သော Bluetooth လုပ်ဆောင်ချက်ကို လိုအပ်သည်။ ၎င်းကို သင့်ကိရိယာ ထုတ်လုပ်သူ၏ Android အပ်ဒိတ်မှ ဖြေရှင်းနိုင်သည်။</string>
+    <string name="device_settings_aap_unavailable_action">လိုက်ဖက်ညီမှု ခြေရာခံကိရိယာကို ကြည့်ရှုရန်</string>
     <string name="device_settings_category_sound_label">အသံ</string>
     <string name="device_settings_category_controls_label">ထိန်းချုပ်မှုများ</string>
     <string name="device_settings_nc_one_airpod_label">Pod တစ်ခုနှင့် ANC</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">မိုက်ခဖိသိမ်းရန် တစ်ကြိမ်နှိပ်ပါ</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ဖုန်းပြတ်ရန် နှစ်ကြိမ်နှိပ်ပါ</string>
     <string name="device_settings_open_cd">ကိရိယာ ဆက်တင်များ ဖွင့်ထားပါ</string>
+    <string name="overview_card_missing_paired_device">ဤပရိုဖိုင်တွင် တွဲချိတ်ထားသော Bluetooth စက်ပစ္စည်း မရှိပါ။</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ယေဘူယျ</string>
     <string name="device_settings_microphone_mode_label">မိုက်ခရိုဖုန်း</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">Off ကို စတ်လှောကး ဆူညံသံထိန်းချုပ် မုဒ်တစ်ခုအဖြစ်အသုံး ခွင့်ပြုနိုင်သည်။ ပိတ်ထားသည်အခါ၊ stem များသည် စက်ပြေးစေအခါ Off ကို ကြားသောမည်။</string>
     <string name="device_settings_sleep_detection_label">အိပ်ငိုက်မှု ရှာဖွေမှု</string>
     <string name="device_settings_sleep_detection_description">အိပ်ပျားသည့်အချား အသံ အလိုအလျောက် ခညေရပ်ပါ</string>
+    <string name="reaction_sleep_channel_label">အိပ်ငိုက်ခြင်း ထောက်လှမ်းခြင်း</string>
+    <string name="reaction_sleep_notification_title">အိပ်ငိုက်ခြင်း ထောက်လှမ်းခြင်းဖြင့် ခေတ္တရပ်ထားသည်</string>
+    <string name="reaction_sleep_notification_text">%1$s က သင်အိပ်ငိုက်သွားသည်ဟု သတင်းပို့သောကြောင့် သင့်သီချင်းကို ခေတ္တရပ်ထားသည်။ ဤဆက်တင်ကို စက်ပစ္စည်းဆက်တင်များတွင် ပိတ်နိုင်သည်။</string>
     <string name="device_settings_rename_label">အမည်ပြောင်းပါ</string>
     <string name="device_settings_rename_hint">ကိရိယာ အမည်</string>
     <string name="device_settings_rename_confirm">အမည်ပြောင်းပါ</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth ဆက်တင်များ</string>
     <string name="device_settings_send_failed">ဆက်တင် မသက်ဆိုင်နိုင်ပါ: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Off မုဒ်ကို ဤကိရိယာတွင် ဖွင့်ထားမခီမယန်။ ဆူညံသံ ထိန်းချုပ် အအောက \"Allow Off mode\" ကို ဖွင့်ပါ။</string>
+    <string name="device_settings_category_battery_label">ဘက်ထရီ</string>
+    <string name="device_settings_charge_cap_label">အကောင်းဆုံး အားသွင်းမှု အဆုံးအမှတ်</string>
+    <string name="device_settings_charge_cap_description">သင့်ပုံမှန်ကျင့်ထုံးကို လေ့လာပြီး ဘက်ထရီသက်တမ်း တိုးရှည်စေရန် 80%% ဝန်းကျင်တွင် အားသွင်းခြင်းကို ခေတ္တရပ်ကာ သင်အသုံးပြုဖွယ်ရှိမီ pods များကို ပြည့်အောင် ပြုလုပ်ပေးသည်။</string>
+    <string name="device_settings_charge_cap_rejected_message">အကောင်းဆုံး အားသွင်းမှု အဆုံးအမှတ်ကို ပြောင်းလဲ၍ မရဘူး။ ၎င်းသည် စမ်းသပ်ဆဲ အင်္ဂါရပ်တစ်ခုဖြစ်သည် — ဆက်လက်မအောင်မြင်ပါက ကျေးဇူးပြု၍ အစီရင်ခံပါ။</string>
     <string name="device_settings_category_connections_label">ချိတ်ဆက်ထားသည် ကိရိယာများ</string>
     <string name="device_settings_connected_devices_description">အပီ AirPods နှင့် လက်ရှိချိတ်ဆက်ထားသည် အခြားကိရိယာများ</string>
     <string name="device_settings_connected_device_label">ကိရိယာ %d</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Bakgrunnsgjennomsiktighet</string>
     <string name="widget_config_show_device_label">Vis enhetsnavn</string>
     <string name="widget_config_reset_label">Tilbakestill til standardinnstillinger</string>
+    <string name="widget_config_preview_resize_hint">Du kan endre størrelsen på widgeten etter at du har plassert den på startskjermen.</string>
     <string name="widget_config_custom_label">Egendefinert</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Mørk</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Dette er en ukjent enhet, men den bruker et lignende meldingsformat. La oss legge til støtte for den, kontakt meg :)</string>
     <string name="pods_none_label_short">Ingen enhet</string>
     <string name="pods_charging_label">Lader</string>
+    <string name="pods_charging_optimized_label">Optimalisert</string>
     <string name="pods_inear_label">I øret</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Av</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-enhetsnavn</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Produsent</string>
+    <string name="device_settings_info_hardware_label">Maskinvare</string>
     <string name="device_settings_info_serial_label">Serienummer</string>
     <string name="device_settings_info_firmware_label">Fastvare</string>
+    <string name="device_settings_info_firmware_pending_label">Ventende fastvare</string>
     <string name="device_settings_info_build_label">Byggnummer</string>
     <string name="device_settings_info_left_serial_label">Venstre pod-serienummer</string>
     <string name="device_settings_info_right_serial_label">Høyre pod-serienummer</string>
+    <string name="device_settings_info_left_bonded_label">Venstre tilkoblet</string>
+    <string name="device_settings_info_right_bonded_label">Høyre tilkoblet</string>
     <string name="device_settings_info_details_label">Enhetsdetaljer</string>
     <string name="device_settings_info_details_action">Vis enhetsdetaljer</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Denne enheten er i nærheten, men ikke tilkoblet denne telefonen. Koble til for å få tilgang til innstillinger og kontroller.</string>
     <string name="device_settings_not_connected_connect_action">Koble til</string>
     <string name="device_settings_not_connected_open_settings_action">Åpne Bluetooth-innstillinger</string>
+    <string name="device_settings_not_nearby_label">Enheten er ikke i nærheten</string>
+    <string name="device_settings_not_nearby_description">Innstillinger er kun tilgjengelige når denne enheten er i nærheten og koblet til telefonen din.</string>
     <string name="device_settings_aap_unavailable_label">Avanserte innstillinger utilgjengelige</string>
     <string name="device_settings_aap_unavailable_description">Avanserte AirPods-innstillinger krever en Bluetooth-funksjon som ikke er tilgjengelig på denne telefonen. Dette kan bli løst av en fremtidig Android-oppdatering fra enhetsprodusenten din.</string>
+    <string name="device_settings_aap_unavailable_action">Vis kompatibilitetssporing</string>
     <string name="device_settings_category_sound_label">Lyd</string>
     <string name="device_settings_category_controls_label">Kontroller</string>
     <string name="device_settings_nc_one_airpod_label">ANC med én pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkelttrykk for å dempe mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dobbelttrykk for å avslutte samtale</string>
     <string name="device_settings_open_cd">Åpne enhetsinnstillinger</string>
+    <string name="overview_card_missing_paired_device">Denne profilen har ingen sammenkoblet Bluetooth-enhet.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generelt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Tillat Av som en valgbar støykontrrollmodus. Når deaktivert, hopper stilkene over Av under sykling.</string>
     <string name="device_settings_sleep_detection_label">Søvndeteksjon</string>
     <string name="device_settings_sleep_detection_description">Sett automatisk lyd på pause når du sovner</string>
+    <string name="reaction_sleep_channel_label">Søvnregistrering</string>
+    <string name="reaction_sleep_notification_title">Satt på pause av søvnregistrering</string>
+    <string name="reaction_sleep_notification_text">%1$s registrerte at du sovnet, så musikken ble satt på pause. Du kan deaktivere dette i enhetsinnstillingene.</string>
     <string name="device_settings_rename_label">Gi nytt navn</string>
     <string name="device_settings_rename_hint">Enhetsnavn</string>
     <string name="device_settings_rename_confirm">Gi nytt navn</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-innstillinger</string>
     <string name="device_settings_send_failed">Kunne ikke bruke innstilling: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Av-modus er ikke aktivert på denne enheten. Aktiver \"Tillat Av-modus\" under Støykontroll.</string>
+    <string name="device_settings_category_battery_label">Batteri</string>
+    <string name="device_settings_charge_cap_label">Optimalisert ladeterskel</string>
+    <string name="device_settings_charge_cap_description">Lær rutinen din og sett ladingen på pause rundt 80%% for å forlenge batterilevetiden, og lad opp podene før du sannsynligvis skal bruke dem.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimalisert ladeterskel kunne ikke endres. Dette er en eksperimentell funksjon — rapporter gjerne hvis det fortsetter å feile.</string>
     <string name="device_settings_category_connections_label">Tilkoblede enheter</string>
     <string name="device_settings_connected_devices_description">Andre enheter som for øyeblikket er koblet til disse AirPods</string>
     <string name="device_settings_connected_device_label">Enhet %d</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">पृष्ठभूमि पारदर्शिता</string>
     <string name="widget_config_show_device_label">डिभाइस नाम देखाउनुहोस्</string>
     <string name="widget_config_reset_label">पूर्वनिर्धारितमा रिसेट गर्नुहोस्</string>
+    <string name="widget_config_preview_resize_hint">तपाईंले होम स्क्रिनमा राखेपछि विजेटको आकार परिवर्तन गर्न सक्नुहुन्छ।</string>
     <string name="widget_config_custom_label">अनुकूल</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">गहिरो</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">यो अज्ञात उपकरण हो, तर यसले समान सन्देश ढाँचा प्रयोग गरिरहेको छ। यसको लागि समर्थन थपौं, मलाई सम्पर्क गर्नुहोस् :)</string>
     <string name="pods_none_label_short">उपकरण छैन</string>
     <string name="pods_charging_label">चार्ज हुँदैछ</string>
+    <string name="pods_charging_optimized_label">अनुकूलित</string>
     <string name="pods_inear_label">कानमा</string>
     <string name="pods_microphone_label">माइक्रोफोन</string>
     <string name="anc_mode_off">बन्द</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">ब्लुटुथ उपकरण लेबल</string>
     <string name="device_settings_info_model_label">मोडेल</string>
     <string name="device_settings_info_manufacturer_label">निर्माता</string>
+    <string name="device_settings_info_hardware_label">हार्डवेयर</string>
     <string name="device_settings_info_serial_label">क्रमिक नम्बर</string>
     <string name="device_settings_info_firmware_label">फर्मवेयर</string>
+    <string name="device_settings_info_firmware_pending_label">पेन्डिङ फर्मवेयर</string>
     <string name="device_settings_info_build_label">बिल्ड</string>
     <string name="device_settings_info_left_serial_label">बायाँ पड सिरियल</string>
     <string name="device_settings_info_right_serial_label">दायाँ पड सिरियल</string>
+    <string name="device_settings_info_left_bonded_label">बायाँ बन्डेड</string>
+    <string name="device_settings_info_right_bonded_label">दायाँ बन्डेड</string>
     <string name="device_settings_info_details_label">उपकरण विवरण</string>
     <string name="device_settings_info_details_action">उपकरण विवरण देखाउनुहोस्</string>
     <string name="device_settings_info_status_label">स्थिति</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">यो उपकरण नजिक छ तर यस फोनमा जडान छैन। सेटिङ र नियन्त्रणहरू पहुँच गर्न जडान गर्नुहोस्।</string>
     <string name="device_settings_not_connected_connect_action">जडान गर्नुहोस्</string>
     <string name="device_settings_not_connected_open_settings_action">ब्लुटुथ सेटिङ खोल्नुहोस्</string>
+    <string name="device_settings_not_nearby_label">यन्त्र नजिकमा छैन</string>
+    <string name="device_settings_not_nearby_description">सेटिङहरू केवल तब उपलब्ध हुन्छन् जब यो यन्त्र नजिकमा छ र तपाईंको फोनमा जडान छ।</string>
     <string name="device_settings_aap_unavailable_label">उन्नत सेटिङहरू उपलब्ध छैनन्</string>
     <string name="device_settings_aap_unavailable_description">उन्नत AirPods सेटिङहरूका लागि ब्लुटुथ सुविधा आवश्यक छ जु यस फोनमा उपलब्ध छैन। यो तपाईंको उपकरण निर्माताको भविष्यको Android अपडेटले समाधान गर्न सक्छ।</string>
+    <string name="device_settings_aap_unavailable_action">अनुकूलता ट्र्याकर हेर्नुहोस्</string>
     <string name="device_settings_category_sound_label">ध्वनि</string>
     <string name="device_settings_category_controls_label">नियन्त्रणहरू</string>
     <string name="device_settings_nc_one_airpod_label">एउटा पडसँग ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">माइक्रोफोन म्युट गर्न एकपटक थिच्नुहोस्</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कल समाप्त गर्न दुईपटक थिच्नुहोस्</string>
     <string name="device_settings_open_cd">उपकरण सेटिङहरू खोल्नुहोस्</string>
+    <string name="overview_card_missing_paired_device">यस प्रोफाइलमा कुनै जोडिएको Bluetooth उपकरण छैन।</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफोन</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">अफलाई चयन गर्न मिल्ने ध्वनि नियन्त्रण मोडको रूपमा अनुमति दिनुहोस्। अक्षम गर्दा, स्टेमले चक्र गर्दा अफ छोड्छ।</string>
     <string name="device_settings_sleep_detection_label">निद्रा पहिचान</string>
     <string name="device_settings_sleep_detection_description">सुत्दा स्वचालित रूपमा अडियो रोक्नुहोस्</string>
+    <string name="reaction_sleep_channel_label">निद्रा पत्ता लगाउने</string>
+    <string name="reaction_sleep_notification_title">निद्रा पत्ता लगाउनेद्वारा रोकिएको</string>
+    <string name="reaction_sleep_notification_text">%1$s ले रिपोर्ट गर्यो कि तपाईं सुत्नुभयो, त्यसैले तपाईंको संगीत रोकिएको थियो। तपाईं यसलाई यन्त्र सेटिङहरूमा अक्षम गर्न सक्नुहुन्छ।</string>
     <string name="device_settings_rename_label">नाम बदल्नुहोस्</string>
     <string name="device_settings_rename_hint">उपकरणको नाम</string>
     <string name="device_settings_rename_confirm">नाम बदल्नुहोस्</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">ब्लुटुथ सेटिङहरू</string>
     <string name="device_settings_send_failed">सेटिङ लागू गर्न सकिएन: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">अफ मोड यस उपकरणमा सक्षम छैन। ध्वनि नियन्त्रण अन्तर्गत \"अफ मोड अनुमति दिनुहोस्\" सक्षम गर्नुहोस्।</string>
+    <string name="device_settings_category_battery_label">ब्याट्री</string>
+    <string name="device_settings_charge_cap_label">अनुकूलित चार्ज सीमा</string>
+    <string name="device_settings_charge_cap_description">तपाईंको दिनचर्या सिकेर ब्याट्री जीवन बढाउन ८०%% को आसपास चार्जिङ रोक्छ र तपाईंले प्रयोग गर्ने सम्भावना हुँदा पड्सलाई पूर्ण गर्छ।</string>
+    <string name="device_settings_charge_cap_rejected_message">अनुकूलित चार्ज सीमा परिवर्तन गर्न सकिएन। यो एउटा प्रयोगात्मक सुविधा हो — यदि यो असफल हुन जारी राख्छ भने कृपया रिपोर्ट गर्नुहोस्।</string>
     <string name="device_settings_category_connections_label">जडान भएका उपकरणहरू</string>
     <string name="device_settings_connected_devices_description">यी AirPods मा हाल जडान भएका अन्य उपकरणहरू</string>
     <string name="device_settings_connected_device_label">उपकरण %d</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Achtergrondtransparantie</string>
     <string name="widget_config_show_device_label">Toon apparaatnaam</string>
     <string name="widget_config_reset_label">Standaardinstellingen herstellen</string>
+    <string name="widget_config_preview_resize_hint">U kan de widgetgrootte aanpassen nadat u het op het beginscherm hebt geplaatst.</string>
     <string name="widget_config_custom_label">Aangepast</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Donker</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Dit is een onbekend apparaat, maar het gebruikt hetzelfde berichtformaat</string>
     <string name="pods_none_label_short">Geen apparaat</string>
     <string name="pods_charging_label">Opladen</string>
+    <string name="pods_charging_optimized_label">Geoptimaliseerd</string>
     <string name="pods_inear_label">In oor</string>
     <string name="pods_microphone_label">Microfoon</string>
     <string name="anc_mode_off">Uit</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-apparaatlabel</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Fabrikant</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Serienummer</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware in behandeling</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Serienummer linker oordopje</string>
     <string name="device_settings_info_right_serial_label">Serienummer rechter oordopje</string>
+    <string name="device_settings_info_left_bonded_label">Links gekoppeld</string>
+    <string name="device_settings_info_right_bonded_label">Rechts gekoppeld</string>
     <string name="device_settings_info_details_label">Apparaatdetails</string>
     <string name="device_settings_info_details_action">Apparaatdetails weergeven</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Dit apparaat bevindt zich in de buurt, maar is niet verbonden met deze telefoon. Maak verbinding om toegang te krijgen tot de instellingen en bedieningsopties.</string>
     <string name="device_settings_not_connected_connect_action">Verbinden</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth-instellingen Openen</string>
+    <string name="device_settings_not_nearby_label">Apparaat is niet in de buurt</string>
+    <string name="device_settings_not_nearby_description">Instellingen zijn alleen beschikbaar wanneer dit apparaat in de buurt is en verbonden is met uw telefoon.</string>
     <string name="device_settings_aap_unavailable_label">Geavanceerde instellingen niet beschikbaar</string>
     <string name="device_settings_aap_unavailable_description">Geavanceerde AirPods-instellingen vereisen een Bluetooth-functie die niet beschikbaar is op deze telefoon. Dit kan worden opgelost door een toekomstige Android-update van uw apparaatfabrikant.</string>
+    <string name="device_settings_aap_unavailable_action">Laat de compatibele tracker zien</string>
     <string name="device_settings_category_sound_label">Geluid</string>
     <string name="device_settings_category_controls_label">Bediening</string>
     <string name="device_settings_nc_one_airpod_label">ANC met één oordopje</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Druk één keer om de microfoon te dempen</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbelklik om het gesprek te beëindigen</string>
     <string name="device_settings_open_cd">Apparaatinstellingen openen</string>
+    <string name="overview_card_missing_paired_device">Dit profiel heeft geen verbonden bluetooth-apparaat.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Microfoon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Uit als selecteerbare ruisonderdrukkingsmodus toestaan. Wanneer uitgeschakeld, slaan stems Uit over tijdens het cycleren.</string>
     <string name="device_settings_sleep_detection_label">Slaapdetectie</string>
     <string name="device_settings_sleep_detection_description">Audio automatisch pauzeren wanneer je in slaap valt</string>
+    <string name="reaction_sleep_channel_label">Slaapdetectie</string>
+    <string name="reaction_sleep_notification_title">Gepauzeerd door slaapdetectie</string>
+    <string name="reaction_sleep_notification_text">%1$s heeft gedetecteerd dat u in slaap bent gevallen, dus uw muziek is gepauzeerd. U kunt dit uitschakelen in de apparaatinstellingen.</string>
     <string name="device_settings_rename_label">Hernoemen</string>
     <string name="device_settings_rename_hint">Apparaatnaam</string>
     <string name="device_settings_rename_confirm">Hernoemen</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-instellingen</string>
     <string name="device_settings_send_failed">Instelling kon niet worden toegepast: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Uit-modus is niet ingeschakeld op dit apparaat. Schakel \"Uit-modus toestaan\" in onder Ruisonderdrukking.</string>
+    <string name="device_settings_category_battery_label">Batterij</string>
+    <string name="device_settings_charge_cap_label">Geoptimaliseerde oplaadlimiet</string>
+    <string name="device_settings_charge_cap_description">Leert uw routine en pauzeert het opladen rond 80%% om de batterijlevensduur te verlengen, waarna de pods worden bijgeladen voordat u ze waarschijnlijk gebruikt.</string>
+    <string name="device_settings_charge_cap_rejected_message">Geoptimaliseerde oplaadlimiet kon niet worden gewijzigd. Dit is een experimentele functie — meld het als dit blijft mislukken.</string>
     <string name="device_settings_category_connections_label">Verbonden apparaten</string>
     <string name="device_settings_connected_devices_description">Andere apparaten die momenteel verbonden zijn met deze AirPods</string>
     <string name="device_settings_connected_device_label">Apparaat %d</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -154,6 +154,7 @@ K4r0lSz;</string>
     <string name="widget_config_transparency_label">Przezroczystość tła</string>
     <string name="widget_config_show_device_label">Pokaż nazwę urządzenia</string>
     <string name="widget_config_reset_label">Przywróć ustawienia domyślne</string>
+    <string name="widget_config_preview_resize_hint">Możesz zmienić rozmiar widżetu po umieszczeniu go na ekranie głównym.</string>
     <string name="widget_config_custom_label">Niestandardowy</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Ciemny</string>
@@ -256,6 +257,7 @@ K4r0lSz;</string>
     <string name="pods_unknown_contact_dev">Urządzenie nie zostało rozpoznane, ale korzysta z podobnego formatu danych. Możemy dodać jego obsługę - skontaktuj się ze mną :)</string>
     <string name="pods_none_label_short">Brak urządzenia</string>
     <string name="pods_charging_label">Ładowanie</string>
+    <string name="pods_charging_optimized_label">Zoptymalizowane</string>
     <string name="pods_inear_label">W uszach</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Wyłączony</string>
@@ -419,11 +421,15 @@ K4r0lSz;</string>
     <string name="device_settings_info_bt_name_label">Etykieta urządzenia Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producent</string>
+    <string name="device_settings_info_hardware_label">Sprzęt</string>
     <string name="device_settings_info_serial_label">Numer seryjny</string>
     <string name="device_settings_info_firmware_label">Oprogramowanie</string>
+    <string name="device_settings_info_firmware_pending_label">Oczekujące oprogramowanie</string>
     <string name="device_settings_info_build_label">Kompilacja</string>
     <string name="device_settings_info_left_serial_label">Numer seryjny lewej słuchawki</string>
     <string name="device_settings_info_right_serial_label">Numer seryjny prawej słuchawki</string>
+    <string name="device_settings_info_left_bonded_label">Lewy sparowany</string>
+    <string name="device_settings_info_right_bonded_label">Prawy sparowany</string>
     <string name="device_settings_info_details_label">Szczegóły urządzenia</string>
     <string name="device_settings_info_details_action">Pokaż szczegóły urządzenia</string>
     <string name="device_settings_info_status_label">Stan</string>
@@ -433,8 +439,11 @@ K4r0lSz;</string>
     <string name="device_settings_not_connected_description">To urządzenie jest w pobliżu, ale nie jest połączone z tym telefonem. Połącz się, aby uzyskać dostęp do ustawień i elementów sterowania.</string>
     <string name="device_settings_not_connected_connect_action">Połącz</string>
     <string name="device_settings_not_connected_open_settings_action">Otwórz ustawienia Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Urządzenie nie jest w pobliżu</string>
+    <string name="device_settings_not_nearby_description">Ustawienia są dostępne tylko wtedy, gdy to urządzenie jest w pobliżu i połączone z telefonem.</string>
     <string name="device_settings_aap_unavailable_label">Zaawansowane ustawienia są niedostępne</string>
     <string name="device_settings_aap_unavailable_description">Zaawansowane ustawienia AirPods wymagają funkcji Bluetooth, która nie jest dostępna w tym telefonie. Może to zostać rozwiązane przez przyszłą aktualizację Androida od producenta urządzenia.</string>
+    <string name="device_settings_aap_unavailable_action">Wyświetl śledzenie zgodności</string>
     <string name="device_settings_category_sound_label">Dźwięk</string>
     <string name="device_settings_category_controls_label">Sterowanie</string>
     <string name="device_settings_nc_one_airpod_label">ANC z jedną słuchawką</string>
@@ -472,6 +481,7 @@ K4r0lSz;</string>
     <string name="device_settings_end_call_mute_mic_option_b_title">Pojedyncze naciśnięcie wycisza mikrofon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Naciśnij dwukrotnie, aby zakończyć połączenie</string>
     <string name="device_settings_open_cd">Otwórz ustawienia urządzenia</string>
+    <string name="overview_card_missing_paired_device">Ten profil nie ma sparowanego urządzenia Bluetooth.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ogólne</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -494,6 +504,9 @@ K4r0lSz;</string>
     <string name="device_settings_allow_off_description">Zezwól na tryb wyłączony jako wybieralny tryb kontroli hałasu. Gdy wyłączony, trzony pomijają tryb wyłączony podczas cyklu.</string>
     <string name="device_settings_sleep_detection_label">Wykrywanie snu</string>
     <string name="device_settings_sleep_detection_description">Automatycznie wstrzymaj audio, gdy zasypiasz</string>
+    <string name="reaction_sleep_channel_label">Wykrywanie snu</string>
+    <string name="reaction_sleep_notification_title">Wstrzymano przez wykrywanie snu</string>
+    <string name="reaction_sleep_notification_text">%1$s wykrył, że zasnąłeś, więc muzyka została wstrzymana. Możesz to wyłączyć w ustawieniach urządzenia.</string>
     <string name="device_settings_rename_label">Zmień nazwę</string>
     <string name="device_settings_rename_hint">Nazwa urządzenia</string>
     <string name="device_settings_rename_confirm">Zmień nazwę</string>
@@ -503,6 +516,10 @@ K4r0lSz;</string>
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Ustawienia Bluetooth</string>
     <string name="device_settings_send_failed">Nie można zastosować ustawienia: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Tryb wyłączony nie jest włączony na tym urządzeniu. Włącz „Zezwól na tryb wyłączony” w sekcji Kontrola hałasu.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Zoptymalizowany limit ładowania</string>
+    <string name="device_settings_charge_cap_description">Uczy się Twojego harmonogramu i wstrzymuje ładowanie około 80%%, aby wydłużyć żywotność baterii, doładowując słuchawki przed prawdopodobnym ich użyciem.</string>
+    <string name="device_settings_charge_cap_rejected_message">Nie udało się zmienić zoptymalizowanego limitu ładowania. To funkcja eksperymentalna — prosimy o zgłoszenie, jeśli problem będzie się powtarzał.</string>
     <string name="device_settings_category_connections_label">Połączone urządzenia</string>
     <string name="device_settings_connected_devices_description">Inne urządzenia aktualnie podłączone do tych AirPodsów </string>
     <string name="device_settings_connected_device_label">Urządzenie %d</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparência do fundo</string>
     <string name="widget_config_show_device_label">Mostrar nome do dispositivo</string>
     <string name="widget_config_reset_label">Restaurar padrões</string>
+    <string name="widget_config_preview_resize_hint">Você pode redimensionar o widget após colocá-lo na tela inicial.</string>
     <string name="widget_config_custom_label">Personalizado</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Escuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Este é um dispositivo desconhecido, mas está usando um formato de mensagem similar. Vamos adicionar suporte para ele, entre em contato comigo :)</string>
     <string name="pods_none_label_short">Nenhum dispositivo</string>
     <string name="pods_charging_label">Carregando</string>
+    <string name="pods_charging_optimized_label">Otimizado</string>
     <string name="pods_inear_label">No ouvido</string>
     <string name="pods_microphone_label">Microfone</string>
     <string name="anc_mode_off">Desligado</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Rótulo do dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Número de série</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware Pendente</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Serial do pod esquerdo</string>
     <string name="device_settings_info_right_serial_label">Serial do pod direito</string>
+    <string name="device_settings_info_left_bonded_label">Esquerdo Vinculado</string>
+    <string name="device_settings_info_right_bonded_label">Direito Vinculado</string>
     <string name="device_settings_info_details_label">Detalhes do dispositivo</string>
     <string name="device_settings_info_details_action">Mostrar detalhes do dispositivo</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Este dispositivo está próximo, mas não está conectado a este telefone. Conecte-se para acessar configurações e controles.</string>
     <string name="device_settings_not_connected_connect_action">Conectar</string>
     <string name="device_settings_not_connected_open_settings_action">Abrir Configurações de Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo não está próximo</string>
+    <string name="device_settings_not_nearby_description">As configurações só estão disponíveis quando este dispositivo está próximo e conectado ao seu telefone.</string>
     <string name="device_settings_aap_unavailable_label">Configurações avançadas indisponíveis</string>
     <string name="device_settings_aap_unavailable_description">As configurações avançadas de AirPods requerem um recurso Bluetooth que não está disponível neste telefone. Isso pode ser resolvido por uma atualização futura do Android pelo fabricante do seu dispositivo.</string>
+    <string name="device_settings_aap_unavailable_action">Ver rastreador de compatibilidade</string>
     <string name="device_settings_category_sound_label">Som</string>
     <string name="device_settings_category_controls_label">Controles</string>
     <string name="device_settings_nc_one_airpod_label">ANC com um pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pressionar uma vez para silenciar o microfone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pressionar duas vezes para encerrar a chamada</string>
     <string name="device_settings_open_cd">Abrir configurações do dispositivo</string>
+    <string name="overview_card_missing_paired_device">Este perfil não tem nenhum dispositivo Bluetooth pareado.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Gerais</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permitir Desligado como um modo de controle de ruído selecionável. Quando desativado, os cabos ignoram o Desligado ao ciclar.</string>
     <string name="device_settings_sleep_detection_label">Detecção de sono</string>
     <string name="device_settings_sleep_detection_description">Pausar áudio automaticamente quando você adormecer</string>
+    <string name="reaction_sleep_channel_label">Detecção de Sono</string>
+    <string name="reaction_sleep_notification_title">Pausado pela Detecção de Sono</string>
+    <string name="reaction_sleep_notification_text">%1$s informou que você adormeceu, então sua música foi pausada. Você pode desativar isso nas configurações do dispositivo.</string>
     <string name="device_settings_rename_label">Renomear</string>
     <string name="device_settings_rename_hint">Nome do dispositivo</string>
     <string name="device_settings_rename_confirm">Renomear</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Configurações do Bluetooth</string>
     <string name="device_settings_send_failed">Não foi possível aplicar a configuração: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">O modo Desligado não está ativado neste dispositivo. Ative \"Permitir modo Desligado\" em Controle de Ruído.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Limite de Carga Otimizado</string>
+    <string name="device_settings_charge_cap_description">Aprende sua rotina e pausa o carregamento em torno de 80%% para prolongar a vida útil da bateria, completando a carga dos pods antes de você provavelmente usá-los.</string>
+    <string name="device_settings_charge_cap_rejected_message">O Limite de Carga Otimizado não pôde ser alterado. Este é um recurso experimental — por favor, reporte se continuar falhando.</string>
     <string name="device_settings_category_connections_label">Dispositivos conectados</string>
     <string name="device_settings_connected_devices_description">Outros dispositivos atualmente conectados a estes AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -61,7 +61,7 @@
     <string name="settings_signal_minimum_label">Qualidade mínima do sinal</string>
     <string name="settings_signal_minimum_description">A qualidade mínima do sinal que um dispositivo tem de ter para ser considerado seu.</string>
     <string name="settings_autoconnect_label">Ligar automaticamente</string>
-    <string name="settings_autoconnect_description">Se o Android não ligar automaticamente, também podemos pedi-lo. Isto irá definir a definição do modo de monitorização para \"Sempre\".</string>
+    <string name="settings_autoconnect_description">Se o Android не ligar automaticamente, também podemos pedi-lo. Isto irá definir a definição do modo de monitorização para \"Sempre\".</string>
     <string name="settings_autoconnect_info_android12">A ligação automática depende de uma funcionalidade do sistema que o Android 12 e versões mais recentes restringem. Pode não funcionar no seu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condição de ligação automática</string>
     <string name="settings_autoconnect_condition_description">Quando é que devemos tentar ligar ao seu dispositivo?</string>
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparência do fundo</string>
     <string name="widget_config_show_device_label">Mostrar nome do dispositivo</string>
     <string name="widget_config_reset_label">Restaurar padrões</string>
+    <string name="widget_config_preview_resize_hint">Pode redimensionar o widget depois de o colocar no seu ecrã inicial.</string>
     <string name="widget_config_custom_label">Personalizado</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Escuro</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Este é um dispositivo desconhecido, mas está a usar um formato de mensagem semelhante. Vamos adicionar suporte para ele, contacte-me :)</string>
     <string name="pods_none_label_short">Sem dispositivo</string>
     <string name="pods_charging_label">A carregar</string>
+    <string name="pods_charging_optimized_label">Otimizado</string>
     <string name="pods_inear_label">No ouvido</string>
     <string name="pods_microphone_label">Microfone</string>
     <string name="anc_mode_off">Desligado</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etiqueta do Dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Número de série</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware Pendente</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Número de Série do Auricular Esquerdo</string>
     <string name="device_settings_info_right_serial_label">Número de Série do Auricular Direito</string>
+    <string name="device_settings_info_left_bonded_label">Esquerdo Vinculado</string>
+    <string name="device_settings_info_right_bonded_label">Direito Vinculado</string>
     <string name="device_settings_info_details_label">Detalhes do Dispositivo</string>
     <string name="device_settings_info_details_action">Mostrar detalhes do dispositivo</string>
     <string name="device_settings_info_status_label">Estado</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Este dispositivo está próximo mas não está conectado a este telemóvel. Conecte-se para aceder às definições e controlos.</string>
     <string name="device_settings_not_connected_connect_action">Conectar</string>
     <string name="device_settings_not_connected_open_settings_action">Abrir definições de Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivo não está próximo</string>
+    <string name="device_settings_not_nearby_description">As definições só estão disponíveis quando este dispositivo está próximo e ligado ao seu telemóvel.</string>
     <string name="device_settings_aap_unavailable_label">Definições avançadas indisponíveis</string>
     <string name="device_settings_aap_unavailable_description">As definições avançadas dos AirPods requerem uma funcionalidade Bluetooth que não está disponível neste telefóne. Isto pode ser resolvido por uma futura atualização Android do fabricante do seu dispositivo.</string>
+    <string name="device_settings_aap_unavailable_action">Ver rastreador de compatibilidade</string>
     <string name="device_settings_category_sound_label">Som</string>
     <string name="device_settings_category_controls_label">Controlos</string>
     <string name="device_settings_nc_one_airpod_label">ANC com um auricular</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Pressão simples para silenciar microfone</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pressão dupla para terminar chamada</string>
     <string name="device_settings_open_cd">Abrir definições do dispositivo</string>
+    <string name="overview_card_missing_paired_device">Este perfil não tem nenhum dispositivo Bluetooth emparelhado.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Geral</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permitir Desligado como modo de controlo de ruído selecionável. Quando desativado, os hastes ignoram Desligado ao ciclar.</string>
     <string name="device_settings_sleep_detection_label">Deteção de sono</string>
     <string name="device_settings_sleep_detection_description">Pausar automaticamente o áudio quando adormece</string>
+    <string name="reaction_sleep_channel_label">Deteção de Sono</string>
+    <string name="reaction_sleep_notification_title">Pausado pela Deteção de Sono</string>
+    <string name="reaction_sleep_notification_text">%1$s detetou que adormeceu, por isso a sua música foi pausada. Pode desativar esta funcionalidade nas definições do dispositivo.</string>
     <string name="device_settings_rename_label">Mudar nome</string>
     <string name="device_settings_rename_hint">Nome do dispositivo</string>
     <string name="device_settings_rename_confirm">Mudar nome</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Definições de Bluetooth</string>
     <string name="device_settings_send_failed">Não foi possível aplicar a definição: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">O modo Desligado não está ativado neste dispositivo. Ative \"Permitir modo Desligado\" em Controlo de Ruído.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Limite de Carga Otimizado</string>
+    <string name="device_settings_charge_cap_description">Aprende a sua rotina e pausa a carga por volta dos 80%% para prolongar a vida útil da bateria, carregando os AirPods antes de os usar.</string>
+    <string name="device_settings_charge_cap_rejected_message">O Limite de Carga Otimizado não pôde ser alterado. Esta é uma funcionalidade experimental — por favor reporte se continuar a falhar.</string>
     <string name="device_settings_category_connections_label">Dispositivos ligados</string>
     <string name="device_settings_connected_devices_description">Outros dispositivos atualmente ligados a estes AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparenza dal fonds</string>
     <string name="widget_config_show_device_label">Mussar nom dal dispositiv</string>
     <string name="widget_config_reset_label">Reinizialischar als standardis</string>
+    <string name="widget_config_preview_resize_hint">Ti pos midiar la dimensiun dal widget suenter haver collocat il sin tia pantschina da chasa.</string>
     <string name="widget_config_custom_label">Persunalisà</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Stgir</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Quai è in apparat nunenconuschent, ma el dovra in format da messadi sumegliont. Agiuntin il support, contactai me :)</string>
     <string name="pods_none_label_short">Nagin apparat</string>
     <string name="pods_charging_label">Chargiar</string>
+    <string name="pods_charging_optimized_label">Optimisà</string>
     <string name="pods_inear_label">En l\'ureglia</string>
     <string name="pods_microphone_label">Microfon</string>
     <string name="anc_mode_off">Inactiv</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Designaziun da l\'apparat Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producent</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Numer serial</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware Pendant</string>
     <string name="device_settings_info_build_label">Versiun da construcziun</string>
     <string name="device_settings_info_left_serial_label">Numer serial da l\'AirPod sanester</string>
     <string name="device_settings_info_right_serial_label">Numer serial da l\'AirPod dretg</string>
+    <string name="device_settings_info_left_bonded_label">Sanglà Seniester</string>
+    <string name="device_settings_info_right_bonded_label">Sanglà Dretg</string>
     <string name="device_settings_info_details_label">Detagls da l\'apparat</string>
     <string name="device_settings_info_details_action">Mussar detagls da l\'apparat</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Quest apparat è nas ma betg connectà cun quest telefon. Connecta per acceder als parameters ed als controls.</string>
     <string name="device_settings_not_connected_connect_action">Connectar</string>
     <string name="device_settings_not_connected_open_settings_action">Avrir parameters Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Apparat betg proximità</string>
+    <string name="device_settings_not_nearby_description">Las configurazions èn mo accessiblas sche quest apparat è proximità ed connectà cun Voss telefon.</string>
     <string name="device_settings_aap_unavailable_label">Parameters avanzads betg disponibels</string>
     <string name="device_settings_aap_unavailable_description">Las preferenzas avanzadas per AirPods pretendeschan ina funcziun Bluetooth che n\'è betg disponibla sin quest telefon. Quai po vegnir resolvì cun ina futura actualisaziun d\'Android dal producent da voss apparat.</string>
+    <string name="device_settings_aap_unavailable_action">Mussar il tracker da compatibilitad</string>
     <string name="device_settings_category_sound_label">Sun</string>
     <string name="device_settings_category_controls_label">Controlla</string>
     <string name="device_settings_nc_one_airpod_label">ANC cun in singul pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">In presser per tasar il microfon</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dupel presser per terminar il clom</string>
     <string name="device_settings_open_cd">Avrir ils parameters da l\'apparat</string>
+    <string name="overview_card_missing_paired_device">Quest profil na ha nagin apparat Bluetooth copulà.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permetter il modus Deactivà sco modus selectabel da controlla dal rumur. Cur che deactivà, ils stems survolan Deactivà durant la cicla.</string>
     <string name="device_settings_sleep_detection_label">Detecziun dal durmir</string>
     <string name="device_settings_sleep_detection_description">Pausa automatica dal audio sche ti t\'endormas</string>
+    <string name="reaction_sleep_channel_label">Detecziun dal Somen</string>
+    <string name="reaction_sleep_notification_title">Stoppà da la Detecziun dal Somen</string>
+    <string name="reaction_sleep_notification_text">%1$s ha rapportà ch\'Vus avais endormì, uschia è Vossa musica vegnida stoppada. Vus pudais deactivar quai en las configurazions dal apparat.</string>
     <string name="device_settings_rename_label">Renumerar</string>
     <string name="device_settings_rename_hint">Num da l\'apparat</string>
     <string name="device_settings_rename_confirm">Renumerar</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Parameters Bluetooth</string>
     <string name="device_settings_send_failed">Betg pussibel d\'applitgar il parameter: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Il modus Deactivà n\'è betg activà sin quest apparat. Activa «Permetter il modus Deactivà» sut Controlla dal rumur.</string>
+    <string name="device_settings_category_battery_label">Batteria</string>
+    <string name="device_settings_charge_cap_label">Limit Optimisà da Chargia</string>
+    <string name="device_settings_charge_cap_description">Emprenda Vossa rutina e metta en pausa la chargia tar environ 80%% per prolungar la vita da la batteria, cargond ils pods avant ch\'Vus ils utilisais probablamain.</string>
+    <string name="device_settings_charge_cap_rejected_message">Il Limit Optimisà da Chargia n\'ha betg pudì vegnir midà. Quai è ina funcziun experimentala — per plaschair rapportai sch\'ella cuntinuescha a fallar.</string>
     <string name="device_settings_category_connections_label">Apparats connectads</string>
     <string name="device_settings_connected_devices_description">Auters apparats actualmain connectads a quests AirPods</string>
     <string name="device_settings_connected_device_label">Apparat %d</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparența fundalului</string>
     <string name="widget_config_show_device_label">Afișează numele dispozitivului</string>
     <string name="widget_config_reset_label">Resetează la setări implicite</string>
+    <string name="widget_config_preview_resize_hint">Puteți redimensiona widgetul după ce îl plasați pe ecranul de pornire.</string>
     <string name="widget_config_custom_label">Personalizat</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Întunecat</string>
@@ -252,6 +253,7 @@
     <string name="pods_unknown_contact_dev">Acesta este un dispozitiv necunoscut, dar folosește un format de mesaj similar. Să adăugăm suport pentru el, contactați-mă :)</string>
     <string name="pods_none_label_short">Niciun dispozitiv</string>
     <string name="pods_charging_label">Se încarcă</string>
+    <string name="pods_charging_optimized_label">Optimizat</string>
     <string name="pods_inear_label">În ureche</string>
     <string name="pods_microphone_label">Microfon</string>
     <string name="anc_mode_off">Oprit</string>
@@ -412,11 +414,15 @@
     <string name="device_settings_info_bt_name_label">Etichetă dispozitiv Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producător</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Număr de serie</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware în așteptare</string>
     <string name="device_settings_info_build_label">Build</string>
     <string name="device_settings_info_left_serial_label">Serial pod stâng</string>
     <string name="device_settings_info_right_serial_label">Serial pod drept</string>
+    <string name="device_settings_info_left_bonded_label">Stânga asociată</string>
+    <string name="device_settings_info_right_bonded_label">Dreapta asociată</string>
     <string name="device_settings_info_details_label">Detalii dispozitiv</string>
     <string name="device_settings_info_details_action">Arată detalii dispozitiv</string>
     <string name="device_settings_info_status_label">Stare</string>
@@ -426,8 +432,11 @@
     <string name="device_settings_not_connected_description">Acest dispozitiv este în apropiere, dar nu este conectat la acest telefon. Conectați-vă pentru a accesa setările și comenzile.</string>
     <string name="device_settings_not_connected_connect_action">Conectare</string>
     <string name="device_settings_not_connected_open_settings_action">Deschide Setările Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispozitiv în afara razei</string>
+    <string name="device_settings_not_nearby_description">Setările sunt disponibile numai când acest dispozitiv este în apropiere și conectat la telefonul tău.</string>
     <string name="device_settings_aap_unavailable_label">Setări avansate indisponibile</string>
     <string name="device_settings_aap_unavailable_description">Setările avansate pentru AirPods necesită o funcție Bluetooth care nu este disponibilă pe acest telefon. Aceasta ar putea fi rezolvată printr-o actualizare viitoare Android de la producătorul dispozitivului tău.</string>
+    <string name="device_settings_aap_unavailable_action">Vizualizați tracker-ul de compatibilitate</string>
     <string name="device_settings_category_sound_label">Sunet</string>
     <string name="device_settings_category_controls_label">Controale</string>
     <string name="device_settings_nc_one_airpod_label">ANC cu un singur pod</string>
@@ -465,6 +474,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Apăsare simplă pentru a dezactiva microfonul</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dublă apăsare pentru a încheia apelul</string>
     <string name="device_settings_open_cd">Deschide setările dispozitivului</string>
+    <string name="overview_card_missing_paired_device">Acest profil nu are niciun dispozitiv Bluetooth asociat.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
@@ -487,6 +497,9 @@
     <string name="device_settings_allow_off_description">Permite selectarea modului Off ca mod de control al zgomotului. Când este dezactivat, tijele sărită modul Off la ciclare.</string>
     <string name="device_settings_sleep_detection_label">Detectare somn</string>
     <string name="device_settings_sleep_detection_description">Pauzează automat audio când adormi</string>
+    <string name="reaction_sleep_channel_label">Detectare somn</string>
+    <string name="reaction_sleep_notification_title">Pauză prin Detectare somn</string>
+    <string name="reaction_sleep_notification_text">%1$s a detectat că ai adormit, astfel că muzica a fost oprită. Poți dezactiva aceasta din setările dispozitivului.</string>
     <string name="device_settings_rename_label">Redenumește</string>
     <string name="device_settings_rename_hint">Numele dispozitivului</string>
     <string name="device_settings_rename_confirm">Redenumește</string>
@@ -496,6 +509,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Setări Bluetooth</string>
     <string name="device_settings_send_failed">Nu s-a putut aplica setarea: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Modul Off nu este activat pe acest dispozitiv. Activând \"Permite modul Off\" la Controlul zgomotului.</string>
+    <string name="device_settings_category_battery_label">Baterie</string>
+    <string name="device_settings_charge_cap_label">Limită de încărcare optimizată</string>
+    <string name="device_settings_charge_cap_description">Îvăță rutina ta și întrerupe încărcarea la aproximativ 80%% pentru a prelungi durata de viață a bateriei, reîncărcând căștile înainte să fie necesare.</string>
+    <string name="device_settings_charge_cap_rejected_message">Limita de încărcare optimizată nu a putut fi modificată. Aceasta este o funcție experimentală — raportează dacă continuă să eșueze.</string>
     <string name="device_settings_category_connections_label">Dispozitive conectate</string>
     <string name="device_settings_connected_devices_description">Alte dispozitive conectate în prezent la aceste AirPods</string>
     <string name="device_settings_connected_device_label">Dispozitiv %d</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -62,7 +62,7 @@
     <string name="settings_signal_minimum_description">Минимальное качество сигнала, необходимое устройству, чтобы оно опознавалось как Ваше.</string>
     <string name="settings_autoconnect_label">Автоподключение</string>
     <string name="settings_autoconnect_description">Если Android не подключается автоматически, мы можем послать ему запрос. Это установит режим мониторинга на \'Всегда\'.</string>
-    <string name="settings_autoconnect_info_android12">Автоподключение использует системную функцию, ограниченную в Android 12 и новее. Может не работать на вашем устройстве.</string>
+    <string name="settings_autoconnect_info_android12">Автоподключение использует системную функцию, ограниченную в Android 12 и новее. Может не работать на Вашем устройстве.</string>
     <string name="settings_autoconnect_condition_label">Условия автоподключения</string>
     <string name="settings_autoconnect_condition_description">Когда мы должны пытаться подключить Ваше устройство?</string>
     <string name="settings_devices_label">Устройства</string>
@@ -86,7 +86,7 @@
     <string name="general_fix_it_action">Исправить</string>
     <string name="device_settings_experimental_title">Экспериментальная функция</string>
     <string name="device_settings_experimental_description">Эта функция ещё не протестирована на всех устройствах. Если что-то работает неправильно, пожалуйста, создайте обращение с журналом отладки.</string>
-    <string name="device_settings_experimental_action">Открыть трекер задач</string>
+    <string name="device_settings_experimental_action">Открыть трекер проблем</string>
     <string name="notification_channel_device_status_label">Статус устройства</string>
     <string name="notification_channel_device_status_connected_label">Подключенное устройство</string>
     <string name="monitor_notification_extra_enabled_hint">Вы можете отключить это уведомление в системных настройках.</string>
@@ -153,6 +153,7 @@ AL_Cool_T</string>
     <string name="widget_config_transparency_label">Прозрачность фона</string>
     <string name="widget_config_show_device_label">Показывать имя устройства</string>
     <string name="widget_config_reset_label">Сброс к умолчаниям</string>
+    <string name="widget_config_preview_resize_hint">Вы можете изменить размер виджета после его размещения на Вашем экране.</string>
     <string name="widget_config_custom_label">Пользовательский</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Тёмный</string>
@@ -255,6 +256,7 @@ AL_Cool_T</string>
     <string name="pods_unknown_contact_dev">Это неизвестное устройство, но оно использует аналогичный формат сообщения. Давайте добавим поддержку, свяжитесь со мной :)</string>
     <string name="pods_none_label_short">Нет устройства</string>
     <string name="pods_charging_label">Зарядка</string>
+    <string name="pods_charging_optimized_label">Оптимизировано</string>
     <string name="pods_inear_label">В ухе</string>
     <string name="pods_microphone_label">Микрофон</string>
     <string name="anc_mode_off">Выкл.</string>
@@ -418,11 +420,15 @@ AL_Cool_T</string>
     <string name="device_settings_info_bt_name_label">Название Bluetooth-устройства</string>
     <string name="device_settings_info_model_label">Модель</string>
     <string name="device_settings_info_manufacturer_label">Производитель</string>
+    <string name="device_settings_info_hardware_label">Аппаратная часть</string>
     <string name="device_settings_info_serial_label">Серийный номер</string>
     <string name="device_settings_info_firmware_label">Прошивка</string>
+    <string name="device_settings_info_firmware_pending_label">Ожидание прошивки</string>
     <string name="device_settings_info_build_label">Сборка</string>
     <string name="device_settings_info_left_serial_label">Серийный номер левого наушника</string>
     <string name="device_settings_info_right_serial_label">Серийный номер правого наушника</string>
+    <string name="device_settings_info_left_bonded_label">Левый сопряжён</string>
+    <string name="device_settings_info_right_bonded_label">Правый сопряжён</string>
     <string name="device_settings_info_details_label">Подробности устройства</string>
     <string name="device_settings_info_details_action">Показать подробности устройства</string>
     <string name="device_settings_info_status_label">Состояние</string>
@@ -432,8 +438,11 @@ AL_Cool_T</string>
     <string name="device_settings_not_connected_description">Это устройство находится рядом, но не подключено к этому телефону. Подключитесь для доступа к настройкам и элементам управления.</string>
     <string name="device_settings_not_connected_connect_action">Подключить</string>
     <string name="device_settings_not_connected_open_settings_action">Открыть настройки Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Устройство не рядом</string>
+    <string name="device_settings_not_nearby_description">Настройки доступны только когда это устройство находится рядом и подключено к вашему телефону.</string>
     <string name="device_settings_aap_unavailable_label">Расширенные настройки недоступны</string>
     <string name="device_settings_aap_unavailable_description">Расширенные настройки AirPods требуют функцию Bluetooth, недоступную на этом телефоне. Это может быть исправлено в будущем обновлении Android от производителя устройства.</string>
+    <string name="device_settings_aap_unavailable_action">Просмотр трекера совместимости</string>
     <string name="device_settings_category_sound_label">Звук</string>
     <string name="device_settings_category_controls_label">Управление</string>
     <string name="device_settings_nc_one_airpod_label">ANC с одним наушником</string>
@@ -471,6 +480,7 @@ AL_Cool_T</string>
     <string name="device_settings_end_call_mute_mic_option_b_title">Одинарное нажатие для отключения микрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двойное нажатие для завершения звонка</string>
     <string name="device_settings_open_cd">Открыть настройки устройства</string>
+    <string name="overview_card_missing_paired_device">В этом профиле нет сопряженных устройств Bluetooth.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Общее</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -480,10 +490,10 @@ AL_Cool_T</string>
     <string name="device_settings_microphone_mode_left">Левый</string>
     <string name="device_settings_noise_control_current_mode_label">Текущий режим</string>
     <string name="device_settings_listening_mode_cycle_label">Цикл по долгому нажатию</string>
-    <string name="device_settings_listening_mode_cycle_description">Выберите, какие режимы доступны при удержании штокера и в быстром переключателе.</string>
+    <string name="device_settings_listening_mode_cycle_description">Выберите, какие режимы доступны при удержании штока и в быстром переключателе.</string>
     <string name="device_settings_listening_mode_cycle_dialog_title">Настроить цикл долгого нажатия</string>
-    <string name="device_settings_listening_mode_cycle_summary_helper">Используется при удержании штокера и в быстром переключателе</string>
-    <string name="device_settings_listening_mode_cycle_summary_helper_override">Используется в быстром переключателе. Установленное действие долгого нажатия штокера переопределяет циклическое переключение AirPods.</string>
+    <string name="device_settings_listening_mode_cycle_summary_helper">Используется при удержании штока и в быстром переключателе</string>
+    <string name="device_settings_listening_mode_cycle_summary_helper_override">Используется в быстром переключателе. Установленное действие долгого нажатия штока переопределяет циклическое переключение AirPods.</string>
     <string name="device_settings_listening_mode_cycle_minimum">Должно оставаться включенными не менее 2 режимов.</string>
     <string name="device_settings_listening_mode_cycle_off">Выкл.</string>
     <string name="device_settings_listening_mode_cycle_anc">Шумоподавление</string>
@@ -493,6 +503,9 @@ AL_Cool_T</string>
     <string name="device_settings_allow_off_description">Разрешить режим «Отключено» как выбираемый режим управления шумом. При отключении штокер пропускает «Отключено» при циклическом переключении.</string>
     <string name="device_settings_sleep_detection_label">Определение сна</string>
     <string name="device_settings_sleep_detection_description">Автоматическая пауза звука, когда Вы засыпаете</string>
+    <string name="reaction_sleep_channel_label">Определение сна</string>
+    <string name="reaction_sleep_notification_title">Приостановлено функцией обнаружения сна</string>
+    <string name="reaction_sleep_notification_text">%1$s обнаружил, что вы уснули, поэтому музыка была приостановлена. Вы можете отключить это в настройках устройства.</string>
     <string name="device_settings_rename_label">Переименовать</string>
     <string name="device_settings_rename_hint">Имя устройства</string>
     <string name="device_settings_rename_confirm">Переименовать</string>
@@ -502,6 +515,10 @@ AL_Cool_T</string>
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Настройки Bluetooth</string>
     <string name="device_settings_send_failed">Не удалось применить настройку: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Режим «Отключено» не включён на этом устройстве. Включите «Разрешить режим Отключено» в разделе Управление шумом.</string>
+    <string name="device_settings_category_battery_label">Батарея</string>
+    <string name="device_settings_charge_cap_label">Оптимизированный лимит заряда</string>
+    <string name="device_settings_charge_cap_description">Изучает ваш распорядок и приостанавливает зарядку около 80%%, чтобы продлить срок службы аккумулятора, дозаряжая наушники перед тем, как вы будете ими пользоваться.</string>
+    <string name="device_settings_charge_cap_rejected_message">Не удалось изменить оптимизированный лимит заряда. Это экспериментальная функция — пожалуйста, сообщите об ошибке, если это повторится.</string>
     <string name="device_settings_category_connections_label">Подключённые устройства</string>
     <string name="device_settings_connected_devices_description">Другие устройства, подключённые к этим AirPods</string>
     <string name="device_settings_connected_device_label">Устройство %d</string>
@@ -528,7 +545,7 @@ AL_Cool_T</string>
     <string name="press_action_previous_track">Предыдущий трек</string>
     <string name="press_action_volume_up">Громче</string>
     <string name="press_action_volume_down">Тише</string>
-    <string name="press_action_mute_toggle">Автозатухание музыки</string>
+    <string name="press_action_mute_toggle">Заглушить музыку</string>
     <string name="press_action_stop">Стоп</string>
     <string name="press_action_fast_forward">Перемотка вперёд</string>
     <string name="press_action_rewind">Перемотка назад</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Trasparentia de fundus</string>
     <string name="widget_config_show_device_label">Ammustra nòmene de su dispositivu</string>
     <string name="widget_config_reset_label">Reabilita a defaults</string>
+    <string name="widget_config_preview_resize_hint">Podes redimensionare su widget a pustis de lu ponner in sa pantalla printzipale.</string>
     <string name="widget_config_custom_label">Personalizau</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Preu</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Custu est unu dispositivu disconnotu, ma imperat unu formadu de messàgios sìmile. Agiunghemus su suportu, cuntata·mi :)</string>
     <string name="pods_none_label_short">Perunu dispositivu</string>
     <string name="pods_charging_label">Carrighende</string>
+    <string name="pods_charging_optimized_label">Optimizadu</string>
     <string name="pods_inear_label">In s\'origra</string>
     <string name="pods_microphone_label">Micròfonu</string>
     <string name="anc_mode_off">Ispentadu</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Eticheta de su Dispositivu Bluetooth</string>
     <string name="device_settings_info_model_label">Modello</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Númeru de sèria</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware in Atesa</string>
     <string name="device_settings_info_build_label">Versione</string>
     <string name="device_settings_info_left_serial_label">Númeru de serie de su pod mancinu</string>
     <string name="device_settings_info_right_serial_label">Númeru de serie de su pod drittu</string>
+    <string name="device_settings_info_left_bonded_label">Manca Ligadu</string>
+    <string name="device_settings_info_right_bonded_label">Dereta Ligada</string>
     <string name="device_settings_info_details_label">Detàllios de su Dispositivu</string>
     <string name="device_settings_info_details_action">Mustra sos detàllios de su dispositivu</string>
     <string name="device_settings_info_status_label">Istadu</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Custu dispositivu est in sa zona ma non est connètidu a custu telèfonu. Connete·ti pro atzeder a sos impostamentos e sos controlos.</string>
     <string name="device_settings_not_connected_connect_action">Connete</string>
     <string name="device_settings_not_connected_open_settings_action">Aberi sos impostamentos Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Dispositivu non a curtzu</string>
+    <string name="device_settings_not_nearby_description">Sas impostatziones sun disponìbiles petzi cando custu dispositivu est a curtzu e connètidu a su telefuninu tuo.</string>
     <string name="device_settings_aap_unavailable_label">Impostatziones avanzadas non disponìbiles</string>
     <string name="device_settings_aap_unavailable_description">Sos impostamentos avanzados de AirPods rechercant una funzionalidade Bluetooth chi non est disponibile in custu telefoninu. Custu podet essere resolvidu cun un\'aggiornamentu futuru de Android de su fabricante de su dispositivu tuo.</string>
+    <string name="device_settings_aap_unavailable_action">Bide su registru de compatibilidade</string>
     <string name="device_settings_category_sound_label">Sonu</string>
     <string name="device_settings_category_controls_label">Controlos</string>
     <string name="device_settings_nc_one_airpod_label">ANC cun unu solu pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Premida sola pro mutar su micròfonu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dòpia premida pro terminare sa chiamada</string>
     <string name="device_settings_open_cd">Abri sas impostatziones de su dispositivo</string>
+    <string name="overview_card_missing_paired_device">Custu profilu non tenet perunu dispositibu Bluetooth abbinadu.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Permiti Ispento comente modu de controllo de su rumore seletzionabile. Cando est disabilitadu, sos stems saltant Ispento durante su ciclo.</string>
     <string name="device_settings_sleep_detection_label">Detzetzione de su sonnu</string>
     <string name="device_settings_sleep_detection_description">Pausa automàticamente s\'àudiu cando t\'addurmistas</string>
+    <string name="reaction_sleep_channel_label">Detecada de su Sonnu</string>
+    <string name="reaction_sleep_notification_title">Pausada dae sa Detecada de su Sonnu</string>
+    <string name="reaction_sleep_notification_text">%1$s at reportadu ca t\'as dormidu, gasi sa musica tua est istada pausada. Podes disabilitare custu in sas impostatziones de su dispositivu.</string>
     <string name="device_settings_rename_label">Torrare a numenare</string>
     <string name="device_settings_rename_hint">Nùmene de su dispositivo</string>
     <string name="device_settings_rename_confirm">Torrare a numenare</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Impostatziones Bluetooth</string>
     <string name="device_settings_send_failed">Non si podet aplicare s\'impostamentu: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Su modu Ispento non est abilitadu in custu dispositivu. Abilita \"Permiti su modu Ispento\" in su Controllo de su Rumore.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Limite de Carica Optimizadu</string>
+    <string name="device_settings_charge_cap_description">Imparas sa tua rutina e pausas sa carica a curtzu de su 80%% pro allongheddare sa vida de sa bateria, torrende a carrigare sas cuffietas prima chi siat probabile de las impreare.</string>
+    <string name="device_settings_charge_cap_rejected_message">Su Limite de Carica Optimizadu no at pòdidu èssere cambiadu. Custu est una funtzionalidade experimentale — segnala si sighit a fallire.</string>
     <string name="device_settings_category_connections_label">Dispositivos cullegados</string>
     <string name="device_settings_connected_devices_description">Àteros dispositivos cullegados a custos AirPods</string>
     <string name="device_settings_connected_device_label">Dispositivo %d</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">පසුබිම් පාරදෘශ්‍යතාවය</string>
     <string name="widget_config_show_device_label">උපාංග නම පෙන්වන්න</string>
     <string name="widget_config_reset_label">පෙරනිමි බිම් කරන්න</string>
+    <string name="widget_config_preview_resize_hint">ඔබේ මුල් තිරය මත එය තැබීමෙන් පසු ඔබට විජටය ප්‍රතිප්‍රමාණ කළ හැක.</string>
     <string name="widget_config_custom_label">රුචිකර</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">අඳුරු</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">මෙය නොදන්නා උපාංගයකි, නමුත් එය සමාන පණිවිඩ ආකෘතියක් භාවිතා කරයි. අපි එයට සහාය එක් කරමු, මට සම්බන්ධ වන්න :)</string>
     <string name="pods_none_label_short">උපාංග නොමැත</string>
     <string name="pods_charging_label">ආරෝපණය වෙමින්</string>
+    <string name="pods_charging_optimized_label">ප්‍රශස්ත කළා</string>
     <string name="pods_inear_label">කනේ</string>
     <string name="pods_microphone_label">මයික්‍රෆෝනය</string>
     <string name="anc_mode_off">ක්‍රියා විරහිත</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth උපකරණ ලේබලය</string>
     <string name="device_settings_info_model_label">ආකෘතිය</string>
     <string name="device_settings_info_manufacturer_label">නිෂ්පාදකයා</string>
+    <string name="device_settings_info_hardware_label">දෘඪාංග</string>
     <string name="device_settings_info_serial_label">අනුක්‍රමික අංකය</string>
     <string name="device_settings_info_firmware_label">ෆර්ම්වෙයාර්</string>
+    <string name="device_settings_info_firmware_pending_label">බලාපොරොත්තුවෙන් සිටින ෆාම්වෙයාර්</string>
     <string name="device_settings_info_build_label">සංස්කරණය</string>
     <string name="device_settings_info_left_serial_label">වම් Pod අනුක්‍රමික අංකය</string>
     <string name="device_settings_info_right_serial_label">දකුණු Pod අනුක්‍රමික අංකය</string>
+    <string name="device_settings_info_left_bonded_label">වම් බැඳුණා</string>
+    <string name="device_settings_info_right_bonded_label">දකුණු බැඳුණා</string>
     <string name="device_settings_info_details_label">උපකරණ විස්තර</string>
     <string name="device_settings_info_details_action">උපකරණ විස්තර පේන්වන්න</string>
     <string name="device_settings_info_status_label">තත්වය</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">මෙම උපකරණය ආසන්නයේ ඇත, නමුත් මෙම දුරකථනයට සම්බන්ධ නොවී ඇත. සැකසුම් සහ පාලකයන් ලබා ගැනීමට සම්බන්ධ කරන්න.</string>
     <string name="device_settings_not_connected_connect_action">සම්බන්ධ කරන්න</string>
     <string name="device_settings_not_connected_open_settings_action">බ්ලූටූත් සැකසුම් විවෘත කරන්න</string>
+    <string name="device_settings_not_nearby_label">උපාංගය ආසන්නයේ නැත</string>
+    <string name="device_settings_not_nearby_description">මෙම උපාංගය ආසන්නයේ සහ ඔබේ දුරකථනයට සම්බන්ධ වූ විට පමණක් සැකසුම් ලබා ගත හැකිය.</string>
     <string name="device_settings_aap_unavailable_label">උසස් සැකසුම් නොතිබේ</string>
     <string name="device_settings_aap_unavailable_description">උසස් AirPods සැකසුම් සඟහා මෙම දුරකතහනේනොමැති Bluetooth ලක්ෂණයක් අවශ්‍ය වේ. ඔබේ උපකරණ නිෂ්පාදකයාගෙන් ලැබේන Android යාවත්කාලීනයකින් මෙය විසණිය හැක.</string>
+    <string name="device_settings_aap_unavailable_action">අනුකූලතා ට්‍රැකර් බලන්න</string>
     <string name="device_settings_category_sound_label">ශබ්දය</string>
     <string name="device_settings_category_controls_label">පාලන</string>
     <string name="device_settings_nc_one_airpod_label">pod එකකින් ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">මයික්‍රොෆෝනය නිශ්ශබ්ද කිරීමට එක් වරක් එබන්න</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ඇමතුම අවසන් කිරීමට දෙවරක් එබන්න</string>
     <string name="device_settings_open_cd">උපාංග සැකසීම් විවර්ත කරන්න</string>
+    <string name="overview_card_missing_paired_device">මෙම පැතිකඩට යුගල කළ Bluetooth උපකරණයක් නොමැත.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">සාමාන්‍ය</string>
     <string name="device_settings_microphone_mode_label">ශබ්දවාහිනිය</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Off ශබ්ද පාලන මාතයක් ලේස තෝරාගත හැකි ලේස ඉඩ දෙන්න. අක්‍රිය වූ විට, දණ්ඩු චක්‍රගත කිරීමේදී Off මාතය මග් හරී.</string>
     <string name="device_settings_sleep_detection_label">නිදි හොදුනාගෙඳීම</string>
     <string name="device_settings_sleep_detection_description">ඔබ නිදා වැටෙන විට ස්වයංක්‍රීයව ශ්‍රව්‍ය විරාම කරන්න</string>
+    <string name="reaction_sleep_channel_label">නිදිමත හඳුනාගැනීම</string>
+    <string name="reaction_sleep_notification_title">නිදිමත හඳුනාගැනීම මගින් විරාම කළා</string>
+    <string name="reaction_sleep_notification_text">%1$s ඔබ නිදා ගැනීම වාර්තා කළා, එබැවින් ඔබේ සංගීතය විරාම කළා. ඔබට උපාංග සැකසුම් තුළ මෙය අක්‍රිය කළ හැකිය.</string>
     <string name="device_settings_rename_label">නැවත් නම් කරන්න</string>
     <string name="device_settings_rename_hint">උපාංගයේ නම</string>
     <string name="device_settings_rename_confirm">නැවත් නම් කරන්න</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">බ්ලූටූත් සැකසුම්</string>
     <string name="device_settings_send_failed">සැකසුම යෙදිය නොහැකි විය: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Off මාතය මෙම උපකරණයේ සක්‍රිය නැත. ශබ්ද පාලනය යටතේ \"Off මාතය ඉඩ දෙන්න\" සක්‍රිය කරන්න.</string>
+    <string name="device_settings_category_battery_label">බැටරිය</string>
+    <string name="device_settings_charge_cap_label">ප්‍රශස්ත ආරොපණ සීමාව</string>
+    <string name="device_settings_charge_cap_description">ඔබේ දිනඩරිය ඉගෙන ගෙන බැටරි ජීවිතය දීර්ඝ කිරීමට 80%% ආසන්නයේ ආරොපණය ළිරාම කරයි, ඔබ බහුතා කිරීමට ඉරින් පැන pod ආරොපණය කරයි.</string>
+    <string name="device_settings_charge_cap_rejected_message">ප්‍රශස්ත ආරොපණ සීමාව වේනස් කළ නොහැකි ළිය. මෙය පරීක්ශණාත්මක ළිශේෂාංගයකිස් — දිගටම අසාර්තක වුවහොත් කරුණාකර වාර්තා කරන්න.</string>
     <string name="device_settings_category_connections_label">සම්බන්ධිත උපාංග</string>
     <string name="device_settings_connected_devices_description">දැනට මෙම AirPods හා සම්බන්ධිත අනේකුත් උපාංග</string>
     <string name="device_settings_connected_device_label">උපාංගය %d</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Priehľadnosť pozadia</string>
     <string name="widget_config_show_device_label">Zobraziť meno zariadenia</string>
     <string name="widget_config_reset_label">Obnoviť na predvolené</string>
+    <string name="widget_config_preview_resize_hint">Veľkosť widgetu môžete zmeniť po jeho umiestnení na domovskú obrazovku.</string>
     <string name="widget_config_custom_label">Vlastný</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tmavý</string>
@@ -254,6 +255,7 @@
     <string name="pods_unknown_contact_dev">Toto je neznáme zariadenie, ale používa podobný formát správ. Pridajme preň podporu, kontaktujte ma :)</string>
     <string name="pods_none_label_short">Žiadne zariadenie</string>
     <string name="pods_charging_label">Nabíjanie</string>
+    <string name="pods_charging_optimized_label">Optimalizovaný</string>
     <string name="pods_inear_label">V uchu</string>
     <string name="pods_microphone_label">Mikrofón</string>
     <string name="anc_mode_off">Vypnuté</string>
@@ -400,7 +402,7 @@
     <string name="support_contact_debuglog_label">Ladiaci log</string>
     <string name="support_contact_debuglog_picker_hint">Priložte existujúci ladíaci záznam alebo nahrajte nový.</string>
     <string name="support_contact_debuglog_picker_empty">Žiadne ladíace záznamy sa nenašli. Najskôr nahraje jeden.</string>
-    <string name="support_contact_debuglog_zip_error">Komprimovanie ladiaceho záznamu zlyhalo</string>
+    <string name="support_contact_debuglog_zip_error">Komprimovanie ladÚciaho záznamu zlyhalo</string>
     <string name="support_contact_send_action">Otvoriť e-mailovú aplikáciu</string>
     <string name="support_contact_no_email_app">Na tomto zariadení sa nenašla žiadna e-mailová aplikácia.</string>
     <string name="support_contact_debuglog_delete_title">Odstrániť ladíaci záznam?</string>
@@ -417,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">Označenie Bluetooth zariadenia</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Výrobca</string>
+    <string name="device_settings_info_hardware_label">Hardvér</string>
     <string name="device_settings_info_serial_label">Sériové číslo</string>
     <string name="device_settings_info_firmware_label">Firmvér</string>
+    <string name="device_settings_info_firmware_pending_label">Čakajúci firmvér</string>
     <string name="device_settings_info_build_label">Zostava</string>
     <string name="device_settings_info_left_serial_label">Sériové číslo ľavého slúchadla</string>
     <string name="device_settings_info_right_serial_label">Sériové číslo pravého slúchadla</string>
+    <string name="device_settings_info_left_bonded_label">Ľavé spárované</string>
+    <string name="device_settings_info_right_bonded_label">Pravé spárované</string>
     <string name="device_settings_info_details_label">Detaily zariadenia</string>
     <string name="device_settings_info_details_action">Zobraziť detaily zariadenia</string>
     <string name="device_settings_info_status_label">Stav</string>
@@ -431,8 +437,11 @@
     <string name="device_settings_not_connected_description">Toto zariadenie je nablízku, ale nie je pripojené k tomuto telefónu. Pripojte sa pre prístup k nastaveniam a ovládacím prvkom.</string>
     <string name="device_settings_not_connected_connect_action">Pripojiť</string>
     <string name="device_settings_not_connected_open_settings_action">Otvoriť nastavenia Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Zariadenie nie je nablízku</string>
+    <string name="device_settings_not_nearby_description">Nastavenia sú dostupné iba vtedy, keď je toto zariadenie nablízku a pripojené k vášmu telefónu.</string>
     <string name="device_settings_aap_unavailable_label">Rozšírené nastavenia nie sú dostupné</string>
     <string name="device_settings_aap_unavailable_description">Rozšírené nastavenia AirPods vyžadujú funkciu Bluetooth, ktorá nie je dostupná v tomto telefóne. Tento problém môže vyriešiť budúca aktualizácia Androidu od výrobcu vašho zariadenia.</string>
+    <string name="device_settings_aap_unavailable_action">Zobraziť sledovač kompatibility</string>
     <string name="device_settings_category_sound_label">Zvuk</string>
     <string name="device_settings_category_controls_label">Ovládanie</string>
     <string name="device_settings_nc_one_airpod_label">ANC s jedným slúchadlom</string>
@@ -470,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Jedno stlačenie na stlmenie mikrofónu</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojité stlačenie na ukončenie hovoru</string>
     <string name="device_settings_open_cd">Otvoriť nastavenia zariadenia</string>
+    <string name="overview_card_missing_paired_device">Tento profil nemá spárované Bluetooth zariadenie.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Všeobecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofón</string>
@@ -492,6 +502,9 @@
     <string name="device_settings_allow_off_description">Povoliť Vypnuté ako vyberatelý režim ovládania hluku. Keď je vypnuté, stonky preskakujú režim Vypnuté pri cyklovaní.</string>
     <string name="device_settings_sleep_detection_label">Detekcia spánku</string>
     <string name="device_settings_sleep_detection_description">Automaticky pozastaviť zvuk, keď zaspíte</string>
+    <string name="reaction_sleep_channel_label">Detekcia spánku</string>
+    <string name="reaction_sleep_notification_title">Pozastavené detekciou spánku</string>
+    <string name="reaction_sleep_notification_text">%1$s zistilo, že ste zaspali, preto bola vaša hudba pozastavená. Toto môžete vypnúť v nastaveniach zariadenia.</string>
     <string name="device_settings_rename_label">Premenovať</string>
     <string name="device_settings_rename_hint">Názov zariadenia</string>
     <string name="device_settings_rename_confirm">Premenovať</string>
@@ -501,6 +514,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Nastavenia Bluetooth</string>
     <string name="device_settings_send_failed">Nepodarilo sa použiť nastavenie: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Režim Vypnuté nie je na tomto zariadení povolený. Povolte „Povoliť režim Vypnuté“ v časti Ovládanie hluku.</string>
+    <string name="device_settings_category_battery_label">Batéria</string>
+    <string name="device_settings_charge_cap_label">Optimalizovaný limit nabíjania</string>
+    <string name="device_settings_charge_cap_description">Naučí sa vašu rutinu a okolo 80 %% pozastaví nabíjanie, aby predĺžilo životnosť batérie, a doplňí slúchadlá pred ich pravdepodobným použitím.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimalizovaný limit nabíjania sa nedal zmeniť. Toto je experimentálna funkcia — prosím, nahlaste to, ak to stále zlyhanéva.</string>
     <string name="device_settings_category_connections_label">Pripojené zariadenia</string>
     <string name="device_settings_connected_devices_description">Iné zariadenia aktuálne pripojené k týmto AirPods</string>
     <string name="device_settings_connected_device_label">Zariadenie %d</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Prosojnost ozadja</string>
     <string name="widget_config_show_device_label">Prikaži ime naprave</string>
     <string name="widget_config_reset_label">Ponastavi na privzete vrednosti</string>
+    <string name="widget_config_preview_resize_hint">Pripomoček lahko spremenite po namestitvi na začetni zaslon.</string>
     <string name="widget_config_custom_label">Prilagojeno</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Temno</string>
@@ -254,6 +255,7 @@
     <string name="pods_unknown_contact_dev">To je neznana naprava, vendar uporablja podoben format sporočil. Dodajmo podporo zanjo, kontaktirajte me :)</string>
     <string name="pods_none_label_short">Ni naprave</string>
     <string name="pods_charging_label">Polnjenje</string>
+    <string name="pods_charging_optimized_label">Optimizirano</string>
     <string name="pods_inear_label">V ušesu</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Izklopljeno</string>
@@ -417,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">Oznaka naprave Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Proizvajalec</string>
+    <string name="device_settings_info_hardware_label">Strojna oprema</string>
     <string name="device_settings_info_serial_label">Serijska številka</string>
     <string name="device_settings_info_firmware_label">Vdelana programska oprema</string>
+    <string name="device_settings_info_firmware_pending_label">Čakajoča strojna programska oprema</string>
     <string name="device_settings_info_build_label">Različica</string>
     <string name="device_settings_info_left_serial_label">Serijska številka levega slušalnika</string>
     <string name="device_settings_info_right_serial_label">Serijska številka desnega slušalnika</string>
+    <string name="device_settings_info_left_bonded_label">Levo sparjeno</string>
+    <string name="device_settings_info_right_bonded_label">Desno sparjeno</string>
     <string name="device_settings_info_details_label">Podrobnosti naprave</string>
     <string name="device_settings_info_details_action">Prikaži podrobnosti naprave</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -431,8 +437,11 @@
     <string name="device_settings_not_connected_description">Ta naprava je v bližini, a ni povezana s tem telefonom. Povežite se za dostop do nastavitev in upravljanja.</string>
     <string name="device_settings_not_connected_connect_action">Poveži</string>
     <string name="device_settings_not_connected_open_settings_action">Odpri nastavitve Bluetootha</string>
+    <string name="device_settings_not_nearby_label">Naprava ni v bližini</string>
+    <string name="device_settings_not_nearby_description">Nastavitve so na voljo samo, ko je ta naprava v bližini in povezana z vašim telefonom.</string>
     <string name="device_settings_aap_unavailable_label">Napredne nastavitve niso na voljo</string>
     <string name="device_settings_aap_unavailable_description">Napredne nastavitve AirPods zahtevajo funkcijo Bluetooth, ki ni na voljo na tem telefonu. To se lahko reši s prihodnjimi posodobitvami Androida od vašega proizvajalca naprave.</string>
+    <string name="device_settings_aap_unavailable_action">Oglejte si sledilnik združljivosti</string>
     <string name="device_settings_category_sound_label">Zvok</string>
     <string name="device_settings_category_controls_label">Upravljanje</string>
     <string name="device_settings_nc_one_airpod_label">ANC z enim slušalnikom</string>
@@ -470,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">En pritisk za izklop mikrofona</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojni pritisk za končanje klica</string>
     <string name="device_settings_open_cd">Odpri nastavitve naprave</string>
+    <string name="overview_card_missing_paired_device">Ta profil nima sparene naprave Bluetooth.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Splošno</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -492,6 +502,9 @@
     <string name="device_settings_allow_off_description">Dovoli Izklop kot izbiročeni način nadzora hrupa. Ko je onemogočeno, stebla preskakujejo Izklop med menjavo.</string>
     <string name="device_settings_sleep_detection_label">Zaznavanje spanja</string>
     <string name="device_settings_sleep_detection_description">Samodejno ustavi zvok, ko zaspite</string>
+    <string name="reaction_sleep_channel_label">Zaznavanje spanja</string>
+    <string name="reaction_sleep_notification_title">Zaustavljeno z zaznavanjem spanja</string>
+    <string name="reaction_sleep_notification_text">%1$s je zaznal, da ste zaspali, zato je bila glasba zaustavljena. To lahko onemogočite v nastavitvah naprave.</string>
     <string name="device_settings_rename_label">Preimenuj</string>
     <string name="device_settings_rename_hint">Ime naprave</string>
     <string name="device_settings_rename_confirm">Preimenuj</string>
@@ -501,6 +514,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Nastavitve Bluetooth</string>
     <string name="device_settings_send_failed">Nastavitve ni bilo mogoče uporabiti: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Način Izklop ni omogočen na tej napravi. Omogočite „Dovoli način Izklop“ v razdelku Nadzor hrupa.</string>
+    <string name="device_settings_category_battery_label">Baterija</string>
+    <string name="device_settings_charge_cap_label">Optimizirana omejitev polnjenja</string>
+    <string name="device_settings_charge_cap_description">Nauči se vaše rutine in med polnjenjem zaustavi pri okoli 80%%, da podaljša življenjsko dobo baterije ter napolni slušalke, preden jih verjetno uporabite.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimizirane omejitve polnjenja ni bilo mogoče spremeniti. To je eksperimentalna funkcija — prosimo, prijavite težavo, če se napaka ponavlja.</string>
     <string name="device_settings_category_connections_label">Povezane naprave</string>
     <string name="device_settings_connected_devices_description">Druge naprave, ki so trenutno povezane s temi AirPodi</string>
     <string name="device_settings_connected_device_label">Naprava %d</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Transparenca e sfondit</string>
     <string name="widget_config_show_device_label">Shfaq emrin e pajisjes</string>
     <string name="widget_config_reset_label">Rivendos në paracaktimet</string>
+    <string name="widget_config_preview_resize_hint">Mund ta ndryshoni madhësinë e miniaplikacionit pasi ta vendosni në ekranin tuaj kryesor.</string>
     <string name="widget_config_custom_label">Vetjak</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">E errët</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Kjo është një pajisje e panjohur, por përdor format të ngjashëm mesazhi. Le të shtojmë mbështetje për të, më kontaktoni :)</string>
     <string name="pods_none_label_short">Asnjë pajisje</string>
     <string name="pods_charging_label">Po karikohet</string>
+    <string name="pods_charging_optimized_label">E optimizuar</string>
     <string name="pods_inear_label">Në vesh</string>
     <string name="pods_microphone_label">Mikrofoni</string>
     <string name="anc_mode_off">Joaktive</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Etiketa e pajisjes Bluetooth</string>
     <string name="device_settings_info_model_label">Modeli</string>
     <string name="device_settings_info_manufacturer_label">Prodhuesi</string>
+    <string name="device_settings_info_hardware_label">Hardware</string>
     <string name="device_settings_info_serial_label">Numri serial</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware në pritje</string>
     <string name="device_settings_info_build_label">Versioni</string>
     <string name="device_settings_info_left_serial_label">Numri serial i kapsulit të majtë</string>
     <string name="device_settings_info_right_serial_label">Numri serial i kapsulit të djathtë</string>
+    <string name="device_settings_info_left_bonded_label">E lidhur majtas</string>
+    <string name="device_settings_info_right_bonded_label">E lidhur djathtas</string>
     <string name="device_settings_info_details_label">Detajet e pajisjes</string>
     <string name="device_settings_info_details_action">Shfaq detajet e pajisjes</string>
     <string name="device_settings_info_status_label">Statusi</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Ky pajisje është afër, por nuk është i lidhur me këtë telefon. Lidhuni për të hyrë në cilësimet dhe kontrollet.</string>
     <string name="device_settings_not_connected_connect_action">Lidhu</string>
     <string name="device_settings_not_connected_open_settings_action">Hap Cilësimet Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Pajisja nuk është afër</string>
+    <string name="device_settings_not_nearby_description">Cilësimet janë të disponueshme vetëm kur kjo pajisje është afër dhe e lidhur me telefonin tuaj.</string>
     <string name="device_settings_aap_unavailable_label">Cilësimet e avancuara të padisponueshme</string>
     <string name="device_settings_aap_unavailable_description">Cilësimet e avancuara të AirPods kërkojnë një funksion Bluetooth që nuk disponohet në këtë telefon. Kjo mund të zgjidhet nga një përditësim i ardhshëm i Android nga prodhuesi i pajisjes tuaj.</string>
+    <string name="device_settings_aap_unavailable_action">Shiko gjurmuesin e përputhshmërisë</string>
     <string name="device_settings_category_sound_label">Zëri</string>
     <string name="device_settings_category_controls_label">Kontrollet</string>
     <string name="device_settings_nc_one_airpod_label">ANC me një kapsulë</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Shtypje e vetme për të hështur mikrofonin</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Shtypje e dyfishtë për të mbyllur thirrjen</string>
     <string name="device_settings_open_cd">Hap cilësimet e pajisjes</string>
+    <string name="overview_card_missing_paired_device">Ky profil nuk ka asnjë pajisje Bluetooth të çiftuar.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Gjenerik</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Lejo modalitetin Joaktiv si modalitet i zgjedhshëm i kontrollit të zhurmës. Kur çaktivizohet, kërcellet kalojnë Joaktiv gjatë ciklimit.</string>
     <string name="device_settings_sleep_detection_label">Zbulimi i gjumit</string>
     <string name="device_settings_sleep_detection_description">Ndal automatikisht audion kur bini në gjumë</string>
+    <string name="reaction_sleep_channel_label">Zbulimi i gjumit</string>
+    <string name="reaction_sleep_notification_title">Pauzuar nga Zbulimi i gjumit</string>
+    <string name="reaction_sleep_notification_text">%1$s raportoi se keni rënë në gjumë, kështu që muzika juaj u pauzua. Mund ta çaktivizoni këtë në cilësimet e pajisjes.</string>
     <string name="device_settings_rename_label">Riemrëro</string>
     <string name="device_settings_rename_hint">Emri i pajisjes</string>
     <string name="device_settings_rename_confirm">Riemrëro</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Cilësimet e Bluetooth</string>
     <string name="device_settings_send_failed">Nuk mund të aplikohet cilësimi: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Modaliteti Joaktiv nuk është i aktivizuar në këtë pajisje. Aktivizoni \"Lejo modalitetin Joaktiv\" nën Kontrollin e Zhurmës.</string>
+    <string name="device_settings_category_battery_label">Bateria</string>
+    <string name="device_settings_charge_cap_label">Kufiri i ngarkimit të optimizuar</string>
+    <string name="device_settings_charge_cap_description">Mëson rutinën tuaj dhe pauzues ngarkimin rreth 80%% për të zgjatur jetën e baterisë, duke plotësuar pods-at para se t\'i përdorni.</string>
+    <string name="device_settings_charge_cap_rejected_message">Kufiri i ngarkimit të optimizuar nuk mund të ndryshohej. Kjo është një funksion eksperimental — ju lutemi raportoni nëse vazhdon të dështojë.</string>
     <string name="device_settings_category_connections_label">Pajisjet e lidhura</string>
     <string name="device_settings_connected_devices_description">Pajisjet e tjera aktualisht të lidhura me këta AirPods</string>
     <string name="device_settings_connected_device_label">Pajisja %d</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Прозирност позадине</string>
     <string name="widget_config_show_device_label">Прикажи назив уређаја</string>
     <string name="widget_config_reset_label">Врати на подразумеване</string>
+    <string name="widget_config_preview_resize_hint">Можете да промените величину виџета након постављања на почетни екран.</string>
     <string name="widget_config_custom_label">Прилагођено</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Тамно</string>
@@ -252,6 +253,7 @@
     <string name="pods_unknown_contact_dev">Ово је непознат уређај, али користи сличан формат порука. Хајде да додамо подршку за њега, контактирајте ме :)</string>
     <string name="pods_none_label_short">Нема уређаја</string>
     <string name="pods_charging_label">Пуњење</string>
+    <string name="pods_charging_optimized_label">Оптимизовано</string>
     <string name="pods_inear_label">У уху</string>
     <string name="pods_microphone_label">Микрофон</string>
     <string name="anc_mode_off">Искључено</string>
@@ -412,11 +414,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth ознака уређаја</string>
     <string name="device_settings_info_model_label">Модел</string>
     <string name="device_settings_info_manufacturer_label">Произвођач</string>
+    <string name="device_settings_info_hardware_label">Хардвер</string>
     <string name="device_settings_info_serial_label">Серијски број</string>
     <string name="device_settings_info_firmware_label">Фирмвер</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware на чекању</string>
     <string name="device_settings_info_build_label">Верзија</string>
     <string name="device_settings_info_left_serial_label">Серијски број левог слушалица</string>
     <string name="device_settings_info_right_serial_label">Серијски број десног слушалица</string>
+    <string name="device_settings_info_left_bonded_label">Лево повезано</string>
+    <string name="device_settings_info_right_bonded_label">Десно повезано</string>
     <string name="device_settings_info_details_label">Детаљи уређаја</string>
     <string name="device_settings_info_details_action">Прикажи детаље уређаја</string>
     <string name="device_settings_info_status_label">Статус</string>
@@ -426,8 +432,11 @@
     <string name="device_settings_not_connected_description">Овај уређај је у близини, али није повезан са овим телефоном. Повежите се да бисте приступили подешавањима и контролама.</string>
     <string name="device_settings_not_connected_connect_action">Повежи се</string>
     <string name="device_settings_not_connected_open_settings_action">Отвори Bluetooth подешавања</string>
+    <string name="device_settings_not_nearby_label">Уређај није у близини</string>
+    <string name="device_settings_not_nearby_description">Подешавања су доступна само када је овај уређај у близини и повезан са вашим телефоном.</string>
     <string name="device_settings_aap_unavailable_label">Напредна подешавања нису доступна</string>
     <string name="device_settings_aap_unavailable_description">Напредна подешавања AirPods-а захтевају Bluetooth функцију која није доступна на овом телефону. Ово може бити решено будућим Android ажурирањем произвођача вашег уређаја.</string>
+    <string name="device_settings_aap_unavailable_action">Погледај листу компатибилности</string>
     <string name="device_settings_category_sound_label">Звук</string>
     <string name="device_settings_category_controls_label">Контроле</string>
     <string name="device_settings_nc_one_airpod_label">ANC са једним слушалицом</string>
@@ -465,6 +474,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Једноструко притисак за искључивање микрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двоструко притисак за завршавање позива</string>
     <string name="device_settings_open_cd">Отворите подешавања уређаја</string>
+    <string name="overview_card_missing_paired_device">Овај профил нема упарен Bluetooth уређај.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Oпште</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -487,6 +497,9 @@
     <string name="device_settings_allow_off_description">Дозволи режим Искључено као режим контроле буке. Када је онемогућено, стабла прескачу Искључено током циклусирања.</string>
     <string name="device_settings_sleep_detection_label">Откривање спавања</string>
     <string name="device_settings_sleep_detection_description">Аутоматски паузирај звук кад заспите</string>
+    <string name="reaction_sleep_channel_label">Детекција спавања</string>
+    <string name="reaction_sleep_notification_title">Паузирано детекцијом спавања</string>
+    <string name="reaction_sleep_notification_text">%1$s је пријавио да сте заспали, па је ваша музика паузирана. Ово можете онемогућити у подешавањима уређаја.</string>
     <string name="device_settings_rename_label">Преименуј</string>
     <string name="device_settings_rename_hint">Назив уређаја</string>
     <string name="device_settings_rename_confirm">Преименуј</string>
@@ -496,6 +509,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth подешавања</string>
     <string name="device_settings_send_failed">Подешавање није могло да буде примењено: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Режим Искључено није омогућен на овом уређају. Омогућите „Дозволи режим Искључено“ под Контролом буке.</string>
+    <string name="device_settings_category_battery_label">Батерија</string>
+    <string name="device_settings_charge_cap_label">Оптимизовано ограничење пуњења</string>
+    <string name="device_settings_charge_cap_description">Научите вашу рутину и паузирајте пуњење oko 80%% ради продужења трајања батерије, допуњујући слушалице пре него што их будете највероватније користили.</string>
+    <string name="device_settings_charge_cap_rejected_message">Оптимизовано ограничење пуњења није могло да се промени. Ово је експериментална функција — пријавите ако наставља да не ради.</string>
     <string name="device_settings_category_connections_label">Повезани уређаји</string>
     <string name="device_settings_connected_devices_description">Други уређаји тренутно повезани на ове AirPods</string>
     <string name="device_settings_connected_device_label">Уређај %d</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Bakgrundstransparens</string>
     <string name="widget_config_show_device_label">Visa enhetens namn</string>
     <string name="widget_config_reset_label">Återställ till standardvärden</string>
+    <string name="widget_config_preview_resize_hint">Du kan ändra storlek på widgeten efter att du placerat den på din hemskärm.</string>
     <string name="widget_config_custom_label">Anpassad</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Mörk</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Detta är en okänd enhet, men den använder ett liknande meddelandeformat. Låt oss lägga till stöd för den, kontakta mig :)</string>
     <string name="pods_none_label_short">Ingen enhet</string>
     <string name="pods_charging_label">Laddar</string>
+    <string name="pods_charging_optimized_label">Optimerad</string>
     <string name="pods_inear_label">I örat</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Av</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth-enhetsetikett</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Tillverkare</string>
+    <string name="device_settings_info_hardware_label">Hårdvara</string>
     <string name="device_settings_info_serial_label">Serienummer</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Väntande firmware</string>
     <string name="device_settings_info_build_label">Bygge</string>
     <string name="device_settings_info_left_serial_label">Vänster pod-serienummer</string>
     <string name="device_settings_info_right_serial_label">Höger pod-serienummer</string>
+    <string name="device_settings_info_left_bonded_label">Vänster parkopplad</string>
+    <string name="device_settings_info_right_bonded_label">Höger parkopplad</string>
     <string name="device_settings_info_details_label">Enhetsinformation</string>
     <string name="device_settings_info_details_action">Visa enhetsinformation</string>
     <string name="device_settings_info_status_label">Status</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Den här enheten är i närheten men inte ansluten till den här telefonen. Anslut för att komma åt inställningar och kontroller.</string>
     <string name="device_settings_not_connected_connect_action">Anslut</string>
     <string name="device_settings_not_connected_open_settings_action">Öppna Bluetooth-inställningar</string>
+    <string name="device_settings_not_nearby_label">Enheten är inte i närheten</string>
+    <string name="device_settings_not_nearby_description">Inställningar är endast tillgängliga när den här enheten är i närheten och ansluten till din telefon.</string>
     <string name="device_settings_aap_unavailable_label">Avancerade inställningar otillgängliga</string>
     <string name="device_settings_aap_unavailable_description">Avancerade AirPods-inställningar kräver en Bluetooth-funktion som inte är tillgänglig på den här telefonen. Detta kan lösas av en framtida Android-uppdatering från din enhetstillverkare.</string>
+    <string name="device_settings_aap_unavailable_action">Visa kompatibilitetsspårare</string>
     <string name="device_settings_category_sound_label">Ljud</string>
     <string name="device_settings_category_controls_label">Kontroller</string>
     <string name="device_settings_nc_one_airpod_label">ANC med en pod</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Enkeltryck för att stänga av mikrofonen</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbeltryck för att avsluta samtal</string>
     <string name="device_settings_open_cd">Öppna enhetsinställningar</string>
+    <string name="overview_card_missing_paired_device">Den här profilen har ingen kopplad Bluetooth-enhet.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Allmänt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Tillåt Av som ett valbart brusregleringläge. När inaktiverat hoppar stammarna över Av under cykling.</string>
     <string name="device_settings_sleep_detection_label">Själbdetektering</string>
     <string name="device_settings_sleep_detection_description">Pausa automatiskt ljud när du somnar</string>
+    <string name="reaction_sleep_channel_label">Sömnidentifiering</string>
+    <string name="reaction_sleep_notification_title">Pausad av sömnidentifiering</string>
+    <string name="reaction_sleep_notification_text">%1$s rapporterade att du somnade, så din musik pausades. Du kan inaktivera detta i enhetsinställningarna.</string>
     <string name="device_settings_rename_label">Byt namn</string>
     <string name="device_settings_rename_hint">Enhetsnamn</string>
     <string name="device_settings_rename_confirm">Byt namn</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth-inställningar</string>
     <string name="device_settings_send_failed">Det gick inte att tillämpa inställningen: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Läget Av är inte aktiverat på den här enheten. Aktivera „Tillåt läget Av“ under Brusreglering.</string>
+    <string name="device_settings_category_battery_label">Batteri</string>
+    <string name="device_settings_charge_cap_label">Optimerad laddningsgräns</string>
+    <string name="device_settings_charge_cap_description">Lär sig din rutin och pausar laddningen runt 80 %% för att förlänga batteritiden och laddar upp podsarna innan du troligtvis ska använda dem.</string>
+    <string name="device_settings_charge_cap_rejected_message">Det gick inte att ändra optimerad laddningsgräns. Det här är en experimentell funktion — rapportera om det fortsätter att misslyckas.</string>
     <string name="device_settings_category_connections_label">Anslutna enheter</string>
     <string name="device_settings_connected_devices_description">Andra enheter som för närvarande är anslutna till dessa AirPods</string>
     <string name="device_settings_connected_device_label">Enhet %d</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Uwazi wa msingi</string>
     <string name="widget_config_show_device_label">Onyesha jina la kifaa</string>
     <string name="widget_config_reset_label">Rejesha kwenye chaguo-mtindo</string>
+    <string name="widget_config_preview_resize_hint">Unaweza kubadilisha ukubwa wa widget baada ya kuiweka kwenye skrini yako ya nyumbani.</string>
     <string name="widget_config_custom_label">Kabidhia</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Giza</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Hiki ni kifaa kisichojulikana, lakini kinatumia muundo sawa wa ujumbe. Tuongeze usaidizi wake, wasiliana nami :)</string>
     <string name="pods_none_label_short">Hakuna kifaa</string>
     <string name="pods_charging_label">Inachaji</string>
+    <string name="pods_charging_optimized_label">Ilioboreshwa</string>
     <string name="pods_inear_label">Ndani ya sikio</string>
     <string name="pods_microphone_label">Kipaza sauti</string>
     <string name="anc_mode_off">Zima</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Lebo ya Kifaa cha Bluetooth</string>
     <string name="device_settings_info_model_label">Mfano</string>
     <string name="device_settings_info_manufacturer_label">Mtengenezaji</string>
+    <string name="device_settings_info_hardware_label">Maunzi</string>
     <string name="device_settings_info_serial_label">Nambari ya Mfululizo</string>
     <string name="device_settings_info_firmware_label">Programu Dhibiti</string>
+    <string name="device_settings_info_firmware_pending_label">Programu Dhibiti Inayosubiri</string>
     <string name="device_settings_info_build_label">Toleo</string>
     <string name="device_settings_info_left_serial_label">Nambari ya Mfululizo ya Pod ya Kushoto</string>
     <string name="device_settings_info_right_serial_label">Nambari ya Mfululizo ya Pod ya Kulia</string>
+    <string name="device_settings_info_left_bonded_label">Imefungwa Kushoto</string>
+    <string name="device_settings_info_right_bonded_label">Imefungwa Kulia</string>
     <string name="device_settings_info_details_label">Maelezo ya Kifaa</string>
     <string name="device_settings_info_details_action">Onyesha maelezo ya kifaa</string>
     <string name="device_settings_info_status_label">Hali</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Kifaa hiki kipo karibu lakini hakijaunganishwa na simu hii. Unganisha ili kufikia mipangilio na vidhibiti.</string>
     <string name="device_settings_not_connected_connect_action">Unganisha</string>
     <string name="device_settings_not_connected_open_settings_action">Fungua Mipangilio ya Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Kifaa kiko mbali</string>
+    <string name="device_settings_not_nearby_description">Mipangilio inapatikana tu wakati kifaa hiki kiko karibu na kimeunganishwa na simu yako.</string>
     <string name="device_settings_aap_unavailable_label">Mipangilio ya hali ya juu haipatikani</string>
     <string name="device_settings_aap_unavailable_description">Mipangilio ya AirPods ya hali ya juu inahitaji kipengele cha Bluetooth ambacho hakipatikani kwenye simu hii. Hii inaweza kutatuliwa na sasisho la baadaye la Android kutoka kwa mtengenezaji wa kifaa chako.</string>
+    <string name="device_settings_aap_unavailable_action">Angalia kifuatiliaji cha uoanifu</string>
     <string name="device_settings_category_sound_label">Sauti</string>
     <string name="device_settings_category_controls_label">Vidhibiti</string>
     <string name="device_settings_nc_one_airpod_label">ANC na pod moja</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Bonyeza mara moja kuzima kipaza sauti</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Bonyeza mara mbili kumaliza simu</string>
     <string name="device_settings_open_cd">Fungua mipangilio ya kifaa</string>
+    <string name="overview_card_missing_paired_device">Wasifu huu hauna kifaa cha Bluetooth kilichounganishwa.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Jumla</string>
     <string name="device_settings_microphone_mode_label">Maikrofoni</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Ruhusu Kuzima kama hali ya udhibiti wa kelele inayoweza kuchaguliwa. Ikiwa imezimwa, vishikio hupita Kuzima wakati wa mzunguko.</string>
     <string name="device_settings_sleep_detection_label">Ugunduzi wa Usingizi</string>
     <string name="device_settings_sleep_detection_description">Simamisha sauti otomatiki unapolala</string>
+    <string name="reaction_sleep_channel_label">Ugunduzi wa Usingizi</string>
+    <string name="reaction_sleep_notification_title">Imesimamishwa na Ugunduzi wa Usingizi</string>
+    <string name="reaction_sleep_notification_text">%1$s iliripoti kuwa umelala, hivyo muziki wako ulisimamishwa. Unaweza kuzima hili katika mipangilio ya kifaa.</string>
     <string name="device_settings_rename_label">Badilisha Jina</string>
     <string name="device_settings_rename_hint">Jina la kifaa</string>
     <string name="device_settings_rename_confirm">Badilisha Jina</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Mipangilio ya Bluetooth</string>
     <string name="device_settings_send_failed">Haikuweza kutumia mipangilio: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Hali ya Kuzima haijawashwa kwenye kifaa hiki. Washa \"Ruhusu hali ya Kuzima\" chini ya Udhibiti wa Kelele.</string>
+    <string name="device_settings_category_battery_label">Betri</string>
+    <string name="device_settings_charge_cap_label">Kikomo cha Kuchaji kilichoboreshwa</string>
+    <string name="device_settings_charge_cap_description">Jifunza ratiba yako na usimamishe kuchaji karibu na 80%% ili kupanua maisha ya betri, ukijaza vipande kabla ya uwezekano wa kuvitumia.</string>
+    <string name="device_settings_charge_cap_rejected_message">Kikomo cha Kuchaji kilichoboreshwa hakikuweza kubadilishwa. Hii ni kipengele cha majaribio — tafadhali ripoti ikiwa itaendelea kushindwa.</string>
     <string name="device_settings_category_connections_label">Vifaa Vilivyounganishwa</string>
     <string name="device_settings_connected_devices_description">Vifaa vingine vilivyounganishwa sasa hivi na AirPods hizi</string>
     <string name="device_settings_connected_device_label">Kifaa %d</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">பின்னணி வெளிப்படையாக்கம்</string>
     <string name="widget_config_show_device_label">சாதன பெயரைக் காட்டு</string>
     <string name="widget_config_reset_label">இயல்பிற்கு மீட்டமை</string>
+    <string name="widget_config_preview_resize_hint">உங்கள் முகப்புத் திரையில் வைத்த பிறகு விட்ஜெட்டை மறுஅளவிடலாம்.</string>
     <string name="widget_config_custom_label">தனிப்பயன்</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">இருண்ட</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">இது அறியப்படாத சாதனம், ஆனால் இது ஒத்த செய்தி வடிவமைப்பைப் பயன்படுத்துகிறது. இதற்கான ஆதரவைச் சேர்ப்போம், என்னைத் தொடர்பு கொள்ளுங்கள் :)</string>
     <string name="pods_none_label_short">சாதனம் இல்லை</string>
     <string name="pods_charging_label">சார்ஜ் ஆகிறது</string>
+    <string name="pods_charging_optimized_label">உகந்தமயமாக்கப்பட்டது</string>
     <string name="pods_inear_label">காதில்</string>
     <string name="pods_microphone_label">ஒலிபெருக்கி</string>
     <string name="anc_mode_off">ஆஃப்</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth சாதன பெயர்</string>
     <string name="device_settings_info_model_label">மாடல்</string>
     <string name="device_settings_info_manufacturer_label">உற்பத்தியாளர்</string>
+    <string name="device_settings_info_hardware_label">வன்பொருள்</string>
     <string name="device_settings_info_serial_label">தொடர் எண்</string>
     <string name="device_settings_info_firmware_label">நிலைப்பொருள்</string>
+    <string name="device_settings_info_firmware_pending_label">நிலுவையில் உள்ள firmware</string>
     <string name="device_settings_info_build_label">உருவாக்கம்</string>
     <string name="device_settings_info_left_serial_label">இடது பாட் தொடர் எண்</string>
     <string name="device_settings_info_right_serial_label">வலது பாட் தொடர் எண்</string>
+    <string name="device_settings_info_left_bonded_label">இடது இணைக்கப்பட்டது</string>
+    <string name="device_settings_info_right_bonded_label">வலது இணைக்கப்பட்டது</string>
     <string name="device_settings_info_details_label">சாதன விவரங்கள்</string>
     <string name="device_settings_info_details_action">சாதன விவரங்களைக் காட்டு</string>
     <string name="device_settings_info_status_label">நிலை</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">இந்த சாதனம் அருகில் உள்ளது ஆனால் இந்த தொலைபேசியுடன் இணைக்கப்படவில்லை. அமைப்புகள் மற்றும் கட்டுப்பாடுகளை அணுக இணைக்கவும்.</string>
     <string name="device_settings_not_connected_connect_action">இணை</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth அமைப்புகளை திற</string>
+    <string name="device_settings_not_nearby_label">சாதனம் அருகில் இல்லை</string>
+    <string name="device_settings_not_nearby_description">இந்த சாதனம் அருகில் இருக்கும் போதும் உங்கள் தொலைபேசியுடன் இணைக்கப்பட்டிருக்கும் போதும் மட்டுமே அமைப்புகள் கிடைக்கும்.</string>
     <string name="device_settings_aap_unavailable_label">மேம்பட்ட அமைப்புகள் கிடைக்கவில்லை</string>
     <string name="device_settings_aap_unavailable_description">மேம்பட்ட AirPods அமைப்புகளுக்கு இந்த தொலைபேசியில் கிடைக்காத Bluetooth அம்சம் தேவை. இது உங்கள் சாதன உற்பத்தியாளரிடமிருந்து வரும் எதிர்கால Android புதுப்பிப்பால் தீர்க்கப்படலாம்.</string>
+    <string name="device_settings_aap_unavailable_action">இணக்கத்தன்மை கண்காணிப்பியை பார்க்க</string>
     <string name="device_settings_category_sound_label">ஒலி</string>
     <string name="device_settings_category_controls_label">கட்டுப்பாடுகள்</string>
     <string name="device_settings_nc_one_airpod_label">ஒரு பாட்டுடன் ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">மைக்ரோஃபோனை முடக்க ஒரே ஒரு அழுத்தம்</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">அழைப்பை முடிக்க இரண்டு முறை அழுத்தவும்</string>
     <string name="device_settings_open_cd">சாதன அமைப்புகளைத் திறக்கவும்</string>
+    <string name="overview_card_missing_paired_device">இந்த சுயவிவரத்தில் இணைக்கப்பட்ட Bluetooth சாதனம் இல்லை.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">பொது</string>
     <string name="device_settings_microphone_mode_label">மைக்ரோஃபோன்</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">ஆஃஃப்-ஐ தேர்வுசெய்யக்கூடிய சத்தக் கட்டுப்பாட்டு முறையாக அனுமதிக்கவும். முடக்கப்படும்போது, சுழற்சியின் போது ஸ்டெம்கள் ஆஃஃப்-ஐ தவிர்க்கும்.</string>
     <string name="device_settings_sleep_detection_label">தூக்க கண்டறிதல்</string>
     <string name="device_settings_sleep_detection_description">நீங்கள் தூங்கும்போது ஆடியோவை தானாக இடைநிறுத்தவும்</string>
+    <string name="reaction_sleep_channel_label">தூக்க கண்டறிதல்</string>
+    <string name="reaction_sleep_notification_title">தூக்க கண்டறிதலால் இடைநிறுத்தப்பட்டது</string>
+    <string name="reaction_sleep_notification_text">%1$s நீங்கள் தூங்கிவிட்டீர்கள் என்று தெரிவித்தது, எனவே உங்கள் இசை இடைநிறுத்தப்பட்டது. சாதன அமைப்புகளில் இதை முடக்கலாம்.</string>
     <string name="device_settings_rename_label">மறுபெயரிடு</string>
     <string name="device_settings_rename_hint">சாதன பெயர்</string>
     <string name="device_settings_rename_confirm">மறுபெயரிடு</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth அமைப்புகள்</string>
     <string name="device_settings_send_failed">அமைப்பை பயன்படுத்த முடியவில்லை: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">இந்த சாதனத்தில் ஆஃஃப் முறை இயக்கப்படவில்லை. சத்தக் கட்டுப்பாட்டின் கீழ் \"ஆஃஃப் முறையை அனுமதி\" என்பதை இயக்கவும்.</string>
+    <string name="device_settings_category_battery_label">பேட்டரி</string>
+    <string name="device_settings_charge_cap_label">உகந்த சார்ஜ் வரம்பு</string>
+    <string name="device_settings_charge_cap_description">உங்கள் அன்றாட வழக்கத்தை கற்று 80%% அளவில் சார்ஜிங்கை இடைநிறுத்தி பேட்டரி ஆயுளை நீட்டிக்கும், நீங்கள் பயன்படுத்தும் முன் pods-ஐ முழுவதும் சார்ஜ் செய்யும்.</string>
+    <string name="device_settings_charge_cap_rejected_message">உகந்த சார்ஜ் வரம்பை மாற்ற முடியவில்லை. இது ஒரு சோதனை அம்சம் — தொடர்ந்து தோல்வியுற்றால் தயவுசெய்து தெரிவிக்கவும்.</string>
     <string name="device_settings_category_connections_label">இணைக்கப்பட்ட சாதனங்கள்</string>
     <string name="device_settings_connected_devices_description">தற்போது இந்த AirPods உடன் இணைக்கப்பட்ட மற்ற சாதனங்கள்</string>
     <string name="device_settings_connected_device_label">சாதனம் %d</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">నేపథ్య నిజ్జీవనత</string>
     <string name="widget_config_show_device_label">పరికర పేరు చూపించు</string>
     <string name="widget_config_reset_label">డిఫాల్ట్‌లకు రీసెట్ చేయండి</string>
+    <string name="widget_config_preview_resize_hint">మీరు హోమ్ స్క్రీన్‌పై విడ్జెట్‌ను ఉంచిన తర్వాత దాన్ని పరిమాణం మార్చవచ్చు.</string>
     <string name="widget_config_custom_label">కస్టమ్</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">చీకటి</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">ఇది తెలియని పరికరం, కానీ ఇది సారూప్య సందేశ ఆకృతిని ఉపయోగిస్తోంది. దీనికి మద్దతు జోడిద్దాం, నన్ను సంప్రదించండి :)</string>
     <string name="pods_none_label_short">పరికరం లేదు</string>
     <string name="pods_charging_label">ఛార్జ్ అవుతోంది</string>
+    <string name="pods_charging_optimized_label">ఆప్టిమైజ్ చేయబడింది</string>
     <string name="pods_inear_label">చెవిలో</string>
     <string name="pods_microphone_label">మైక్రోఫోన్</string>
     <string name="anc_mode_off">ఆఫ్</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">బ్లూటూత్ పరికరం లేబుల్</string>
     <string name="device_settings_info_model_label">మోడల్</string>
     <string name="device_settings_info_manufacturer_label">తయారీదారు</string>
+    <string name="device_settings_info_hardware_label">హార్డ్‌వేర్</string>
     <string name="device_settings_info_serial_label">సీరియల్ నంబర్</string>
     <string name="device_settings_info_firmware_label">ఫర్మ్‌వేర్</string>
+    <string name="device_settings_info_firmware_pending_label">పెండింగ్ ఫర్మ్‌వేర్</string>
     <string name="device_settings_info_build_label">బిల్డ్</string>
     <string name="device_settings_info_left_serial_label">ఎడమ పాడ్ సీరియల్</string>
     <string name="device_settings_info_right_serial_label">కుడి పాడ్ సీరియల్</string>
+    <string name="device_settings_info_left_bonded_label">ఎడమ బంధించబడింది</string>
+    <string name="device_settings_info_right_bonded_label">కుడి బంధించబడింది</string>
     <string name="device_settings_info_details_label">పరికరం వివరాలు</string>
     <string name="device_settings_info_details_action">పరికరం వివరాలు చూపించు</string>
     <string name="device_settings_info_status_label">స్థితి</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">ఈ పరికరం దగ్గరలో ఉంది కానీ ఈ ఫోన్‌కు కనెక్ట్ కాలేదు. సెట్టింగ్‌లు మరియు నియంత్రణలను యాక్సెస్ చేయడానికి కనెక్ట్ చేయండి.</string>
     <string name="device_settings_not_connected_connect_action">కనెక్ట్ చేయండి</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth సెట్టింగ్‌లు తెరవండి</string>
+    <string name="device_settings_not_nearby_label">పరికరం సమీపంలో లేదు</string>
+    <string name="device_settings_not_nearby_description">ఈ పరికరం మీ ఫోన్‌కు సమీపంలో మరియు కనెక్ట్ చేయబడినప్పుడు మాత్రమే సెట్టింగ్‌లు అందుబాటులో ఉంటాయి.</string>
     <string name="device_settings_aap_unavailable_label">అధునాతన సెట్టింగ్‌లు అందుబాటులో లేవు</string>
     <string name="device_settings_aap_unavailable_description">అడ్వాన్స్డ్ AirPods సెట్టింగ్‌లకు ఈ ఫోన్‌లో అందుబాటు లేని బ్లూటూత్ ఫీచర్ అవసరం. మీ పరికరం తయారీదారు నుంచి భవిష్యత్ Android అప్డేట్‌ద్వారా ఇది పరిహరించబడవచ్చు.</string>
+    <string name="device_settings_aap_unavailable_action">అనుకూలత ట్రాకర్‌ను చూడండి</string>
     <string name="device_settings_category_sound_label">శబ్దం</string>
     <string name="device_settings_category_controls_label">నియంత్రణలు</string>
     <string name="device_settings_nc_one_airpod_label">ఒకే పాడ్‌తో ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">మైక్రోఫోన్ మ్యూట్ చేయడానికి ఒకసారి నొక్కండి</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">కాల్ ముగించడానికి రెండుసార్లు నొక్కండి</string>
     <string name="device_settings_open_cd">పరికర సెట్టింగ్‌లు తెరవండి</string>
+    <string name="overview_card_missing_paired_device">ఈ ప్రొఫైల్‌కు పెయిర్ చేయబడిన Bluetooth పరికరం లేదు.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">సాధారణ</string>
     <string name="device_settings_microphone_mode_label">మైక్రోఫోన్</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">ఎంచుకోదగిన నాయిస్ కంట్రోల్ మోడ్‌గా Offను అనుమతించండి. నిష్క్రియం చేసినప్పుడు, సైకలింగ్ చేసే సమయంలో స్టెమ్ Offను దాటుతాయి.</string>
     <string name="device_settings_sleep_detection_label">నిద్ర గుర్తింపు</string>
     <string name="device_settings_sleep_detection_description">మీరు నిద్రపోయినప్పుడు స్వయంచాలకంగా ఆడియో పాజ్ చేయండి</string>
+    <string name="reaction_sleep_channel_label">నిద్ర గుర్తింపు</string>
+    <string name="reaction_sleep_notification_title">నిద్ర గుర్తింపు ద్వారా నిలిపివేయబడింది</string>
+    <string name="reaction_sleep_notification_text">%1$s మీరు నిద్రపోయారని నివేదించింది, కాబట్టి మీ సంగీతం నిలిపివేయబడింది. మీరు దీన్ని పరికర సెట్టింగ్‌లలో నిలిపివేయవచ్చు.</string>
     <string name="device_settings_rename_label">పేరు మార్చండి</string>
     <string name="device_settings_rename_hint">పరికర పేరు</string>
     <string name="device_settings_rename_confirm">పేరు మార్చండి</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">బ్లూటూత్ సెట్టింగ్‌లు</string>
     <string name="device_settings_send_failed">సెట్టింగ్ వర్తింపజేయడం సాధ్యపడలేదు: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Off మోడ్ ఈ పరికరంలో సక్రియం కాదు. నాయిస్ కంట్రోల్ కింద \"Off మోడ్ అనుమతించు\"ను సక్రియం చేయండి.</string>
+    <string name="device_settings_category_battery_label">బ్యాటరీ</string>
+    <string name="device_settings_charge_cap_label">ఆప్టిమైజ్ చేయబడిన చార్జ్ పరిమితి</string>
+    <string name="device_settings_charge_cap_description">మీ దినచర్యను నేర్చుకుని బ్యాటరీ జీవితాన్ని పొడిగించడానికి 80%% వద్ద చార్జింగ్‌ను నిలిపి, మీరు వాటిని ఉపయోగించే ముందు పాడ్‌లను పూర్తిగా చార్జ్ చేస్తుంది.</string>
+    <string name="device_settings_charge_cap_rejected_message">ఆప్టిమైజ్ చేయబడిన చార్జ్ పరిమితిని మార్చడం సాధ్యపడలేదు. ఇది ఒక ప్రయోగాత్మక ఫీచర్ — ఇది పదే పదే విఫలమవుతుంటే దయచేసి నివేదించండి.</string>
     <string name="device_settings_category_connections_label">కనెక్ట్ అయిన పరికరాలు</string>
     <string name="device_settings_connected_devices_description">ఈ AirPodsకు ప్రస్తుతం కనెక్ట్ అయిన ఇతర పరికరాలు</string>
     <string name="device_settings_connected_device_label">పరికరం %d</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">ความโปร่งใสของพื้นหลัง</string>
     <string name="widget_config_show_device_label">แสดงชื่ออุปกรณ์</string>
     <string name="widget_config_reset_label">รีเซ็ตเป็นค่าเริ่มต้น</string>
+    <string name="widget_config_preview_resize_hint">คุณสามารถปรับขนาดวิดเจ็ตได้หลังจากวางไว้บนหน้าจอหลักของคุณ</string>
     <string name="widget_config_custom_label">กำหนดเอง</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">มืด</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">นี่คืออุปกรณ์ที่ไม่รู้จัก แต่ใช้รูปแบบข้อความที่คล้ายกัน มาเพิ่มการรองรับกันเถอะ ติดต่อฉัน :)</string>
     <string name="pods_none_label_short">ไม่มีอุปกรณ์</string>
     <string name="pods_charging_label">กำลังชาร์จ</string>
+    <string name="pods_charging_optimized_label">ปรับให้เหมาะสม</string>
     <string name="pods_inear_label">อยู่ในหู</string>
     <string name="pods_microphone_label">ไมโครโฟน</string>
     <string name="anc_mode_off">ปิด</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">ชื่ออุปกรณ์บลูทูธ</string>
     <string name="device_settings_info_model_label">รุ่น</string>
     <string name="device_settings_info_manufacturer_label">ผู้ผลิต</string>
+    <string name="device_settings_info_hardware_label">ฮาร์ดแวร์</string>
     <string name="device_settings_info_serial_label">หมายเลขซีเรียล</string>
     <string name="device_settings_info_firmware_label">เฟิร์มแวร์</string>
+    <string name="device_settings_info_firmware_pending_label">เฟิร์มแวร์ที่รอดำเนินการ</string>
     <string name="device_settings_info_build_label">บิลด์</string>
     <string name="device_settings_info_left_serial_label">ซีเรียลหูฟังซ้าย</string>
     <string name="device_settings_info_right_serial_label">ซีเรียลหูฟังขวา</string>
+    <string name="device_settings_info_left_bonded_label">จับคู่ซ้าย</string>
+    <string name="device_settings_info_right_bonded_label">จับคู่ขวา</string>
     <string name="device_settings_info_details_label">รายละเอียดอุปกรณ์</string>
     <string name="device_settings_info_details_action">แสดงรายละเอียดอุปกรณ์</string>
     <string name="device_settings_info_status_label">สถานะ</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">อุปกรณ์นี้อยู่ใกล้เคียงแต่ไม่ได้เชื่อมต่อกับโทรศัพท์เครื่องนี้ เชื่อมต่อเพื่อเข้าถึงการตั้งค่าและตัวควบคุม</string>
     <string name="device_settings_not_connected_connect_action">เชื่อมต่อ</string>
     <string name="device_settings_not_connected_open_settings_action">เปิดการตั้งค่า Bluetooth</string>
+    <string name="device_settings_not_nearby_label">ไม่พบอุปกรณ์ในบริเวณใกล้เคียง</string>
+    <string name="device_settings_not_nearby_description">การตั้งค่าจะใช้งานได้เฉพาะเมื่ออุปกรณ์นี้อยู่ใกล้เคียงและเชื่อมต่อกับโทรศัพท์ของคุณแล้วเท่านั้น</string>
     <string name="device_settings_aap_unavailable_label">ไม่สามารถใช้การตั้งค่าขั้นสูงได้</string>
     <string name="device_settings_aap_unavailable_description">การตั้งค่า AirPods ขั้นสูงต้องใช้ฟีเจอร์บลูทูธที่ไม่มีในโทรศัพท์นี้ อาจบรรเทาได้ด้วยการอัปเดต Android ในอนาคตจากผู้ผลิตอุปกรณ์ของคุณ</string>
+    <string name="device_settings_aap_unavailable_action">ดูตัวติดตามความเข้ากันได้</string>
     <string name="device_settings_category_sound_label">เสียง</string>
     <string name="device_settings_category_controls_label">การควบคุม</string>
     <string name="device_settings_nc_one_airpod_label">ANC ด้วย pod เดียว</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">กดครั้งเดียวเพื่อปิดเสียงไมโครโฟน</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">กดสองครั้งเพื่อวางสาย</string>
     <string name="device_settings_open_cd">เปิดการตั้งค่าอุปกรณ์</string>
+    <string name="overview_card_missing_paired_device">โปรไฟล์นี้ไม่มีอุปกรณ์ Bluetooth ที่จับคู่แล้ว</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ทั่วไป</string>
     <string name="device_settings_microphone_mode_label">ไมโครโฟน</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">อนุญาต ปิด เป็นโหมดควบคุมเสียงรบกวนที่เลือกได้ เมื่อปิดใช้งาน ก้านหูฟังจะข้ามโหมด ปิด ขณะสลับ</string>
     <string name="device_settings_sleep_detection_label">การตรวจจับการหลับ</string>
     <string name="device_settings_sleep_detection_description">หยุดเสียงโดยอัตโนมัติเมื่อคุณหลับไป</string>
+    <string name="reaction_sleep_channel_label">การตรวจจับการนอนหลับ</string>
+    <string name="reaction_sleep_notification_title">หยุดชั่วคราวโดยการตรวจจับการนอนหลับ</string>
+    <string name="reaction_sleep_notification_text">%1$s รายงานว่าคุณหลับไป ดังนั้นเพลงของคุณจึงถูกหยุดชั่วคราว คุณสามารถปิดใช้งานได้ในการตั้งค่าอุปกรณ์</string>
     <string name="device_settings_rename_label">เปลี่ยนชื่อ</string>
     <string name="device_settings_rename_hint">ชื่ออุปกรณ์</string>
     <string name="device_settings_rename_confirm">เปลี่ยนชื่อ</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">การตั้งค่า Bluetooth</string>
     <string name="device_settings_send_failed">ไม่สามารถใช้การตั้งค่าได้: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">โหมด ปิด ไม่ถูกเปิดใช้งานบนอุปกรณ์นี้ เปิดใช้งาน ยอมให้โหมด ปิด ภายใต้การควบคุมเสียงรบกวน</string>
+    <string name="device_settings_category_battery_label">แบตเตอรี่</string>
+    <string name="device_settings_charge_cap_label">ขีดจำกัดการชาร์จที่ปรับให้เหมาะสม</string>
+    <string name="device_settings_charge_cap_description">เรียนรู้กิจวัตรของคุณและหยุดการชาร์จที่ประมาณ 80%% เพื่อยืดอายุแบตเตอรี่ และชาร์จให้เต็มก่อนที่คุณจะใช้งาน</string>
+    <string name="device_settings_charge_cap_rejected_message">ไม่สามารถเปลี่ยนขีดจำกัดการชาร์จที่ปรับให้เหมาะสมได้ นี่เป็นฟีเจอร์ทดลอง — โปรดรายงานหากยังคงล้มเหลวต่อไป</string>
     <string name="device_settings_category_connections_label">อุปกรณ์ที่เชื่อมต่อ</string>
     <string name="device_settings_connected_devices_description">อุปกรณ์อื่นที่เชื่อมต่อกับ AirPods เหล่านี้อยู่ในขณะนี้</string>
     <string name="device_settings_connected_device_label">อุปกรณ์ %d</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Arka plan saydamlığı</string>
     <string name="widget_config_show_device_label">Cihaz adını göster</string>
     <string name="widget_config_reset_label">Varsayılan ayarlara sıfırla</string>
+    <string name="widget_config_preview_resize_hint">Ana ekranına widget\'ı koyduktan sonra yeniden boyutlandırabilirsin.</string>
     <string name="widget_config_custom_label">Özel</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Koyu</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Bu bilinmeyen bir cihaz, ancak benzer mesaj biçimi kullanıyor. Destek ekleyelim, benimle iletişime geçin :)</string>
     <string name="pods_none_label_short">Cihaz yok</string>
     <string name="pods_charging_label">Şarj oluyor</string>
+    <string name="pods_charging_optimized_label">Optimize Edildi</string>
     <string name="pods_inear_label">Kulakta</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">Kapalı</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth Cihaz Adı</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Üretici</string>
+    <string name="device_settings_info_hardware_label">Donanım</string>
     <string name="device_settings_info_serial_label">Seri Numarası</string>
     <string name="device_settings_info_firmware_label">Yazılım</string>
+    <string name="device_settings_info_firmware_pending_label">Bekleyen Yazılım</string>
     <string name="device_settings_info_build_label">Yapı</string>
     <string name="device_settings_info_left_serial_label">Sol Kulaklık Seri Numarası</string>
     <string name="device_settings_info_right_serial_label">Sağ Kulaklık Seri Numarası</string>
+    <string name="device_settings_info_left_bonded_label">Sol Eşleştirildi</string>
+    <string name="device_settings_info_right_bonded_label">Sağ Eşleştirildi</string>
     <string name="device_settings_info_details_label">Cihaz Detayları</string>
     <string name="device_settings_info_details_action">Cihaz detaylarını göster</string>
     <string name="device_settings_info_status_label">Durum</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Bu cihaz yakında ama bu telefona bağlı değil. Ayarlara ve kontrollere erişmek için bağlan.</string>
     <string name="device_settings_not_connected_connect_action">Bağlan</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth Ayarlarını Aç</string>
+    <string name="device_settings_not_nearby_label">Cihaz yakında değil</string>
+    <string name="device_settings_not_nearby_description">Ayarlar yalnızca bu cihaz yakınınızda ve telefonunuza bağlı olduğunda kullanılabilir.</string>
     <string name="device_settings_aap_unavailable_label">Gelişmiş ayarlar kullanılamıyor</string>
     <string name="device_settings_aap_unavailable_description">Gelişmiş AirPods ayarları, bu telefonda bulunmayan bir Bluetooth özelliği gerektiriyor. Bu durum, cihaz üreticinizin gelecekteki bir Android güncellemesiyle çözülebilir.</string>
+    <string name="device_settings_aap_unavailable_action">Uyumluluk izleyicisini görüntüle</string>
     <string name="device_settings_category_sound_label">Ses</string>
     <string name="device_settings_category_controls_label">Kontroller</string>
     <string name="device_settings_nc_one_airpod_label">Tek kulaklıkla ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Mikrofonu kapatıp açmak için tek basım</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Aramayı bitirmek için çift basım</string>
     <string name="device_settings_open_cd">Cihaz ayarlarını aç</string>
+    <string name="overview_card_missing_paired_device">Bu profilde eşlenmiş bir Bluetooth cihazı yok.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Genel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Kapalı modun seçilebilir bir gürültü kontrol modu olarak kullanılmasına izin verir. Devre dışı bırakıldığında, saplar döngü yaparken Kapalı modunu atlar.</string>
     <string name="device_settings_sleep_detection_label">Uyku Algılama</string>
     <string name="device_settings_sleep_detection_description">Uyuyakaldığınızda sesi otomatik olarak duraklat</string>
+    <string name="reaction_sleep_channel_label">Uyku Algılama</string>
+    <string name="reaction_sleep_notification_title">Uyku Algılama ile Duraklatıldı</string>
+    <string name="reaction_sleep_notification_text">%1$s uyuduğunuzu bildirdi, bu nedenle müziğiniz duraklatıldı. Bunu cihaz ayarlarından devre dışı bırakabilirsiniz.</string>
     <string name="device_settings_rename_label">Yeniden Adlandır</string>
     <string name="device_settings_rename_hint">Cihaz adı</string>
     <string name="device_settings_rename_confirm">Yeniden Adlandır</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth Ayarları</string>
     <string name="device_settings_send_failed">Ayar uygulanamadı: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Bu cihazda Kapalı modu etkin değil. Gürültü Kontrolü altında \"Kapalı moda izin ver\" seçeneğini etkinleştirin.</string>
+    <string name="device_settings_category_battery_label">Pil</string>
+    <string name="device_settings_charge_cap_label">Optimize Edilmiş Şarj Limiti</string>
+    <string name="device_settings_charge_cap_description">Rutininizi öğrenin ve pil ömrünü uzatmak için şarjı %80 civarında duraklatın; kullanmadan önce kulaklıkları tamamen şarj eder.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimize Edilmiş Şarj Limiti değiştirilemedi. Bu deneysel bir özellik — başarısız olmaya devam ederse lütfen bildirin.</string>
     <string name="device_settings_category_connections_label">Bağlı Cihazlar</string>
     <string name="device_settings_connected_devices_description">Bu AirPod’lara şu anda bağlı diğer cihazlar</string>
     <string name="device_settings_connected_device_label">Cihaz %d</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Прозорість фону</string>
     <string name="widget_config_show_device_label">Показувати назву пристрою</string>
     <string name="widget_config_reset_label">Скинути на стандартні значення</string>
+    <string name="widget_config_preview_resize_hint">Ви можете змінити розмір віджета після розміщення його на головному екрані.</string>
     <string name="widget_config_custom_label">Користувацьке</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Темна</string>
@@ -254,6 +255,7 @@
     <string name="pods_unknown_contact_dev">Це невідомий пристрій, але він використовує схожий формат повідомлень. Давайте додамо підтримку для нього, зв\'яжіться зі мною :)</string>
     <string name="pods_none_label_short">Немає пристрою</string>
     <string name="pods_charging_label">Заряджається</string>
+    <string name="pods_charging_optimized_label">Оптимізовано</string>
     <string name="pods_inear_label">У вусі</string>
     <string name="pods_microphone_label">Мікрофон</string>
     <string name="anc_mode_off">Вимкнено</string>
@@ -417,11 +419,15 @@
     <string name="device_settings_info_bt_name_label">Мітка пристрою Bluetooth</string>
     <string name="device_settings_info_model_label">Модель</string>
     <string name="device_settings_info_manufacturer_label">Виробник</string>
+    <string name="device_settings_info_hardware_label">Залізо</string>
     <string name="device_settings_info_serial_label">Серійний номер</string>
     <string name="device_settings_info_firmware_label">Прошивка</string>
+    <string name="device_settings_info_firmware_pending_label">Очікуване мікропрограмне забезпечення</string>
     <string name="device_settings_info_build_label">Збірка</string>
     <string name="device_settings_info_left_serial_label">Серійний номер лівого навушника</string>
     <string name="device_settings_info_right_serial_label">Серійний номер правого навушника</string>
+    <string name="device_settings_info_left_bonded_label">Ліве з\'єднано</string>
+    <string name="device_settings_info_right_bonded_label">Праве з\'єднано</string>
     <string name="device_settings_info_details_label">Деталі пристрою</string>
     <string name="device_settings_info_details_action">Показати деталі пристрою</string>
     <string name="device_settings_info_status_label">Стан</string>
@@ -431,8 +437,11 @@
     <string name="device_settings_not_connected_description">Цей пристрій поблизу, але не підключений до цього телефону. Підключіться для доступу до налаштувань та елементів керування.</string>
     <string name="device_settings_not_connected_connect_action">Підключити</string>
     <string name="device_settings_not_connected_open_settings_action">Відкрити налаштування Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Пристрій не поруч</string>
+    <string name="device_settings_not_nearby_description">Налаштування доступні лише тоді, коли цей пристрій знаходиться поруч і підключений до вашого телефону.</string>
     <string name="device_settings_aap_unavailable_label">Розширені налаштування недоступні</string>
     <string name="device_settings_aap_unavailable_description">Розширені налаштування AirPods потребують функції Bluetooth, недоступної на цьому телефоні. Це може бути вирішено майбутнім оновленням Android від виробника вашого пристрою.</string>
+    <string name="device_settings_aap_unavailable_action">Переглянути трекер сумісності</string>
     <string name="device_settings_category_sound_label">Звук</string>
     <string name="device_settings_category_controls_label">Управління</string>
     <string name="device_settings_nc_one_airpod_label">ANC з одним навушником</string>
@@ -470,6 +479,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Одне натискання для вимкнення мікрофона</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Подвійне натискання для завершення дзвінка</string>
     <string name="device_settings_open_cd">Відкрити налаштування пристрою</string>
+    <string name="overview_card_missing_paired_device">До цього профілю не підключено жодного Bluetooth-пристрою.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Загальні</string>
     <string name="device_settings_microphone_mode_label">Мікрофон</string>
@@ -492,6 +502,9 @@
     <string name="device_settings_allow_off_description">Дозволити «Вимкнено» як вибираний режим контролю шуму. Якщо вимкнено, ніжки пропускають режим «Вимкнено» при циклічному перемиканні.</string>
     <string name="device_settings_sleep_detection_label">Визначення сну</string>
     <string name="device_settings_sleep_detection_description">Автоматично призупиняти аудіо, коли ви засинаєте</string>
+    <string name="reaction_sleep_channel_label">Виявлення сну</string>
+    <string name="reaction_sleep_notification_title">Призупинено виявленням сну</string>
+    <string name="reaction_sleep_notification_text">%1$s визначив, що ви заснули, тому музику було призупинено. Ви можете вимкнути це в налаштуваннях пристрою.</string>
     <string name="device_settings_rename_label">Перейменувати</string>
     <string name="device_settings_rename_hint">Назва пристрою</string>
     <string name="device_settings_rename_confirm">Перейменувати</string>
@@ -501,6 +514,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Налаштування Bluetooth</string>
     <string name="device_settings_send_failed">Не вдалося застосувати налаштування: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Режим «Вимкнено» не увімкнено на цьому пристрої. Увімкніть «Дозволити режим Вимкнено» у розділі Контроль шуму.</string>
+    <string name="device_settings_category_battery_label">Батарея</string>
+    <string name="device_settings_charge_cap_label">Оптимізований ліміт заряду</string>
+    <string name="device_settings_charge_cap_description">Вивчає ваш режим і призупиняє зарядку приблизно на 80%%, щоб продовжити термін служби батареї, заряджаючи навушники перед тим, як ви, ймовірно, скористаєтеся ними.</string>
+    <string name="device_settings_charge_cap_rejected_message">Не вдалося змінити оптимізований ліміт заряду. Це експериментальна функція — будь ласка, повідомте, якщо вона продовжує не працювати.</string>
     <string name="device_settings_category_connections_label">Підключені пристрої</string>
     <string name="device_settings_connected_devices_description">Інші пристрої, зараз підключені до цих AirPods</string>
     <string name="device_settings_connected_device_label">Пристрій %d</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">پس منظر کی شفافیت</string>
     <string name="widget_config_show_device_label">ڈیوائس کا نام دکھائیں</string>
     <string name="widget_config_reset_label">ڈیفالٹ پر دوبارہ سیٹ کریں</string>
+    <string name="widget_config_preview_resize_hint">آپ ویجٹ کو اپنی ہوم اسکرین پر رکھنے کے بعد اس کا سائز تبدیل کر سکتے ہیں۔</string>
     <string name="widget_config_custom_label">حسب ضرورت</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">گہرا</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">یہ ایک نامعلوم آلہ ہے، لیکن یہ ملتے جلتے پیغام کے فارمیٹ کا استعمال کر رہا ہے۔ آئیے اس کے لئے سپورٹ شامل کریں، مجھ سے رابطہ کریں :)</string>
     <string name="pods_none_label_short">کوئی آلہ نہیں</string>
     <string name="pods_charging_label">چارج ہو رہا ہے</string>
+    <string name="pods_charging_optimized_label">بہتر بنایا گیا</string>
     <string name="pods_inear_label">کان میں</string>
     <string name="pods_microphone_label">مائیکروفون</string>
     <string name="anc_mode_off">بند</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">بلوٹوتھ ڈیوائس لیبل</string>
     <string name="device_settings_info_model_label">ماڈل</string>
     <string name="device_settings_info_manufacturer_label">مینوفیکچرر</string>
+    <string name="device_settings_info_hardware_label">ہارڈ ویئر</string>
     <string name="device_settings_info_serial_label">سیریل نمبر</string>
     <string name="device_settings_info_firmware_label">فرم ویئر</string>
+    <string name="device_settings_info_firmware_pending_label">زیر التواء فرم ویئر</string>
     <string name="device_settings_info_build_label">بلڈ</string>
     <string name="device_settings_info_left_serial_label">بائیں پوڈ سیریل</string>
     <string name="device_settings_info_right_serial_label">دائیں پوڈ سیریل</string>
+    <string name="device_settings_info_left_bonded_label">بائیں بونڈڈ</string>
+    <string name="device_settings_info_right_bonded_label">دائیں بونڈڈ</string>
     <string name="device_settings_info_details_label">ڈیوائس کی تفصیلات</string>
     <string name="device_settings_info_details_action">ڈیوائس کی تفصیلات دیکھائیں</string>
     <string name="device_settings_info_status_label">حیثیت</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">یہ ڈیوائس قریب ہے لیکن اس فون سے منسلک نہیں ہے۔ ترتیبات اور کنٹرولز تک رسائی کے لیے منسلک کریں۔</string>
     <string name="device_settings_not_connected_connect_action">منسلک کریں</string>
     <string name="device_settings_not_connected_open_settings_action">بلوٹوتھ ترتیبات کھولیں</string>
+    <string name="device_settings_not_nearby_label">ڈیوائس قریب نہیں ہے</string>
+    <string name="device_settings_not_nearby_description">ترتیبات صرف اس وقت دستیاب ہیں جب یہ ڈیوائس قریب ہو اور آپ کے فون سے منسلک ہو۔</string>
     <string name="device_settings_aap_unavailable_label">جدید ترتیبات دستیاب نہیں</string>
     <string name="device_settings_aap_unavailable_description">ایڈوانسڈ AirPods سیٹنگز کے لیے بلوٹوتھ فیچر کی ضرورت ہے جو اس فون پر دستیاب نہیں ہے۔ یہ آپ کے ڈیوائس مینوفیکچرر کی طرف سے آئندہ Android اپڈیٹ سے حل ہو سکتا ہے۔</string>
+    <string name="device_settings_aap_unavailable_action">مطابقت ٹریکر دیکھیں</string>
     <string name="device_settings_category_sound_label">آواز</string>
     <string name="device_settings_category_controls_label">کنٹرولز</string>
     <string name="device_settings_nc_one_airpod_label">ایک پوڈ کے ساتھ ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">مائیکروفون خاموش کرنے کے لیے ایک بار دبائیں</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">کال ختم کرنے کے لیے دو بار دبائیں</string>
     <string name="device_settings_open_cd">ڈیوائس کی ترتیبات کھولیں</string>
+    <string name="overview_card_missing_paired_device">اس پروفائل میں کوئی جوڑا بلوٹوتھ ڈیوائس نہیں ہے۔</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">مائیکروفون</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">آف کو قابل انتخاب شور کنٹرول موڈ کے طور پر اجازت دیں۔ بند ہونے پر، سٹیمز سائکلنگ کے دوران آف کو چھوڑ دیتے ہیں۔</string>
     <string name="device_settings_sleep_detection_label">نیند کا پتہ لگانا</string>
     <string name="device_settings_sleep_detection_description">جب آپ سو جائیں تو خودبخود آڈیو روکیں</string>
+    <string name="reaction_sleep_channel_label">نیند کا پتہ لگانا</string>
+    <string name="reaction_sleep_notification_title">نیند کا پتہ لگانے سے روکا گیا</string>
+    <string name="reaction_sleep_notification_text">%1$s نے اطلاع دی کہ آپ سو گئے، اس لیے آپ کی موسیقی روک دی گئی۔ آپ اسے ڈیوائس سیٹنگز میں غیر فعال کر سکتے ہیں۔</string>
     <string name="device_settings_rename_label">نام تبدیل کریں</string>
     <string name="device_settings_rename_hint">ڈیوائس کا نام</string>
     <string name="device_settings_rename_confirm">نام تبدیل کریں</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">بلوٹوتھ ترتیبات</string>
     <string name="device_settings_send_failed">ترتیب لاگو نہیں ہو سکی: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">آف موڈ اس ڈیوائس پر فعال نہیں ہے۔ شور کنٹرول کے تحت \"آف موڈ کی اجازت دیں\" فعال کریں۔</string>
+    <string name="device_settings_category_battery_label">بیٹری</string>
+    <string name="device_settings_charge_cap_label">بہتر بنایا گیا چارج لمٹ</string>
+    <string name="device_settings_charge_cap_description">اپنا معمول سیکھیں اور بیٹری کی زندگی بڑھانے کے لیے 80%% کے آس پاس چارجنگ روکیں، پوڈز کو اس سے پہلے مکمل چارج کریں جب آپ انہیں استعمال کرنے کا امکان ہو۔</string>
+    <string name="device_settings_charge_cap_rejected_message">بہتر بنایا گیا چارج لمٹ تبدیل نہیں ہو سکا۔ یہ ایک تجرباتی فیچر ہے — اگر یہ ناکام ہوتا رہے تو براہ کرم رپورٹ کریں۔</string>
     <string name="device_settings_category_connections_label">منسلک ڈیوائسز</string>
     <string name="device_settings_connected_devices_description">دیگر ڈیوائسز جو ابھی ان AirPods سے منسلک ہیں</string>
     <string name="device_settings_connected_device_label">ڈیوائس %d</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Fon shaffoflik</string>
     <string name="widget_config_show_device_label">Qurilma nomini ko‘rsatish</string>
     <string name="widget_config_reset_label">Standartga qaytarish</string>
+    <string name="widget_config_preview_resize_hint">Vidjetni bosh ekraningizga joylashtirganingizdan so\'ng uning o\'lchamini o\'zgartirishingiz mumkin.</string>
     <string name="widget_config_custom_label">Boshqacha</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Qora</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Bu noma\'lum qurilma, lekin u shunga o\'xshash xabar formatidan foydalanmoqda. Keling, uni qo\'llab-quvvatlashni qo\'shaylik, men bilan bog\'laning :)</string>
     <string name="pods_none_label_short">Qurilma yo\'q</string>
     <string name="pods_charging_label">Quvvat olmoqda</string>
+    <string name="pods_charging_optimized_label">Optimallashtirilgan</string>
     <string name="pods_inear_label">Quloqda</string>
     <string name="pods_microphone_label">Mikrofon</string>
     <string name="anc_mode_off">O\'chiq</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Bluetooth qurilma yorlig\'i</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Ishlab chiqaruvchi</string>
+    <string name="device_settings_info_hardware_label">Apparat ta\'minoti</string>
     <string name="device_settings_info_serial_label">Seriya raqami</string>
     <string name="device_settings_info_firmware_label">Dasturiy ta\'minot</string>
+    <string name="device_settings_info_firmware_pending_label">Kutilayotgan Proshivka</string>
     <string name="device_settings_info_build_label">Versiya</string>
     <string name="device_settings_info_left_serial_label">Chap naushnik seriya raqami</string>
     <string name="device_settings_info_right_serial_label">O\'ng naushnik seriya raqami</string>
+    <string name="device_settings_info_left_bonded_label">Chap Bog\'langan</string>
+    <string name="device_settings_info_right_bonded_label">O\'ng Bog\'langan</string>
     <string name="device_settings_info_details_label">Qurilma tafsilotlari</string>
     <string name="device_settings_info_details_action">Qurilma tafsilotlarini ko\'rsatish</string>
     <string name="device_settings_info_status_label">Holat</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Bu qurilma yaqin atrofda, lekin ushbu telefonga ulanmagan. Sozlamalar va boshqaruvlarga kirish uchun ulaning.</string>
     <string name="device_settings_not_connected_connect_action">Ulash</string>
     <string name="device_settings_not_connected_open_settings_action">Bluetooth sozlamalarini ochish</string>
+    <string name="device_settings_not_nearby_label">Qurilma yaqin atrofda emas</string>
+    <string name="device_settings_not_nearby_description">Sozlamalar faqat bu qurilma yaqin atrofda bo\'lgan va telefoningizga ulangan paytda mavjud.</string>
     <string name="device_settings_aap_unavailable_label">Kengaytirilgan sozlamalar mavjud emas</string>
     <string name="device_settings_aap_unavailable_description">Kengaytirilgan AirPods sozlamalari ushbu telefonda mavjud bo\'lmagan Bluetooth xususiyatini talab qiladi. Bu qurilma ishlab chiqaruvchingizning kelajakdagi Android yangilanishi bilan hal qilinishi mumkin.</string>
+    <string name="device_settings_aap_unavailable_action">Moslik kuzatuvchisini ko\'rish</string>
     <string name="device_settings_category_sound_label">Tovush</string>
     <string name="device_settings_category_controls_label">Boshqaruvlar</string>
     <string name="device_settings_nc_one_airpod_label">Bitta naushnik bilan ANC</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Mikrofonni o\'chirish uchun bir marta bosing</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Qo\'ng\'iroqni tugatish uchun ikki marta bosing</string>
     <string name="device_settings_open_cd">Qurilma sozlamalarini ochish</string>
+    <string name="overview_card_missing_paired_device">Bu profilga ulangan Bluetooth qurilmasi yo\'q.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umumiy</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">O\'chirishni tanlash mumkin bo\'lgan shovqin boshqaruvi rejimi sifatida ruxsat bering. O\'chirilganda, stvol aylanishida O\'chirishni o\'tkazib ketadi.</string>
     <string name="device_settings_sleep_detection_label">Uyqu aniqlash</string>
     <string name="device_settings_sleep_detection_description">Uxlab qolganingizda audioni avtomatik to\'xtatib turish</string>
+    <string name="reaction_sleep_channel_label">Uyqu Aniqlash</string>
+    <string name="reaction_sleep_notification_title">Uyqu Aniqlash tomonidan to\'xtatildi</string>
+    <string name="reaction_sleep_notification_text">%1$s siz uxlab qolganingizni aniqladi, shuning uchun musiqangiz to\'xtatildi. Buni qurilma sozlamalarida o\'chirib qo\'yishingiz mumkin.</string>
     <string name="device_settings_rename_label">Qayta nomlash</string>
     <string name="device_settings_rename_hint">Qurilma nomi</string>
     <string name="device_settings_rename_confirm">Qayta nomlash</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Bluetooth sozlamalari</string>
     <string name="device_settings_send_failed">Sozlamani qo\'llab bo\'lmadi: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">O\'chirish rejimi bu qurilmada yoqilmagan. Shovqin boshqaruvi bo\'limida \"O\'chirish rejimiga ruxsat berish\" ni yoqing.</string>
+    <string name="device_settings_category_battery_label">Batareya</string>
+    <string name="device_settings_charge_cap_label">Optimallashtirilgan Zaryad Chegarasi</string>
+    <string name="device_settings_charge_cap_description">Odatlaringizni o\'rganib, batareya muddatini uzaytirish uchun zaryad berish 80%% atrofida to\'xtatiladi va qurilmalarni ishlatishdan oldin to\'liq zaryadlanadi.</string>
+    <string name="device_settings_charge_cap_rejected_message">Optimallashtirilgan Zaryad Chegarasini o\'zgartirib bo\'lmadi. Bu tajriba xususiyati — agar muammo davom etsa, xabar bering.</string>
     <string name="device_settings_category_connections_label">Ulangan qurilmalar</string>
     <string name="device_settings_connected_devices_description">Hozirda ushbu AirPods ga ulangan boshqa qurilmalar</string>
     <string name="device_settings_connected_device_label">Qurilma %d</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Độ trong suốt nền</string>
     <string name="widget_config_show_device_label">Hiển thị tên thiết bị</string>
     <string name="widget_config_reset_label">Đặt lại về mặc định</string>
+    <string name="widget_config_preview_resize_hint">Bạn có thể thay đổi kích thước widget sau khi đặt nó trên màn hình chính.</string>
     <string name="widget_config_custom_label">Tùy chỉnh</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Tối</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">Đây là một thiết bị chưa được nhận diện nhưng đang dùng định dạng tin nhắn tương tự. Hãy thêm hỗ trợ cho nó, liên hệ với tôi :)</string>
     <string name="pods_none_label_short">Không có thiết bị</string>
     <string name="pods_charging_label">Đang sạc</string>
+    <string name="pods_charging_optimized_label">Đã tối ưu hóa</string>
     <string name="pods_inear_label">Trong tai</string>
     <string name="pods_microphone_label">Micrô</string>
     <string name="anc_mode_off">Tắt</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">Nhãn thiết bị Bluetooth</string>
     <string name="device_settings_info_model_label">Mẫu máy</string>
     <string name="device_settings_info_manufacturer_label">Nhà sản xuất</string>
+    <string name="device_settings_info_hardware_label">Phần cứng</string>
     <string name="device_settings_info_serial_label">Số Serial</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Firmware đang chờ</string>
     <string name="device_settings_info_build_label">Phiên bản</string>
     <string name="device_settings_info_left_serial_label">Số sên tai nghe trái</string>
     <string name="device_settings_info_right_serial_label">Số sên tai nghe phải</string>
+    <string name="device_settings_info_left_bonded_label">Trái đã ghép</string>
+    <string name="device_settings_info_right_bonded_label">Phải đã ghép</string>
     <string name="device_settings_info_details_label">Chi tiết thiết bị</string>
     <string name="device_settings_info_details_action">Hiển thị chi tiết thiết bị</string>
     <string name="device_settings_info_status_label">Trạng thái</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">Thiết bị này ở gần nhưng chưa được kết nối với điện thoại này. Hãy kết nối để truy cập cài đặt và điều khiển.</string>
     <string name="device_settings_not_connected_connect_action">Kết nối</string>
     <string name="device_settings_not_connected_open_settings_action">Mở Cài đặt Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Thiết bị không ở gần</string>
+    <string name="device_settings_not_nearby_description">Cài đặt chỉ khả dụng khi thiết bị này ở gần và được kết nối với điện thoại của bạn.</string>
     <string name="device_settings_aap_unavailable_label">Cài đặt nâng cao không khả dụng</string>
     <string name="device_settings_aap_unavailable_description">Cài đặt AirPods nâng cao yêu cầu tính năng Bluetooth không có trên điện thoại này. Vấn đề này có thể được giải quyết bằng bản cập nhật Android trong tương lai từ nhà sản xuất thiết bị của bạn.</string>
+    <string name="device_settings_aap_unavailable_action">Xem trình theo dõi tương thích</string>
     <string name="device_settings_category_sound_label">Âm thanh</string>
     <string name="device_settings_category_controls_label">Điều khiển</string>
     <string name="device_settings_nc_one_airpod_label">Chống ồn ANC với một tai nghe</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Nhấn một lần để tắt tiếng micro</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Nhấn hai lần để kết thúc cuộc gọi</string>
     <string name="device_settings_open_cd">Mở cài đặt thiết bị</string>
+    <string name="overview_card_missing_paired_device">Hồ sơ này không có thiết bị Bluetooth nào được ghép nối.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Chung</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">Cho phép Tắt là chế độ kiểm soát tiếng ồn có thể chọn. Khi tắt, thân tai nghe sẽ bỏ qua Tắt trong khi chu kỳ.</string>
     <string name="device_settings_sleep_detection_label">Phát hiện ngủ</string>
     <string name="device_settings_sleep_detection_description">Tự động tạm dừng âm thanh khi bạn ngủ thiết đi</string>
+    <string name="reaction_sleep_channel_label">Phát hiện ngủ</string>
+    <string name="reaction_sleep_notification_title">Đã tạm dừng bởi Phát hiện ngủ</string>
+    <string name="reaction_sleep_notification_text">%1$s phát hiện bạn đã ngủ quên, vì vậy nhạc của bạn đã được tạm dừng. Bạn có thể tắt tính năng này trong cài đặt thiết bị.</string>
     <string name="device_settings_rename_label">Đổi tên</string>
     <string name="device_settings_rename_hint">Tên thiết bị</string>
     <string name="device_settings_rename_confirm">Đổi tên</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Cài đặt Bluetooth</string>
     <string name="device_settings_send_failed">Không thể áp dụng cài đặt: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Chế độ Tắt chưa được bật trên thiết bị này. Bật “Cho phép chế độ Tắt” trong Kiểm soát tiếng ồn.</string>
+    <string name="device_settings_category_battery_label">Pin</string>
+    <string name="device_settings_charge_cap_label">Giới hạn sạc tối ưu</string>
+    <string name="device_settings_charge_cap_description">Học thói quen của bạn và tạm dừng sạc ở khoảng 80%% để kéo dài tuổi thọ pin, sạc đầy pods trước khi bạn có khả năng sử dụng chúng.</string>
+    <string name="device_settings_charge_cap_rejected_message">Không thể thay đổi Giới hạn sạc tối ưu. Đây là tính năng thử nghiệm — vui lòng báo cáo nếu tiếp tục xảy ra lỗi.</string>
     <string name="device_settings_category_connections_label">Thiết bị đã kết nối</string>
     <string name="device_settings_connected_devices_description">Các thiết bị khác hiện đang kết nối với AirPods này</string>
     <string name="device_settings_connected_device_label">Thiết bị %d</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">背景透明度</string>
     <string name="widget_config_show_device_label">显示设备名称</string>
     <string name="widget_config_reset_label">重置为默认值</string>
+    <string name="widget_config_preview_resize_hint">将小组件放置到主屏幕后，您可以调整其大小。</string>
     <string name="widget_config_custom_label">自定义</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">深色</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">这是一个未知设备，但它使用了类似的消息格式。与我联系以协助添加对它的支持 :)</string>
     <string name="pods_none_label_short">暂无设备</string>
     <string name="pods_charging_label">充电中</string>
+    <string name="pods_charging_optimized_label">已优化</string>
     <string name="pods_inear_label">在耳中</string>
     <string name="pods_microphone_label">麦克风</string>
     <string name="anc_mode_off">关闭</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">蓝牙设备标签</string>
     <string name="device_settings_info_model_label">型号</string>
     <string name="device_settings_info_manufacturer_label">制造商</string>
+    <string name="device_settings_info_hardware_label">硬件</string>
     <string name="device_settings_info_serial_label">序列号</string>
     <string name="device_settings_info_firmware_label">固件</string>
+    <string name="device_settings_info_firmware_pending_label">待处理固件</string>
     <string name="device_settings_info_build_label">版本号</string>
     <string name="device_settings_info_left_serial_label">左耳机序列号</string>
     <string name="device_settings_info_right_serial_label">右耳机序列号</string>
+    <string name="device_settings_info_left_bonded_label">左耳已配对</string>
+    <string name="device_settings_info_right_bonded_label">右耳已配对</string>
     <string name="device_settings_info_details_label">设备详情</string>
     <string name="device_settings_info_details_action">显示设备详情</string>
     <string name="device_settings_info_status_label">状态</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">此设备在附近但未连接到此手机。连接后可访问设置和控制选项。</string>
     <string name="device_settings_not_connected_connect_action">连接</string>
     <string name="device_settings_not_connected_open_settings_action">打开蓝牙设置</string>
+    <string name="device_settings_not_nearby_label">设备不在附近</string>
+    <string name="device_settings_not_nearby_description">仅当此设备在附近并连接到您的手机时，设置才可用。</string>
     <string name="device_settings_aap_unavailable_label">高级设置不可用</string>
     <string name="device_settings_aap_unavailable_description">高级 AirPods 设置需要此手机不支持的蓝牙功能。此问题可能会通过您设备制造商未来的 Android 更新得到解决。</string>
+    <string name="device_settings_aap_unavailable_action">查看兼容性追踪器</string>
     <string name="device_settings_category_sound_label">声音</string>
     <string name="device_settings_category_controls_label">控制</string>
     <string name="device_settings_nc_one_airpod_label">单耳 ANC</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">单按静音麦克风</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">双按结束通话</string>
     <string name="device_settings_open_cd">打开设备设置</string>
+    <string name="overview_card_missing_paired_device">此配置文件没有已配对的蓝牙设备。</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">常规</string>
     <string name="device_settings_microphone_mode_label">麦克风</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">允许将“关闭”作为可选噪音控制模式。禁用后，耳机杆循环时将跳过关闭模式。</string>
     <string name="device_settings_sleep_detection_label">睡眠检测</string>
     <string name="device_settings_sleep_detection_description">入睡时自动暂停音频</string>
+    <string name="reaction_sleep_channel_label">睡眠检测</string>
+    <string name="reaction_sleep_notification_title">已被睡眠检测暂停</string>
+    <string name="reaction_sleep_notification_text">%1$s 检测到您已入睡，音乐已暂停。您可以在设备设置中关闭此功能。</string>
     <string name="device_settings_rename_label">重命名</string>
     <string name="device_settings_rename_hint">设备名称</string>
     <string name="device_settings_rename_confirm">重命名</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">蓝牙设置</string>
     <string name="device_settings_send_failed">无法应用设置：%1$s</string>
     <string name="device_settings_anc_off_rejected_message">此设备未启用关闭模式。请在“噪音控制”下启用“允许关闭模式”。</string>
+    <string name="device_settings_category_battery_label">电池</string>
+    <string name="device_settings_charge_cap_label">优化充电上限</string>
+    <string name="device_settings_charge_cap_description">学习您的使用习惯，在电量约达到 80%% 时暂停充电以延长电池寿命，并在您可能使用前将耳机充满。</string>
+    <string name="device_settings_charge_cap_rejected_message">优化充电上限更改失败。这是一项实验性功能——如果持续失败，请反馈报告。</string>
     <string name="device_settings_category_connections_label">已连接设备</string>
     <string name="device_settings_connected_devices_description">当前连接到这些 AirPods 的其他设备</string>
     <string name="device_settings_connected_device_label">设备 %d</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">背景透明度</string>
     <string name="widget_config_show_device_label">顯示裝置名稱</string>
     <string name="widget_config_reset_label">重設為預設值</string>
+    <string name="widget_config_preview_resize_hint">您可以在將小工具放置到主畫面後調整其大小。</string>
     <string name="widget_config_custom_label">自訂</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">深色</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">這是未知裝置，但使用了類似的訊息格式。讓我們為它加入支援，請聯絡我 :)</string>
     <string name="pods_none_label_short">無裝置</string>
     <string name="pods_charging_label">充電中</string>
+    <string name="pods_charging_optimized_label">已優化</string>
     <string name="pods_inear_label">已入耳</string>
     <string name="pods_microphone_label">麥克風</string>
     <string name="anc_mode_off">關閉</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">藍牙裝置標籤</string>
     <string name="device_settings_info_model_label">型號</string>
     <string name="device_settings_info_manufacturer_label">製造商</string>
+    <string name="device_settings_info_hardware_label">硬件</string>
     <string name="device_settings_info_serial_label">序列號</string>
     <string name="device_settings_info_firmware_label">軟體</string>
+    <string name="device_settings_info_firmware_pending_label">待安裝韌體</string>
     <string name="device_settings_info_build_label">版本</string>
     <string name="device_settings_info_left_serial_label">左耳機序列號</string>
     <string name="device_settings_info_right_serial_label">右耳機序列號</string>
+    <string name="device_settings_info_left_bonded_label">左耳已配對</string>
+    <string name="device_settings_info_right_bonded_label">右耳已配對</string>
     <string name="device_settings_info_details_label">裝置詳情</string>
     <string name="device_settings_info_details_action">顯示裝置詳情</string>
     <string name="device_settings_info_status_label">狀態</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">此裝置在附近，但未連接到此手機。請連接以存取設定及控制項。</string>
     <string name="device_settings_not_connected_connect_action">連接</string>
     <string name="device_settings_not_connected_open_settings_action">開啟藍牙設定</string>
+    <string name="device_settings_not_nearby_label">裝置不在附近</string>
+    <string name="device_settings_not_nearby_description">設定只在此裝置在附近並已連接至您的手機時才可使用。</string>
     <string name="device_settings_aap_unavailable_label">進階設定不可用</string>
     <string name="device_settings_aap_unavailable_description">進階 AirPods 設定需要此手機不支援的藍牙功能。您的裝置製造商發布的未來 Android 更新可能解決此問題。</string>
+    <string name="device_settings_aap_unavailable_action">查看相容性追蹤器</string>
     <string name="device_settings_category_sound_label">音效</string>
     <string name="device_settings_category_controls_label">控制</string>
     <string name="device_settings_nc_one_airpod_label">單個耳機的 ANC</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">單擊靜音麥克風</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">雙擊結束通話</string>
     <string name="device_settings_open_cd">開啟裝置設定</string>
+    <string name="overview_card_missing_paired_device">此設定檔沒有已配對的藍牙裝置。</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">將關閉作為可選噪音控制模式。當停用時，提頓在循環時會跳過關閉。</string>
     <string name="device_settings_sleep_detection_label">睡眠偵測</string>
     <string name="device_settings_sleep_detection_description">入睡時自動暫停播放</string>
+    <string name="reaction_sleep_channel_label">睡眠偵測</string>
+    <string name="reaction_sleep_notification_title">已被睡眠偵測暫停</string>
+    <string name="reaction_sleep_notification_text">%1$s 偵測到您已入睡，因此音樂已暫停。您可在裝置設定中停用此功能。</string>
     <string name="device_settings_rename_label">重新命名</string>
     <string name="device_settings_rename_hint">裝置名稱</string>
     <string name="device_settings_rename_confirm">重新命名</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">藍牙設定</string>
     <string name="device_settings_send_failed">無法套用設定：%1$s</string>
     <string name="device_settings_anc_off_rejected_message">此裝置未啟用關閉模式。請在「噪音控制」下啟用「允許關閉模式」。</string>
+    <string name="device_settings_category_battery_label">電池</string>
+    <string name="device_settings_charge_cap_label">優化充電上限</string>
+    <string name="device_settings_charge_cap_description">學習您的使用習慣，在充電達 80%% 左右時暫停充電以延長電池壽命，並在您可能使用前將耳機充滿。</string>
+    <string name="device_settings_charge_cap_rejected_message">優化充電上限無法更改。這是一項實驗性功能——如果持續失敗，請回報。</string>
     <string name="device_settings_category_connections_label">已連接裝置</string>
     <string name="device_settings_connected_devices_description">目前連接至此 AirPods 的其他裝置</string>
     <string name="device_settings_connected_device_label">裝置 %d</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">背景透明度</string>
     <string name="widget_config_show_device_label">顯示裝置名稱</string>
     <string name="widget_config_reset_label">重設為預設值</string>
+    <string name="widget_config_preview_resize_hint">將小工具放置到主畫面後，您可以調整其大小。</string>
     <string name="widget_config_custom_label">自訂</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">深色</string>
@@ -248,6 +249,7 @@
     <string name="pods_unknown_contact_dev">這是一個未知裝置，但可以使用相似的訊息格式。聯絡我以為此裝置新增相關支援 :)</string>
     <string name="pods_none_label_short">無裝置</string>
     <string name="pods_charging_label">充電中</string>
+    <string name="pods_charging_optimized_label">已最佳化</string>
     <string name="pods_inear_label">在耳中</string>
     <string name="pods_microphone_label">麥克風</string>
     <string name="anc_mode_off">關閉</string>
@@ -402,11 +404,15 @@
     <string name="device_settings_info_bt_name_label">藍牙裝置標籤</string>
     <string name="device_settings_info_model_label">型號</string>
     <string name="device_settings_info_manufacturer_label">製造商</string>
+    <string name="device_settings_info_hardware_label">硬體</string>
     <string name="device_settings_info_serial_label">序列號</string>
     <string name="device_settings_info_firmware_label">固件</string>
+    <string name="device_settings_info_firmware_pending_label">待更新韌體</string>
     <string name="device_settings_info_build_label">版本號</string>
     <string name="device_settings_info_left_serial_label">左耳機序號</string>
     <string name="device_settings_info_right_serial_label">右耳機序號</string>
+    <string name="device_settings_info_left_bonded_label">左耳已配對</string>
+    <string name="device_settings_info_right_bonded_label">右耳已配對</string>
     <string name="device_settings_info_details_label">裝置詳情</string>
     <string name="device_settings_info_details_action">顯示裝置詳情</string>
     <string name="device_settings_info_status_label">狀態</string>
@@ -416,8 +422,11 @@
     <string name="device_settings_not_connected_description">此裝置在附近，但尚未連線至本手機。連線後即可存取設定與控制項。</string>
     <string name="device_settings_not_connected_connect_action">連線</string>
     <string name="device_settings_not_connected_open_settings_action">開啟藍牙設定</string>
+    <string name="device_settings_not_nearby_label">裝置不在附近</string>
+    <string name="device_settings_not_nearby_description">只有當此裝置在附近並連接至您的手機時，才能使用設定。</string>
     <string name="device_settings_aap_unavailable_label">進階設定無法使用</string>
     <string name="device_settings_aap_unavailable_description">進階 AirPods 設定需要此手機上不提供的藍牙功能。您的裝置製造商將來發布的 Android 更新可能解決此問題。</string>
+    <string name="device_settings_aap_unavailable_action">查看相容性追蹤器</string>
     <string name="device_settings_category_sound_label">音效</string>
     <string name="device_settings_category_controls_label">控制</string>
     <string name="device_settings_nc_one_airpod_label">單個耳機的 ANC</string>
@@ -455,6 +464,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">單擊靖音麥克風</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">雙擊結束通話</string>
     <string name="device_settings_open_cd">開啟裝置設定</string>
+    <string name="overview_card_missing_paired_device">此設定檔沒有已配對的藍牙裝置。</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>
@@ -477,6 +487,9 @@
     <string name="device_settings_allow_off_description">將「關閉」作為可選擇的噪音控制模式。停用後，提桿循環時會跳過「關閉」模式。</string>
     <string name="device_settings_sleep_detection_label">睡眠偵測</string>
     <string name="device_settings_sleep_detection_description">入睡後自動暫停播放</string>
+    <string name="reaction_sleep_channel_label">睡眠偵測</string>
+    <string name="reaction_sleep_notification_title">已由睡眠偵測暫停</string>
+    <string name="reaction_sleep_notification_text">%1$s 偵測到您已入睡，因此您的音樂已暫停。您可以在裝置設定中停用此功能。</string>
     <string name="device_settings_rename_label">重新命名</string>
     <string name="device_settings_rename_hint">裝置名稱</string>
     <string name="device_settings_rename_confirm">重新命名</string>
@@ -486,6 +499,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">藍牙設定</string>
     <string name="device_settings_send_failed">無法套用設定：%1$s</string>
     <string name="device_settings_anc_off_rejected_message">此裝置未啟用「關閉」模式。請在「噪音控制」下啟用「允許關閉模式」。</string>
+    <string name="device_settings_category_battery_label">電池</string>
+    <string name="device_settings_charge_cap_label">最佳化充電上限</string>
+    <string name="device_settings_charge_cap_description">學習您的使用習慣，在充電達 80%% 左右時暫停充電以延長電池壽命，並在您可能使用前補滿電量。</string>
+    <string name="device_settings_charge_cap_rejected_message">最佳化充電上限無法變更。這是實驗性功能——如果持續失敗，請回報問題。</string>
     <string name="device_settings_category_connections_label">已連線裝置</string>
     <string name="device_settings_connected_devices_description">目前連接到這款 AirPods 的其他裝置</string>
     <string name="device_settings_connected_device_label">裝置 %d</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -152,6 +152,7 @@
     <string name="widget_config_transparency_label">Ukucatshulwa kwemuva</string>
     <string name="widget_config_show_device_label">Bonisa igama ledivayisi</string>
     <string name="widget_config_reset_label">Zinzele kuzilungiselelo ezisetshenziswayo</string>
+    <string name="widget_config_preview_resize_hint">Ungashintsha usayizi we-widget ngemuva kokuyibeka esikrini sakho sasekhaya.</string>
     <string name="widget_config_custom_label">Okwenziwe ngezinga</string>
     <string name="widget_config_preset_material_you">Material You</string>
     <string name="widget_config_preset_dark">Mnyama</string>
@@ -250,6 +251,7 @@
     <string name="pods_unknown_contact_dev">Lena yidivayisi engaziwa, kodwa isebenzisa ifomathi yomlayezo efanayo. Ake sengeze ukusekelwa kwayo, xhumana nami :)</string>
     <string name="pods_none_label_short">Ayikho idivayisi</string>
     <string name="pods_charging_label">Iyashaja</string>
+    <string name="pods_charging_optimized_label">Ilungisiwe</string>
     <string name="pods_inear_label">Endlebeni</string>
     <string name="pods_microphone_label">Imakrofoni</string>
     <string name="anc_mode_off">Vala</string>
@@ -407,11 +409,15 @@
     <string name="device_settings_info_bt_name_label">Ilebuli Ledivayisi ye-Bluetooth</string>
     <string name="device_settings_info_model_label">Imodeli</string>
     <string name="device_settings_info_manufacturer_label">Umdali</string>
+    <string name="device_settings_info_hardware_label">Izinto zekhompyutha</string>
     <string name="device_settings_info_serial_label">Inombolo Yesiri</string>
     <string name="device_settings_info_firmware_label">Firmware</string>
+    <string name="device_settings_info_firmware_pending_label">Isofthiwe Elindile</string>
     <string name="device_settings_info_build_label">Ukwakhiwa</string>
     <string name="device_settings_info_left_serial_label">Inombolo Yesitho Sasekhohlo</string>
     <string name="device_settings_info_right_serial_label">Inombolo Yesitho Sesokudla</string>
+    <string name="device_settings_info_left_bonded_label">Okuxhunyiwe Kwesokunxele</string>
+    <string name="device_settings_info_right_bonded_label">Okuxhunyiwe Kwesokudla</string>
     <string name="device_settings_info_details_label">Imininingwane Yedivayisi</string>
     <string name="device_settings_info_details_action">Bonisa imininingwane yedivayisi</string>
     <string name="device_settings_info_status_label">Isimo</string>
@@ -421,8 +427,11 @@
     <string name="device_settings_not_connected_description">Le divayisi iseduzane kodwa ayixhunyiwe kulefoni. Xhuma ukuze ufinyelele izilungiselelo nezilawuli.</string>
     <string name="device_settings_not_connected_connect_action">Xhuma</string>
     <string name="device_settings_not_connected_open_settings_action">Vula Izilungiselelo ze-Bluetooth</string>
+    <string name="device_settings_not_nearby_label">Idivayisi ayikho eduze</string>
+    <string name="device_settings_not_nearby_description">Izilungiselelo zitholakala kuphela lapho le divayisi iseduzane futhi ixhunywe kumakhala akho.</string>
     <string name="device_settings_aap_unavailable_label">Izilungiselelo ezithuthukisiwe azitholakali</string>
     <string name="device_settings_aap_unavailable_description">Izilungiselelo ze-AirPods ezikhethekile zidinga isici se-Bluetooth esingekho kuleli foni. Lokhu kungaxazululwa ukubuyekeza kwe-Android okuzayo kumkhiqizi wedivayisi yakho.</string>
+    <string name="device_settings_aap_unavailable_action">Buka umlandi wobufaneleko</string>
     <string name="device_settings_category_sound_label">Umsindo</string>
     <string name="device_settings_category_controls_label">Izilawuli</string>
     <string name="device_settings_nc_one_airpod_label">I-ANC nge-pod eyodwa</string>
@@ -460,6 +469,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_title">Cindezela kanye ukuvimba umsindo wekhadi</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Cindezela kabili ukuqeda ikholi</string>
     <string name="device_settings_open_cd">Vula izilungiselelo zedivayisi</string>
+    <string name="overview_card_missing_paired_device">Leli profile alinayo idivayisi ye-Bluetooth ehlanganisiwe.</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Okujwayelekile</string>
     <string name="device_settings_microphone_mode_label">Imakrofoni</string>
@@ -482,6 +492,9 @@
     <string name="device_settings_allow_off_description">Vumela imodi evaliwe njengemodi yokukhethwa yokulawula umsindo. Uma ivaliwe, imisuka yeqa imodi evaliwe ngesikhathi ijikele.</string>
     <string name="device_settings_sleep_detection_label">Ukubona Ukulala</string>
     <string name="device_settings_sleep_detection_description">Misa umsindo ngokuzenzakalela lapho ulele</string>
+    <string name="reaction_sleep_channel_label">Ukuhlola Ukulala</string>
+    <string name="reaction_sleep_notification_title">Imisiwe yi-Sleep Detection</string>
+    <string name="reaction_sleep_notification_text">%1$s wabika ukuthi ulele, ngakho umculo wakho wamiswa. Ungakuvula lokhu ezilungiselelo zedivayisi.</string>
     <string name="device_settings_rename_label">Qamba kabusha</string>
     <string name="device_settings_rename_hint">Igama ledivayisi</string>
     <string name="device_settings_rename_confirm">Qamba kabusha</string>
@@ -491,6 +504,10 @@
     <string name="device_settings_rename_system_unavailable_bt_settings_action">Izilungiselelo ze-Bluetooth</string>
     <string name="device_settings_send_failed">Akunakwenzeka ukusebenzisa ilungiselelo: %1$s</string>
     <string name="device_settings_anc_off_rejected_message">Imodi evaliwe ayisebenziswanga kule divayisi. Vula \"Vumela imodi evaliwe\" ngaphansi kwe-Noise Control.</string>
+    <string name="device_settings_category_battery_label">IBhethri</string>
+    <string name="device_settings_charge_cap_label">Umkhawulo Wokushaja Olungisiwe</string>
+    <string name="device_settings_charge_cap_description">Funda imikhuba yakho futhi misa ukushaja mayelana no-80%% ukuze ukhulise impilo yebhethri, ugcwalise amapodi ngaphambi kokuba uwasetshenzise.</string>
+    <string name="device_settings_charge_cap_rejected_message">Umkhawulo Wokushaja Olungisiwe awukwazanga ukushintshwa. Lena isici esiphenyiwe — sicela ubike uma ihluleka njalo.</string>
     <string name="device_settings_category_connections_label">Amadivayisi Axhunyiwe</string>
     <string name="device_settings_connected_devices_description">Ezinye izidivayisi ezixhunywe manje kule-AirPods</string>
     <string name="device_settings_connected_device_label">Idivayisi %d</string>


### PR DESCRIPTION
## What changed

Routine translation update from Crowdin across 75 languages. Picks up community contributions for strings added in recent feature work — optimized charge cap, sleep detection notification, the "device not nearby" connection state, the widget resize hint, and new device info labels (hardware, pending firmware, left/right bonded).

## Technical Context

- No code changes; pure Crowdin sync via `./crowdin.sh download --skip-untranslated-strings`.
- Validated for escape errors, placeholder mismatches, and vandalism — none found in the new content. Build passes.
- Some pre-existing translation quality issues surfaced during validation (e.g. garbled Armenian press controls, wrong-script characters in Khmer/Macedonian, typos in Zulu). They predate this pull and are out of scope here — fixes need to come from the respective Crowdin communities.
