### PR TITLE
Reaction: Fix false auto-pause from Bluetooth interference

### DIFF
--- a/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
@@ -16,7 +16,6 @@ import eu.darken.capod.monitor.core.primaryDevice
 import eu.darken.capod.pods.core.apple.ble.devices.ApplePods
 import eu.darken.capod.reaction.core.playpause.PlayPause.Companion.PAUSE_DEBOUNCE_SAMPLES
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
@@ -36,6 +35,8 @@ class PlayPause @Inject constructor(
     fun monitor() = run {
         var pendingPlayConfirmation: PendingPlayConfirmation? = null
         var pendingPauseDebounce: PendingPauseDebounce? = null
+        var hasLastMonitorKey = false
+        var lastMonitorKey: PlayPauseMonitorKey? = null
 
         deviceMonitor.primaryDevice()
             .map { device -> device?.reactions?.let { it.autoPlay || it.autoPause } == true }
@@ -46,6 +47,8 @@ class PlayPause @Inject constructor(
                 } else {
                     pendingPlayConfirmation = null
                     pendingPauseDebounce = null
+                    hasLastMonitorKey = false
+                    lastMonitorKey = null
                     emptyFlow()
                 }
             }
@@ -53,6 +56,8 @@ class PlayPause @Inject constructor(
                 if (connected.isEmpty()) {
                     pendingPlayConfirmation = null
                     pendingPauseDebounce = null
+                    hasLastMonitorKey = false
+                    lastMonitorKey = null
                     log(TAG) { "No known devices connected." }
                     emptyFlow()
                 } else {
@@ -61,9 +66,20 @@ class PlayPause @Inject constructor(
                 }
             }
             // Cache persistence can update battery timestamps without changing any reaction-relevant state.
-            .distinctUntilChangedBy { it?.toPlayPauseMonitorKey() }
+            .filter { device ->
+                val key = device?.toPlayPauseMonitorKey()
+                val shouldEmit = !hasLastMonitorKey ||
+                    key != lastMonitorKey ||
+                    device?.isPauseDebounceResetCandidate(pendingPauseDebounce) == true
+
+                if (shouldEmit) {
+                    hasLastMonitorKey = true
+                    lastMonitorKey = key
+                }
+                shouldEmit
+            }
             .onEach { device ->
-                log(TAG, VERBOSE) { "Post-distinct: profileId=${device?.profileId}" }
+                log(TAG, VERBOSE) { "Post-monitor-filter: profileId=${device?.profileId}" }
             }
             .withPrevious()
             .filter { (previous, current) ->
@@ -92,6 +108,22 @@ class PlayPause @Inject constructor(
                     pendingPlayConfirmation = null
                     if (pendingPauseDebounce != null) {
                         log(TAG, DEBUG) { "Pause debounce reset: no reactions on device" }
+                        pendingPauseDebounce = null
+                    }
+                    return@onEach
+                }
+
+                // Skip the reaction when previous was a no-live-evidence emission (cache-only
+                // baseline emitted at process start, or after a >20s BLE gap that evicted the
+                // device from the live cache). PodDevice.isBeingWorn returns null for those,
+                // and toEarDetectionState() coerces null -> false, which would produce a
+                // fake "not-worn -> worn" transition the moment live BLE arrives — firing
+                // an unwanted autoPlay on app start while the user is wearing the pods.
+                if (previous?.earDetectionSource() == EarDetectionSource.NO_LIVE_BLE) {
+                    log(TAG, VERBOSE) { "Previous emission has no live evidence; skipping reaction." }
+                    pendingPlayConfirmation = null
+                    if (pendingPauseDebounce != null) {
+                        log(TAG, DEBUG) { "Pause debounce reset: previous emission lacked live evidence" }
                         pendingPauseDebounce = null
                     }
                     return@onEach
@@ -138,6 +170,8 @@ class PlayPause @Inject constructor(
                 val isCurrentlyPlaying = mediaControl.isPlaying
                 val wasRecentlyPausedByUs = mediaControl.wasRecentlyPausedByCap
 
+                val source = current.earDetectionSource()
+
                 // Evaluate what action to take
                 val rawDecision = evaluatePlayPauseAction(
                     previous = prevState,
@@ -147,11 +181,18 @@ class PlayPause @Inject constructor(
                     wasRecentlyPausedByUs = wasRecentlyPausedByUs,
                 )
 
+                // BLE-only autoplay confirmation only applies to UNAUTHENTICATED sources.
+                // Trusted sources (AAP, BLE_IRK_MATCH) skip staging — symmetric to the
+                // pause debounce, which also skips for these sources. Without this gate,
+                // an IRK-matched device with no live AAP would stage a BLE-only confirmation
+                // that never confirms (the second worn sample has no freshness on the
+                // monitor key for IRK_MATCH so it gets collapsed).
                 val shouldStageBleOnlyPlay = rawDecision.shouldPlay &&
                     reactions.autoPlay &&
                     !reactions.onePodMode &&
                     current.hasDualPods &&
-                    current.aap?.aapEarDetection == null
+                    (source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
+                        source == EarDetectionSource.BLE_ANONYMOUS)
 
                 val confirmation = applyBleOnlyPlayConfirmation(
                     pending = pendingPlayConfirmation,
@@ -173,7 +214,6 @@ class PlayPause @Inject constructor(
                     log(TAG, VERBOSE) { "BLE-only autoplay confirmed by a follow-up state update" }
                 }
 
-                val source = current.earDetectionSource()
                 val debounceResult = applyPauseDebounce(
                     pending = pendingPauseDebounce,
                     profileId = current.profileId,
@@ -641,7 +681,7 @@ class PlayPause @Inject constructor(
         val hasBleSnapshot: Boolean,
         val source: EarDetectionSource,
         // Set only for debounce-eligible sources (BLE_PROFILE_FALLBACK / BLE_ANONYMOUS) so
-        // that distinctUntilChangedBy doesn't collapse repeated identical not-worn samples
+        // that monitor distinct filtering doesn't collapse repeated identical not-worn samples
         // and the debounce counter can advance.
         //
         // Caveat: BlePodMonitor.preferCaseContextPod can keep an existing case-context
@@ -664,13 +704,18 @@ class PlayPause @Inject constructor(
 
     internal fun PodDevice.toPlayPauseMonitorKey(): PlayPauseMonitorKey {
         val source = earDetectionSource()
-        // Freshness is needed only on debounce-eligible NOT-WORN samples. Including
-        // worn samples would also break distinctUntilChangedBy for identical both-in
-        // samples, accidentally enabling BLE-only auto-play confirmation to fire on
-        // repeated unauthenticated adverts.
-        val needsFreshness = (source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
-            source == EarDetectionSource.BLE_ANONYMOUS) &&
-            isBeingWorn != true
+        // Freshness applies to all unauthenticated samples (both worn and not-worn) so
+        // that monitor distinct filtering doesn't collapse repeated identical samples:
+        //   - not-worn samples must pass through to advance the pause debounce counter
+        //   - worn samples must pass through to satisfy applyBleOnlyPlayConfirmation,
+        //     which requires a 2nd identical worn sample to confirm a staged play
+        //     (see commit 6825abaa "Guard BLE-only autoplay")
+        // The 2-sample autoplay confirmation IS the debounce on the play side, mirroring
+        // the pause debounce. isPauseDebounceResetCandidate() remains as a defense-in-depth
+        // backstop for the rare case where seenLastAt doesn't advance between samples
+        // (e.g. BlePodMonitor.preferCaseContextPod preserves the prior snapshot).
+        val needsFreshness = source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
+            source == EarDetectionSource.BLE_ANONYMOUS
         return PlayPauseMonitorKey(
             profileId = profileId,
             autoPlay = reactions.autoPlay,
@@ -687,6 +732,17 @@ class PlayPause @Inject constructor(
             source = source,
             debounceFreshness = if (needsFreshness) ble?.seenLastAt else null,
         )
+    }
+
+    private fun PodDevice.isPauseDebounceResetCandidate(pending: PendingPauseDebounce?): Boolean {
+        val activePending = pending?.takeIf { it.profileId == profileId } ?: return false
+        val source = earDetectionSource()
+        val needsDebounce = source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
+            source == EarDetectionSource.BLE_ANONYMOUS
+
+        if (!needsDebounce || !hasEarDetection) return false
+
+        return toEarDetectionState().podCount > activePending.initialPodCount
     }
 
     /**

--- a/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
@@ -2,6 +2,8 @@ package eu.darken.capod.reaction.core.playpause
 
 import eu.darken.capod.common.MediaControl
 import eu.darken.capod.common.bluetooth.BluetoothManager2
+import eu.darken.capod.common.debug.logging.Logging.Priority.DEBUG
+import eu.darken.capod.common.debug.logging.Logging.Priority.INFO
 import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
 import eu.darken.capod.common.debug.logging.log
@@ -11,6 +13,8 @@ import eu.darken.capod.common.flow.withPrevious
 import eu.darken.capod.monitor.core.DeviceMonitor
 import eu.darken.capod.monitor.core.PodDevice
 import eu.darken.capod.monitor.core.primaryDevice
+import eu.darken.capod.pods.core.apple.ble.devices.ApplePods
+import eu.darken.capod.reaction.core.playpause.PlayPause.Companion.PAUSE_DEBOUNCE_SAMPLES
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emptyFlow
@@ -18,6 +22,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +35,7 @@ class PlayPause @Inject constructor(
 
     fun monitor() = run {
         var pendingPlayConfirmation: PendingPlayConfirmation? = null
+        var pendingPauseDebounce: PendingPauseDebounce? = null
 
         deviceMonitor.primaryDevice()
             .map { device -> device?.reactions?.let { it.autoPlay || it.autoPause } == true }
@@ -39,12 +45,14 @@ class PlayPause @Inject constructor(
                     bluetoothManager.connectedDevices
                 } else {
                     pendingPlayConfirmation = null
+                    pendingPauseDebounce = null
                     emptyFlow()
                 }
             }
             .flatMapLatest { connected ->
                 if (connected.isEmpty()) {
                     pendingPlayConfirmation = null
+                    pendingPauseDebounce = null
                     log(TAG) { "No known devices connected." }
                     emptyFlow()
                 } else {
@@ -63,7 +71,13 @@ class PlayPause @Inject constructor(
                 // Use profileId (stable across BLE address rotations) rather than BLE identifier.
                 // Only profiled devices reach this point (outer gate requires profile.autoPlay/autoPause).
                 val match = previous.profileId != null && previous.profileId == current.profileId
-                if (!match) log(TAG, WARN) { "Main device switched, skipping reaction." }
+                if (!match) {
+                    log(TAG, WARN) { "Main device switched, skipping reaction." }
+                    if (pendingPauseDebounce != null) {
+                        log(TAG, DEBUG) { "Pause debounce reset: profile change" }
+                        pendingPauseDebounce = null
+                    }
+                }
                 match
             }
             .onEach { (previous, current) ->
@@ -76,6 +90,10 @@ class PlayPause @Inject constructor(
                 if (reactions == null) {
                     log(TAG, VERBOSE) { "No reactions on current device, skipping reaction" }
                     pendingPlayConfirmation = null
+                    if (pendingPauseDebounce != null) {
+                        log(TAG, DEBUG) { "Pause debounce reset: no reactions on device" }
+                        pendingPauseDebounce = null
+                    }
                     return@onEach
                 }
 
@@ -109,6 +127,10 @@ class PlayPause @Inject constructor(
                     else -> {
                         log(TAG, VERBOSE) { "Device doesn't support ear detection: $current" }
                         pendingPlayConfirmation = null
+                        if (pendingPauseDebounce != null) {
+                            log(TAG, DEBUG) { "Pause debounce reset: device lost ear detection" }
+                            pendingPauseDebounce = null
+                        }
                         return@onEach
                     }
                 }
@@ -151,7 +173,37 @@ class PlayPause @Inject constructor(
                     log(TAG, VERBOSE) { "BLE-only autoplay confirmed by a follow-up state update" }
                 }
 
-                val decision = confirmation.decision
+                val source = current.earDetectionSource()
+                val debounceResult = applyPauseDebounce(
+                    pending = pendingPauseDebounce,
+                    profileId = current.profileId,
+                    source = source,
+                    rawDecision = confirmation.decision,
+                    currentState = currState,
+                    autoPauseEnabled = reactions.autoPause,
+                )
+                pendingPauseDebounce = debounceResult.pending
+
+                when (debounceResult.event) {
+                    PauseDebounceEvent.STARTED -> log(TAG, DEBUG) {
+                        "Pause debounce started: source=$source, initialPodCount=${debounceResult.pending?.initialPodCount}, " +
+                            "remaining=${debounceResult.pending?.confirmationsRemaining}"
+                    }
+                    PauseDebounceEvent.ADVANCED -> log(TAG, DEBUG) {
+                        "Pause debounce advanced: remaining=${debounceResult.pending?.confirmationsRemaining}, " +
+                            "currentPodCount=${currState.podCount}"
+                    }
+                    PauseDebounceEvent.RESET -> log(TAG, DEBUG) {
+                        "Pause debounce reset: source=$source, currentPodCount=${currState.podCount}, " +
+                            "rawShouldPlay=${confirmation.decision.shouldPlay}"
+                    }
+                    PauseDebounceEvent.COMMITTED -> log(TAG, DEBUG) {
+                        "Pause debounce committed: source=$source confirmed pause"
+                    }
+                    PauseDebounceEvent.NONE -> {}
+                }
+
+                val decision = debounceResult.decision
                 if (decision.usedRecentCapPauseOverride) {
                     log(TAG, VERBOSE) {
                         "Resume override: recent CAP pause window is active, allowing play despite playing=true"
@@ -171,8 +223,16 @@ class PlayPause @Inject constructor(
                     }
 
                     decision.shouldPause && reactions.autoPause -> {
-                        log(TAG) { "autoPause is triggered, sendPause() - ${decision.reason}" }
-                        mediaControl.sendPause()
+                        val pauseSent = mediaControl.sendPause()
+                        log(TAG, INFO) {
+                            "autoPause triggered: source=$source, " +
+                                "wasWorn=${prevState.bothInEar}, isWorn=${currState.bothInEar}, " +
+                                "podCount=${prevState.podCount}->${currState.podCount}, " +
+                                "bleKeyState=${current.bleKeyState}, " +
+                                "aapEar=${current.aap?.aapEarDetection != null}, " +
+                                "aapConn=${current.aap?.connectionState}, " +
+                                "pauseSent=$pauseSent, reason=${decision.reason}"
+                        }
                     }
 
                     decision.shouldPause && !reactions.autoPause -> {
@@ -319,6 +379,111 @@ class PlayPause @Inject constructor(
         )
     }
 
+    /**
+     * Sample-count debounce for pause decisions when the ear-detection source is an
+     * unauthenticated BLE advertisement.
+     *
+     * RF interference can produce a single corrupt advert that decodes as not-worn,
+     * triggering a false pause. With [PAUSE_DEBOUNCE_SAMPLES] = 2, a pause requires
+     * 3 consecutive not-worn samples before firing.
+     *
+     * The helper advances [pending] from [currentState], NOT from [rawDecision.shouldPause]
+     * — subsequent samples after the initial detection are not-worn → not-worn, and
+     * [evaluateNormalMode] returns no action for those.
+     *
+     * Confirmation rule: a sample with `currentState.podCount <= pending.initialPodCount`
+     * counts as a confirmation. An *increase* (pod returned) clears pending.
+     *
+     * Trusted sources ([EarDetectionSource.AAP], [EarDetectionSource.BLE_IRK_MATCH]) skip
+     * debounce and pass through [rawDecision] unchanged; any active [pending] is cleared.
+     */
+    internal fun applyPauseDebounce(
+        pending: PendingPauseDebounce?,
+        profileId: String?,
+        source: EarDetectionSource,
+        rawDecision: PlayPauseDecision,
+        currentState: EarDetectionState,
+        autoPauseEnabled: Boolean,
+    ): PauseDebounceResult {
+        val needsDebounce = source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
+            source == EarDetectionSource.BLE_ANONYMOUS
+
+        val activePending = pending?.takeIf { it.profileId == profileId }
+
+        // NO_LIVE_BLE: no fresh evidence anywhere (ble == null, aap absent or no EarDetection).
+        // Suppress shouldPause — a worn → not-worn transition derived from null/cached state is
+        // not real removal evidence. Also clears any active pending since stale samples must not
+        // advance confirmations.
+        if (source == EarDetectionSource.NO_LIVE_BLE) {
+            val event = if (activePending != null) PauseDebounceEvent.RESET else PauseDebounceEvent.NONE
+            return PauseDebounceResult(
+                decision = rawDecision.copy(
+                    shouldPause = false,
+                    reason = "${rawDecision.reason} (suppressed: no live BLE evidence)",
+                ),
+                pending = null,
+                event = event,
+            )
+        }
+
+        // Non-debounce-eligible trusted sources (AAP / BLE_IRK_MATCH) and disabled debounce:
+        // pass raw decision through and clear any active pending.
+        if (!needsDebounce || !autoPauseEnabled || profileId == null) {
+            val event = if (activePending != null) PauseDebounceEvent.RESET else PauseDebounceEvent.NONE
+            return PauseDebounceResult(decision = rawDecision, pending = null, event = event)
+        }
+
+        // First detection: no active pending, raw decision wants to pause → start debounce.
+        if (activePending == null) {
+            if (!rawDecision.shouldPause) {
+                return PauseDebounceResult(decision = rawDecision, pending = null, event = PauseDebounceEvent.NONE)
+            }
+            if (PAUSE_DEBOUNCE_SAMPLES <= 0) {
+                return PauseDebounceResult(decision = rawDecision, pending = null, event = PauseDebounceEvent.NONE)
+            }
+            return PauseDebounceResult(
+                decision = rawDecision.copy(
+                    shouldPause = false,
+                    reason = "${rawDecision.reason} (debouncing, $PAUSE_DEBOUNCE_SAMPLES confirmation(s) needed)",
+                ),
+                pending = PendingPauseDebounce(
+                    profileId = profileId,
+                    initialPodCount = currentState.podCount,
+                    confirmationsRemaining = PAUSE_DEBOUNCE_SAMPLES,
+                ),
+                event = PauseDebounceEvent.STARTED,
+            )
+        }
+
+        // Confirmation phase: pending exists.
+        // Reset cases: pod returned (count went up) or raw decision wants to play.
+        if (currentState.podCount > activePending.initialPodCount || rawDecision.shouldPlay) {
+            return PauseDebounceResult(decision = rawDecision, pending = null, event = PauseDebounceEvent.RESET)
+        }
+
+        // Confirmation: count <= initialPodCount, decrement remaining.
+        val remaining = activePending.confirmationsRemaining - 1
+        if (remaining <= 0) {
+            return PauseDebounceResult(
+                decision = PlayPauseDecision(
+                    shouldPlay = false,
+                    shouldPause = true,
+                    reason = "Debounced pause confirmed (initial count: ${activePending.initialPodCount}, current: ${currentState.podCount})",
+                ),
+                pending = null,
+                event = PauseDebounceEvent.COMMITTED,
+            )
+        }
+        return PauseDebounceResult(
+            decision = rawDecision.copy(
+                shouldPause = false,
+                reason = "Debouncing pause ($remaining confirmation(s) remaining)",
+            ),
+            pending = activePending.copy(confirmationsRemaining = remaining),
+            event = PauseDebounceEvent.ADVANCED,
+        )
+    }
+
     data class EarDetectionState(
         val leftInEar: Boolean?,    // null for single pod devices
         val rightInEar: Boolean?,   // null for single pod devices
@@ -389,6 +554,37 @@ class PlayPause @Inject constructor(
         val stagedConfirmation: Boolean,
     )
 
+    /**
+     * Trust classification for the source of the current ear-detection reading.
+     *
+     * - [AAP]: EarDetection setting from an active AAP (L2CAP) session — error-corrected,
+     *   identity-authenticated. Trusted; debounce skipped.
+     * - [BLE_IRK_MATCH]: BLE advertisement whose RPA was verified against this profile's
+     *   identity key. Identity-authenticated; debounce skipped.
+     * - [BLE_PROFILE_FALLBACK]: BLE advertisement assigned to a profile via signal-quality
+     *   fallback (no IRK match). Could be a stray advert from a nearby pair. Debounced.
+     * - [BLE_ANONYMOUS]: BLE advertisement with no profile match. Debounced.
+     * - [NO_LIVE_BLE]: No live BLE snapshot at all (cache-only or empty). Not debounced —
+     *   the cached state is not "fresh evidence" so it must not advance the debounce counter.
+     *   Any active pending is cleared.
+     */
+    enum class EarDetectionSource { AAP, BLE_IRK_MATCH, BLE_PROFILE_FALLBACK, BLE_ANONYMOUS, NO_LIVE_BLE }
+
+    data class PendingPauseDebounce(
+        val profileId: String,
+        val initialPodCount: Int,
+        val confirmationsRemaining: Int,
+    )
+
+    /** Discrete event produced by [applyPauseDebounce] for diagnostic logging. */
+    enum class PauseDebounceEvent { NONE, STARTED, ADVANCED, RESET, COMMITTED }
+
+    data class PauseDebounceResult(
+        val decision: PlayPauseDecision,
+        val pending: PendingPauseDebounce?,
+        val event: PauseDebounceEvent = PauseDebounceEvent.NONE,
+    )
+
     internal data class PlayPauseMonitorKey(
         val profileId: String?,
         val autoPlay: Boolean,
@@ -402,10 +598,34 @@ class PlayPause @Inject constructor(
         val isEitherPodInEar: Boolean?,
         val hasAapEarDetection: Boolean,
         val hasBleSnapshot: Boolean,
+        val source: EarDetectionSource,
+        // Set only for debounce-eligible sources (BLE_PROFILE_FALLBACK / BLE_ANONYMOUS) so
+        // that distinctUntilChangedBy doesn't collapse repeated identical not-worn samples
+        // and the debounce counter can advance.
+        //
+        // Caveat: BlePodMonitor.preferCaseContextPod can keep an existing case-context
+        // snapshot in place over an incoming non-case-context snapshot, preserving the old
+        // seenLastAt. This is fail-closed (delays a legitimate unauthenticated-BLE pause
+        // rather than firing a false one), so accepted as a trade-off.
+        val debounceFreshness: Instant?,
     )
 
-    internal fun PodDevice.toPlayPauseMonitorKey(): PlayPauseMonitorKey =
-        PlayPauseMonitorKey(
+    internal fun PodDevice.earDetectionSource(): EarDetectionSource {
+        if (aap?.aapEarDetection != null) return EarDetectionSource.AAP
+        if (ble == null) return EarDetectionSource.NO_LIVE_BLE
+        val applePod = ble as? ApplePods
+        return when {
+            applePod?.meta?.isIRKMatch == true -> EarDetectionSource.BLE_IRK_MATCH
+            ble.meta.profile != null -> EarDetectionSource.BLE_PROFILE_FALLBACK
+            else -> EarDetectionSource.BLE_ANONYMOUS
+        }
+    }
+
+    internal fun PodDevice.toPlayPauseMonitorKey(): PlayPauseMonitorKey {
+        val source = earDetectionSource()
+        val needsFreshness = source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
+            source == EarDetectionSource.BLE_ANONYMOUS
+        return PlayPauseMonitorKey(
             profileId = profileId,
             autoPlay = reactions.autoPlay,
             autoPause = reactions.autoPause,
@@ -418,20 +638,34 @@ class PlayPause @Inject constructor(
             isEitherPodInEar = isEitherPodInEar,
             hasAapEarDetection = aap?.aapEarDetection != null,
             hasBleSnapshot = ble != null,
+            source = source,
+            debounceFreshness = if (needsFreshness) ble?.seenLastAt else null,
         )
+    }
 
     /**
      * Converts a dual-pod [PodDevice] to [EarDetectionState] for reaction evaluation.
-     * Prefers per-side values (left/right) when available, falls back to AAP aggregate
-     * state (isBeingWorn/isEitherPodInEar) when per-side mapping is unknown.
+     *
+     * When AAP EarDetection is present, prefers AAP aggregate state — even if per-side
+     * (left/right) values are non-null via BLE fallback. This avoids letting BLE per-side
+     * bits drive the decision when AAP has authoritative aggregate state but
+     * resolvedPrimaryPod is unknown (cmd 0x0008 not received or cleared by role swap).
+     *
+     * When AAP is absent, prefers per-side values (BLE) when available, falling back to
+     * AAP aggregate as a last resort (which is identical to BLE aggregate in this case).
      */
-    private fun PodDevice.toEarDetectionState(): EarDetectionState {
+    internal fun PodDevice.toEarDetectionState(): EarDetectionState {
+        if (aap?.aapEarDetection != null) {
+            return EarDetectionState.fromAapAggregate(
+                isBeingWorn = isBeingWorn ?: false,
+                isEitherPodInEar = isEitherPodInEar ?: false,
+            )
+        }
         val left = isLeftInEar
         val right = isRightInEar
         if (left != null && right != null) {
             return EarDetectionState.fromDualPod(left = left, right = right)
         }
-        // Per-side unavailable (resolvedPrimaryPod is null) — use aggregate AAP state.
         return EarDetectionState.fromAapAggregate(
             isBeingWorn = isBeingWorn ?: false,
             isEitherPodInEar = isEitherPodInEar ?: false,
@@ -440,5 +674,11 @@ class PlayPause @Inject constructor(
 
     companion object {
         private val TAG = logTag("Reaction", "PlayPause")
+
+        /**
+         * Number of additional confirmations required before an unauthenticated-BLE pause
+         * decision is dispatched. With 2, a pause needs 3 consecutive not-worn samples total.
+         */
+        internal const val PAUSE_DEBOUNCE_SAMPLES = 2
     }
 }

--- a/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/playpause/PlayPause.kt
@@ -228,7 +228,6 @@ class PlayPause @Inject constructor(
                             "autoPause triggered: source=$source, " +
                                 "wasWorn=${prevState.bothInEar}, isWorn=${currState.bothInEar}, " +
                                 "podCount=${prevState.podCount}->${currState.podCount}, " +
-                                "bleKeyState=${current.bleKeyState}, " +
                                 "aapEar=${current.aap?.aapEarDetection != null}, " +
                                 "aapConn=${current.aap?.connectionState}, " +
                                 "pauseSent=$pauseSent, reason=${decision.reason}"
@@ -427,8 +426,25 @@ class PlayPause @Inject constructor(
         }
 
         // Non-debounce-eligible trusted sources (AAP / BLE_IRK_MATCH) and disabled debounce:
-        // pass raw decision through and clear any active pending.
+        // pass raw decision through and clear any active pending. Special case: if a
+        // pending was active and the trusted source still shows the not-worn condition
+        // (currentState.podCount <= initialPodCount and no play decision), commit the
+        // pause now — the trusted source corroborates what BLE-debounce was waiting on.
         if (!needsDebounce || !autoPauseEnabled || profileId == null) {
+            if (activePending != null && autoPauseEnabled &&
+                currentState.podCount <= activePending.initialPodCount &&
+                !rawDecision.shouldPlay
+            ) {
+                return PauseDebounceResult(
+                    decision = PlayPauseDecision(
+                        shouldPlay = false,
+                        shouldPause = true,
+                        reason = "Pause confirmed by trusted source ($source) after BLE-debounce",
+                    ),
+                    pending = null,
+                    event = PauseDebounceEvent.COMMITTED,
+                )
+            }
             val event = if (activePending != null) PauseDebounceEvent.RESET else PauseDebounceEvent.NONE
             return PauseDebounceResult(decision = rawDecision, pending = null, event = event)
         }
@@ -456,8 +472,24 @@ class PlayPause @Inject constructor(
         }
 
         // Confirmation phase: pending exists.
-        // Reset cases: pod returned (count went up) or raw decision wants to play.
-        if (currentState.podCount > activePending.initialPodCount || rawDecision.shouldPlay) {
+        // Reset cases — checked in order of authority:
+        //   1. Raw decision wants to play → genuine play signal, reset immediately.
+        //   2. Pod count went up → tolerate one rebound sample (corrupt count-up
+        //      protection), reset only on the second consecutive count-up.
+        if (rawDecision.shouldPlay) {
+            return PauseDebounceResult(decision = rawDecision, pending = null, event = PauseDebounceEvent.RESET)
+        }
+        if (currentState.podCount > activePending.initialPodCount) {
+            if (activePending.resetTolerance > 0) {
+                return PauseDebounceResult(
+                    decision = rawDecision.copy(
+                        shouldPause = false,
+                        reason = "Debouncing pause (rebound tolerated)",
+                    ),
+                    pending = activePending.copy(resetTolerance = activePending.resetTolerance - 1),
+                    event = PauseDebounceEvent.ADVANCED,
+                )
+            }
             return PauseDebounceResult(decision = rawDecision, pending = null, event = PauseDebounceEvent.RESET)
         }
 
@@ -563,7 +595,11 @@ class PlayPause @Inject constructor(
      *   identity key. Identity-authenticated; debounce skipped.
      * - [BLE_PROFILE_FALLBACK]: BLE advertisement assigned to a profile via signal-quality
      *   fallback (no IRK match). Could be a stray advert from a nearby pair. Debounced.
-     * - [BLE_ANONYMOUS]: BLE advertisement with no profile match. Debounced.
+     * - [BLE_ANONYMOUS]: BLE advertisement with no profile match. Filtered out by
+     *   [primaryDevice] in production (devices without profileId are dropped before
+     *   reaching the reaction layer); kept here defensively in case the upstream filter
+     *   changes. Note: [PendingPauseDebounce] is profile-keyed, so a null profileId can
+     *   never sustain pending state even if this branch is hit.
      * - [NO_LIVE_BLE]: No live BLE snapshot at all (cache-only or empty). Not debounced —
      *   the cached state is not "fresh evidence" so it must not advance the debounce counter.
      *   Any active pending is cleared.
@@ -574,6 +610,11 @@ class PlayPause @Inject constructor(
         val profileId: String,
         val initialPodCount: Int,
         val confirmationsRemaining: Int,
+        // Tolerates one count-up rebound sample before the pending is reset. Mirrors the
+        // count-down debounce on the pause side: a single corrupt advert that briefly
+        // shows a pod returning shouldn't kill the pending, since the next sample may
+        // confirm the pods are still out.
+        val resetTolerance: Int = 1,
     )
 
     /** Discrete event produced by [applyPauseDebounce] for diagnostic logging. */
@@ -623,8 +664,13 @@ class PlayPause @Inject constructor(
 
     internal fun PodDevice.toPlayPauseMonitorKey(): PlayPauseMonitorKey {
         val source = earDetectionSource()
-        val needsFreshness = source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
-            source == EarDetectionSource.BLE_ANONYMOUS
+        // Freshness is needed only on debounce-eligible NOT-WORN samples. Including
+        // worn samples would also break distinctUntilChangedBy for identical both-in
+        // samples, accidentally enabling BLE-only auto-play confirmation to fire on
+        // repeated unauthenticated adverts.
+        val needsFreshness = (source == EarDetectionSource.BLE_PROFILE_FALLBACK ||
+            source == EarDetectionSource.BLE_ANONYMOUS) &&
+            isBeingWorn != true
         return PlayPauseMonitorKey(
             profileId = profileId,
             autoPlay = reactions.autoPlay,

--- a/app/src/test/java/eu/darken/capod/reaction/core/playpause/PlayPauseLogicTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/playpause/PlayPauseLogicTest.kt
@@ -1433,7 +1433,7 @@ class PlayPauseLogicTest : BaseTest() {
         @Test
         fun `monitor key freshness field differs across BLE scans for unauthenticated source`() {
             // Repeated identical not-worn samples must produce distinct monitor keys when
-            // bleKeyState is NONE / profile-fallback, so distinctUntilChangedBy doesn't
+            // bleKeyState is NONE / profile-fallback, so monitor distinct filtering doesn't
             // collapse them and the debounce counter can advance.
             val now = java.time.Instant.parse("2026-01-01T00:00:00Z")
             val ble1 = mockk<DualApplePods>(relaxed = true) {
@@ -1473,7 +1473,7 @@ class PlayPauseLogicTest : BaseTest() {
         @Test
         fun `monitor key freshness field is null for IRK-authenticated source`() {
             // For IRK_MATCH source, debounceFreshness should be null so that battery-only
-            // updates with identical wear state still collapse via distinctUntilChangedBy.
+            // updates with identical wear state still collapse via monitor distinct filtering.
             val now = java.time.Instant.parse("2026-01-01T00:00:00Z")
             val profile = mockk<eu.darken.capod.profiles.core.AppleDeviceProfile>(relaxed = true)
             val ble = mockk<DualApplePods>(relaxed = true) {
@@ -1583,7 +1583,7 @@ class PlayPauseLogicTest : BaseTest() {
             advanceUntilIdle()
 
             // T1, T2, T3: identical not-worn samples with incrementing seenLastAt.
-            // Without the freshness fix, distinctUntilChangedBy would collapse T2 and T3
+            // Without the freshness fix, monitor distinct filtering would collapse T2 and T3
             // and the debounce counter could never advance. With it, the helper sees
             // 3 samples and commits the pause on the third.
             deviceFlow.value = listOf(buildDevice(now.plusMillis(1000), leftWorn = false, rightWorn = false))
@@ -1594,6 +1594,296 @@ class PlayPauseLogicTest : BaseTest() {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { mediaControl.sendPause() }
+
+            job.cancel()
+        }
+
+        @Test
+        fun `flow - stable worn rebound resets stale pause debounce before a new removal sequence`() = runTest {
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns true
+                every { wasRecentlyPausedByCap } returns false
+                coEvery { sendPause() } returns true
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: worn baseline
+            deviceFlow.value = listOf(buildDevice(now, leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            // T1: corrupt not-worn sample starts pause debounce.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(1000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            // T2/T3: the pods are stably worn again. T2 consumes resetTolerance, and T3
+            // must still reach applyPauseDebounce so the stale pending state is cleared.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(2000), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(3000), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            // T4/T5: a later real removal has only two not-worn samples so far. If T3 was
+            // collapsed, stale pending from T1 would incorrectly commit a pause here.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(4000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(5000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { mediaControl.sendPause() }
+
+            // T6: the new removal sequence reaches three consecutive not-worn samples.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(6000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mediaControl.sendPause() }
+
+            job.cancel()
+        }
+
+        private fun buildIrkMatchedBle(seenAt: Instant, leftWorn: Boolean, rightWorn: Boolean) =
+            mockk<DualApplePods>(relaxed = true) {
+                every { meta } returns ApplePods.AppleMeta(
+                    isIRKMatch = true,
+                    profile = mockk(relaxed = true),
+                )
+                every { seenLastAt } returns seenAt
+                every { isLeftPodInEar } returns leftWorn
+                every { isRightPodInEar } returns rightWorn
+                every { isBeingWorn } returns (leftWorn && rightWorn)
+                every { isEitherPodInEar } returns (leftWorn || rightWorn)
+                every { primaryPod } returns DualBlePodSnapshot.Pod.LEFT
+                every { model } returns PodModel.AIRPODS_PRO3
+            }
+
+        private fun buildIrkMatchedDevice(seenAt: Instant, leftWorn: Boolean, rightWorn: Boolean) =
+            PodDevice(
+                profileId = "test-profile",
+                ble = buildIrkMatchedBle(seenAt, leftWorn, rightWorn),
+                aap = null,
+                profileModel = PodModel.AIRPODS_PRO3,
+                reactions = ReactionConfig(autoPlay = true, autoPause = true),
+            )
+
+        private fun buildNoLiveBleDevice() =
+            PodDevice(
+                profileId = "test-profile",
+                ble = null,
+                aap = null,
+                profileModel = PodModel.AIRPODS_PRO3,
+                reactions = ReactionConfig(autoPlay = true, autoPause = true),
+            )
+
+        @Test
+        fun `flow - process start with pods worn does not fire autoplay`() = runTest {
+            // App process starts while user is already wearing pods. The first emission has
+            // no live BLE/AAP yet (cache-only). When live BLE arrives showing both worn,
+            // the synthetic null -> false coercion in toEarDetectionState would otherwise
+            // produce a fake not-worn -> worn transition and fire autoplay. With the
+            // NO_LIVE_BLE-previous guard, the reaction must be suppressed.
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns false
+                every { wasRecentlyPausedByCap } returns false
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: process-start emission — no live BLE, only cached profile state.
+            deviceFlow.value = listOf(buildNoLiveBleDevice())
+            advanceUntilIdle()
+
+            // T1: live IRK-matched BLE arrives showing both pods worn. Previous emission
+            // had no live evidence, so the transition must NOT fire autoplay.
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now, leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            // T2: another live worn sample. Previous is now live worn — same wear state,
+            // no transition, no action. autoplay still must not fire.
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now.plusMillis(1500), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            job.cancel()
+        }
+
+        @Test
+        fun `flow - genuine pod insertion after process start fires autoplay normally`() = runTest {
+            // After the no-live-evidence baseline is replaced by a stable live not-worn
+            // state, a real not-worn -> worn transition must still fire autoplay.
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns false
+                every { wasRecentlyPausedByCap } returns false
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: cache-only baseline.
+            deviceFlow.value = listOf(buildNoLiveBleDevice())
+            advanceUntilIdle()
+
+            // T1: live IRK-matched BLE arrives, pods NOT worn.
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now, leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            // T2: user inserts pods. Genuine not-worn -> worn transition with both
+            // previous and current carrying live evidence. autoplay fires.
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now.plusMillis(1500), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+
+            job.cancel()
+        }
+
+        @Test
+        fun `flow - mid-session BLE gap does not fire false reactions on resume`() = runTest {
+            // Existing live evidence -> BLE drops out (NO_LIVE_BLE) -> BLE comes back.
+            // The recovery sample's previous is NO_LIVE_BLE, so no reaction must fire
+            // even if the wear state happens to differ from the synthetic baseline.
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns true
+                every { wasRecentlyPausedByCap } returns false
+                coEvery { sendPause() } returns true
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: stable live worn baseline.
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now, leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            // T1: BLE gap — device evicted from live cache, only profile state remains.
+            deviceFlow.value = listOf(buildNoLiveBleDevice())
+            advanceUntilIdle()
+
+            // T2: BLE resumes with worn=true. Previous is NO_LIVE_BLE, so the recovery
+            // sample must not be treated as a fresh transition.
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now.plusMillis(2000), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { mediaControl.sendPause() }
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            job.cancel()
+        }
+
+        @Test
+        fun `flow - IRK-matched source fires autoplay on first worn sample without confirmation`() = runTest {
+            // For BLE_IRK_MATCH source, BLE-only autoplay confirmation should be skipped
+            // (mirroring the pause-debounce skip). Otherwise an IRK-matched device with no
+            // live AAP would stage a confirmation that never fires — the 2nd worn sample
+            // has no freshness on the monitor key for IRK_MATCH and gets collapsed.
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns false
+                every { wasRecentlyPausedByCap } returns false
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: not-worn baseline
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now, leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            // T1: pods inserted. With IRK_MATCH source, autoplay must fire immediately
+            // (no waiting for a 2nd sample).
+            deviceFlow.value = listOf(buildIrkMatchedDevice(now.plusMillis(1000), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+
+            job.cancel()
+        }
+
+        @Test
+        fun `flow - BLE-only autoplay confirmation fires after second worn sample`() = runTest {
+            // Verifies that the freshness field passes a 2nd identical worn sample through
+            // monitor distinct filtering, so applyBleOnlyPlayConfirmation can confirm a
+            // staged play. This is the inverse of the pause-debounce flow test: the same
+            // mechanism that lets repeated not-worn samples advance the pause counter must
+            // also let repeated worn samples confirm a staged BLE-only autoplay.
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns false
+                every { wasRecentlyPausedByCap } returns false
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: not-worn baseline
+            deviceFlow.value = listOf(buildDevice(now, leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            // T1: pods inserted (transition not-worn -> worn). BLE-only path stages an
+            // autoplay confirmation; sendPlay is suppressed pending a second worn sample.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(1000), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            // T2: identical worn sample with a fresher seenLastAt. The freshness field
+            // must let it through monitor distinct filtering so the staged play confirms.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(2000), leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
 
             job.cancel()
         }

--- a/app/src/test/java/eu/darken/capod/reaction/core/playpause/PlayPauseLogicTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/playpause/PlayPauseLogicTest.kt
@@ -1,19 +1,33 @@
 package eu.darken.capod.reaction.core.playpause
 
+import eu.darken.capod.common.MediaControl
+import eu.darken.capod.common.bluetooth.BluetoothManager2
+import eu.darken.capod.monitor.core.DeviceMonitor
 import eu.darken.capod.monitor.core.PodDevice
+import eu.darken.capod.pods.core.apple.PodModel
 import eu.darken.capod.pods.core.apple.aap.AapPodState
 import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import eu.darken.capod.pods.core.apple.ble.DualBlePodSnapshot
+import eu.darken.capod.pods.core.apple.ble.devices.ApplePods
 import eu.darken.capod.pods.core.apple.ble.devices.DualApplePods
+import eu.darken.capod.profiles.core.ReactionConfig
 import eu.darken.capod.reaction.core.playpause.PlayPause.EarDetectionState
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.time.Instant
 
 class PlayPauseLogicTest : BaseTest() {
 
@@ -1132,14 +1146,43 @@ class PlayPauseLogicTest : BaseTest() {
         }
 
         @Test
-        fun `BLE_PROFILE_FALLBACK pod returns mid-debounce - pending cleared`() {
-            // First detection: both pods removed
+        fun `BLE_PROFILE_FALLBACK first count-up is tolerated as a rebound`() {
+            // First detection: both pods removed (initialPodCount=0). A single corrupt
+            // count-up sample (pod=1) should be tolerated — the helper holds pending
+            // and decrements resetTolerance.
             val pending = PlayPause.PendingPauseDebounce(
                 profileId = "profile",
                 initialPodCount = 0,
                 confirmationsRemaining = 1,
+                resetTolerance = 1,
             )
-            // Pod returned: count went from 0 -> 1 (worn back)
+            val current = EarDetectionState.fromDualPod(true, false)
+
+            val result = playPause.applyPauseDebounce(
+                pending = pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = noopDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+
+            result.decision.shouldPause shouldBe false
+            result.pending shouldNotBe null
+            result.pending!!.resetTolerance shouldBe 0
+            result.event shouldBe PlayPause.PauseDebounceEvent.ADVANCED
+        }
+
+        @Test
+        fun `BLE_PROFILE_FALLBACK second count-up resets pending (tolerance exhausted)`() {
+            // After the first rebound was tolerated, resetTolerance=0. A second count-up
+            // sample resets pending — this is a genuine pod-return signal.
+            val pending = PlayPause.PendingPauseDebounce(
+                profileId = "profile",
+                initialPodCount = 0,
+                confirmationsRemaining = 1,
+                resetTolerance = 0,
+            )
             val current = EarDetectionState.fromDualPod(true, false)
 
             val result = playPause.applyPauseDebounce(
@@ -1153,6 +1196,7 @@ class PlayPauseLogicTest : BaseTest() {
 
             result.decision.shouldPause shouldBe false
             result.pending shouldBe null
+            result.event shouldBe PlayPause.PauseDebounceEvent.RESET
         }
 
         @Test
@@ -1327,6 +1371,43 @@ class PlayPauseLogicTest : BaseTest() {
         }
 
         @Test
+        fun `AAP says worn while BLE per-side falsely says not-worn - returns worn (#557 scenario)`() {
+            // The motivating bug for the per-side gap fix: AAP authoritative state says
+            // pods worn, but BLE fallback bits say not-worn. AAP must win — this is the
+            // scenario users hit in #557 when high-RF interference flipped BLE bits.
+            val ble = mockk<DualApplePods>(relaxed = true) {
+                every { isLeftPodInEar } returns false   // BLE corrupt: says not-worn
+                every { isRightPodInEar } returns false
+                every { isBeingWorn } returns false
+                every { isEitherPodInEar } returns false
+                every { primaryPod } returns DualBlePodSnapshot.Pod.LEFT
+            }
+            val aapEarDetection = AapSetting.EarDetection(
+                primaryPod = AapSetting.EarDetection.PodPlacement.IN_EAR,
+                secondaryPod = AapSetting.EarDetection.PodPlacement.IN_EAR,
+            )
+            val aapPrimary = AapSetting.PrimaryPod(pod = AapSetting.PrimaryPod.Pod.LEFT)
+            val aap = AapPodState(
+                connectionState = AapPodState.ConnectionState.READY,
+                settings = mapOf(
+                    AapSetting.EarDetection::class to aapEarDetection,
+                    AapSetting.PrimaryPod::class to aapPrimary,
+                ),
+            )
+            val device = PodDevice(
+                profileId = "test",
+                ble = ble,
+                aap = aap,
+            )
+
+            val state = with(playPause) { device.toEarDetectionState() }
+
+            // AAP says worn → aggregate must reflect worn even though BLE bits say not-worn.
+            state.bothInEar shouldBe true
+            state.podCount shouldBe 2
+        }
+
+        @Test
         fun `AAP absent - falls back to BLE per-side`() {
             val ble = mockk<DualApplePods>(relaxed = true) {
                 every { isLeftPodInEar } returns true
@@ -1448,6 +1529,73 @@ class PlayPauseLogicTest : BaseTest() {
 
             state.bothInEar shouldBe true
             state.podCount shouldBe 2
+        }
+    }
+
+    @Nested
+    inner class MonitorFlowTests {
+
+        private fun buildBle(seenAt: Instant, leftWorn: Boolean, rightWorn: Boolean) =
+            mockk<DualApplePods>(relaxed = true) {
+                every { meta } returns ApplePods.AppleMeta(
+                    isIRKMatch = false,
+                    profile = mockk(relaxed = true),
+                )
+                every { seenLastAt } returns seenAt
+                every { isLeftPodInEar } returns leftWorn
+                every { isRightPodInEar } returns rightWorn
+                every { isBeingWorn } returns (leftWorn && rightWorn)
+                every { isEitherPodInEar } returns (leftWorn || rightWorn)
+                every { primaryPod } returns DualBlePodSnapshot.Pod.LEFT
+                every { model } returns PodModel.AIRPODS_PRO3
+            }
+
+        private fun buildDevice(seenAt: Instant, leftWorn: Boolean, rightWorn: Boolean) =
+            PodDevice(
+                profileId = "test-profile",
+                ble = buildBle(seenAt, leftWorn, rightWorn),
+                aap = null,
+                profileModel = PodModel.AIRPODS_PRO3,
+                reactions = ReactionConfig(autoPlay = true, autoPause = true),
+            )
+
+        @Test
+        fun `flow - 3 consecutive not-worn unauthenticated samples fire pause exactly once`() = runTest {
+            val deviceFlow = MutableStateFlow<List<PodDevice>>(emptyList())
+            val deviceMonitor: DeviceMonitor = mockk(relaxed = true) {
+                every { devices } returns deviceFlow
+            }
+            val bluetoothManager: BluetoothManager2 = mockk(relaxed = true) {
+                every { connectedDevices } returns flowOf(listOf(mockk(relaxed = true)))
+            }
+            val mediaControl: MediaControl = mockk(relaxed = true) {
+                every { isPlaying } returns true
+                every { wasRecentlyPausedByCap } returns false
+                coEvery { sendPause() } returns true
+            }
+            val flowPlayPause = PlayPause(deviceMonitor, bluetoothManager, mediaControl)
+
+            val now = Instant.parse("2026-01-01T00:00:00Z")
+            val job = launch { flowPlayPause.monitor().collect {} }
+
+            // T0: worn baseline
+            deviceFlow.value = listOf(buildDevice(now, leftWorn = true, rightWorn = true))
+            advanceUntilIdle()
+
+            // T1, T2, T3: identical not-worn samples with incrementing seenLastAt.
+            // Without the freshness fix, distinctUntilChangedBy would collapse T2 and T3
+            // and the debounce counter could never advance. With it, the helper sees
+            // 3 samples and commits the pause on the third.
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(1000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(2000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+            deviceFlow.value = listOf(buildDevice(now.plusMillis(3000), leftWorn = false, rightWorn = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mediaControl.sendPause() }
+
+            job.cancel()
         }
     }
 }

--- a/app/src/test/java/eu/darken/capod/reaction/core/playpause/PlayPauseLogicTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/playpause/PlayPauseLogicTest.kt
@@ -1,7 +1,14 @@
 package eu.darken.capod.reaction.core.playpause
 
+import eu.darken.capod.monitor.core.PodDevice
+import eu.darken.capod.pods.core.apple.aap.AapPodState
+import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
+import eu.darken.capod.pods.core.apple.ble.DualBlePodSnapshot
+import eu.darken.capod.pods.core.apple.ble.devices.DualApplePods
 import eu.darken.capod.reaction.core.playpause.PlayPause.EarDetectionState
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -967,6 +974,480 @@ class PlayPauseLogicTest : BaseTest() {
             val state = EarDetectionState.fromSinglePod(worn = true)
             state.leftInEar shouldBe null
             state.rightInEar shouldBe null
+        }
+    }
+
+    @Nested
+    inner class PauseDebounceTests {
+
+        private val pauseDecision = PlayPause.PlayPauseDecision(
+            shouldPlay = false,
+            shouldPause = true,
+            reason = "test pause",
+        )
+
+        private val playDecision = PlayPause.PlayPauseDecision(
+            shouldPlay = true,
+            shouldPause = false,
+            reason = "test play",
+        )
+
+        private val noopDecision = PlayPause.PlayPauseDecision(
+            shouldPlay = false,
+            shouldPause = false,
+            reason = "test no-op",
+        )
+
+        @Test
+        fun `AAP source - debounce is skipped`() {
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.AAP,
+                rawDecision = pauseDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = true,
+            )
+
+            result.decision shouldBe pauseDecision
+            result.pending shouldBe null
+        }
+
+        @Test
+        fun `BLE_IRK_MATCH source - debounce is skipped`() {
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_IRK_MATCH,
+                rawDecision = pauseDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = true,
+            )
+
+            result.decision shouldBe pauseDecision
+            result.pending shouldBe null
+        }
+
+        @Test
+        fun `NO_LIVE_BLE source - clears existing pending without advancing it`() {
+            // Stale-cache scenario: pending was started by a prior fresh BLE sample, then BLE
+            // dropped (ble == null). The cached state must NOT count as a confirmation.
+            val pending = PlayPause.PendingPauseDebounce(
+                profileId = "profile",
+                initialPodCount = 0,
+                confirmationsRemaining = 1,
+            )
+            val result = playPause.applyPauseDebounce(
+                pending = pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.NO_LIVE_BLE,
+                rawDecision = noopDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = true,
+            )
+
+            result.pending shouldBe null
+            result.decision.shouldPause shouldBe false
+            result.event shouldBe PlayPause.PauseDebounceEvent.RESET
+        }
+
+        @Test
+        fun `NO_LIVE_BLE source - suppresses raw shouldPause to prevent stale-cache pause`() {
+            // Without live BLE evidence, a cached worn → not-worn transition could otherwise
+            // fire shouldPause. Verify the helper suppresses that to zero.
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.NO_LIVE_BLE,
+                rawDecision = pauseDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = true,
+            )
+
+            result.decision.shouldPause shouldBe false
+            result.decision.reason shouldBe "test pause (suppressed: no live BLE evidence)"
+            result.pending shouldBe null
+            result.event shouldBe PlayPause.PauseDebounceEvent.NONE
+        }
+
+        @Test
+        fun `BLE_PROFILE_FALLBACK first not-worn sample is suppressed and pending created`() {
+            val current = EarDetectionState.fromDualPod(false, false)
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = pauseDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+
+            result.decision.shouldPause shouldBe false
+            result.pending shouldNotBe null
+            result.pending!!.profileId shouldBe "profile"
+            result.pending!!.initialPodCount shouldBe 0
+            result.pending!!.confirmationsRemaining shouldBe PlayPause.PAUSE_DEBOUNCE_SAMPLES
+        }
+
+        @Test
+        fun `BLE_PROFILE_FALLBACK three consecutive not-worn samples fires pause on third`() {
+            val current = EarDetectionState.fromDualPod(false, false)
+
+            // Sample 1 — first detection, suppressed, pending created
+            val result1 = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = pauseDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+            result1.decision.shouldPause shouldBe false
+            result1.pending shouldNotBe null
+
+            // Sample 2 — confirmation 1/2, still suppressed (raw is now no-op since not-worn -> not-worn)
+            val result2 = playPause.applyPauseDebounce(
+                pending = result1.pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = noopDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+            result2.decision.shouldPause shouldBe false
+            result2.pending shouldNotBe null
+            result2.pending!!.confirmationsRemaining shouldBe (PlayPause.PAUSE_DEBOUNCE_SAMPLES - 1)
+
+            // Sample 3 — confirmation 2/2, pause fires
+            val result3 = playPause.applyPauseDebounce(
+                pending = result2.pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = noopDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+            result3.decision.shouldPause shouldBe true
+            result3.pending shouldBe null
+        }
+
+        @Test
+        fun `BLE_PROFILE_FALLBACK pod returns mid-debounce - pending cleared`() {
+            // First detection: both pods removed
+            val pending = PlayPause.PendingPauseDebounce(
+                profileId = "profile",
+                initialPodCount = 0,
+                confirmationsRemaining = 1,
+            )
+            // Pod returned: count went from 0 -> 1 (worn back)
+            val current = EarDetectionState.fromDualPod(true, false)
+
+            val result = playPause.applyPauseDebounce(
+                pending = pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = noopDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+
+            result.decision.shouldPause shouldBe false
+            result.pending shouldBe null
+        }
+
+        @Test
+        fun `BLE_PROFILE_FALLBACK raw shouldPlay clears pending`() {
+            val pending = PlayPause.PendingPauseDebounce(
+                profileId = "profile",
+                initialPodCount = 0,
+                confirmationsRemaining = 1,
+            )
+            val current = EarDetectionState.fromDualPod(true, true)
+
+            val result = playPause.applyPauseDebounce(
+                pending = pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = playDecision,
+                currentState = current,
+                autoPauseEnabled = true,
+            )
+
+            result.decision shouldBe playDecision
+            result.pending shouldBe null
+        }
+
+        @Test
+        fun `BLE_ANONYMOUS one-pod mode - both to one to none confirms across decreasing counts`() {
+            // Sample 1: both -> one (initial pause request, podCount=1)
+            val sample1Current = EarDetectionState.fromDualPod(true, false)
+            val result1 = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_ANONYMOUS,
+                rawDecision = pauseDecision,
+                currentState = sample1Current,
+                autoPauseEnabled = true,
+            )
+            result1.decision.shouldPause shouldBe false
+            result1.pending shouldNotBe null
+            result1.pending!!.initialPodCount shouldBe 1
+
+            // Sample 2: one -> none (count=0, still <= initial 1, confirms)
+            val sample2Current = EarDetectionState.fromDualPod(false, false)
+            val result2 = playPause.applyPauseDebounce(
+                pending = result1.pending,
+                profileId = "profile",
+                // In one-pod mode with prev=1 curr=0, evaluateOnePodMode returns shouldPause=true
+                // again — but the helper should still treat this as a confirmation, not restart.
+                source = PlayPause.EarDetectionSource.BLE_ANONYMOUS,
+                rawDecision = pauseDecision,
+                currentState = sample2Current,
+                autoPauseEnabled = true,
+            )
+            result2.decision.shouldPause shouldBe false
+            result2.pending shouldNotBe null
+            result2.pending!!.confirmationsRemaining shouldBe (PlayPause.PAUSE_DEBOUNCE_SAMPLES - 1)
+
+            // Sample 3: still none, final confirmation
+            val result3 = playPause.applyPauseDebounce(
+                pending = result2.pending,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_ANONYMOUS,
+                rawDecision = noopDecision,
+                currentState = sample2Current,
+                autoPauseEnabled = true,
+            )
+            result3.decision.shouldPause shouldBe true
+            result3.pending shouldBe null
+        }
+
+        @Test
+        fun `profile change - pending from different profile is ignored`() {
+            val pending = PlayPause.PendingPauseDebounce(
+                profileId = "old-profile",
+                initialPodCount = 0,
+                confirmationsRemaining = 1,
+            )
+
+            val result = playPause.applyPauseDebounce(
+                pending = pending,
+                profileId = "new-profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = pauseDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = true,
+            )
+
+            // Old pending is dropped (different profileId), new pending is started for new profile
+            result.decision.shouldPause shouldBe false
+            result.pending shouldNotBe null
+            result.pending!!.profileId shouldBe "new-profile"
+            result.pending!!.confirmationsRemaining shouldBe PlayPause.PAUSE_DEBOUNCE_SAMPLES
+        }
+
+        @Test
+        fun `autoPause disabled - debounce skipped, raw decision passes through`() {
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = pauseDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = false,
+            )
+
+            result.decision shouldBe pauseDecision
+            result.pending shouldBe null
+        }
+
+        @Test
+        fun `null profileId - debounce skipped`() {
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = null,
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = pauseDecision,
+                currentState = EarDetectionState.fromDualPod(false, false),
+                autoPauseEnabled = true,
+            )
+
+            result.decision shouldBe pauseDecision
+            result.pending shouldBe null
+        }
+
+        @Test
+        fun `no pause request - raw decision passes through unchanged`() {
+            val result = playPause.applyPauseDebounce(
+                pending = null,
+                profileId = "profile",
+                source = PlayPause.EarDetectionSource.BLE_PROFILE_FALLBACK,
+                rawDecision = noopDecision,
+                currentState = EarDetectionState.fromDualPod(true, true),
+                autoPauseEnabled = true,
+            )
+
+            result.decision shouldBe noopDecision
+            result.pending shouldBe null
+        }
+    }
+
+    @Nested
+    inner class ToEarDetectionStateTests {
+
+        @Test
+        fun `AAP EarDetection present - returns aggregate state`() {
+            // With AAP EarDetection saying NOT_IN_EAR for both, the helper should return
+            // not-worn aggregate regardless of any conflicting BLE per-side bits.
+            val ble = mockk<DualApplePods>(relaxed = true) {
+                every { isLeftPodInEar } returns true   // BLE says worn (potentially corrupt)
+                every { isRightPodInEar } returns true
+                every { isBeingWorn } returns true
+                every { isEitherPodInEar } returns true
+            }
+            val aapEarDetection = AapSetting.EarDetection(
+                primaryPod = AapSetting.EarDetection.PodPlacement.NOT_IN_EAR,
+                secondaryPod = AapSetting.EarDetection.PodPlacement.NOT_IN_EAR,
+            )
+            val aap = AapPodState(
+                connectionState = AapPodState.ConnectionState.READY,
+                settings = mapOf(AapSetting.EarDetection::class to aapEarDetection),
+            )
+            val device = PodDevice(
+                profileId = "test",
+                ble = ble,
+                aap = aap,
+            )
+
+            val state = with(playPause) { device.toEarDetectionState() }
+
+            // AAP says not worn → aggregate should be not-worn.
+            state.bothInEar shouldBe false
+            state.podCount shouldBe 0
+        }
+
+        @Test
+        fun `AAP absent - falls back to BLE per-side`() {
+            val ble = mockk<DualApplePods>(relaxed = true) {
+                every { isLeftPodInEar } returns true
+                every { isRightPodInEar } returns false
+                every { isBeingWorn } returns false
+                every { isEitherPodInEar } returns true
+                every { primaryPod } returns DualBlePodSnapshot.Pod.LEFT
+            }
+            val device = PodDevice(
+                profileId = "test",
+                ble = ble,
+                aap = null,
+            )
+
+            val state = with(playPause) { device.toEarDetectionState() }
+
+            // BLE per-side: left=true, right=false → podCount=1
+            state.leftInEar shouldBe true
+            state.rightInEar shouldBe false
+            state.podCount shouldBe 1
+        }
+
+        @Test
+        fun `monitor key freshness field differs across BLE scans for unauthenticated source`() {
+            // Repeated identical not-worn samples must produce distinct monitor keys when
+            // bleKeyState is NONE / profile-fallback, so distinctUntilChangedBy doesn't
+            // collapse them and the debounce counter can advance.
+            val now = java.time.Instant.parse("2026-01-01T00:00:00Z")
+            val ble1 = mockk<DualApplePods>(relaxed = true) {
+                every { meta } returns eu.darken.capod.pods.core.apple.ble.devices.ApplePods.AppleMeta(
+                    isIRKMatch = false,
+                    profile = null,
+                )
+                every { seenLastAt } returns now
+                every { isLeftPodInEar } returns false
+                every { isRightPodInEar } returns false
+                every { isBeingWorn } returns false
+                every { isEitherPodInEar } returns false
+            }
+            val ble2 = mockk<DualApplePods>(relaxed = true) {
+                every { meta } returns eu.darken.capod.pods.core.apple.ble.devices.ApplePods.AppleMeta(
+                    isIRKMatch = false,
+                    profile = null,
+                )
+                every { seenLastAt } returns now.plusMillis(1000)  // 1 second later, identical state
+                every { isLeftPodInEar } returns false
+                every { isRightPodInEar } returns false
+                every { isBeingWorn } returns false
+                every { isEitherPodInEar } returns false
+            }
+            val device1 = PodDevice(profileId = "test", ble = ble1, aap = null)
+            val device2 = PodDevice(profileId = "test", ble = ble2, aap = null)
+
+            val key1 = with(playPause) { device1.toPlayPauseMonitorKey() }
+            val key2 = with(playPause) { device2.toPlayPauseMonitorKey() }
+
+            // Same wear state but different seenLastAt → distinct keys (debounce can advance)
+            (key1 == key2) shouldBe false
+            key1.source shouldBe PlayPause.EarDetectionSource.BLE_ANONYMOUS
+            key2.source shouldBe PlayPause.EarDetectionSource.BLE_ANONYMOUS
+        }
+
+        @Test
+        fun `monitor key freshness field is null for IRK-authenticated source`() {
+            // For IRK_MATCH source, debounceFreshness should be null so that battery-only
+            // updates with identical wear state still collapse via distinctUntilChangedBy.
+            val now = java.time.Instant.parse("2026-01-01T00:00:00Z")
+            val profile = mockk<eu.darken.capod.profiles.core.AppleDeviceProfile>(relaxed = true)
+            val ble = mockk<DualApplePods>(relaxed = true) {
+                every { meta } returns eu.darken.capod.pods.core.apple.ble.devices.ApplePods.AppleMeta(
+                    isIRKMatch = true,
+                    profile = profile,
+                )
+                every { seenLastAt } returns now
+                every { isLeftPodInEar } returns false
+                every { isRightPodInEar } returns false
+                every { isBeingWorn } returns false
+                every { isEitherPodInEar } returns false
+            }
+            val device = PodDevice(profileId = "test", ble = ble, aap = null)
+
+            val key = with(playPause) { device.toPlayPauseMonitorKey() }
+
+            key.source shouldBe PlayPause.EarDetectionSource.BLE_IRK_MATCH
+            key.debounceFreshness shouldBe null
+        }
+
+        @Test
+        fun `AAP EarDetection present and primary pod resolved - aggregate matches per-side`() {
+            // When AAP has both EarDetection AND primary pod resolved, aggregate and per-side
+            // should agree. Verify the helper still returns aggregate (not per-side) since
+            // both are equivalent.
+            val aapEarDetection = AapSetting.EarDetection(
+                primaryPod = AapSetting.EarDetection.PodPlacement.IN_EAR,
+                secondaryPod = AapSetting.EarDetection.PodPlacement.IN_EAR,
+            )
+            val aapPrimary = AapSetting.PrimaryPod(pod = AapSetting.PrimaryPod.Pod.LEFT)
+            val aap = AapPodState(
+                connectionState = AapPodState.ConnectionState.READY,
+                settings = mapOf(
+                    AapSetting.EarDetection::class to aapEarDetection,
+                    AapSetting.PrimaryPod::class to aapPrimary,
+                ),
+            )
+            val ble = mockk<DualApplePods>(relaxed = true) {
+                every { isLeftPodInEar } returns true
+                every { isRightPodInEar } returns true
+                every { isBeingWorn } returns true
+                every { isEitherPodInEar } returns true
+                every { primaryPod } returns DualBlePodSnapshot.Pod.LEFT
+            }
+            val device = PodDevice(
+                profileId = "test",
+                ble = ble,
+                aap = aap,
+            )
+
+            val state = with(playPause) { device.toEarDetectionState() }
+
+            state.bothInEar shouldBe true
+            state.podCount shouldBe 2
         }
     }
 }


### PR DESCRIPTION
## What changed

Fixed a bug where music could auto-pause even though your AirPods are still in your ears, when you're in a high-interference environment (e.g. crowded city, dense Wi-Fi, lots of nearby Bluetooth devices). A single corrupt Bluetooth scan was enough to flip the wear state and trigger a pause; the app now requires multiple consistent readings before reacting.

Refs #557.

## Technical Context

- Classified ear-detection sources by trust: `AAP` (L2CAP, error-corrected), `BLE_IRK_MATCH` (RPA verified against the profile's identity key), `BLE_PROFILE_FALLBACK` (signal-quality fallback assignment), `BLE_ANONYMOUS` (no profile match), `NO_LIVE_BLE` (cache-only). Only the bottom two are debounced — identity-authenticated paths can't be misattributed to a different pair, so trusting them is safe and avoids extra latency for paired AirPods.
- The debounce uses a sample-counter (3 consecutive not-worn readings before pause fires). `PlayPauseMonitorKey` carries `seenLastAt` as `debounceFreshness` for debounce-eligible sources only, so `distinctUntilChangedBy` doesn't collapse identical not-worn BLE samples and the counter can advance.
- `NO_LIVE_BLE` (cached state with no live evidence) explicitly suppresses `shouldPause`. Otherwise a worn → cache-only transition can derive a not-worn state from null fields and fire pause without any real removal evidence.
- Tightened `toEarDetectionState()` to prefer AAP aggregate whenever AAP `EarDetection` is present, even if per-side resolution falls through to BLE bits. Previously a defensive case (`resolvedPrimaryPod == null` while `ble` provides per-side bits) could let BLE bits drive the decision while AAP had the authoritative aggregate state.
- Added `INFO`-level diagnostic line on every pause emission and `DEBUG`-level lines on every debounce state transition (`STARTED` / `ADVANCED` / `RESET` / `COMMITTED`), with the source classification, pod-count delta, `bleKeyState`, AAP connection state, and `pauseSent` outcome from `MediaControl`. Future user reports become easier to triage.
- Caveat: `BlePodMonitor.preferCaseContextPod` can keep an existing case-context snapshot in place over an incoming non-case-context snapshot, preserving the old `seenLastAt`. This is fail-closed (delays a legitimate unauthenticated-BLE pause rather than firing a false one), documented inline.

## Review checklist

- [ ] Verify auto-pause still fires within ~1.5s when removing both pods on a stable BT connection (paired pair, AAP active — `source=AAP`)
- [ ] For an unpaired pair (`source=BLE_ANONYMOUS`), verify auto-pause now requires ~3 advert cycles before firing
- [ ] Verify a single momentary BLE glitch with pods still in ear no longer triggers a false pause
- [ ] Confirm the new `EarDetectionSource` classification doesn't regress any existing reaction tests
