### PR TITLE
Fix: Auto-exit press controls screen when AirPods disconnect

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsViewModel.kt
@@ -439,6 +439,11 @@ class DeviceSettingsViewModel @Inject constructor(
     fun navToPressControls() = launch {
         log(TAG, INFO) { "navToPressControls()" }
         val profileId = targetProfileId.value ?: return@launch
+        val device = deviceMonitor.getDeviceForProfile(profileId)
+        if (device?.isAapReady != true) {
+            log(TAG, INFO) { "navToPressControls(): aborted, device not AAP-ready" }
+            return@launch
+        }
         navTo(Nav.Main.PressControls(profileId = profileId))
     }
 

--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/NoiseControlCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/NoiseControlCard.kt
@@ -133,7 +133,10 @@ internal fun NoiseControlCard(
                     text = stringResource(R.string.press_controls_long_press_anc_cycle_info),
                     type = InfoBoxType.INFO,
                     action = {
-                        TextButton(onClick = onPressControlsClick) {
+                        TextButton(
+                            onClick = onPressControlsClick,
+                            enabled = enabled,
+                        ) {
                             Text(stringResource(R.string.device_settings_noise_control_open_press_controls_action))
                         }
                     },

--- a/app/src/main/java/eu/darken/capod/main/ui/presscontrols/PressControlsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/presscontrols/PressControlsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -69,6 +70,18 @@ fun PressControlsScreenHost(
 
     val state by vm.state.collectAsStateWithLifecycle(initialValue = null)
     val currentState = state ?: return
+
+    val isAapConnected = currentState.device?.isAapConnected == true
+    var hasSeenAapConnected by rememberSaveable(profileId) { mutableStateOf(false) }
+    var didAutoNavigate by rememberSaveable(profileId) { mutableStateOf(false) }
+    LaunchedEffect(profileId, isAapConnected) {
+        if (isAapConnected) {
+            hasSeenAapConnected = true
+        } else if (hasSeenAapConnected && !didAutoNavigate) {
+            didAutoNavigate = true
+            vm.navUp()
+        }
+    }
 
     PressControlsScreen(
         state = currentState,


### PR DESCRIPTION
## What changed

When AirPods disconnect while you're on the press controls sub-screen (stem action mappings, press timing options), most controls used to silently hide without telling you why — leaving a half-rendered page where any setting tweak would silently fail. The screen now closes back to device settings as soon as the connection ends, where the existing "Not connected" / "Out of range" cards explain what happened.

Also tightens a couple of entry points so press controls can no longer be opened from device settings while AirPods aren't ready in the first place.

## Technical Context

- Sub-screen had no disconnect feedback because the existing `state ?: return` early-exit never fires after init — the VM emits a non-null `State` with `device = null` on disconnect. The cached profile fallback keeps `model.features` alive, so stem mappings kept rendering while AAP-gated press-timing rows vanished, producing the half-rendered look.
- Disconnect signal is `device?.isAapConnected` (= `aap != null`), not `isAapReady`. AAP sessions normally pass through `CONNECTING` / `HANDSHAKING` states, so `isAapReady` would pop users out during routine re-handshakes — `isAapConnected` only flips when the L2CAP socket actually tears down.
- Falling-edge flags (`hasSeenAapConnected`, `didAutoNavigate`) use `rememberSaveable` keyed on the profile id. Plain `remember` would lose the seen-connected bit across rotation, so a rotation that lands after disconnect would leave the user stuck on the stale screen. `didAutoNavigate` is a one-shot guard against a `READY → drop → READY → drop` bounce enqueueing two `NavEvent.Up` and popping past device settings.
- Entry-gating fixes: the long-press-conflict info-box's "open press controls" button and `navToPressControls()` itself now both gate on `isAapReady`. Stricter than the in-session check on purpose — entry should require a fully ready session, but mid-session brief handshaking shouldn't kick the user out.
