### PR TITLE
Device: Tune Bluetooth scanning power automatically

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/AppForegroundState.kt
+++ b/app/src/main/java/eu/darken/capod/common/AppForegroundState.kt
@@ -1,0 +1,85 @@
+package eu.darken.capod.common
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.ProcessLifecycleOwner
+import eu.darken.capod.common.coroutine.AppScope
+import eu.darken.capod.common.coroutine.DispatcherProvider
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.asLog
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppForegroundState @Inject constructor(
+    @AppScope appScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+) {
+
+    val isForeground: StateFlow<Boolean> = callbackFlow {
+        val lifecycle = runCatching { ProcessLifecycleOwner.get().lifecycle }
+            .getOrElse {
+                log(TAG, WARN) { "Failed to access process lifecycle, assuming background: ${it.asLog()}" }
+                trySend(false)
+                close()
+                return@callbackFlow
+            }
+
+        trySend(safeCurrentForegroundState())
+
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> trySend(true)
+                Lifecycle.Event.ON_STOP -> trySend(false)
+                else -> Unit
+            }
+        }
+
+        runCatching { lifecycle.addObserver(observer) }
+            .onFailure {
+                log(TAG, WARN) { "Failed to observe process lifecycle, assuming background: ${it.asLog()}" }
+                trySend(false)
+                close()
+            }
+
+        awaitClose {
+            runCatching { lifecycle.removeObserver(observer) }
+                .onFailure { log(TAG, WARN) { "Failed to remove process lifecycle observer: ${it.asLog()}" } }
+        }
+    }
+        .flowOn(dispatcherProvider.MainImmediate)
+        .catch {
+            log(TAG, WARN) { "Foreground state flow failed, assuming background: ${it.asLog()}" }
+            emit(false)
+        }
+        .distinctUntilChanged()
+        .onEach { log(TAG) { "isForeground=$it" } }
+        .stateIn(
+            scope = appScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+            initialValue = safeCurrentForegroundState(),
+        )
+
+    private fun safeCurrentForegroundState(): Boolean = runCatching {
+        ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    }.getOrElse {
+        log(TAG, WARN) { "Failed to read process lifecycle state, assuming background: ${it.asLog()}" }
+        false
+    }
+
+    companion object {
+        private val TAG = logTag("App", "ForegroundState")
+    }
+}

--- a/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
+++ b/app/src/main/java/eu/darken/capod/common/bluetooth/BluetoothManager2.kt
@@ -318,6 +318,74 @@ class BluetoothManager2 @Inject constructor(
         emit(wrappedDevices)
     }
 
+    @android.annotation.SuppressLint("MissingPermission")
+    private fun queryBondedAddresses(): Set<BluetoothAddress> =
+        adapter?.bondedDevices?.map { it.address }?.toSet() ?: emptySet()
+
+    val bondedDeviceAddresses: Flow<Set<BluetoothAddress>> = callbackFlow {
+        fun sendBondedAddresses(): Boolean = try {
+            trySend(queryBondedAddresses())
+            true
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Error querying bonded device addresses: $e" }
+            trySend(emptySet())
+            close(e)
+            false
+        }
+
+        if (!sendBondedAddresses()) return@callbackFlow
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action != BluetoothDevice.ACTION_BOND_STATE_CHANGED) return
+                sendBondedAddresses()
+            }
+        }
+        try {
+            context.registerReceiver(receiver, IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED))
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to register bond-state receiver: $e" }
+            close(e)
+            return@callbackFlow
+        }
+
+        awaitClose {
+            try {
+                context.unregisterReceiver(receiver)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Error unregistering bond-state receiver: $e" }
+            }
+        }
+    }
+        .retryWhen { cause, attempt ->
+            log(TAG, WARN) { "bondedDeviceAddresses Flow failed (attempt ${attempt + 1}): $cause" }
+            when {
+                cause is SecurityException -> {
+                    delay(3_000L)
+                    true
+                }
+                attempt < 3 -> {
+                    delay(1000 * (attempt + 1))
+                    true
+                }
+                else -> false
+            }
+        }
+        .catch { e ->
+            log(TAG, ERROR) { "bondedDeviceAddresses Flow failed after retries: $e" }
+            emit(emptySet())
+        }
+        .distinctUntilChanged()
+        .setupCommonEventHandlers(TAG) { "bondedDeviceAddresses" }
+        .stateIn(
+            scope = appScope + dispatcherProvider.IO,
+            started = SharingStarted.WhileSubscribed(
+                stopTimeoutMillis = 5_000L,
+                replayExpirationMillis = 0L,
+            ),
+            initialValue = emptySet(),
+        )
+
     private var _isNudgeAvailable: Boolean = true
     val isNudgeAvailable: Boolean get() = _isNudgeAvailable
 

--- a/app/src/main/java/eu/darken/capod/common/bluetooth/ScannerMode.kt
+++ b/app/src/main/java/eu/darken/capod/common/bluetooth/ScannerMode.kt
@@ -1,25 +1,11 @@
 package eu.darken.capod.common.bluetooth
 
-import androidx.annotation.StringRes
-import eu.darken.capod.R
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class ScannerMode(
-    val identifier: String,
-    @StringRes val labelRes: Int
-) {
-    @SerialName("scanner.mode.lowpower") LOW_POWER(
-        "scanner.mode.lowpower",
-        R.string.settings_scanner_mode_lowpower_label
-    ),
-    @SerialName("scanner.mode.balanced") BALANCED(
-        "scanner.mode.balanced",
-        R.string.settings_scanner_mode_balanced_label
-    ),
-    @SerialName("scanner.mode.lowlatency") LOW_LATENCY(
-        "scanner.mode.lowlatency",
-        R.string.settings_scanner_mode_lowlatency_label
-    ),
+enum class ScannerMode {
+    @SerialName("scanner.mode.lowpower") LOW_POWER,
+    @SerialName("scanner.mode.balanced") BALANCED,
+    @SerialName("scanner.mode.lowlatency") LOW_LATENCY,
 }

--- a/app/src/main/java/eu/darken/capod/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/capod/main/core/GeneralSettings.kt
@@ -9,7 +9,6 @@ import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.capod.common.BuildConfigWrap
 import eu.darken.capod.common.bluetooth.BluetoothAddress
-import eu.darken.capod.common.bluetooth.ScannerMode
 import eu.darken.capod.common.datastore.createValue
 import eu.darken.capod.common.serialization.ByteArrayBase64Serializer
 import eu.darken.capod.common.serialization.SerializationCapod
@@ -43,8 +42,6 @@ class GeneralSettings @Inject constructor(
 
     val keepConnectedNotificationAfterDisconnect =
         dataStore.createValue("core.monitor.notification.connected.keepafterdisconnected", false)
-
-    val scannerMode = dataStore.createValue("core.scanner.mode", ScannerMode.BALANCED, json, onErrorFallbackToDefault = true)
 
     val oldMinimumSignalQuality = dataStore.createValue("core.signal.minimum", 0.20f)
 

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.twotone.FilterList
 import androidx.compose.material.icons.automirrored.twotone.Message
 import androidx.compose.material.icons.twotone.Notifications
 import androidx.compose.material.icons.twotone.Palette
-import androidx.compose.material.icons.twotone.SettingsBluetooth
 import androidx.compose.material.icons.automirrored.twotone.ViewList
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -45,7 +44,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.capod.R
 import eu.darken.capod.common.compose.Preview2
 import eu.darken.capod.common.compose.PreviewWrapper
-import eu.darken.capod.common.bluetooth.ScannerMode
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.capod.common.error.ErrorEventHandler
 import eu.darken.capod.common.navigation.NavigationEventHandler
@@ -70,7 +68,6 @@ fun GeneralSettingsScreenHost(vm: GeneralSettingsViewModel = hiltViewModel()) {
             state = it,
             onNavigateUp = { vm.navUp() },
             onMonitorModeSelected = { mode -> vm.setMonitorMode(mode) },
-            onScannerModeSelected = { mode -> vm.setScannerMode(mode) },
             onShowConnectedNotificationChanged = { enabled -> vm.setShowConnectedNotification(enabled) },
             onKeepNotificationAfterDisconnectChanged = { enabled -> vm.setKeepNotificationAfterDisconnect(enabled) },
             onDebugSettings = { vm.goToDebugSettings() },
@@ -90,7 +87,6 @@ fun GeneralSettingsScreen(
     state: GeneralSettingsViewModel.State,
     onNavigateUp: () -> Unit,
     onMonitorModeSelected: (MonitorMode) -> Unit,
-    onScannerModeSelected: (ScannerMode) -> Unit,
     onShowConnectedNotificationChanged: (Boolean) -> Unit,
     onKeepNotificationAfterDisconnectChanged: (Boolean) -> Unit,
     onDebugSettings: () -> Unit,
@@ -104,7 +100,6 @@ fun GeneralSettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     var showMonitorModeDialog by remember { mutableStateOf(false) }
-    var showScannerModeDialog by remember { mutableStateOf(false) }
     var showColorDialog by remember { mutableStateOf(false) }
 
     val isMaterialYouActive = state.themeState.style == ThemeStyle.MATERIAL_YOU &&
@@ -136,14 +131,6 @@ fun GeneralSettingsScreen(
                     subtitle = stringResource(state.monitorMode.labelRes),
                     icon = Icons.TwoTone.DisabledVisible,
                     onClick = { showMonitorModeDialog = true },
-                )
-            }
-            item {
-                SettingsBaseItem(
-                    title = stringResource(R.string.settings_scanner_mode_label),
-                    subtitle = stringResource(state.scannerMode.labelRes),
-                    icon = Icons.TwoTone.SettingsBluetooth,
-                    onClick = { showScannerModeDialog = true },
                 )
             }
             item {
@@ -313,20 +300,6 @@ fun GeneralSettingsScreen(
         )
     }
 
-    if (showScannerModeDialog) {
-        ListPreferenceDialog(
-            title = stringResource(R.string.settings_scanner_mode_label),
-            entries = ScannerMode.entries,
-            selectedEntry = state.scannerMode,
-            onEntrySelected = {
-                onScannerModeSelected(it)
-                showScannerModeDialog = false
-            },
-            entryLabel = { stringResource(it.labelRes) },
-            onDismiss = { showScannerModeDialog = false },
-        )
-    }
-
     if (showColorDialog) {
         ThemeColorSelectorDialog(
             selectedColor = state.themeState.color,
@@ -342,7 +315,6 @@ fun GeneralSettingsScreen(
 private fun previewGeneralState(isPro: Boolean) = GeneralSettingsViewModel.State(
     isPro = isPro,
     monitorMode = MonitorMode.AUTOMATIC,
-    scannerMode = ScannerMode.BALANCED,
     showConnectedNotification = true,
     keepNotificationAfterDisconnect = false,
     isOffloadedFilteringDisabled = false,
@@ -358,7 +330,6 @@ private fun GeneralSettingsScreenProPreview() = PreviewWrapper {
         state = previewGeneralState(isPro = true),
         onNavigateUp = {},
         onMonitorModeSelected = {},
-        onScannerModeSelected = {},
         onShowConnectedNotificationChanged = {},
         onKeepNotificationAfterDisconnectChanged = {},
         onDebugSettings = {},
@@ -375,7 +346,6 @@ private fun GeneralSettingsScreenNonProPreview() = PreviewWrapper {
         state = previewGeneralState(isPro = false),
         onNavigateUp = {},
         onMonitorModeSelected = {},
-        onScannerModeSelected = {},
         onShowConnectedNotificationChanged = {},
         onKeepNotificationAfterDisconnectChanged = {},
         onDebugSettings = {},

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsViewModel.kt
@@ -1,7 +1,6 @@
 package eu.darken.capod.main.ui.settings.general
 
 import dagger.hilt.android.lifecycle.HiltViewModel
-import eu.darken.capod.common.bluetooth.ScannerMode
 import eu.darken.capod.common.coroutine.DispatcherProvider
 import eu.darken.capod.common.debug.logging.Logging.Priority.INFO
 import eu.darken.capod.common.debug.logging.log
@@ -32,7 +31,6 @@ class GeneralSettingsViewModel @Inject constructor(
     data class State(
         val isPro: Boolean,
         val monitorMode: MonitorMode,
-        val scannerMode: ScannerMode,
         val showConnectedNotification: Boolean,
         val keepNotificationAfterDisconnect: Boolean,
         val isOffloadedFilteringDisabled: Boolean,
@@ -46,12 +44,11 @@ class GeneralSettingsViewModel @Inject constructor(
     val state = combine(
         combine(
             generalSettings.monitorMode.flow,
-            generalSettings.scannerMode.flow,
             generalSettings.useExtraMonitorNotification.flow,
             generalSettings.keepConnectedNotificationAfterDisconnect.flow,
-        ) { monitorMode, scannerMode, showNotif, keepNotif ->
+        ) { monitorMode, showNotif, keepNotif ->
             @Suppress("USELESS_CAST")
-            arrayOf<Any>(monitorMode as Any, scannerMode as Any, showNotif as Any, keepNotif as Any)
+            arrayOf<Any>(monitorMode as Any, showNotif as Any, keepNotif as Any)
         },
         combine(
             generalSettings.isOffloadedFilteringDisabled.flow,
@@ -67,9 +64,8 @@ class GeneralSettingsViewModel @Inject constructor(
         State(
             isPro = isPro,
             monitorMode = general[0] as MonitorMode,
-            scannerMode = general[1] as ScannerMode,
-            showConnectedNotification = general[2] as Boolean,
-            keepNotificationAfterDisconnect = general[3] as Boolean,
+            showConnectedNotification = general[1] as Boolean,
+            keepNotificationAfterDisconnect = general[2] as Boolean,
             isOffloadedFilteringDisabled = compat[0] as Boolean,
             isOffloadedBatchingDisabled = compat[1] as Boolean,
             useIndirectScanResultCallback = compat[2] as Boolean,
@@ -80,11 +76,6 @@ class GeneralSettingsViewModel @Inject constructor(
     fun setMonitorMode(mode: MonitorMode) {
         log(TAG, INFO) { "setMonitorMode($mode)" }
         generalSettings.monitorMode.valueBlocking = mode
-    }
-
-    fun setScannerMode(mode: ScannerMode) {
-        log(TAG, INFO) { "setScannerMode($mode)" }
-        generalSettings.scannerMode.valueBlocking = mode
     }
 
     fun setShowConnectedNotification(enabled: Boolean) {

--- a/app/src/main/java/eu/darken/capod/monitor/core/ble/BlePodMonitor.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/ble/BlePodMonitor.kt
@@ -45,6 +45,7 @@ import javax.inject.Singleton
 class BlePodMonitor @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val bleScanner: BleScanner,
+    private val bleScanModeController: BleScanModeController,
     private val podFactory: PodFactory,
     private val timeSource: TimeSource,
     private val generalSettings: GeneralSettings,
@@ -128,7 +129,7 @@ class BlePodMonitor @Inject constructor(
     )
 
     private fun createBleScanner() = combine(
-        generalSettings.scannerMode.flow,
+        bleScanModeController.scannerMode,
         debugSettings.showUnfiltered.flow,
         generalSettings.isOffloadedBatchingDisabled.flow,
         generalSettings.isOffloadedFilteringDisabled.flow,

--- a/app/src/main/java/eu/darken/capod/monitor/core/ble/BleScanModeController.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/ble/BleScanModeController.kt
@@ -1,0 +1,114 @@
+package eu.darken.capod.monitor.core.ble
+
+import eu.darken.capod.common.AppForegroundState
+import eu.darken.capod.common.bluetooth.BluetoothAddress
+import eu.darken.capod.common.bluetooth.BluetoothManager2
+import eu.darken.capod.common.bluetooth.ScannerMode
+import eu.darken.capod.common.coroutine.AppScope
+import eu.darken.capod.common.debug.logging.Logging
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.flow.replayingShare
+import eu.darken.capod.common.flow.setupCommonEventHandlers
+import eu.darken.capod.profiles.core.DeviceProfilesRepo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BleScanModeController @Inject constructor(
+    @AppScope appScope: CoroutineScope,
+    appForegroundState: AppForegroundState,
+    profilesRepo: DeviceProfilesRepo,
+    bluetoothManager: BluetoothManager2,
+) {
+
+    private val overrideCounts = MutableStateFlow<Map<ScannerMode, Int>>(emptyMap())
+    private val activeOverride: Flow<ScannerMode?> = overrideCounts.map { it.topPriority() }
+
+    val scannerMode: Flow<ScannerMode> = combine(
+        activeOverride,
+        appForegroundState.isForeground,
+        profilesRepo.profiles,
+        bluetoothManager.connectedDevices
+            .onStart { emit(emptyList()) }
+            .catch {
+                log(TAG, Logging.Priority.WARN) { "connectedDevices failed, treating as empty: $it" }
+                emit(emptyList())
+            },
+        bluetoothManager.bondedDeviceAddresses,
+    ) { override, isForeground, profiles, connectedDevices, bondedAddresses ->
+        resolveScannerMode(
+            overrideMode = override,
+            isForeground = isForeground,
+            profileAddresses = profiles.mapNotNull { it.address }.toSet(),
+            bondedAddresses = bondedAddresses,
+            connectedAddresses = connectedDevices.map { it.address }.toSet(),
+        )
+    }
+        .distinctUntilChanged()
+        .onEach { log(TAG) { "Effective scanner mode: $it" } }
+        .setupCommonEventHandlers(TAG) { "scannerMode" }
+        .replayingShare(appScope)
+
+    suspend fun <T> withTemporaryOverride(mode: ScannerMode, block: suspend () -> T): T {
+        log(TAG) { "withTemporaryOverride($mode) acquire" }
+        overrideCounts.update { it.adjust(mode, +1) }
+        try {
+            return block()
+        } finally {
+            overrideCounts.update { it.adjust(mode, -1) }
+            log(TAG) { "withTemporaryOverride($mode) release" }
+        }
+    }
+
+    private fun Map<ScannerMode, Int>.adjust(mode: ScannerMode, delta: Int): Map<ScannerMode, Int> {
+        val current = this[mode] ?: 0
+        val next = current + delta
+        return when {
+            next <= 0 -> this - mode
+            else -> this + (mode to next)
+        }
+    }
+
+    private fun Map<ScannerMode, Int>.topPriority(): ScannerMode? = OVERRIDE_PRIORITY.firstOrNull { containsKey(it) }
+
+    companion object {
+        private val TAG = logTag("Bluetooth", "ScannerMode")
+        private val OVERRIDE_PRIORITY = listOf(ScannerMode.LOW_LATENCY, ScannerMode.BALANCED, ScannerMode.LOW_POWER)
+    }
+}
+
+internal fun resolveScannerMode(
+    overrideMode: ScannerMode?,
+    isForeground: Boolean,
+    profileAddresses: Set<BluetoothAddress>,
+    bondedAddresses: Set<BluetoothAddress>,
+    connectedAddresses: Set<BluetoothAddress>,
+): ScannerMode {
+    if (overrideMode != null) return overrideMode
+
+    val connectedProfileAddresses = profileAddresses.normalized()
+        .intersect(bondedAddresses.normalized())
+        .intersect(connectedAddresses.normalized())
+
+    return when {
+        connectedProfileAddresses.isNotEmpty() -> ScannerMode.LOW_LATENCY
+        isForeground -> ScannerMode.BALANCED
+        else -> ScannerMode.LOW_POWER
+    }
+}
+
+private fun Iterable<BluetoothAddress>.normalized(): Set<BluetoothAddress> = this
+    .map { it.uppercase(Locale.US) }
+    .toSet()

--- a/app/src/main/java/eu/darken/capod/troubleshooter/ui/TroubleShooterViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/troubleshooter/ui/TroubleShooterViewModel.kt
@@ -16,6 +16,7 @@ import eu.darken.capod.common.uix.ViewModel4
 import eu.darken.capod.main.core.GeneralSettings
 import eu.darken.capod.monitor.core.DeviceMonitor
 import eu.darken.capod.monitor.core.ble.BlePodMonitor
+import eu.darken.capod.monitor.core.ble.BleScanModeController
 import eu.darken.capod.monitor.core.primaryDevice
 import eu.darken.capod.pods.core.apple.ble.BlePodSnapshot
 import eu.darken.capod.pods.core.unknown.UnknownSnapshotBle
@@ -40,6 +41,7 @@ class TroubleShooterViewModel @Inject constructor(
     private val generalSettings: GeneralSettings,
     private val profilesRepo: DeviceProfilesRepo,
     private val blePodMonitor: BlePodMonitor,
+    private val bleScanModeController: BleScanModeController,
     private val deviceMonitor: DeviceMonitor,
     private val debugSettings: DebugSettings,
     private val timeSource: TimeSource,
@@ -84,39 +86,119 @@ class TroubleShooterViewModel @Inject constructor(
     fun troubleShootBle() = launch(context = dispatcherProvider.IO) {
         log(TAG, INFO) { "troubleShootBle()" }
 
-        generalSettings.scannerMode.valueBlocking = ScannerMode.LOW_LATENCY
-
-        run {
-            progress("Checking for headphones...")
-            val mainDevice = withTimeoutOrNull(STEP_TIME) {
-                deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
+        bleScanModeController.withTemporaryOverride(ScannerMode.LOW_LATENCY) override@{
+            run {
+                progress("Checking for headphones...")
+                val mainDevice = withTimeoutOrNull(STEP_TIME) {
+                    deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
+                }
+                if (mainDevice != null) {
+                    success("Headphones found, nothing to troubleshoot.")
+                    return@override
+                } else {
+                    progress("Headphones not detected.\n")
+                }
             }
-            if (mainDevice != null) {
-                success("Headphones found, nothing to troubleshoot.")
-                return@launch
-            } else {
-                progress("Headphones not detected.\n")
+
+            val doScan: suspend (Boolean, Boolean, Boolean, Boolean) -> Collection<BlePodSnapshot> =
+                { hardwareFilteringDisabled,
+                  hardwareBatchingDisabled,
+                  indirectCallback,
+                  unfiltered ->
+                    val sb = StringBuilder("SCAN - Settings: ")
+                    sb.append("hardwareFilteringDisabled=$hardwareFilteringDisabled, ")
+                    sb.append("hardwareBatchingDisabled=$hardwareBatchingDisabled, ")
+                    sb.append("indirectCallback=$indirectCallback, ")
+                    sb.append("unfiltered=$unfiltered")
+                    progress(sb.toString())
+                    generalSettings.isOffloadedFilteringDisabled.valueBlocking = hardwareFilteringDisabled
+                    generalSettings.isOffloadedBatchingDisabled.valueBlocking = hardwareBatchingDisabled
+                    generalSettings.useIndirectScanResultCallback.valueBlocking = indirectCallback
+                    debugSettings.showUnfiltered.valueBlocking = unfiltered
+
+                    val start = timeSource.elapsedRealtime()
+                    val devices = withTimeoutOrNull(STEP_TIME) {
+                        blePodMonitor.devices
+                            .take(10)
+                            .takeWhile { timeSource.elapsedRealtime() - start < STEP_TIME - 1000 }
+                            .toList()
+                            .flatten()
+                            .distinctBy { it.address }
+                    } ?: emptyList()
+                    log(TAG) { "SCAN: BLE Devices: $devices" }
+                    if (devices.isNotEmpty()) {
+                        progress("SCAN: Received data from ${devices.size} BLE devices")
+                        devices
+                    } else {
+                        progress("SCAN: No data received")
+                        devices
+                    }
+                }
+
+            run {
+                progress("Checking if we can receive BLE data at all.")
+                if (doScan(false, false, false, true).isNotEmpty()) return@run
+                if (doScan(false, false, true, true).isNotEmpty()) return@run
+                if (doScan(true, true, true, true).isNotEmpty()) return@run
+                if (doScan(true, true, false, true).isNotEmpty()) return@run
+                if (doScan(true, false, true, true).isNotEmpty()) return@run
+                if (doScan(true, false, false, true).isNotEmpty()) return@run
+                if (doScan(false, true, true, true).isNotEmpty()) return@run
+                if (doScan(false, true, false, true).isNotEmpty()) return@run
+
+                failure("Phone is not receiving BLE data.", BleState.Result.Failure.Type.PHONE)
+
+                generalSettings.isOffloadedFilteringDisabled.valueBlocking = false
+                generalSettings.isOffloadedBatchingDisabled.valueBlocking = false
+                generalSettings.useIndirectScanResultCallback.valueBlocking = false
+                debugSettings.showUnfiltered.valueBlocking = false
+
+                return@override
             }
-        }
 
-        val doScan: suspend (Boolean, Boolean, Boolean, Boolean) -> Collection<BlePodSnapshot> =
-            { hardwareFilteringDisabled,
-              hardwareBatchingDisabled,
-              indirectCallback,
-              unfiltered ->
-                val sb = StringBuilder("SCAN - Settings: ")
-                sb.append("hardwareFilteringDisabled=$hardwareFilteringDisabled, ")
-                sb.append("hardwareBatchingDisabled=$hardwareBatchingDisabled, ")
-                sb.append("indirectCallback=$indirectCallback, ")
-                sb.append("unfiltered=$unfiltered")
-                progress(sb.toString())
-                generalSettings.isOffloadedFilteringDisabled.valueBlocking = hardwareFilteringDisabled
-                generalSettings.isOffloadedBatchingDisabled.valueBlocking = hardwareBatchingDisabled
-                generalSettings.useIndirectScanResultCallback.valueBlocking = indirectCallback
-                debugSettings.showUnfiltered.valueBlocking = unfiltered
+            progress("We received at least some BLE data.\n")
 
-                val start = timeSource.elapsedRealtime()
-                val devices = withTimeoutOrNull(STEP_TIME) {
+            run {
+                progress("Checking for supported headphones.")
+
+                if (doScan(false, false, false, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(false, false, true, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(true, true, true, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(true, true, false, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(true, false, true, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(true, false, false, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(false, true, true, false).any { it !is UnknownSnapshotBle }) return@run
+                if (doScan(false, true, false, false).any { it !is UnknownSnapshotBle }) return@run
+
+                failure("No compatible headphones found", BleState.Result.Failure.Type.HEADPHONES)
+
+                generalSettings.isOffloadedFilteringDisabled.valueBlocking = false
+                generalSettings.isOffloadedBatchingDisabled.valueBlocking = false
+                generalSettings.useIndirectScanResultCallback.valueBlocking = false
+
+                return@override
+            }
+
+            progress("Found some headphones that are supported by CAPod.\n")
+
+            run {
+                progress("Checking for your headphones with new BLE settings...")
+                val mainDevice = withTimeoutOrNull(STEP_TIME) {
+                    deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
+                }
+                if (mainDevice != null) {
+                    success("Found your headphones, new BLE settings worked :)!")
+                    return@override
+                }
+            }
+
+            progress("Still no headphones detected that count as yours.\n")
+
+            run {
+                progress("Checking all closeby headphones.")
+
+                val otherDevices = withTimeoutOrNull(STEP_TIME) {
+                    val start = timeSource.elapsedRealtime()
                     blePodMonitor.devices
                         .take(10)
                         .takeWhile { timeSource.elapsedRealtime() - start < STEP_TIME - 1000 }
@@ -124,122 +206,40 @@ class TroubleShooterViewModel @Inject constructor(
                         .flatten()
                         .distinctBy { it.address }
                 } ?: emptyList()
-                log(TAG) { "SCAN: BLE Devices: $devices" }
-                if (devices.isNotEmpty()) {
-                    progress("SCAN: Received data from ${devices.size} BLE devices")
-                    devices
-                } else {
-                    progress("SCAN: No data received")
-                    devices
+
+                otherDevices.forEachIndexed { index, dev -> log(TAG) { "Device #$index: $dev" } }
+
+                if (otherDevices.isEmpty()) {
+                    failure("No supported headphones found near your device.", BleState.Result.Failure.Type.HEADPHONES)
+                    return@override
                 }
-            }
 
-        run {
-            progress("Checking if we can receive BLE data at all.")
-            if (doScan(false, false, false, true).isNotEmpty()) return@run
-            if (doScan(false, false, true, true).isNotEmpty()) return@run
-            if (doScan(true, true, true, true).isNotEmpty()) return@run
-            if (doScan(true, true, false, true).isNotEmpty()) return@run
-            if (doScan(true, false, true, true).isNotEmpty()) return@run
-            if (doScan(true, false, false, true).isNotEmpty()) return@run
-            if (doScan(false, true, true, true).isNotEmpty()) return@run
-            if (doScan(false, true, false, true).isNotEmpty()) return@run
+                progress("Headphones found nearby, but not detected as yours.\n")
+                progress("Creating profile for closest headphones.")
 
-            failure("Phone is not receiving BLE data.", BleState.Result.Failure.Type.PHONE)
+                val candidate = otherDevices
+                    .filter { it !is UnknownSnapshotBle }
+                    .maxBy { it.signalQuality }
 
-            generalSettings.isOffloadedFilteringDisabled.valueBlocking = false
-            generalSettings.isOffloadedBatchingDisabled.valueBlocking = false
-            generalSettings.useIndirectScanResultCallback.valueBlocking = false
-            debugSettings.showUnfiltered.valueBlocking = false
+                log(TAG, INFO) { "Candidate is $candidate" }
 
-            return@launch
-        }
+                profilesRepo.addProfile(
+                    profile = AppleDeviceProfile(
+                        label = context.getString(R.string.troubleshooter_title),
+                        model = candidate.model,
+                    ),
+                    addFirst = true,
+                )
 
-        progress("We received at least some BLE data.\n")
+                val mainDevice = withTimeoutOrNull(STEP_TIME) {
+                    deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
+                }
 
-        run {
-            progress("Checking for supported headphones.")
-
-            if (doScan(false, false, false, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(false, false, true, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(true, true, true, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(true, true, false, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(true, false, true, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(true, false, false, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(false, true, true, false).any { it !is UnknownSnapshotBle }) return@run
-            if (doScan(false, true, false, false).any { it !is UnknownSnapshotBle }) return@run
-
-            failure("No compatible headphones found", BleState.Result.Failure.Type.HEADPHONES)
-
-            generalSettings.isOffloadedFilteringDisabled.valueBlocking = false
-            generalSettings.isOffloadedBatchingDisabled.valueBlocking = false
-            generalSettings.useIndirectScanResultCallback.valueBlocking = false
-
-            return@launch
-        }
-
-        progress("Found some headphones that are supported by CAPod.\n")
-
-        run {
-            progress("Checking for your headphones with new BLE settings...")
-            val mainDevice = withTimeoutOrNull(STEP_TIME) {
-                deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
-            }
-            if (mainDevice != null) {
-                success("Found your headphones, new BLE settings worked :)!")
-                return@launch
-            }
-        }
-
-        progress("Still no headphones detected that count as yours.\n")
-
-        run {
-            progress("Checking all closeby headphones.")
-
-            val otherDevices = withTimeoutOrNull(STEP_TIME) {
-                val start = timeSource.elapsedRealtime()
-                blePodMonitor.devices
-                    .take(10)
-                    .takeWhile { timeSource.elapsedRealtime() - start < STEP_TIME - 1000 }
-                    .toList()
-                    .flatten()
-                    .distinctBy { it.address }
-            } ?: emptyList()
-
-            otherDevices.forEachIndexed { index, dev -> log(TAG) { "Device #$index: $dev" } }
-
-            if (otherDevices.isEmpty()) {
-                failure("No supported headphones found near your device.", BleState.Result.Failure.Type.HEADPHONES)
-                return@launch
-            }
-
-            progress("Headphones found nearby, but not detected as yours.\n")
-            progress("Creating profile for closest headphones.")
-
-            val candidate = otherDevices
-                .filter { it !is UnknownSnapshotBle }
-                .maxBy { it.signalQuality }
-
-            log(TAG, INFO) { "Candidate is $candidate" }
-
-            profilesRepo.addProfile(
-                profile = AppleDeviceProfile(
-                    label = context.getString(R.string.troubleshooter_title),
-                    model = candidate.model,
-                ),
-                addFirst = true,
-            )
-
-            val mainDevice = withTimeoutOrNull(STEP_TIME) {
-                deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
-            }
-
-            generalSettings.scannerMode.valueBlocking = ScannerMode.BALANCED
-
-            if (mainDevice != null) {
-                success("Success! Detected your headphones.")
-            } else {
-                failure("No headphones detected near your device.", BleState.Result.Failure.Type.HEADPHONES)
+                if (mainDevice != null) {
+                    success("Success! Detected your headphones.")
+                } else {
+                    failure("No headphones detected near your device.", BleState.Result.Failure.Type.HEADPHONES)
+                }
             }
         }
     }

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Wys \'n ekstra kennisgewing wanneer \'n toestel gekoppel is. Dit laat jou toe om die permanente \"Geen toestelle\" kennisgewing te versteek deur die \"Toestelstatus\" kanaal te deaktiveer.</string>
     <string name="settings_keep_notification_after_disconnect_label">Hou kennisgewing ná ontkoppeling</string>
     <string name="settings_keep_notification_after_disconnect_description">Hou aan om die laaste bekende batteryvlakke te wys selfs nadat jou AirPods ontkoppel.</string>
-    <string name="settings_scanner_mode_label">Skandeerdermodus</string>
-    <string name="settings_scanner_mode_description">Moet die Bluetooth Lae Energie-dataskandeerder werkverrigting prioritiseer of energie bespaar?</string>
     <string name="settings_autopause_label">Outo-pouse</string>
     <string name="settings_autopause_description">Pouseer oudio wanneer die toestel uit jou oor verwyder word.</string>
     <string name="settings_autopplay_label">Outo-speel</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Die volgende toestemming is vereis:</string>
     <string name="permission_system_alert_window_label">Stelselwaarskuwingsvenster</string>
     <string name="permission_system_alert_window_description">Laat CAPod toe om oor ander toepassings te teken om die kenmerk Wys opspringer moontlik te maak.</string>
-    <string name="settings_scanner_mode_lowpower_label">Lae krag</string>
-    <string name="settings_scanner_mode_balanced_label">Gebalanseer</string>
-    <string name="settings_scanner_mode_lowlatency_label">Lae latensie</string>
     <string name="settings_monitor_mode_manual_label">Wanneer toepassing oop is</string>
     <string name="settings_monitor_mode_automatic_label">Wanneer toestel gekoppel is</string>
     <string name="settings_monitor_mode_always_label">Altyd</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">አንድ መሣሪያ ሲገናኝ ተጨማሪ ማሳወቂያ ያሳያል። ይህ የ \"የመሣሪያ ሁኔታ\" ቻናልን በማሰናከል ቋሚውን \"ምንም መሣሪያዎች የሉም\" የሚለውን ማሳወቂያ እንዲደብቁ ያስችልዎታል።</string>
     <string name="settings_keep_notification_after_disconnect_label">ከተነተቀ በኋላ ማሳወቂያውን ይያዙ</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPods ከተነተቁ በኋላም የመጨረሻውን የታወቀ የባትሪ ደረጃ ማሳየቱን ይቀጥሉ</string>
-    <string name="settings_scanner_mode_label">የቃኚ ሁነታ</string>
-    <string name="settings_scanner_mode_description">የብሉቱዝ ዝቅተኛ ኃይል ዳታ ቃኚው አፈጻጸምን ቅድሚያ መስጠት አለበት ወይስ ኃይል መቆጠብ አለበት?</string>
     <string name="settings_autopause_label">ራስ-ሰር ለአፍታ ማቆም</string>
     <string name="settings_autopause_description">መሳሪያውን ከጆሮዎ ሲያወጡ ድምጽን ለአፍታ ያቁሙ።</string>
     <string name="settings_autopplay_label">ራስ-ሰር አጫውት</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">የሚከተለው ፈቃድ ያስፈልጋል:</string>
     <string name="permission_system_alert_window_label">የስርዓት ማስጠንቀቂያ መስኮት</string>
     <string name="permission_system_alert_window_description">\"ብቅ-ባይ አሳይ\" ባህሪውን ለማስቻል CAPod በሌሎች መተግበሪያዎች ላይ እንዲሳል ፍቀድ።</string>
-    <string name="settings_scanner_mode_lowpower_label">ዝቅተኛ ኃይል</string>
-    <string name="settings_scanner_mode_balanced_label">ሚዛናዊ</string>
-    <string name="settings_scanner_mode_lowlatency_label">ዝቅተኛ መዘግየት</string>
     <string name="settings_monitor_mode_manual_label">መተግበሪያው ሲከፈት</string>
     <string name="settings_monitor_mode_automatic_label">መሣሪያ ሲገናኝ</string>
     <string name="settings_monitor_mode_always_label">ሁልጊዜ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">يعرض إشعارًا إضافيًا عند توصيل جهاز. يتيح لك هذا إخفاء الإشعار الدائم \"لا توجد أجهزة\" عن طريق تعطيل قناة \"حالة الجهاز\".</string>
     <string name="settings_keep_notification_after_disconnect_label">الاحتفاظ بالإشعار بعد قطع الاتصال</string>
     <string name="settings_keep_notification_after_disconnect_description">الاستمرار في عرض مستويات البطارية المعروفة الأخيرة حتى بعد قطع اتصال AirPods</string>
-    <string name="settings_scanner_mode_label">وضع الماسح الضوئي</string>
-    <string name="settings_scanner_mode_description">هل يجب أن يعطي ماسح بيانات البلوتوث منخفض الطاقة الأولوية للأداء أم يحافظ على الطاقة؟</string>
     <string name="settings_autopause_label">إيقاف مؤقت تلقائي</string>
     <string name="settings_autopause_description">إيقاف الصوت مؤقتًا عند إزالة الجهاز من أذنك.</string>
     <string name="settings_autopplay_label">تشغيل تلقائي</string>
@@ -230,9 +228,6 @@
     <string name="permission_required_title">الإذن التالي مطلوب:</string>
     <string name="permission_system_alert_window_label">نافذة تنبيه النظام</string>
     <string name="permission_system_alert_window_description">السماح لـ CAPod بالرسم فوق التطبيقات الأخرى لتمكين ميزة \"إظهار النافذة المنبثقة\".</string>
-    <string name="settings_scanner_mode_lowpower_label">طاقة منخفضة</string>
-    <string name="settings_scanner_mode_balanced_label">متوازن</string>
-    <string name="settings_scanner_mode_lowlatency_label">تأخير منخفض</string>
     <string name="settings_monitor_mode_manual_label">عند فتح التطبيق</string>
     <string name="settings_monitor_mode_automatic_label">عند اتصال الجهاز</string>
     <string name="settings_monitor_mode_always_label">دائمًا</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Cihaz qoşulduqda əlavə bildiriş göstərir. Bu, \"Cihaz statusu\" kanalını deaktiv etməklə daimi \"Cihaz yoxdur\" bildirişini gizlətməyə imkan verir.</string>
     <string name="settings_keep_notification_after_disconnect_label">Ayrıldıqdan sonra bildirişi saxla</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPods ayrıldıqdan sonra belə sonuncu bilinən batareya səviyyələrini göstərməyə davam et</string>
-    <string name="settings_scanner_mode_label">Skaner rejimi</string>
-    <string name="settings_scanner_mode_description">Bluetooth Aşağı Enerji məlumat skaneri performansa üstünlük verməli, yoxsa enerjiyə qənaət etməlidir?</string>
     <string name="settings_autopause_label">Avtomatik fasilə</string>
     <string name="settings_autopause_description">Cihazı qulağınızdan çıxardıqda səsi dayandırın.</string>
     <string name="settings_autopplay_label">Avtomatik oxutma</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Aşağıdakı icazə tələb olunur:</string>
     <string name="permission_system_alert_window_label">Sistem xəbərdarlıq pəncərəsi</string>
     <string name="permission_system_alert_window_description">\"Pop-up göstər\" xüsusiyyətini mümkün etmək üçün CAPod-a digər tətbiqlərin üzərində çəkməyə icazə verin.</string>
-    <string name="settings_scanner_mode_lowpower_label">Aşağı güc</string>
-    <string name="settings_scanner_mode_balanced_label">Balanslaşdırılmış</string>
-    <string name="settings_scanner_mode_lowlatency_label">Aşağı gecikmə</string>
     <string name="settings_monitor_mode_manual_label">Tətbiq açıq olduqda</string>
     <string name="settings_monitor_mode_automatic_label">Cihaz qoşulduqda</string>
     <string name="settings_monitor_mode_always_label">Həmişə</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Паказвае дадатковае апавяшчэнне пры падключэнні прылады. Гэта дазваляе схаваць пастаяннае апавяшчэнне \"Няма прылад\" шляхам адключэння канала \"Стан прылады\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Захаваць апавяшчэнне пасля адключэння</string>
     <string name="settings_keep_notification_after_disconnect_description">Працягваць паказваць апошнія вядомыя ўзроўні зарадкі нават пасля адключэння вашых AirPods</string>
-    <string name="settings_scanner_mode_label">Рэжым сканера</string>
-    <string name="settings_scanner_mode_description">Ці павінен сканер даных Bluetooth Low Energy аддаваць перавагу прадукцыйнасці або эканоміць энергію?</string>
     <string name="settings_autopause_label">Аўтаматычная паўза</string>
     <string name="settings_autopause_description">Прыпыняць аўдыя пры выманні прылады з вуха.</string>
     <string name="settings_autopplay_label">Аўтаматычнае прайграванне</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">Патрабуецца наступны дазвол:</string>
     <string name="permission_system_alert_window_label">Сістэмнае акно папярэджання</string>
     <string name="permission_system_alert_window_description">Дазвольце CAPod маляваць паверх іншых праграм, каб зрабіць магчымай функцыю \"Паказаць усплывальнае акно\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Нізкае энергаспажыванне</string>
-    <string name="settings_scanner_mode_balanced_label">Збалансавана</string>
-    <string name="settings_scanner_mode_lowlatency_label">Нізкая затрымка</string>
     <string name="settings_monitor_mode_manual_label">Калі праграма адкрыта</string>
     <string name="settings_monitor_mode_automatic_label">Калі прылада падключана</string>
     <string name="settings_monitor_mode_always_label">Заўсёды</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Показва допълнително известие, когато устройство е свързано. Това ви позволява да скриете постоянното известие \"Няма устройства\" чрез деактивиране на канала \"Състояние на устройството\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Запази известието след прекъсване</string>
     <string name="settings_keep_notification_after_disconnect_description">Продължавай да показваш последните известни нива на батерията дори след прекъсване на връзката с AirPods</string>
-    <string name="settings_scanner_mode_label">Режим на скенер</string>
-    <string name="settings_scanner_mode_description">Трябва ли скенерът за данни с ниска енергия на Bluetooth да даде приоритет на производителността или да пести енергия?</string>
     <string name="settings_autopause_label">Автоматична пауза</string>
     <string name="settings_autopause_description">Поставяне на аудио на пауза при премахване на устройството от ухото ви.</string>
     <string name="settings_autopplay_label">Автоматично възпроизвеждане</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Необходимо е следното разрешение:</string>
     <string name="permission_system_alert_window_label">Системен изскачащ прозорец</string>
     <string name="permission_system_alert_window_description">Позволете на CAPod да рисува върху други приложения, за да направи функцията \"Покажи изскачащ прозорец\" възможна.</string>
-    <string name="settings_scanner_mode_lowpower_label">Ниска мощност</string>
-    <string name="settings_scanner_mode_balanced_label">Балансиран</string>
-    <string name="settings_scanner_mode_lowlatency_label">Ниска латентност</string>
     <string name="settings_monitor_mode_manual_label">Когато приложението е отворено</string>
     <string name="settings_monitor_mode_automatic_label">Когато устройството е свързано</string>
     <string name="settings_monitor_mode_always_label">Винаги</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">একটি ডিভাইস সংযুক্ত হলে একটি অতিরিক্ত বিজ্ঞপ্তি দেখায়। এটি আপনাকে \"ডিভাইস স্ট্যাটাস\" চ্যানেল নিষ্ক্রিয় করে স্থায়ী \"কোনো ডিভাইস নেই\" বিজ্ঞপ্তি লুকাতে দেয়।</string>
     <string name="settings_keep_notification_after_disconnect_label">সংযোগ বিচ্ছিন্নের পরে বিজ্ঞপ্তি রাখুন</string>
     <string name="settings_keep_notification_after_disconnect_description">আপনার AirPods সংযোগ বিচ্ছিন্ন হওয়ার পরেও সর্বশেষ জানা ব্যাটারি স্তর দেখাতে থাকুন</string>
-    <string name="settings_scanner_mode_label">স্ক্যানার মোড</string>
-    <string name="settings_scanner_mode_description">ব্লুটুথ লো এনার্জি ডেটা স্ক্যানার কি কর্মক্ষমতাকে অগ্রাধিকার দেবে নাকি শক্তি সংরক্ষণ করবে?</string>
     <string name="settings_autopause_label">স্বয়ংক্রিয় বিরতি</string>
     <string name="settings_autopause_description">আপনার কান থেকে ডিভাইসটি সরানোর সময় অডিওতে বিরতি দিন।</string>
     <string name="settings_autopplay_label">স্বয়ংক্রিয় প্লে</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">নিম্নলিখিত অনুমতি প্রয়োজন:</string>
     <string name="permission_system_alert_window_label">সিস্টেম অ্যালার্ট উইন্ডো</string>
     <string name="permission_system_alert_window_description">\"পপআপ দেখান\" বৈশিষ্ট্যটি সম্ভব করতে CAPod-কে অন্যান্য অ্যাপের উপরে আঁকতে অনুমতি দিন।</string>
-    <string name="settings_scanner_mode_lowpower_label">কম শক্তি</string>
-    <string name="settings_scanner_mode_balanced_label">ভারসাম্যপূর্ণ</string>
-    <string name="settings_scanner_mode_lowlatency_label">কম বিলম্ব</string>
     <string name="settings_monitor_mode_manual_label">অ্যাপ খোলা থাকলে</string>
     <string name="settings_monitor_mode_automatic_label">ডিভাইস সংযুক্ত থাকলে</string>
     <string name="settings_monitor_mode_always_label">সর্বদা</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mostra una notificació addicional quan hi ha un dispositiu connectat. Això permet ocultar la notificació permanent «Sense dispositius» desactivant el canal «Estat del dispositiu».</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantén les notificacions després de la desconnexió</string>
     <string name="settings_keep_notification_after_disconnect_description">Continua mostrant els últims nivells de bateria coneguts fins i tot després que els AirPods es desconnectin</string>
-    <string name="settings_scanner_mode_label">Mode escàner</string>
-    <string name="settings_scanner_mode_description">L\'escàner de dades Bluetooth de baix consum hauria de prioritzar el rendiment o estalviar energia?</string>
     <string name="settings_autopause_label">Pausa automàtica</string>
     <string name="settings_autopause_description">Pausa l\'àudio quan ús tragueu el dispositiu de l\'orella.</string>
     <string name="settings_autopplay_label">Reproducció automàtica</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Cal el permís següent:</string>
     <string name="permission_system_alert_window_label">Finestra d\'alerta del sistema</string>
     <string name="permission_system_alert_window_description">Permet que el CAPod dibuixi sobre altres aplicacions per fer possible la característica «Mostra emergent».</string>
-    <string name="settings_scanner_mode_lowpower_label">Baixa potència</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrat</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baixa latència</string>
     <string name="settings_monitor_mode_manual_label">Quan l\'aplicació està oberta</string>
     <string name="settings_monitor_mode_automatic_label">Quan el dispositiu està connectat</string>
     <string name="settings_monitor_mode_always_label">Sempre</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Zobrazí dodatečné oznámení, když je zařízení připojeno. To umožňuje skrýt trvalé oznámení \"Žádné zařízení\" vypnutím kanálu \"Stav zařízení\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Uchovat oznámení po odpojení</string>
     <string name="settings_keep_notification_after_disconnect_description">Pokračovat v zobrazování poslední známé úrovně nabití baterie i po odpojení AirPods</string>
-    <string name="settings_scanner_mode_label">Režim skenování</string>
-    <string name="settings_scanner_mode_description">Má skenování Bluetooth Low Energy upřednostnit výkon, nebo úsporu energie?</string>
     <string name="settings_autopause_label">Autom. pozastavení</string>
     <string name="settings_autopause_description">Pozastavení zvuku při vyjmutí zařízení z ucha.</string>
     <string name="settings_autopplay_label">Autom. přehrávání</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">Je vyžadováno následující oprávnění:</string>
     <string name="permission_system_alert_window_label">Okno systémových upozornění</string>
     <string name="permission_system_alert_window_description">Aby bylo možné použít unkci \"Zobrazit vyskakovací okno\", je nutné umožnit aplikaci CAPod vykreslení přes jiné aplikace.</string>
-    <string name="settings_scanner_mode_lowpower_label">Nízký výkon</string>
-    <string name="settings_scanner_mode_balanced_label">Vyvážený</string>
-    <string name="settings_scanner_mode_lowlatency_label">Nízká latence</string>
     <string name="settings_monitor_mode_manual_label">Při otevření aplikace</string>
     <string name="settings_monitor_mode_automatic_label">Při připojení zařízení</string>
     <string name="settings_monitor_mode_always_label">Vždy</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Viser en ekstra notifikation, når en enhed er tilsluttet. Dette lader dig skjule den permanente \"Ingen enheder\"-notifikation ved at deaktivere \"Enhedsstatus\"-kanalen.</string>
     <string name="settings_keep_notification_after_disconnect_label">Behold notifikation efter afbrydelse</string>
     <string name="settings_keep_notification_after_disconnect_description">Fortsæt med at vise de sidst kendte batteriniveauer, selv efter dine AirPods afbrydes</string>
-    <string name="settings_scanner_mode_label">Scannertilstand</string>
-    <string name="settings_scanner_mode_description">Skal Bluetooth Low Energy-datascanneren prioritere ydeevne eller spare på energien?</string>
     <string name="settings_autopause_label">Auto-pause</string>
     <string name="settings_autopause_description">Sæt lyd på pause, når du fjerner enheden fra dit øre.</string>
     <string name="settings_autopplay_label">Auto-afspilning</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Følgende tilladelse er påkrævet:</string>
     <string name="permission_system_alert_window_label">Systemalarmvindue</string>
     <string name="permission_system_alert_window_description">Tillad CAPod at tegne over andre apps for at gøre funktionen \"Vis pop op\" mulig.</string>
-    <string name="settings_scanner_mode_lowpower_label">Lavt strømforbrug</string>
-    <string name="settings_scanner_mode_balanced_label">Balanceret</string>
-    <string name="settings_scanner_mode_lowlatency_label">Lav latens</string>
     <string name="settings_monitor_mode_manual_label">Når appen er åben</string>
     <string name="settings_monitor_mode_automatic_label">Når enheden er tilsluttet</string>
     <string name="settings_monitor_mode_always_label">Altid</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Zeigt eine zusätzliche Benachrichtigung an, wenn ein Gerät verbunden ist. Dadurch kannst du die permanente Benachrichtigung „Keine Geräte“ ausblenden, indem du den Kanal „Gerätestatus“ deaktivierst.</string>
     <string name="settings_keep_notification_after_disconnect_label">Benachrichtigung nach Trennung beibehalten</string>
     <string name="settings_keep_notification_after_disconnect_description">Zeigt weiterhin den letzten bekannten Akkustand an, auch wenn die Verbindung zu deinen AirPods getrennt wurde</string>
-    <string name="settings_scanner_mode_label">Scan-Modus</string>
-    <string name="settings_scanner_mode_description">Soll die Bluetooth Low Energy Überwachung Leistung priorisieren oder Energie sparen?</string>
     <string name="settings_autopause_label">Automatische Pause</string>
     <string name="settings_autopause_description">Musik pausieren, wenn der Kopfhörer vom Ohr entfernt wird.</string>
     <string name="settings_autopplay_label">Automatisches abspielen</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Die folgende Genehmigung ist erforderlich:</string>
     <string name="permission_system_alert_window_label">Systemwarnungsfenster</string>
     <string name="permission_system_alert_window_description">Erlaube CAPod, PopUp Benachrichtigungen über anderen Apps anzuzeigen.</string>
-    <string name="settings_scanner_mode_lowpower_label">Geringer Strom</string>
-    <string name="settings_scanner_mode_balanced_label">Ausgewogen</string>
-    <string name="settings_scanner_mode_lowlatency_label">Geringe Latenz</string>
     <string name="settings_monitor_mode_manual_label">Wenn die App geöffnet ist</string>
     <string name="settings_monitor_mode_automatic_label">Wenn das Gerät verbunden ist</string>
     <string name="settings_monitor_mode_always_label">Immer</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Εμφανίζει μια επιπλέον ειδοποίηση όταν μια συσκευή είναι συνδεδεμένη. Αυτό σας επιτρέπει να αποκρύψετε τη μόνιμη ειδοποίηση \"Δεν υπάρχουν συσκευές\" απενεργοποιώντας το κανάλι \"Κατάσταση συσκευής\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Διατήρηση ειδοποίησης μετά την αποσύνδεση</string>
     <string name="settings_keep_notification_after_disconnect_description">Συνεχίστε να εμφανίζετε τα τελευταία γνωστά επίπεδα μπαταρίας ακόμα και μετά την αποσύνδεση των AirPods σας</string>
-    <string name="settings_scanner_mode_label">Λειτουργία σαρωτή</string>
-    <string name="settings_scanner_mode_description">Ο σαρωτής δεδομένων Bluetooth Low Energy θα πρέπει να δώσει προτεραιότητα στην απόδοση ή στην εξοικονόμηση ενέργειας;</string>
     <string name="settings_autopause_label">Αυτόματη παύση</string>
     <string name="settings_autopause_description">Παύση ήχου κατά την αφαίρεση της συσκευής από το αυτί σας.</string>
     <string name="settings_autopplay_label">Αυτόματη αναπαραγωγή</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Απαιτείται η ακόλουθη άδεια:</string>
     <string name="permission_system_alert_window_label">Παράθυρο ειδοποίησης συστήματος</string>
     <string name="permission_system_alert_window_description">Επιτρέψτε στο CAPod να σχεδιάζει πάνω από άλλες εφαρμογές για να καταστεί δυνατή η λειτουργία \"Εμφάνιση αναδυόμενου\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Χαμηλή ισχύς</string>
-    <string name="settings_scanner_mode_balanced_label">Ισορροπημένο</string>
-    <string name="settings_scanner_mode_lowlatency_label">Χαμηλή καθυστέρηση</string>
     <string name="settings_monitor_mode_manual_label">Όταν η εφαρμογή είναι ανοιχτή</string>
     <string name="settings_monitor_mode_automatic_label">Όταν η συσκευή είναι συνδεδεμένη</string>
     <string name="settings_monitor_mode_always_label">Πάντα</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Muestra una notificación extra cuando un dispositivo está conectado. Esto te permite ocultar la notificación permanente \"Sin dispositivos\" desactivando el canal \"Estado del dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantener la notificación después de la desconexión</string>
     <string name="settings_keep_notification_after_disconnect_description">Seguir mostrando los últimos niveles de batería conocidos incluso después de que tus AirPods se desconecten</string>
-    <string name="settings_scanner_mode_label">Modo escáner</string>
-    <string name="settings_scanner_mode_description">¿Debería el escáner de datos de Bluetooth de baja energía priorizar el rendimiento o conservar energía?</string>
     <string name="settings_autopause_label">Pausa automática</string>
     <string name="settings_autopause_description">Pausar el audio al quitar el dispositivo de tu oreja.</string>
     <string name="settings_autopplay_label">Reproducción automática</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Se requiere el siguiente permiso:</string>
     <string name="permission_system_alert_window_label">Ventana emergente</string>
     <string name="permission_system_alert_window_description">Permite que CAPod se superponga a otras aplicaciones para que la función «Mostrar ventana emergente».</string>
-    <string name="settings_scanner_mode_lowpower_label">Baja energía</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrado</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baja latencia</string>
     <string name="settings_monitor_mode_manual_label">Cuando la aplicación está abierta</string>
     <string name="settings_monitor_mode_automatic_label">Cuando el dispositivo está conectado</string>
     <string name="settings_monitor_mode_always_label">Siempre</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Muestra una notificación adicional cuando un dispositivo está conectado. Esto te permite ocultar la notificación permanente \"Sin dispositivos\" desactivando el canal \"Estado del dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantener la notificación después de la desconexión</string>
     <string name="settings_keep_notification_after_disconnect_description">Seguir mostrando los últimos niveles de batería conocidos incluso después de que tus AirPods se desconecten</string>
-    <string name="settings_scanner_mode_label">Modo escáner</string>
-    <string name="settings_scanner_mode_description">¿Debería el escáner de datos de Bluetooth de baja energía priorizar el rendimiento o conservar energía?</string>
     <string name="settings_autopause_label">Pausa automática</string>
     <string name="settings_autopause_description">Pausar el audio al quitar el dispositivo de tu oreja.</string>
     <string name="settings_autopplay_label">Reproducción automática</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Se requiere el siguiente permiso:</string>
     <string name="permission_system_alert_window_label">Ventana emergente</string>
     <string name="permission_system_alert_window_description">Permite que CAPod se superponga a otras aplicaciones para que la función «Mostrar ventana emergente».</string>
-    <string name="settings_scanner_mode_lowpower_label">Baja energía</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrado</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baja latencia</string>
     <string name="settings_monitor_mode_manual_label">Cuando la aplicación está abierta</string>
     <string name="settings_monitor_mode_automatic_label">Cuando el dispositivo está conectado</string>
     <string name="settings_monitor_mode_always_label">Siempre</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Muestra una notificación adicional cuando un dispositivo está conectado. Esto le permite ocultar la notificación permanente \"Sin dispositivos\" deshabilitando el canal \"Estado del dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantener la notificación después de la desconexión</string>
     <string name="settings_keep_notification_after_disconnect_description">Seguir mostrando los últimos niveles de batería conocidos incluso después de que tus AirPods se desconecten</string>
-    <string name="settings_scanner_mode_label">Modo escáner</string>
-    <string name="settings_scanner_mode_description">¿Debería el escáner de datos de Bluetooth de baja energía priorizar el rendimiento o conservar energía?</string>
     <string name="settings_autopause_label">Pausa automática</string>
     <string name="settings_autopause_description">Pausar el audio al quitar el dispositivo de tu oído.</string>
     <string name="settings_autopplay_label">Reproducción automática</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Se requiere el siguiente permiso:</string>
     <string name="permission_system_alert_window_label">Ventana emergente</string>
     <string name="permission_system_alert_window_description">Permite que CAPod se superponga a otras aplicaciones para que la función «Mostrar ventana emergente».</string>
-    <string name="settings_scanner_mode_lowpower_label">Baja energía</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrado</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baja latencia</string>
     <string name="settings_monitor_mode_manual_label">Cuando la aplicación está abierta</string>
     <string name="settings_monitor_mode_automatic_label">Cuando el dispositivo está conectado</string>
     <string name="settings_monitor_mode_always_label">Siempre</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Kuvab seadme ühendumisel lisateavituse. See peidab pidevalt nähtava „Seadmed puuduvad“ teate, selleks keelates „Seadme olek“ kanali.</string>
     <string name="settings_keep_notification_after_disconnect_label">Kuva teadet ka pärast eemaldamist</string>
     <string name="settings_keep_notification_after_disconnect_description">Jätkake viimase teadaoleva akutaseme kuvamist isegi pärast AirPodside eemaldamist</string>
-    <string name="settings_scanner_mode_label">Skannimisrežiim</string>
-    <string name="settings_scanner_mode_description">Kas Bluetooth madalama energiatarbimisega andmete skanner eelistab jõudlust või mõõdukat energiahaldust?</string>
     <string name="settings_autopause_label">Automaatne peatamine</string>
     <string name="settings_autopause_description">Seadme kõrvast eemaldamisel peata esitamine.</string>
     <string name="settings_autopplay_label">Automaatne esitamine</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Vaja on järgmist luba:</string>
     <string name="permission_system_alert_window_label">Süsteemi teate aken</string>
     <string name="permission_system_alert_window_description">Luba CAPodil toimetada teiste rakenduste kohal, et näha hüpikaknaid.</string>
-    <string name="settings_scanner_mode_lowpower_label">Madal võimsus</string>
-    <string name="settings_scanner_mode_balanced_label">Tasakaalustatud</string>
-    <string name="settings_scanner_mode_lowlatency_label">Madal latents</string>
     <string name="settings_monitor_mode_manual_label">Kui rakendus on avatud</string>
     <string name="settings_monitor_mode_automatic_label">Kui seade on ühendatud</string>
     <string name="settings_monitor_mode_always_label">Alati</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Gailu bat konektatuta dagoenean jakinarazpen gehigarri bat erakusten du. Honek \"Gailurik ez\" jakinarazpen iraunkorra ezkutatzeko aukera ematen dizu \"Gailuaren egoera\" kanala desgaituz.</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantendu jakinarazpena deskonektatu ondoren</string>
     <string name="settings_keep_notification_after_disconnect_description">Jarraitu azken bateria-maila ezagunak erakusten zure AirPods-ak deskonektatu ondoren ere</string>
-    <string name="settings_scanner_mode_label">Eskaner modua</string>
-    <string name="settings_scanner_mode_description">Bluetooth Energia Baxuko datuen eskanerrak errendimendua lehenetsi behar al du ala energia aurreztu?</string>
     <string name="settings_autopause_label">Pausatze automatikoa</string>
     <string name="settings_autopause_description">Pausatu audioa gailua belarritik kentzean.</string>
     <string name="settings_autopplay_label">Erreprodukzio automatikoa</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Hurrengo baimena beharrezkoa da:</string>
     <string name="permission_system_alert_window_label">Sistemaren alerta-leihoa</string>
     <string name="permission_system_alert_window_description">Baimendu CAPod-i beste aplikazioen gainean marraztea \"Erakutsi pop-up-a\" ezaugarria posible egiteko.</string>
-    <string name="settings_scanner_mode_lowpower_label">Potentzia baxua</string>
-    <string name="settings_scanner_mode_balanced_label">Orekatua</string>
-    <string name="settings_scanner_mode_lowlatency_label">Latentzia baxua</string>
     <string name="settings_monitor_mode_manual_label">Aplikazioa irekita dagoenean</string>
     <string name="settings_monitor_mode_automatic_label">Gailua konektatuta dagoenean</string>
     <string name="settings_monitor_mode_always_label">Beti</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">هنگامی که یک دستگاه متصل است، یک اعلان اضافی نشان می‌دهد. این به شما امکان می‌دهد اعلان دائمی \"بدون دستگاه\" را با غیرفعال کردن کانال \"وضعیت دستگاه\" پنهان کنید.</string>
     <string name="settings_keep_notification_after_disconnect_label">حفظ اعلان پس از قطع اتصال</string>
     <string name="settings_keep_notification_after_disconnect_description">نمایش آخرین سطوح شارژ شناخته‌شده حتی پس از قطع اتصال AirPods شما</string>
-    <string name="settings_scanner_mode_label">حالت اسکنر</string>
-    <string name="settings_scanner_mode_description">آیا اسکنر داده بلوتوث کم‌مصرف باید عملکرد را در اولویت قرار دهد یا انرژی را ذخیره کند؟</string>
     <string name="settings_autopause_label">مکث خودکار</string>
     <string name="settings_autopause_description">هنگام برداشتن دستگاه از گوش، صدا را متوقف کنید.</string>
     <string name="settings_autopplay_label">پخش خودکار</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">مجوز زیر مورد نیاز است:</string>
     <string name="permission_system_alert_window_label">پنجره هشدار سیستم</string>
     <string name="permission_system_alert_window_description">به CAPod اجازه دهید روی سایر برنامه‌ها نمایش دهد تا ویژگی \"نمایش پاپ‌آپ\" ممکن شود.</string>
-    <string name="settings_scanner_mode_lowpower_label">کم‌مصرف</string>
-    <string name="settings_scanner_mode_balanced_label">متعادل</string>
-    <string name="settings_scanner_mode_lowlatency_label">تأخیر کم</string>
     <string name="settings_monitor_mode_manual_label">وقتی برنامه باز است</string>
     <string name="settings_monitor_mode_automatic_label">وقتی دستگاه متصل است</string>
     <string name="settings_monitor_mode_always_label">همیشه</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Näyttää lisäilmoituksen, kun laite on yhdistetty. Tämä antaa sinun piilottaa pysyvän \"Ei laitteita\" -ilmoituksen poistamalla \"Laitteen tila\" -kanavan käytöstä.</string>
     <string name="settings_keep_notification_after_disconnect_label">Säilytä ilmoitus yhteyden katkaisun jälkeen</string>
     <string name="settings_keep_notification_after_disconnect_description">Jatka viimeisten tunnettujen akkutasojen näyttämistä senkin jälkeen, kun AirPodit katkaisevat yhteyden</string>
-    <string name="settings_scanner_mode_label">Skanneritila</string>
-    <string name="settings_scanner_mode_description">Pitäisikö Bluetooth Low Energy -dataskannerin priorisoida suorituskykyä vai säästää energiaa?</string>
     <string name="settings_autopause_label">Automaattinen tauko</string>
     <string name="settings_autopause_description">Keskeytä ääni, kun poistat laitteen korvastasi.</string>
     <string name="settings_autopplay_label">Automaattinen toisto</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Seuraava lupa vaaditaan:</string>
     <string name="permission_system_alert_window_label">Järjestelmän hälytysikkuna</string>
     <string name="permission_system_alert_window_description">Salli CAPod-sovelluksen piirtää muiden sovellusten päälle mahdollistaakseen \"Näytä ponnahdusikkuna\" -ominaisuuden.</string>
-    <string name="settings_scanner_mode_lowpower_label">Virransäästö</string>
-    <string name="settings_scanner_mode_balanced_label">Tasapainoinen</string>
-    <string name="settings_scanner_mode_lowlatency_label">Matala viive</string>
     <string name="settings_monitor_mode_manual_label">Kun sovellus on auki</string>
     <string name="settings_monitor_mode_automatic_label">Kun laite on yhdistetty</string>
     <string name="settings_monitor_mode_always_label">Aina</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Nagpapakita ng karagdagang notipikasyon kapag konektado ang isang device. Pinapayagan ka nitong itago ang permanenteng \"Walang mga device\" na notipikasyon sa pamamagitan ng pag-disable sa \"Katayuan ng device\" na channel.</string>
     <string name="settings_keep_notification_after_disconnect_label">Panatilihin ang notipikasyon pagkatapos mag-disconnect</string>
     <string name="settings_keep_notification_after_disconnect_description">Ipagpatuloy ang pagpapakita ng huling kilalang mga antas ng baterya kahit pagkatapos mag-disconnect ang iyong AirPods</string>
-    <string name="settings_scanner_mode_label">Mode ng scanner</string>
-    <string name="settings_scanner_mode_description">Dapat bang unahin ng Bluetooth Low Energy data scanner ang performance o magtipid ng enerhiya?</string>
     <string name="settings_autopause_label">Auto pause</string>
     <string name="settings_autopause_description">I-pause ang audio kapag inaalis ang device sa iyong tainga.</string>
     <string name="settings_autopplay_label">Auto play</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Kailangan ang sumusunod na pahintulot:</string>
     <string name="permission_system_alert_window_label">System Alert Window</string>
     <string name="permission_system_alert_window_description">Payagan ang CAPod na mag-draw sa ibabaw ng ibang mga app para maging posible ang feature na \"Ipakita ang PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Mababang enerhiya</string>
-    <string name="settings_scanner_mode_balanced_label">Balanse</string>
-    <string name="settings_scanner_mode_lowlatency_label">Mababang latency</string>
     <string name="settings_monitor_mode_manual_label">Kapag bukas ang app</string>
     <string name="settings_monitor_mode_automatic_label">Kapag konektado ang device</string>
     <string name="settings_monitor_mode_always_label">Palagi</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Affiche une notification supplémentaire si un appareil est connecté. Cela vous permet de masquer la notification permanente « Aucun appareil » en désactivant le canal « État de l’appareil ».</string>
     <string name="settings_keep_notification_after_disconnect_label">Garder la notification après déconnexion</string>
     <string name="settings_keep_notification_after_disconnect_description">Afficher les derniers niveaux de batterie connus même après déconnexion de vos AirPods</string>
-    <string name="settings_scanner_mode_label">Mode analyse</string>
-    <string name="settings_scanner_mode_description">L’analyseur des données « basse énergie » de Bluetooth devrait-il prioriser les performances ou préserver l’énergie ?</string>
     <string name="settings_autopause_label">Pause automatique</string>
     <string name="settings_autopause_description">Mettre le son en pause si vous ôtez l’appareil de votre oreille.</string>
     <string name="settings_autopplay_label">Lecture automatique</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">L’autorisation suivante est nécessaire :</string>
     <string name="permission_system_alert_window_label">Fenêtre d’alerte système</string>
     <string name="permission_system_alert_window_description">Permettre à CAPod d’apparaître par-dessus les autres applis pour rendre la fonction « Afficher une fenêtre contextuelle » possible.</string>
-    <string name="settings_scanner_mode_lowpower_label">Puissance faible</string>
-    <string name="settings_scanner_mode_balanced_label">Équilibré</string>
-    <string name="settings_scanner_mode_lowlatency_label">Latence faible</string>
     <string name="settings_monitor_mode_manual_label">Si l’appli est ouverte</string>
     <string name="settings_monitor_mode_automatic_label">Si l’appareil est connecté</string>
     <string name="settings_monitor_mode_always_label">Toujours</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mostra unha notificación adicional cando un dispositivo está conectado. Isto permíteche ocultar a notificación permanente de \"Sen dispositivos\" desactivando a canle \"Estado do dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Manter notificación tras desconexión</string>
     <string name="settings_keep_notification_after_disconnect_description">Seguir mostrando os últimos niveis de batería coñecidos mesmo despois de que os teus AirPods se desconecten</string>
-    <string name="settings_scanner_mode_label">Modo de escáner</string>
-    <string name="settings_scanner_mode_description">O escáner de datos Bluetooth de baixa enerxía debería priorizar o rendemento ou conservar enerxía?</string>
     <string name="settings_autopause_label">Pausa automática</string>
     <string name="settings_autopause_description">Pausar o son ao quitar o dispositivo da orella.</string>
     <string name="settings_autopplay_label">Reprodución automática</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">É necesario o seguinte permiso:</string>
     <string name="permission_system_alert_window_label">Xanela de alerta do sistema</string>
     <string name="permission_system_alert_window_description">Permitir que CAPod debuxe sobre outras aplicacións para facer posible a función \"Mostrar PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Baixo consumo</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrado</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baixa latencia</string>
     <string name="settings_monitor_mode_manual_label">Cando a aplicación está aberta</string>
     <string name="settings_monitor_mode_automatic_label">Cando o dispositivo está conectado</string>
     <string name="settings_monitor_mode_always_label">Sempre</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">जब कोई डिवाइस कनेक्ट होता है तो एक अतिरिक्त सूचना दिखाता है। यह आपको \"डिवाइस स्थिति\" चैनल को अक्षम करके स्थायी \"कोई डिवाइस नहीं\" सूचना को छिपाने की अनुमति देता है।</string>
     <string name="settings_keep_notification_after_disconnect_label">डिस्कनेक्ट होने के बाद सूचना बनाए रखें</string>
     <string name="settings_keep_notification_after_disconnect_description">आपके AirPods डिस्कनेक्ट होने के बाद भी अंतिम ज्ञात बैटरी स्तर दिखाना जारी रखें</string>
-    <string name="settings_scanner_mode_label">स्कैनर मोड</string>
-    <string name="settings_scanner_mode_description">क्या ब्लूटूथ लो एनर्जी डेटा स्कैनर को प्रदर्शन को प्राथमिकता देनी चाहिए या ऊर्जा बचानी चाहिए?</string>
     <string name="settings_autopause_label">ऑटो-पॉज़</string>
     <string name="settings_autopause_description">डिवाइस को अपने कान से हटाने पर ऑडियो रोकें।</string>
     <string name="settings_autopplay_label">ऑटो-प्ले</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">निम्नलिखित अनुमति आवश्यक है:</string>
     <string name="permission_system_alert_window_label">सिस्टम अलर्ट विंडो</string>
     <string name="permission_system_alert_window_description">CAPod को अन्य ऐप्स के ऊपर ड्रॉ करने की अनुमति दें ताकि \"पॉपअप दिखाएं\" सुविधा संभव हो सके।</string>
-    <string name="settings_scanner_mode_lowpower_label">कम बिजली</string>
-    <string name="settings_scanner_mode_balanced_label">संतुलित</string>
-    <string name="settings_scanner_mode_lowlatency_label">कम विलंब</string>
     <string name="settings_monitor_mode_manual_label">जब ऐप खुला हो</string>
     <string name="settings_monitor_mode_automatic_label">जब डिवाइस कनेक्ट हो</string>
     <string name="settings_monitor_mode_always_label">हमेशा</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Prikazuje dodatnu obavijest kada je uređaj povezan. To vam omogućuje da sakrijete trajnu obavijest \"Nema uređaja\" onemogućavanjem kanala \"Status uređaja\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Zadrži obavijest nakon prekida veze</string>
     <string name="settings_keep_notification_after_disconnect_description">Nastavi prikazivati zadnje poznate razine baterije i nakon što se vaši AirPods odspoje</string>
-    <string name="settings_scanner_mode_label">Način skeniranja</string>
-    <string name="settings_scanner_mode_description">Treba li Bluetooth Low Energy skener podataka dati prednost performansama ili štedjeti energiju?</string>
     <string name="settings_autopause_label">Automatska pauza</string>
     <string name="settings_autopause_description">Pauzirajte zvuk kada uklonite uređaj iz uha.</string>
     <string name="settings_autopplay_label">Automatska reprodukcija</string>
@@ -224,9 +222,6 @@
     <string name="permission_required_title">Sljedeća dozvola je potrebna:</string>
     <string name="permission_system_alert_window_label">Prozor sistemskog upozorenja</string>
     <string name="permission_system_alert_window_description">Dopustite CAPod-u crtanje preko drugih aplikacija kako bi omogućili značajku \"Prikaži skočni prozor\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Niska potrošnja</string>
-    <string name="settings_scanner_mode_balanced_label">Uravnoteženo</string>
-    <string name="settings_scanner_mode_lowlatency_label">Niska latencija</string>
     <string name="settings_monitor_mode_manual_label">Kada je aplikacija otvorena</string>
     <string name="settings_monitor_mode_automatic_label">Kada je uređaj povezan</string>
     <string name="settings_monitor_mode_always_label">Uvijek</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Extra értesítést jelenít meg, amikor egy eszköz csatlakozik. Ez lehetővé teszi az állandó \"Nincs eszköz\" értesítés elrejtését az \"Eszköz állapota\" csatorna letiltásával.</string>
     <string name="settings_keep_notification_after_disconnect_label">Értesítés megőrzése lecsatlakozás után</string>
     <string name="settings_keep_notification_after_disconnect_description">Az utolsó ismert akkumulátorszintek megjelenítésének folytatása az AirPods lecsatlakozása után is</string>
-    <string name="settings_scanner_mode_label">Szkenner mód</string>
-    <string name="settings_scanner_mode_description">A Bluetooth Low Energy szkenner a teljesítményt vagy az energiatakarékosságot részesítse előnyben?</string>
     <string name="settings_autopause_label">Automatikus szünet</string>
     <string name="settings_autopause_description">Zene leállítása, amikor kiveszi a füléből az eszközt.</string>
     <string name="settings_autopplay_label">Automatikus lejátszás</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">A következő engedély szükséges:</string>
     <string name="permission_system_alert_window_label">Rendszer figyelmeztető ablak</string>
     <string name="permission_system_alert_window_description">Engedélyezze a CAPod-nak, hogy más alkalmazások fölé rajzoljon az \"Előugró ablak megjelenítése\" funkció lehetővé tételéhez.</string>
-    <string name="settings_scanner_mode_lowpower_label">Alacsony fogyasztás</string>
-    <string name="settings_scanner_mode_balanced_label">Kiegyensúlyozott</string>
-    <string name="settings_scanner_mode_lowlatency_label">Alacsony késleltetés</string>
     <string name="settings_monitor_mode_manual_label">Amikor az alkalmazás nyitva van</string>
     <string name="settings_monitor_mode_automatic_label">Amikor az eszköz csatlakozik</string>
     <string name="settings_monitor_mode_always_label">Mindig</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Ցուցադրում է լրացուցիչ ծանուցում, երբ սարքը միացված է։ Սա թույլ է տալիս թաքցնել մշտական \"Սարքեր չկան\" ծանուցումը՝ անջատելով \"Սարքի կարգավիճակը\" ալիքը։</string>
     <string name="settings_keep_notification_after_disconnect_label">Պահել ծանուցումը անջատումից հետո</string>
     <string name="settings_keep_notification_after_disconnect_description">Շարունակել ցուցադրել վերջին հայտնի մարտկոցի մակարդակները նույնիսկ ձեր AirPods-ների անջատումից հետո</string>
-    <string name="settings_scanner_mode_label">Սկաների ռեժիմ</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy տվյալների սկաները պետք է առաջնահերթություն տա արդյունավետությանը, թե՞ խնայի էներգիան։</string>
     <string name="settings_autopause_label">Ինքնադադար</string>
     <string name="settings_autopause_description">Դադարեցրեք ձայնը, երբ սարքը հանում եք ականջից։</string>
     <string name="settings_autopplay_label">Ինքնանվագարկում</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Հետևյալ թույլտվությունն անհրաժեշտ է՝</string>
     <string name="permission_system_alert_window_label">Համակարգային զգուշացման պատուհան</string>
     <string name="permission_system_alert_window_description">Թույլ տվեք CAPod-ին նկարել այլ հավելվածների վերևում՝ \"Ցուցադրել բացվող պատուհան\" գործառույթը հնարավոր դարձնելու համար։</string>
-    <string name="settings_scanner_mode_lowpower_label">Ցածր էներգիա</string>
-    <string name="settings_scanner_mode_balanced_label">Հավասարակշռված</string>
-    <string name="settings_scanner_mode_lowlatency_label">Ցածր ուշացում</string>
     <string name="settings_monitor_mode_manual_label">Երբ հավելվածը բաց է</string>
     <string name="settings_monitor_mode_automatic_label">Երբ սարքը միացված է</string>
     <string name="settings_monitor_mode_always_label">Միշտ</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Menampilkan notifikasi tambahan ketika perangkat terhubung. Ini memungkinkan Anda menyembunyikan notifikasi permanen \"Tidak ada perangkat\" dengan menonaktifkan saluran \"Status perangkat\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Pertahankan notifikasi setelah terputus</string>
     <string name="settings_keep_notification_after_disconnect_description">Terus menampilkan level baterai terakhir yang diketahui bahkan setelah AirPods terputus</string>
-    <string name="settings_scanner_mode_label">Mode pemindai</string>
-    <string name="settings_scanner_mode_description">Haruskah pemindai data Bluetooth Hemat Energi memprioritaskan kinerja atau menghemat energi?</string>
     <string name="settings_autopause_label">Jeda otomatis</string>
     <string name="settings_autopause_description">Jeda audio saat melepas perangkat dari telinga Anda.</string>
     <string name="settings_autopplay_label">Putar otomatis</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">Izin berikut diperlukan:</string>
     <string name="permission_system_alert_window_label">Jendela Peringatan Sistem</string>
     <string name="permission_system_alert_window_description">Izinkan CAPod menggambar di atas aplikasi lain untuk memungkinkan fitur \"Tampilkan PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Hemat daya</string>
-    <string name="settings_scanner_mode_balanced_label">Seimbang</string>
-    <string name="settings_scanner_mode_lowlatency_label">Latensi rendah</string>
     <string name="settings_monitor_mode_manual_label">Saat aplikasi terbuka</string>
     <string name="settings_monitor_mode_automatic_label">Saat perangkat terhubung</string>
     <string name="settings_monitor_mode_always_label">Selalu</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Sýnir auka tilkynningu þegar tæki er tengt. Þetta gerir þér kleift að fela varanlega \"Engin tæki\" tilkynninguna með því að slökkva á \"Staða tækis\" rásinni.</string>
     <string name="settings_keep_notification_after_disconnect_label">Halda tilkynningu eftir aftengi</string>
     <string name="settings_keep_notification_after_disconnect_description">Halda áfram að sýna síðustu þekktu rafhlöðustöðu jafnvel eftir að AirPods tengjast af</string>
-    <string name="settings_scanner_mode_label">Skannastilling</string>
-    <string name="settings_scanner_mode_description">Ætti Bluetooth Low Energy gagnaskanninn að forgangsraða afköstum eða spara orku?</string>
     <string name="settings_autopause_label">Sjálfvirk hlé</string>
     <string name="settings_autopause_description">Gera hlé á hljóði þegar tækið er tekið úr eyranu.</string>
     <string name="settings_autopplay_label">Sjálfvirk spilun</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Eftirfarandi heimild er nauðsynleg:</string>
     <string name="permission_system_alert_window_label">Kerfisviðvörunargluggi</string>
     <string name="permission_system_alert_window_description">Leyfðu CAPod að teikna yfir önnur forrit til að gera eiginleikann \"Sýna upplýsingaglugga\" mögulegan.</string>
-    <string name="settings_scanner_mode_lowpower_label">Lágt afl</string>
-    <string name="settings_scanner_mode_balanced_label">Jafnvægi</string>
-    <string name="settings_scanner_mode_lowlatency_label">Lítil töf</string>
     <string name="settings_monitor_mode_manual_label">Þegar forrit er opið</string>
     <string name="settings_monitor_mode_automatic_label">Þegar tæki er tengt</string>
     <string name="settings_monitor_mode_always_label">Alltaf</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mostra una notifica aggiuntiva quando un dispositivo è connesso. Ciò consente di nascondere la notifica permanente \"Nessun dispositivo\" disabilitando il canale \"Stato del dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantieni notifica dopo la disconnessione</string>
     <string name="settings_keep_notification_after_disconnect_description">Continua a mostrare gli ultimi livelli di batteria noti anche dopo la disconnessione dei tuoi AirPods</string>
-    <string name="settings_scanner_mode_label">Modalità scanner</string>
-    <string name="settings_scanner_mode_description">Lo scanner di dati Bluetooth Low Energy deve dare priorità alle prestazioni o risparmiare energia?</string>
     <string name="settings_autopause_label">Pausa automatica</string>
     <string name="settings_autopause_description">Metti in pausa l\'audio quando rimuovi il dispositivo dall\'orecchio.</string>
     <string name="settings_autopplay_label">Riproduzione automatica</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">È richiesto il seguente permesso:</string>
     <string name="permission_system_alert_window_label">Finestra di avviso di sistema</string>
     <string name="permission_system_alert_window_description">Consenti a CAPod di disegnare sopra altre app per rendere possibile la funzionalità \"Mostra pop-up\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Basso consumo</string>
-    <string name="settings_scanner_mode_balanced_label">Bilanciato</string>
-    <string name="settings_scanner_mode_lowlatency_label">Bassa latenza</string>
     <string name="settings_monitor_mode_manual_label">Quando l\'app è aperta</string>
     <string name="settings_monitor_mode_automatic_label">Quando il dispositivo è connesso</string>
     <string name="settings_monitor_mode_always_label">Sempre</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">מציג התראה נוספת כאשר מכשיר מחובר. זה מאפשר לך להסתיר את ההתראה הקבועה \"אין מכשירים\" על ידי השבתת הערוץ \"סטטוס מכשיר\".</string>
     <string name="settings_keep_notification_after_disconnect_label">שמור התראה לאחר ניתוק</string>
     <string name="settings_keep_notification_after_disconnect_description">המשך להציג את רמות הסוללה האחרונות הידועות גם לאחר ניתוק ה-AirPods</string>
-    <string name="settings_scanner_mode_label">מצב סורק</string>
-    <string name="settings_scanner_mode_description">האם סורק ה-Bluetooth Low Energy צריך לתת עדיפות לביצועים או לחסוך באנרגיה?</string>
     <string name="settings_autopause_label">השהייה אוטומטית</string>
     <string name="settings_autopause_description">עצירת אודיו בהסרת המכשיר מהאוזן.</string>
     <string name="settings_autopplay_label">הפעלה אוטומטית</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">ההרשאה הבאה נדרשת:</string>
     <string name="permission_system_alert_window_label">חלון התראת מערכת</string>
     <string name="permission_system_alert_window_description">אפשר ל-CAPod לצייר מעל אפליקציות אחרות כדי לאפשר את תכונת \"הצג חלון קופץ\".</string>
-    <string name="settings_scanner_mode_lowpower_label">חיסכון באנרגיה</string>
-    <string name="settings_scanner_mode_balanced_label">מאוזן</string>
-    <string name="settings_scanner_mode_lowlatency_label">השהייה נמוכה</string>
     <string name="settings_monitor_mode_manual_label">כשהאפליקציה פתוחה</string>
     <string name="settings_monitor_mode_automatic_label">כשמכשיר מחובר</string>
     <string name="settings_monitor_mode_always_label">תמיד</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">デバイスが接続されると追加の通知を表示します。これにより、「デバイスステータス」チャネルを無効にすることで、永続的な「デバイスなし」通知を非表示にできます。</string>
     <string name="settings_keep_notification_after_disconnect_label">切断後も通知を維持</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPodsが切断された後も、最後に確認されたバッテリー残量を表示し続けます</string>
-    <string name="settings_scanner_mode_label">スキャナーモード</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energyデータスキャナーはパフォーマンスを優先すべきか、エネルギーを節約すべきか？</string>
     <string name="settings_autopause_label">自動一時停止</string>
     <string name="settings_autopause_description">デバイスを耳から外すとオーディオを一時停止します。</string>
     <string name="settings_autopplay_label">自動再生</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">次の権限が必要です:</string>
     <string name="permission_system_alert_window_label">システムアラートウィンドウ</string>
     <string name="permission_system_alert_window_description">「ポップアップを表示」機能を有効にするため、CAPodが他のアプリの上に表示できるようにします。</string>
-    <string name="settings_scanner_mode_lowpower_label">低消費電力</string>
-    <string name="settings_scanner_mode_balanced_label">バランス</string>
-    <string name="settings_scanner_mode_lowlatency_label">低遅延</string>
     <string name="settings_monitor_mode_manual_label">アプリを開いているとき</string>
     <string name="settings_monitor_mode_automatic_label">デバイス接続時</string>
     <string name="settings_monitor_mode_always_label">常に</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">აჩვენებს დამატებით შეტყობინებას, როდესაც მოწყობილობა დაკავშირებულია. ეს საშუალებას გაძლევთ დამალოთ მუდმივი \"მოწყობილობები არ არის\" შეტყობინება \"მოწყობილობის სტატუსის\" არხის გამორთვით.</string>
     <string name="settings_keep_notification_after_disconnect_label">შეტყობინების შენარჩუნება გათიშვის შემდეგ</string>
     <string name="settings_keep_notification_after_disconnect_description">განაგრძეთ ბოლო ცნობილი ბატარეის დონეების ჩვენება მაშინაც კი, როცა თქვენი AirPods გაითიშება</string>
-    <string name="settings_scanner_mode_label">სკანერის რეჟიმი</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy მონაცემთა სკანერმა პრიორიტეტი უნდა მიანიჭოს შესრულებას თუ ენერგიის დაზოგვას?</string>
     <string name="settings_autopause_label">ავტომატური პაუზა</string>
     <string name="settings_autopause_description">აუდიოს დაპაუზება მოწყობილობის ყურიდან ამოღებისას.</string>
     <string name="settings_autopplay_label">ავტომატური დაკვრა</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">საჭიროა შემდეგი ნებართვა:</string>
     <string name="permission_system_alert_window_label">სისტემური გამაფრთხილებელი ფანჯარა</string>
     <string name="permission_system_alert_window_description">დაუშვით, რომ CAPod სხვა აპებზე ზემოდან გამოჩნდეს, რათა \"Show PopUp\" ფუნქცია შესაძლებელი გახდეს.</string>
-    <string name="settings_scanner_mode_lowpower_label">დაბალი ენერგომოხმარება</string>
-    <string name="settings_scanner_mode_balanced_label">ბალანსირებული</string>
-    <string name="settings_scanner_mode_lowlatency_label">დაბალი დაყოვნება</string>
     <string name="settings_monitor_mode_manual_label">როცა აპი ღიაა</string>
     <string name="settings_monitor_mode_automatic_label">როცა მოწყობილობა დაკავშირებულია</string>
     <string name="settings_monitor_mode_always_label">ყოველთვის</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">បង្ហាញការជូនដំណឹងបន្ថែមនៅពេលឧបករណ៍ត្រូវបានភ្ជាប់។ វាអនុញ្ញាតឱ្យអ្នកលាក់ការជូនដំណឹងអចិន្ត្រៃយ៍ \"គ្មានឧបករណ៍\" ដោយបិទឆានែល \"ស្ថានភាពឧបករណ៍\"។</string>
     <string name="settings_keep_notification_after_disconnect_label">រក្សាការជូនដំណឹងបន្ទាប់ពីផ្តាច់</string>
     <string name="settings_keep_notification_after_disconnect_description">បន្តបង្ហាញកម្រិតថ្មចុងក្រោយដែលស្គាល់ សូម្បីបន្ទាប់ពី AirPods របស់អ្នកផ្តាច់ក៏ដោយ</string>
-    <string name="settings_scanner_mode_label">របៀបវិភាគ</string>
-    <string name="settings_scanner_mode_description">តើម៉ាស៊ីនវិភាគទិន្នន័យ Bluetooth Low Energy គួរតែផ្តល់អាទិភាពដល់ដំណើរការ ឬសន្សំសំចៃថាមពល?</string>
     <string name="settings_autopause_label">ផ្អាកដោយស្វ័យប្រវត្តិ</string>
     <string name="settings_autopause_description">ផ្អាកសំឡេងនៅពេលដកឧបករណ៍ចេញពីត្រចៀករបស់អ្នក។</string>
     <string name="settings_autopplay_label">ចាក់ដោយស្វ័យប្រវត្តិ</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">ការអនុញ្ញាតខាងក្រោមត្រូវបានទាមទារ:</string>
     <string name="permission_system_alert_window_label">បង្អួចជូនដំណឹងប្រព័ន្ធ</string>
     <string name="permission_system_alert_window_description">អនុញ្ញាតឱ្យ CAPod គូរពីលើកម្មវិធីផ្សេងទៀតដើម្បីធ្វើឱ្យមុខងារ \"បង្ហាញផ្ទាំងលោត\" អាចធ្វើទៅបាន។</string>
-    <string name="settings_scanner_mode_lowpower_label">ថាមពលទាប</string>
-    <string name="settings_scanner_mode_balanced_label">មានតុល្យភាព</string>
-    <string name="settings_scanner_mode_lowlatency_label">ភាពយឺតយ៉ាវទាប</string>
     <string name="settings_monitor_mode_manual_label">នៅពេលកម្មវិធីបើក</string>
     <string name="settings_monitor_mode_automatic_label">នៅពេលឧបករណ៍បានភ្ជាប់</string>
     <string name="settings_monitor_mode_always_label">ជានិច្ច</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Dema ku amûrek girêdayî ye agahdariyek zêde nîşan dide. Ev dihêle hûn agahdariya daîmî ya \"Amûr tune\" bi neçalakkirina kanala \"Rewşa amûrê\" veşêrin.</string>
     <string name="settings_keep_notification_after_disconnect_label">Piştî qutbûnê agahdariyê biparêze</string>
     <string name="settings_keep_notification_after_disconnect_description">Piştî ku AirPods-ên te qut dibin jî asta dawîn a naskirî ya bataryayê nîşan bide</string>
-    <string name="settings_scanner_mode_label">Moda skanerê</string>
-    <string name="settings_scanner_mode_description">Gelo divê skanera daneyên Bluetooth Kêm Enerjiyê pêşî li performansê bigire an enerjiyê biparêze?</string>
     <string name="settings_autopause_label">Rawestandina otomatîk</string>
     <string name="settings_autopause_description">Dema ku amûrê ji guhê xwe derdixin, deng rawestînin.</string>
     <string name="settings_autopplay_label">Lîstina otomatîk</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Destûra jêrîn hewce ye:</string>
     <string name="permission_system_alert_window_label">Pencereya Hişyariya Pergalê</string>
     <string name="permission_system_alert_window_description">Destûrê bidin CAPod ku li ser sepanên din xêz bike da ku taybetmendiya \"Pop-Up Nîşan Bide\" gengaz bike.</string>
-    <string name="settings_scanner_mode_lowpower_label">Hêza kêm</string>
-    <string name="settings_scanner_mode_balanced_label">Hevseng</string>
-    <string name="settings_scanner_mode_lowlatency_label">Derengiya kêm</string>
     <string name="settings_monitor_mode_manual_label">Dema sepan vekirî ye</string>
     <string name="settings_monitor_mode_automatic_label">Dema amûr girêdayî ye</string>
     <string name="settings_monitor_mode_always_label">Herdem</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">ಸಾಧನ ಸಂಪರ್ಕಗೊಂಡಾಗ ಹೆಚ್ಚುವರಿ ಅಧಿಸೂಚನೆಯನ್ನು ತೋರಿಸುತ್ತದೆ. ಇದು \"ಸಾಧನ ಸ್ಥಿತಿ\" ಚಾನಲ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸುವ ಮೂಲಕ ಶಾಶ್ವತ \"ಯಾವುದೇ ಸಾಧನಗಳಿಲ್ಲ\" ಅಧಿಸೂಚನೆಯನ್ನು ಮರೆಮಾಡಲು ನಿಮಗೆ ಅನುಮತಿಸುತ್ತದೆ.</string>
     <string name="settings_keep_notification_after_disconnect_label">ಸಂಪರ್ಕ ಕಡಿತದ ನಂತರ ಅಧಿಸೂಚನೆ ಇರಿಸಿ</string>
     <string name="settings_keep_notification_after_disconnect_description">ನಿಮ್ಮ AirPods ಸಂಪರ್ಕ ಕಡಿತವಾದ ನಂತರವೂ ಕೊನೆಯ ತಿಳಿದಿರುವ ಬ್ಯಾಟರಿ ಮಟ್ಟವನ್ನು ತೋರಿಸುವುದನ್ನು ಮುಂದುವರಿಸಿ</string>
-    <string name="settings_scanner_mode_label">ಸ್ಕ್ಯಾನರ್ ಮೋಡ್</string>
-    <string name="settings_scanner_mode_description">ಬ್ಲೂಟೂತ್ ಕಡಿಮೆ ಶಕ್ತಿಯ ಡೇಟಾ ಸ್ಕ್ಯಾನರ್ ಕಾರ್ಯಕ್ಷಮತೆಗೆ ಆದ್ಯತೆ ನೀಡಬೇಕೇ ಅಥವಾ ಶಕ್ತಿಯನ್ನು ಉಳಿಸಬೇಕೇ?</string>
     <string name="settings_autopause_label">ಸ್ವಯಂ-ವಿರಾಮ</string>
     <string name="settings_autopause_description">ನಿಮ್ಮ ಕಿವಿಯಿಂದ ಸಾಧನವನ್ನು ತೆಗೆದುಹಾಕಿದಾಗ ಆಡಿಯೊವನ್ನು ವಿರಾಮಗೊಳಿಸಿ.</string>
     <string name="settings_autopplay_label">ಸ್ವಯಂ-ಪ್ಲೇ</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">ಕೆಳಗಿನ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ:</string>
     <string name="permission_system_alert_window_label">ಸಿಸ್ಟಮ್ ಅಲರ್ಟ್ ವಿಂಡೋ</string>
     <string name="permission_system_alert_window_description">\"ಪಾಪ್‌ಅಪ್ ತೋರಿಸಿ\" ವೈಶಿಷ್ಟ್ಯವನ್ನು ಸಾಧ್ಯವಾಗಿಸಲು CAPod ಇತರ ಅಪ್ಲಿಕೇಶನ್‌ಗಳ ಮೇಲೆ ಚಿತ್ರಿಸಲು ಅನುಮತಿಸಿ.</string>
-    <string name="settings_scanner_mode_lowpower_label">ಕಡಿಮೆ ಶಕ್ತಿ</string>
-    <string name="settings_scanner_mode_balanced_label">ಸಮತೋಲಿತ</string>
-    <string name="settings_scanner_mode_lowlatency_label">ಕಡಿಮೆ ವಿಳಂಬ</string>
     <string name="settings_monitor_mode_manual_label">ಅಪ್ಲಿಕೇಶನ್ ತೆರೆದಿರುವಾಗ</string>
     <string name="settings_monitor_mode_automatic_label">ಸಾಧನ ಸಂಪರ್ಕಗೊಂಡಾಗ</string>
     <string name="settings_monitor_mode_always_label">ಯಾವಾಗಲೂ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">기기가 연결되면 추가 알림을 표시합니다. 이렇게 하면 \"기기 상태\" 채널을 비활성화하여 영구적인 \"기기 없음\" 알림을 숨길 수 있습니다.</string>
     <string name="settings_keep_notification_after_disconnect_label">연결 해제 후에도 알림 유지하기</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPods이 연결 해제된 후에도 마지막으로 알려진 배터리 잔량 계속 표시하기</string>
-    <string name="settings_scanner_mode_label">스캐너 모드</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy 데이터 스캐너가 성능을 우선시해야 할까요, 아니면 에너지를 절약해야 할까요?</string>
     <string name="settings_autopause_label">자동 일시 중지</string>
     <string name="settings_autopause_description">기기를 귀에서 빼면 오디오를 일시 중지합니다.</string>
     <string name="settings_autopplay_label">자동 재생</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">다음과 같은 권한이 필요합니다:</string>
     <string name="permission_system_alert_window_label">시스템 알림창</string>
     <string name="permission_system_alert_window_description">\"팝업 표시\" 기능을 사용하려면 다른 앱 위에 그리기를 허용해야 합니다.</string>
-    <string name="settings_scanner_mode_lowpower_label">저전력</string>
-    <string name="settings_scanner_mode_balanced_label">균형잡힌</string>
-    <string name="settings_scanner_mode_lowlatency_label">저지연</string>
     <string name="settings_monitor_mode_manual_label">앱이 열려있을때</string>
     <string name="settings_monitor_mode_automatic_label">장치가 연결되었을때</string>
     <string name="settings_monitor_mode_always_label">항상</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Түзмөк туташканда кошумча билдирүү көрсөтүлөт. Бул \"Түзмөктүн абалы\" каналын өчүрүү менен туруктуу \"Түзмөктөр жок\" билдирүүсүн жашырууга мүмкүндүк берет.</string>
     <string name="settings_keep_notification_after_disconnect_label">Ажыратылгандан кийин билдирүүнү сактоо</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPods ажыратылгандан кийин да акыркы белгилүү батарея деңгээлдерин көрсөтүүнү улантуу</string>
-    <string name="settings_scanner_mode_label">Сканер режими</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy маалымат сканери өндүрүмдүүлүктү биринчи орунга коюшу керекпи же энергияны үнөмдөшү керекпи?</string>
     <string name="settings_autopause_label">Авто тыным</string>
     <string name="settings_autopause_description">Түзмөктү кулагыңыздан чыгарганда аудиону тындырыңыз.</string>
     <string name="settings_autopplay_label">Авто ойнотуу</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Төмөнкү уруксат талап кылынат:</string>
     <string name="permission_system_alert_window_label">Тутум эскертүү терезеси</string>
     <string name="permission_system_alert_window_description">\"Калкыма терезе көрсөтүү\" функциясын мүмкүн кылуу үчүн CAPod\'го башка колдонмолордун үстүнөн тартууга уруксат бериңиз.</string>
-    <string name="settings_scanner_mode_lowpower_label">Аз кубаттуулук</string>
-    <string name="settings_scanner_mode_balanced_label">Тең салмактуу</string>
-    <string name="settings_scanner_mode_lowlatency_label">Аз кечигүү</string>
     <string name="settings_monitor_mode_manual_label">Колдонмо ачык болгондо</string>
     <string name="settings_monitor_mode_automatic_label">Түзмөк туташканда</string>
     <string name="settings_monitor_mode_always_label">Ар дайым</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">ສະແດງການແຈ້ງເຕືອນເພີ່ມເຕີມເມື່ອອຸປະກອນເຊື່ອມຕໍ່ແລ້ວ. ນີ້ຊ່ວຍໃຫ້ທ່ານສາມາດເຊື່ອງການແຈ້ງເຕືອນຖາວອນ \"ບໍ່ມີອຸປະກອນ\" ໂດຍການປິດຊ່ອງ \"ສະຖານະອຸປະກອນ\" .</string>
     <string name="settings_keep_notification_after_disconnect_label">ຮັກສາການແຈ້ງເຕືອນຫຼັງຈາກຕັດການເຊື່ອມຕໍ່</string>
     <string name="settings_keep_notification_after_disconnect_description">ສືບຕໍ່ສະແດງລະດັບແບັດເຕີລີ້ທີ່ຮູ້ຈັກຫຼ້າສຸດແມ້ຫຼັງຈາກ AirPods ຕັດການເຊື່ອມຕໍ່</string>
-    <string name="settings_scanner_mode_label">ໂໝດສະແກນ</string>
-    <string name="settings_scanner_mode_description">ເຄື່ອງສະແກນຂໍ້ມູນ Bluetooth Low Energy ຄວນໃຫ້ຄວາມສຳຄັນກັບປະສິດທິພາບ ຫຼື ປະຢັດພະລັງງານ?</string>
     <string name="settings_autopause_label">ຢຸດອັດຕະໂນມັດ</string>
     <string name="settings_autopause_description">ຢຸດສຽງຊົ່ວຄາວເມື່ອຖອດອຸປະກອນອອກຈາກຫູຂອງທ່ານ.</string>
     <string name="settings_autopplay_label">ຫຼິ້ນອັດຕະໂນມັດ</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">ຕ້ອງການການອະນຸຍາດຕໍ່ໄປນີ້:</string>
     <string name="permission_system_alert_window_label">ໜ້າຕ່າງການແຈ້ງເຕືອນລະບົບ</string>
     <string name="permission_system_alert_window_description">ອະນຸຍາດໃຫ້ CAPod ແຕ້ມທັບແອັບອື່ນເພື່ອໃຫ້ຄຸນສົມບັດ \"ສະແດງປັອບອັບ\" ເປັນໄປໄດ້.</string>
-    <string name="settings_scanner_mode_lowpower_label">ພະລັງງານຕໍ່າ</string>
-    <string name="settings_scanner_mode_balanced_label">ສົມດູນ</string>
-    <string name="settings_scanner_mode_lowlatency_label">ຄວາມຊັກຊ້າຕໍ່າ</string>
     <string name="settings_monitor_mode_manual_label">ເມື່ອແອັບເປີດ</string>
     <string name="settings_monitor_mode_automatic_label">ເມື່ອອຸປະກອນເຊື່ອມຕໍ່</string>
     <string name="settings_monitor_mode_always_label">ສະເໝີ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Rodo papildomą pranešimą, kai prijungiamas įrenginys. Tai leidžia paslėpti nuolatinį pranešimą \"Nėra įrenginių\" išjungiant kanalą \"Įrenginio būsena\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Palikti pranešimą atjungus</string>
     <string name="settings_keep_notification_after_disconnect_description">Toliau rodyti paskutinį žinomą baterijos lygį net ir atjungus „AirPods\"</string>
-    <string name="settings_scanner_mode_label">Skenavimo režimas</string>
-    <string name="settings_scanner_mode_description">Ar „Bluetooth Low Energy\" duomenų skaitytuvas turėtų teikti pirmenybę našumui ar taupyti energiją?</string>
     <string name="settings_autopause_label">Automatinė pauzė</string>
     <string name="settings_autopause_description">Pristabdyti garsą išėmus įrenginį iš ausies.</string>
     <string name="settings_autopplay_label">Automatinis grojimas</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">Reikalingas šis leidimas:</string>
     <string name="permission_system_alert_window_label">Sistemos perspėjimo langas</string>
     <string name="permission_system_alert_window_description">Leiskite CAPod piešti virš kitų programų, kad būtų galima naudoti funkciją „Rodyti iškylantįjį langą\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Mažos galios</string>
-    <string name="settings_scanner_mode_balanced_label">Subalansuotas</string>
-    <string name="settings_scanner_mode_lowlatency_label">Mažas delsimas</string>
     <string name="settings_monitor_mode_manual_label">Kai programa atidaryta</string>
     <string name="settings_monitor_mode_automatic_label">Kai įrenginys prijungtas</string>
     <string name="settings_monitor_mode_always_label">Visada</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Rāda papildu paziņojumu, kad ierīce ir pievienota. Tas ļauj paslēpt pastāvīgo paziņojumu \"Nav ierīču\", atspējojot kanālu \"Ierīces statuss\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Saglabāt paziņojumu pēc atvienošanas</string>
     <string name="settings_keep_notification_after_disconnect_description">Turpināt rādīt pēdējos zināmos baterijas līmeņus arī pēc AirPods atvienošanas</string>
-    <string name="settings_scanner_mode_label">Skenēšanas režīms</string>
-    <string name="settings_scanner_mode_description">Vai Bluetooth Low Energy datu skenerim vajadzētu prioritizēt veiktspēju vai taupīt enerģiju?</string>
     <string name="settings_autopause_label">Automātiska pauze</string>
     <string name="settings_autopause_description">Pauzēt audio, noņemot ierīci no auss.</string>
     <string name="settings_autopplay_label">Automātiska atskaņošana</string>
@@ -224,9 +222,6 @@
     <string name="permission_required_title">Nepieciešama šāda atļauja:</string>
     <string name="permission_system_alert_window_label">Sistēmas brīdinājuma logs</string>
     <string name="permission_system_alert_window_description">Atļaujiet CAPod zīmēt virs citām lietotnēm, lai iespējotu funkciju \"Rādīt uznirstošo logu\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Zema jauda</string>
-    <string name="settings_scanner_mode_balanced_label">Līdzsvarots</string>
-    <string name="settings_scanner_mode_lowlatency_label">Zema latence</string>
     <string name="settings_monitor_mode_manual_label">Kad lietotne ir atvērta</string>
     <string name="settings_monitor_mode_automatic_label">Kad ierīce ir savienota</string>
     <string name="settings_monitor_mode_always_label">Vienmēr</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Прикажува дополнително известување кога уредот е поврзан. Ова ви овозможува да го скриете трајното известување \"Нема уреди\" со оневозможување на каналот \"Статус на уредот\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Задржи го известувањето по прекинување</string>
     <string name="settings_keep_notification_after_disconnect_description">Продолжи да ги прикажуваш последните познати нивоа на батеријата дури и откако вашите AirPods ќе се исклучат</string>
-    <string name="settings_scanner_mode_label">Режим на скенер</string>
-    <string name="settings_scanner_mode_description">Дали скенерот за податоци со ниска енергија на Bluetooth треба да даде приоритет на перформансите или да заштеди енергија?</string>
     <string name="settings_autopause_label">Автоматска пауза</string>
     <string name="settings_autopause_description">Паузирајте го аудиото кога го отстранувате уредот од увото.</string>
     <string name="settings_autopplay_label">Автоматско репродуцирање</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Потребна е следната дозвола:</string>
     <string name="permission_system_alert_window_label">Системски прозорец за предупредување</string>
     <string name="permission_system_alert_window_description">Дозволете CAPod да црта преку други апликации за да ја овозможи функцијата \"Прикажи попап\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Ниска моќност</string>
-    <string name="settings_scanner_mode_balanced_label">Балансирано</string>
-    <string name="settings_scanner_mode_lowlatency_label">Ниска латенција</string>
     <string name="settings_monitor_mode_manual_label">Кога апликацијата е отворена</string>
     <string name="settings_monitor_mode_automatic_label">Кога уредот е поврзан</string>
     <string name="settings_monitor_mode_always_label">Секогаш</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">ഒരു ഉപകരണം കണക്റ്റുചെയ്യുമ്പോൾ ഒരു അധിക അറിയിപ്പ് കാണിക്കുന്നു. \"ഉപകരണ നില\" ചാനൽ പ്രവർത്തനരഹിതമാക്കി സ്ഥിരമായ \"ഉപകരണങ്ങളൊന്നുമില്ല\" അറിയിപ്പ് മറയ്ക്കാൻ ഇത് നിങ്ങളെ അനുവദിക്കുന്നു.</string>
     <string name="settings_keep_notification_after_disconnect_label">വിച്ഛേദിച്ച ശേഷം അറിയിപ്പ് നിലനിർത്തുക</string>
     <string name="settings_keep_notification_after_disconnect_description">നിങ്ങളുടെ AirPods വിച്ഛേദിച്ചാലും അവസാനമായി അറിയപ്പെടുന്ന ബാറ്ററി ലെവലുകൾ കാണിക്കുന്നത് തുടരുക</string>
-    <string name="settings_scanner_mode_label">സ്കാനർ മോഡ്</string>
-    <string name="settings_scanner_mode_description">ബ്ലൂടൂത്ത് ലോ എനർജി ഡാറ്റ സ്കാനർ പ്രകടനത്തിന് മുൻഗണന നൽകണോ അതോ ഊർജ്ജം ലാഭിക്കണോ?</string>
     <string name="settings_autopause_label">യാന്ത്രികമായി താൽക്കാലികമായി നിർത്തുക</string>
     <string name="settings_autopause_description">നിങ്ങളുടെ ചെവിയിൽ നിന്ന് ഉപകരണം നീക്കം ചെയ്യുമ്പോൾ ഓഡിയോ താൽക്കാലികമായി നിർത്തുക.</string>
     <string name="settings_autopplay_label">യാന്ത്രികമായി പ്ലേ ചെയ്യുക</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">ഇനിപ്പറയുന്ന അനുമതി ആവശ്യമാണ്:</string>
     <string name="permission_system_alert_window_label">സിസ്റ്റം അലേർട്ട് വിൻഡോ</string>
     <string name="permission_system_alert_window_description">\"പോപ്പ്അപ്പ് കാണിക്കുക\" സവിശേഷത സാധ്യമാക്കാൻ മറ്റ് ആപ്പുകളുടെ മുകളിൽ വരയ്ക്കാൻ CAPod-നെ അനുവദിക്കുക.</string>
-    <string name="settings_scanner_mode_lowpower_label">കുറഞ്ഞ പവർ</string>
-    <string name="settings_scanner_mode_balanced_label">സന്തുലിതം</string>
-    <string name="settings_scanner_mode_lowlatency_label">കുറഞ്ഞ ലേറ്റൻസി</string>
     <string name="settings_monitor_mode_manual_label">ആപ്പ് തുറന്നിരിക്കുമ്പോൾ</string>
     <string name="settings_monitor_mode_automatic_label">ഉപകരണം കണക്റ്റുചെയ്യുമ്പോൾ</string>
     <string name="settings_monitor_mode_always_label">എപ്പോഴും</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Төхөөрөмж холбогдсон үед нэмэлт мэдэгдэл харуулна. Энэ нь \"Төхөөрөмжийн төлөв\" сувгийг идэвхгүй болгосноор \"Төхөөрөмж алга\" гэсэн байнгын мэдэгдлийг нуух боломжийг олгоно.</string>
     <string name="settings_keep_notification_after_disconnect_label">Салсны дараа мэдэгдлийг хадгалах</string>
     <string name="settings_keep_notification_after_disconnect_description">Таны AirPods салсан ч хамгийн сүүлд мэдэгдэж буй батарейн түвшинг үргэлжлүүлэн харуулна</string>
-    <string name="settings_scanner_mode_label">Сканнерын горим</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy өгөгдлийн сканнер нь гүйцэтгэлийг эсвэл эрчим хүчийг хэмнэхийг урьтал болгох ёстой юу?</string>
     <string name="settings_autopause_label">Автомат түр зогсоох</string>
     <string name="settings_autopause_description">Төхөөрөмжийг чихнээсээ салгахад дууг түр зогсооно.</string>
     <string name="settings_autopplay_label">Автомат тоглуулах</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Дараах зөвшөөрөл шаардлагатай:</string>
     <string name="permission_system_alert_window_label">Системийн анхааруулгын цонх</string>
     <string name="permission_system_alert_window_description">CAPod-д \"Попап харуулах\" боломжийг ажиллуулахын тулд бусад апп-уудын дээр зурах зөвшөөрөл олгоно уу.</string>
-    <string name="settings_scanner_mode_lowpower_label">Бага эрчим хүч</string>
-    <string name="settings_scanner_mode_balanced_label">Тэнцвэртэй</string>
-    <string name="settings_scanner_mode_lowlatency_label">Бага хоцрогдол</string>
     <string name="settings_monitor_mode_manual_label">Апп нээлттэй үед</string>
     <string name="settings_monitor_mode_automatic_label">Төхөөрөмж холбогдсон үед</string>
     <string name="settings_monitor_mode_always_label">Үргэлж</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">जेव्हा एखादे डिव्हाइस कनेक्ट केलेले असते तेव्हा अतिरिक्त सूचना दर्शविते. हे आपल्याला \"डिव्हाइस स्थिती\" चॅनेल अक्षम करून कायमस्वरूपी \"कोणतेही डिव्हाइस नाही\" सूचना लपविण्यास अनुमती देते.</string>
     <string name="settings_keep_notification_after_disconnect_label">डिस्कनेक्ट झाल्यानंतर सूचना ठेवा</string>
     <string name="settings_keep_notification_after_disconnect_description">तुमचे AirPods डिस्कनेक्ट झाल्यानंतरही शेवटचे ज्ञात बॅटरी स्तर दर्शवणे सुरू ठेवा</string>
-    <string name="settings_scanner_mode_label">स्कॅनर मोड</string>
-    <string name="settings_scanner_mode_description">ब्लूटूथ लो एनर्जी डेटा स्कॅनरने कार्यक्षमतेला प्राधान्य द्यावे की ऊर्जा वाचवावी?</string>
     <string name="settings_autopause_label">ऑटो-पॉज</string>
     <string name="settings_autopause_description">आपल्या कानातून डिव्हाइस काढताना ऑडिओ थांबवा.</string>
     <string name="settings_autopplay_label">ऑटो-प्ले</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">खालील परवानगी आवश्यक आहे:</string>
     <string name="permission_system_alert_window_label">सिस्टम अलर्ट विंडो</string>
     <string name="permission_system_alert_window_description">\"पॉपअप दर्शवा\" वैशिष्ट्य शक्य करण्यासाठी CAPod ला इतर अॅप्सवर चित्रे काढण्याची अनुमती द्या.</string>
-    <string name="settings_scanner_mode_lowpower_label">कमी ऊर्जा</string>
-    <string name="settings_scanner_mode_balanced_label">संतुलित</string>
-    <string name="settings_scanner_mode_lowlatency_label">कमी विलंब</string>
     <string name="settings_monitor_mode_manual_label">अॅप उघडे असताना</string>
     <string name="settings_monitor_mode_automatic_label">डिव्हाइस कनेक्ट असताना</string>
     <string name="settings_monitor_mode_always_label">नेहमी</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Memaparkan pemberitahuan tambahan apabila peranti disambungkan. Ini membolehkan anda menyembunyikan pemberitahuan kekal \"Tiada peranti\" dengan melumpuhkan saluran \"Status peranti\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Kekalkan pemberitahuan selepas nyahsambung</string>
     <string name="settings_keep_notification_after_disconnect_description">Terus menunjukkan tahap bateri terakhir yang diketahui walaupun selepas AirPods anda nyahsambung</string>
-    <string name="settings_scanner_mode_label">Mod pengimbas</string>
-    <string name="settings_scanner_mode_description">Patutkah pengimbas data Bluetooth Tenaga Rendah mengutamakan prestasi atau menjimatkan tenaga?</string>
     <string name="settings_autopause_label">Jeda automatik</string>
     <string name="settings_autopause_description">Jeda audio apabila peranti dikeluarkan dari telinga anda.</string>
     <string name="settings_autopplay_label">Main automatik</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">Kebenaran berikut diperlukan:</string>
     <string name="permission_system_alert_window_label">Tetingkap Amaran Sistem</string>
     <string name="permission_system_alert_window_description">Benarkan CAPod melukis di atas apl lain untuk membolehkan ciri \"Tunjukkan pop timbul\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Kuasa rendah</string>
-    <string name="settings_scanner_mode_balanced_label">Seimbang</string>
-    <string name="settings_scanner_mode_lowlatency_label">Kependaman rendah</string>
     <string name="settings_monitor_mode_manual_label">Apabila apl dibuka</string>
     <string name="settings_monitor_mode_automatic_label">Apabila peranti disambungkan</string>
     <string name="settings_monitor_mode_always_label">Sentiasa</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">စက်ပစ္စည်းတစ်ခုချိတ်ဆက်သောအခါ အပိုအသိပေးချက်တစ်ခုပြသသည်။ ၎င်းသည် \"စက်ပစ္စည်းအခြေအနေ\" ချန်နယ်ကို ပိတ်ခြင်းဖြင့် အမြဲတမ်း \"စက်ပစ္စည်းမရှိပါ\" အသိပေးချက်ကို ဝှက်ထားနိုင်စေသည်။</string>
     <string name="settings_keep_notification_after_disconnect_label">ချိတ်ဆက်မှုပြတ်ပြီးနောက် အသိပေးချက်ကိုထားရှိပါ</string>
     <string name="settings_keep_notification_after_disconnect_description">သင့် AirPods ချိတ်ဆက်မှုပြတ်ပြီးနောက်ပင် နောက်ဆုံးသိရှိထားသော ဘက်ထရီအဆင့်များကို ဆက်လက်ပြသပါ</string>
-    <string name="settings_scanner_mode_label">စကင်နာမုဒ်</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy ဒေတာစကင်နာသည် စွမ်းဆောင်ရည်ကို ဦးစားပေးသင့်သလား သို့မဟုတ် စွမ်းအင်ချွေတာသင့်သလား။</string>
     <string name="settings_autopause_label">အလိုအလြှောက်ရပ်တန့်ခြင်း</string>
     <string name="settings_autopause_description">သင့်နားကြပ်ကို နားမှဖယ်ရှားသည့်အခါ အသံကိုခေတ္တရပ်ပါ။</string>
     <string name="settings_autopplay_label">အလိုအလြှောက်ဖွင့်ခြင်း</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">အောက်ပါခွင့်ပြုချက်လိုအပ်သည်:</string>
     <string name="permission_system_alert_window_label">စနစ်သတိပေးချက်ပြတင်းပေါက်</string>
     <string name="permission_system_alert_window_description">\"ပြတင်းပေါက်ပြသခြင်း\" အင်္ဂါရပ်ကိုဖြစ်နိုင်စေရန် CAPod အား အခြားအက်ပ်များပေါ်တွင် ပုံဆွဲခွင့်ပြုပါ။</string>
-    <string name="settings_scanner_mode_lowpower_label">စွမ်းအင်နည်း</string>
-    <string name="settings_scanner_mode_balanced_label">ချိန်ညှိထားသော</string>
-    <string name="settings_scanner_mode_lowlatency_label">နှောင့်နှေးမှုနည်း</string>
     <string name="settings_monitor_mode_manual_label">အက်ပ်ဖွင့်ထားသောအခါ</string>
     <string name="settings_monitor_mode_automatic_label">စက်ပစ္စည်းချိတ်ဆက်ထားသောအခါ</string>
     <string name="settings_monitor_mode_always_label">အမြဲတမ်း</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Viser en ekstra varsling når en enhet er tilkoblet. Dette lar deg skjule det permanente varselet \"Ingen enheter\" ved å deaktivere kanalen \"Enhetsstatus\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Behold varsling etter frakobling</string>
     <string name="settings_keep_notification_after_disconnect_description">Fortsett å vise de sist kjente batterinivåene selv etter at AirPods kobler fra</string>
-    <string name="settings_scanner_mode_label">Skannermodus</string>
-    <string name="settings_scanner_mode_description">Skal Bluetooth Low Energy data-skanneren prioritere ytelse eller å spare energi?</string>
     <string name="settings_autopause_label">Sett på pause automatisk</string>
     <string name="settings_autopause_description">Sett lyden på pause når du fjerner enheten fra øret.</string>
     <string name="settings_autopplay_label">Spill av automatisk</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Følgende tillatelse er påkrevd:</string>
     <string name="permission_system_alert_window_label">Systemvarslingsvindu</string>
     <string name="permission_system_alert_window_description">Tillat CAPod å tegne over andre apper for å gjøre funksjonen \"Vis popup\" mulig.</string>
-    <string name="settings_scanner_mode_lowpower_label">Lavt strømforbruk</string>
-    <string name="settings_scanner_mode_balanced_label">Balansert</string>
-    <string name="settings_scanner_mode_lowlatency_label">Lav forsinkelse</string>
     <string name="settings_monitor_mode_manual_label">Når appen er åpen</string>
     <string name="settings_monitor_mode_automatic_label">Når enheten er tilkoblet</string>
     <string name="settings_monitor_mode_always_label">Alltid</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">उपकरण जडान हुँदा अतिरिक्त सूचना देखाउँछ। यसले तपाईंलाई \"उपकरण स्थिति\" च्यानल असक्षम गरेर स्थायी \"कुनै उपकरण छैन\" सूचना लुकाउन अनुमति दिन्छ।</string>
     <string name="settings_keep_notification_after_disconnect_label">विच्छेद पछि सूचना राख्नुहोस्</string>
     <string name="settings_keep_notification_after_disconnect_description">तपाईंको AirPods विच्छेद भएपछि पनि अन्तिम ज्ञात ब्याट्री स्तर देखाउन जारी राख्नुहोस्</string>
-    <string name="settings_scanner_mode_label">स्क्यानर मोड</string>
-    <string name="settings_scanner_mode_description">ब्लुटुथ कम ऊर्जा डाटा स्क्यानरले प्रदर्शनलाई प्राथमिकता दिनुपर्छ वा ऊर्जा बचत गर्नुपर्छ?</string>
     <string name="settings_autopause_label">स्वत: पज</string>
     <string name="settings_autopause_description">आफ्नो कानबाट उपकरण हटाउँदा अडियो पज गर्नुहोस्।</string>
     <string name="settings_autopplay_label">स्वत: प्ले</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">निम्न अनुमति आवश्यक छ:</string>
     <string name="permission_system_alert_window_label">प्रणाली अलर्ट विन्डो</string>
     <string name="permission_system_alert_window_description">\"पपअप देखाउनुहोस्\" सुविधा सम्भव बनाउन CAPod लाई अन्य एपहरूमाथि कोर्न अनुमति दिनुहोस्।</string>
-    <string name="settings_scanner_mode_lowpower_label">कम ऊर्जा</string>
-    <string name="settings_scanner_mode_balanced_label">सन्तुलित</string>
-    <string name="settings_scanner_mode_lowlatency_label">कम विलम्बता</string>
     <string name="settings_monitor_mode_manual_label">एप खुला हुँदा</string>
     <string name="settings_monitor_mode_automatic_label">उपकरण जडान हुँदा</string>
     <string name="settings_monitor_mode_always_label">सधैं</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Toont een extra melding wanneer een apparaat is verbonden. Hiermee kun je de permanente melding \"Geen apparaten\" verbergen door het kanaal \"Apparaatstatus\" uit te schakelen.</string>
     <string name="settings_keep_notification_after_disconnect_label">Melding behouden na verbreken verbinding</string>
     <string name="settings_keep_notification_after_disconnect_description">Blijf de laatst bekende batterijniveaus weergeven, zelfs nadat je AirPods zijn losgekoppeld</string>
-    <string name="settings_scanner_mode_label">Scannermodus</string>
-    <string name="settings_scanner_mode_description">Moet de \'Bluetooth Low Energy\'-datascanner prioriteit geven aan prestaties of aan energiebesparing?</string>
     <string name="settings_autopause_label">Auto pauze</string>
     <string name="settings_autopause_description">Pauzeer de audio wanneer je het apparaat van je oor haalt.</string>
     <string name="settings_autopplay_label">Automatisch afspelen</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">De volgende toestemming is vereist:</string>
     <string name="permission_system_alert_window_label">Systeemwaarschuwingsvenster</string>
     <string name="permission_system_alert_window_description">Geef CAPod de mogelijkheid om over andere apps heen te tekenen, zodat de functie \"Pop-up weergeven\" mogelijk is.</string>
-    <string name="settings_scanner_mode_lowpower_label">Laag vermogen</string>
-    <string name="settings_scanner_mode_balanced_label">Evenwichtig</string>
-    <string name="settings_scanner_mode_lowlatency_label">Lage latentie</string>
     <string name="settings_monitor_mode_manual_label">Wanneer de app geopend is</string>
     <string name="settings_monitor_mode_automatic_label">Wanneer het apparaat is aangesloten</string>
     <string name="settings_monitor_mode_always_label">Altijd</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Wyświetl dodatkowe powiadomienie, gdy urządzenie jest podłączone. Pozwala to ukryć stałe powiadomienie \"Brak urządzeń\", wyłączając kanał \"Status urządzenia\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Zachowaj powiadomienie po rozłączeniu</string>
     <string name="settings_keep_notification_after_disconnect_description">Kontynuuj wyświetlanie ostatniego znanego poziomu baterii nawet po rozłączeniu AirPods</string>
-    <string name="settings_scanner_mode_label">Tryb skanera</string>
-    <string name="settings_scanner_mode_description">Czy skaner danych Bluetooth Low Energy ma priorytetowo działać w ramach wydajności, czy oszczędzania energii?</string>
     <string name="settings_autopause_label">Automatyczne wstrzymywanie</string>
     <string name="settings_autopause_description">Wstrzymaj odtwarzanie, gdy urządzenia jest wyciągane z ucha.</string>
     <string name="settings_autopplay_label">Automatyczne odtwarzanie</string>
@@ -228,9 +226,6 @@ K4r0lSz;</string>
     <string name="permission_required_title">Następujące uprawnienie jest wymagane:</string>
     <string name="permission_system_alert_window_label">Okna alertów systemowych</string>
     <string name="permission_system_alert_window_description">Zezwól na wyświetlanie CAPod nad innymi aplikacjami, aby aktywować funkcję \"Wyświetlanie informacji\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Oszczędzanie energii</string>
-    <string name="settings_scanner_mode_balanced_label">Zrównoważone</string>
-    <string name="settings_scanner_mode_lowlatency_label">Małe opóźnienia</string>
     <string name="settings_monitor_mode_manual_label">Gdy aplikacja jest uruchomiona</string>
     <string name="settings_monitor_mode_automatic_label">Gdy urządzenie jest podłączone</string>
     <string name="settings_monitor_mode_always_label">Zawsze</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mostra uma notificação extra quando um dispositivo está conectado. Isso permite que você oculte a notificação permanente \"Nenhum dispositivo\" desativando o canal \"Status do dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Manter notificação após desconectar</string>
     <string name="settings_keep_notification_after_disconnect_description">Continuar mostrando os últimos níveis de bateria registrados mesmo após a desconexão do AirPods</string>
-    <string name="settings_scanner_mode_label">Modo de scanner</string>
-    <string name="settings_scanner_mode_description">O scanner de dados Bluetooth de Baixo Consumo de Energia deve priorizar o desempenho ou economizar energia?</string>
     <string name="settings_autopause_label">Pausa automática</string>
     <string name="settings_autopause_description">Pause o áudio ao remover o dispositivo do ouvido.</string>
     <string name="settings_autopplay_label">Reprodução automática</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">A seguinte permissão é necessária:</string>
     <string name="permission_system_alert_window_label">Janela de Alerta do Sistema</string>
     <string name="permission_system_alert_window_description">Permitir que o CAPod desenhe sobre outros aplicativos para tornar possível o recurso \"Mostrar PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Baixa potência</string>
-    <string name="settings_scanner_mode_balanced_label">Balanceado</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baixa latência</string>
     <string name="settings_monitor_mode_manual_label">Quando o aplicativo está aberto</string>
     <string name="settings_monitor_mode_automatic_label">Quando o dispositivo está conectado</string>
     <string name="settings_monitor_mode_always_label">Sempre</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mostra uma notificação extra quando um dispositivo está ligado. Isto permite-lhe ocultar a notificação permanente \"Sem dispositivos\" desativando o canal \"Estado do dispositivo\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Manter notificação após desligar</string>
     <string name="settings_keep_notification_after_disconnect_description">Continuar a mostrar os últimos níveis de bateria conhecidos mesmo após os AirPods desligarem</string>
-    <string name="settings_scanner_mode_label">Modo de scanner</string>
-    <string name="settings_scanner_mode_description">O scanner de dados Bluetooth de Baixo Consumo de Energia deve dar prioridade ao desempenho ou poupar energia?</string>
     <string name="settings_autopause_label">Pausa automática</string>
     <string name="settings_autopause_description">Colocar o áudio em pausa ao remover o dispositivo do ouvido.</string>
     <string name="settings_autopplay_label">Reprodução automática</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">A seguinte permissão é necessária:</string>
     <string name="permission_system_alert_window_label">Janela de alerta do sistema</string>
     <string name="permission_system_alert_window_description">Permitir que o CAPod desenhe sobre outras aplicações para tornar possível a funcionalidade \"Mostrar PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Baixo consumo</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrado</string>
-    <string name="settings_scanner_mode_lowlatency_label">Baixa latência</string>
     <string name="settings_monitor_mode_manual_label">Quando a aplicação está aberta</string>
     <string name="settings_monitor_mode_automatic_label">Quando o dispositivo está ligado</string>
     <string name="settings_monitor_mode_always_label">Sempre</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mussa ina notificaziun supplementara cura ch\'in apparat è connectà. Quai permetta da zoppar la notificaziun permanenta \"Nagins apparats\" cun deactivar il chanal \"Stadi da l\'apparat\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantegnair la notificaziun suenter la deconnexiun</string>
     <string name="settings_keep_notification_after_disconnect_description">Cuntinuar da mussar ils davos nivels da battaria enconuschents er suenter che Voss AirPods sa deconnectan</string>
-    <string name="settings_scanner_mode_label">Modus da scanner</string>
-    <string name="settings_scanner_mode_description">Duai il scanner da datas da Bluetooth Low Energy priorisar la prestaziun u spargnar energia?</string>
     <string name="settings_autopause_label">Pausa automata</string>
     <string name="settings_autopause_description">Interrumper l\'audio cura che l\'apparat vegn allontanà da l\'ureglia.</string>
     <string name="settings_autopplay_label">Play automatic</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">La suandanta permissiun è necessaria:</string>
     <string name="permission_system_alert_window_label">Fanestra d\'avis dal sistem</string>
     <string name="permission_system_alert_window_description">Permetter a CAPod da dessegnar sur autras apps per render pussaivla la funcziun \"Mussar PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Bassa energia</string>
-    <string name="settings_scanner_mode_balanced_label">Equilibrà</string>
-    <string name="settings_scanner_mode_lowlatency_label">Bassa latenza</string>
     <string name="settings_monitor_mode_manual_label">Cura che l\'app è averta</string>
     <string name="settings_monitor_mode_automatic_label">Cura che l\'apparat è connectà</string>
     <string name="settings_monitor_mode_always_label">Adina</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Afișează o notificare suplimentară atunci când un dispozitiv este conectat. Acest lucru vă permite să ascundeți notificarea permanentă \"Niciun dispozitiv\" prin dezactivarea canalului \"Stare dispozitiv\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Păstrează notificarea după deconectare</string>
     <string name="settings_keep_notification_after_disconnect_description">Continuă să afișeze ultimele niveluri cunoscute ale bateriei chiar și după deconectarea AirPods</string>
-    <string name="settings_scanner_mode_label">Modul scanare</string>
-    <string name="settings_scanner_mode_description">Scanerul de date Bluetooth Energie Scăzută (BLE) ar trebui să acorde prioritate performanței sau economiei de energie?</string>
     <string name="settings_autopause_label">Pauză automată</string>
     <string name="settings_autopause_description">Întrerupeți sunetul când scoateți dispozitivul din ureche.</string>
     <string name="settings_autopplay_label">Redare automată</string>
@@ -224,9 +222,6 @@
     <string name="permission_required_title">Următoarea permisiune este necesară:</string>
     <string name="permission_system_alert_window_label">Fereastră alertă sistem</string>
     <string name="permission_system_alert_window_description">Permiteți CAPod să deseneze peste alte aplicații pentru a face posibilă funcția \"Afișare PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Consum redus</string>
-    <string name="settings_scanner_mode_balanced_label">Echilibrat</string>
-    <string name="settings_scanner_mode_lowlatency_label">Latență redusă</string>
     <string name="settings_monitor_mode_manual_label">Când aplicația este deschisă</string>
     <string name="settings_monitor_mode_automatic_label">Când dispozitivul este conectat</string>
     <string name="settings_monitor_mode_always_label">Întotdeauna</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Показывать дополнительное уведомление, когда устройство подключено. Это позволяет скрыть постоянное уведомление «Нет устройств», отключая канал «Статус устройства».</string>
     <string name="settings_keep_notification_after_disconnect_label">Оставить уведомление после отключения</string>
     <string name="settings_keep_notification_after_disconnect_description">Продолжать показывать последний известный заряд батареи даже после отключения AirPods</string>
-    <string name="settings_scanner_mode_label">Режим сканера</string>
-    <string name="settings_scanner_mode_description">Какой режим должен по умолчанию использовать сканер данных Bluetooth Low Energy - производительность или экономию энергии?</string>
     <string name="settings_autopause_label">Автопауза</string>
     <string name="settings_autopause_description">Приостановка аудио при удалении устройства из уха.</string>
     <string name="settings_autopplay_label">Автовоспроизведение</string>
@@ -227,9 +225,6 @@ AL_Cool_T</string>
     <string name="permission_required_title">Требуется следующее разрешение:</string>
     <string name="permission_system_alert_window_label">Окно системных предупреждений</string>
     <string name="permission_system_alert_window_description">Позволить CAPod наложение поверх других приложений для работы функции \"Всплывающие сообщения\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Низкая мощность</string>
-    <string name="settings_scanner_mode_balanced_label">Сбалансированно</string>
-    <string name="settings_scanner_mode_lowlatency_label">Низкая задержка</string>
     <string name="settings_monitor_mode_manual_label">Когда приложение открыто</string>
     <string name="settings_monitor_mode_automatic_label">Когда устройство подключено</string>
     <string name="settings_monitor_mode_always_label">Всегда</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Mustrat una notìfica extra cando unu dispositivu est cullegadu. Custu ti permitit de cuare sa notìfica permanente \"Perunu dispositivu\" disativende su canale \"Istadu de su dispositivu\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mantene sa notìfica a pustis de sa disconnexione</string>
     <string name="settings_keep_notification_after_disconnect_description">Sighi a mustrare is ùrtimos livelos de bateria connotos fintzas a pustis chi is AirPods si disconnetint</string>
-    <string name="settings_scanner_mode_label">Modalidade scanner</string>
-    <string name="settings_scanner_mode_description">S\'iscaner de datos Bluetooth Low Energy depet dare prioridade a is prestatziones o aforrare energia?</string>
     <string name="settings_autopause_label">Pàusa automàtica</string>
     <string name="settings_autopause_description">Pone in pàusa s\'àudio cando bogas su dispositivu dae s\'origra.</string>
     <string name="settings_autopplay_label">Riprodutzione automàtica</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Su permissu in fata est netzessàriu:</string>
     <string name="permission_system_alert_window_label">Ventana de alerta de su sistema</string>
     <string name="permission_system_alert_window_description">Permiti a CAPod de disegnare subra àteras apps pro rèndere possìbile sa funtzione \"Mustra PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Consumu bàsciu</string>
-    <string name="settings_scanner_mode_balanced_label">Ecuilibradu</string>
-    <string name="settings_scanner_mode_lowlatency_label">Latèntzia bàscia</string>
     <string name="settings_monitor_mode_manual_label">Cando s\'app est aberta</string>
     <string name="settings_monitor_mode_automatic_label">Cando su dispositivu est cullegadu</string>
     <string name="settings_monitor_mode_always_label">Sèmper</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">උපාංගයක් සම්බන්ධ වූ විට අමතර දැනුම්දීමක් පෙන්වයි. \"උපාංග තත්ත්වය\" නාලිකාව අක්‍රීය කිරීමෙන් \"උපාංග නොමැත\" ස්ථිර දැනුම්දීම සැඟවීමට මෙය ඔබට ඉඩ සලසයි.</string>
     <string name="settings_keep_notification_after_disconnect_label">විසන්ධි වූ පසු දැනුම්දීම තබන්න</string>
     <string name="settings_keep_notification_after_disconnect_description">ඔබගේ AirPods විසන්ධි වූ පසුවද අවසාන වරට දන්නා බැටරි මට්ටම් පෙන්වීම දිගටම කරන්න</string>
-    <string name="settings_scanner_mode_label">ස්කෑනර් ප්‍රකාරය</string>
-    <string name="settings_scanner_mode_description">බ්ලූටූත් අඩු ශක්ති දත්ත ස්කෑනරය කාර්ය සාධනයට ප්‍රමුඛත්වය දිය යුතුද නැතහොත් ශක්තිය සංරක්ෂණය කළ යුතුද?</string>
     <string name="settings_autopause_label">ස්වයංක්‍රීයව විරාම කරන්න</string>
     <string name="settings_autopause_description">ඔබේ කනෙන් උපාංගය ඉවත් කරන විට ශ්‍රව්‍ය විරාම කරන්න.</string>
     <string name="settings_autopplay_label">ස්වයංක්‍රීයව වාදනය කරන්න</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">පහත අවසරය අවශ්‍ය වේ:</string>
     <string name="permission_system_alert_window_label">පද්ධති ඇඟවුම් කවුළුව</string>
     <string name="permission_system_alert_window_description">\"පොප්-අප් පෙන්වන්න\" විශේෂාංගය හැකි කිරීමට CAPod හට වෙනත් යෙදුම් මත අඳින්නට ඉඩ දෙන්න.</string>
-    <string name="settings_scanner_mode_lowpower_label">අඩු ශක්තිය</string>
-    <string name="settings_scanner_mode_balanced_label">සමතුලිත</string>
-    <string name="settings_scanner_mode_lowlatency_label">අඩු ප්‍රමාදය</string>
     <string name="settings_monitor_mode_manual_label">යෙදුම විවෘතව ඇති විට</string>
     <string name="settings_monitor_mode_automatic_label">උපාංගය සම්බන්ධ වූ විට</string>
     <string name="settings_monitor_mode_always_label">සෑමවිටම</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Zobrazí dodatočné oznámenie keď je zariadenie pripojené. To umožňuje skryť trvalé oznámenie \"Žiadne zariadenia\" vypnutím kanálu \"Stav zariadenia\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Ponechať oznámenie po odpojení</string>
     <string name="settings_keep_notification_after_disconnect_description">Pokračovať v zobrazovaní posledných známych úrovní batérie aj po odpojení vašich AirPods</string>
-    <string name="settings_scanner_mode_label">Režim skenera</string>
-    <string name="settings_scanner_mode_description">Mal by skener Bluetooth Low Energy uprednostňovať výkon alebo šetriť energiu?</string>
     <string name="settings_autopause_label">Automatické pozastavenie</string>
     <string name="settings_autopause_description">Pozastavte zvuk, keď si vyberiete zariadenie z ucha.</string>
     <string name="settings_autopplay_label">Automatické prehrávanie</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">Je vyžadované nasledujúce povolenie:</string>
     <string name="permission_system_alert_window_label">Systémové výstražné okno</string>
     <string name="permission_system_alert_window_description">Povoľte CAPodu kresliť cez iné aplikácie, aby bola možná funkcia \"Zobraziť vyskakovacie okno\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Nízka spotreba</string>
-    <string name="settings_scanner_mode_balanced_label">Vyvážený</string>
-    <string name="settings_scanner_mode_lowlatency_label">Nízka latencia</string>
     <string name="settings_monitor_mode_manual_label">Keď je aplikácia otvorená</string>
     <string name="settings_monitor_mode_automatic_label">Keď je zariadenie pripojené</string>
     <string name="settings_monitor_mode_always_label">Vždy</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Prikaže dodatno obvestilo, ko je naprava povezana. To vam omogoča, da skrijete trajno obvestilo \"Ni naprav\" tako, da onemogočite kanal \"Stanje naprave\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Ohrani obvestilo po prekinitvi povezave</string>
     <string name="settings_keep_notification_after_disconnect_description">Nadaljuj s prikazovanjem zadnjih znanih ravni baterije tudi po prekinitvi povezave z vašimi AirPods</string>
-    <string name="settings_scanner_mode_label">Način optičnega bralnika</string>
-    <string name="settings_scanner_mode_description">Ali naj optični bralnik podatkov Bluetooth Low Energy daje prednost zmogljivosti ali varčuje z energijo?</string>
     <string name="settings_autopause_label">Samodejna prekinitev</string>
     <string name="settings_autopause_description">Začasno ustavi zvok, ko napravo odstranite iz ušesa.</string>
     <string name="settings_autopplay_label">Samodejno predvajanje</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">Zahtevano je naslednje dovoljenje:</string>
     <string name="permission_system_alert_window_label">Sistemsko opozorilno okno</string>
     <string name="permission_system_alert_window_description">Dovolite CAPod risanje čez druge aplikacije, da omogočite funkcijo \"Pokaži pojavno okno\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Nizka poraba</string>
-    <string name="settings_scanner_mode_balanced_label">Uravnoteženo</string>
-    <string name="settings_scanner_mode_lowlatency_label">Nizka zakasnitev</string>
     <string name="settings_monitor_mode_manual_label">Ko je aplikacija odprta</string>
     <string name="settings_monitor_mode_automatic_label">Ko je naprava povezana</string>
     <string name="settings_monitor_mode_always_label">Vedno</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Shfaq një njoftim shtesë kur një pajisje lidhet. Kjo ju lejon të fshihni njoftimin e përhershëm \"Asnjë pajisje\" duke çaktivizuar kanalin \"Statusi i pajisjes\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Mbaj njoftimin pas shkëputjes</string>
     <string name="settings_keep_notification_after_disconnect_description">Vazhdo të shfaqësh nivelet e fundit të njohura të baterisë edhe pasi AirPods tuaja shkëputen</string>
-    <string name="settings_scanner_mode_label">Modaliteti i skanerit</string>
-    <string name="settings_scanner_mode_description">A duhet skaneri i të dhënave Bluetooth Low Energy të prioritizojë performancën apo të kursejë energji?</string>
     <string name="settings_autopause_label">Pauzë automatike</string>
     <string name="settings_autopause_description">Vendos në pauzë audion kur hiqni pajisjen nga veshi.</string>
     <string name="settings_autopplay_label">Luaj automatikisht</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Leja e mëposhtme kërkohet:</string>
     <string name="permission_system_alert_window_label">Dritare Alarmi Sistemi</string>
     <string name="permission_system_alert_window_description">Lejoni CAPod të vizatojë mbi aplikacionet e tjera për të mundësuar veçorinë \"Shfaq PopUp\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Energji e ulët</string>
-    <string name="settings_scanner_mode_balanced_label">I balancuar</string>
-    <string name="settings_scanner_mode_lowlatency_label">Vonesë e ulët</string>
     <string name="settings_monitor_mode_manual_label">Kur aplikacioni është i hapur</string>
     <string name="settings_monitor_mode_automatic_label">Kur pajisja është e lidhur</string>
     <string name="settings_monitor_mode_always_label">Gjithmonë</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Приказује додатно обавештење када је уређај повезан. Ово вам омогућава да сакријете трајно обавештење „Нема уређаја” онемогућавањем канала „Статус уређаја”.</string>
     <string name="settings_keep_notification_after_disconnect_label">Задржи обавештење након прекида везе</string>
     <string name="settings_keep_notification_after_disconnect_description">Настави да приказује последње познате нивое батерије чак и након што се AirPods искључе</string>
-    <string name="settings_scanner_mode_label">Режим скенера</string>
-    <string name="settings_scanner_mode_description">Да ли би скенер података Bluetooth Low Energy требало да да приоритет перформансама или да штеди енергију?</string>
     <string name="settings_autopause_label">Аутоматска пауза</string>
     <string name="settings_autopause_description">Паузирајте звук када уклоните уређај из ува.</string>
     <string name="settings_autopplay_label">Аутоматска репродукција</string>
@@ -224,9 +222,6 @@
     <string name="permission_required_title">Потребна је следећа дозвола:</string>
     <string name="permission_system_alert_window_label">Приказ преко других апликација</string>
     <string name="permission_system_alert_window_description">Дозволите CAPod-у да се приказује преко других апликација да би функција \"Прикажи искачући прозор\" била могућа.</string>
-    <string name="settings_scanner_mode_lowpower_label">Ниска потрошња</string>
-    <string name="settings_scanner_mode_balanced_label">Уравнотежено</string>
-    <string name="settings_scanner_mode_lowlatency_label">Ниска латенција</string>
     <string name="settings_monitor_mode_manual_label">Када је апликација отворена</string>
     <string name="settings_monitor_mode_automatic_label">Када је уређај повезан</string>
     <string name="settings_monitor_mode_always_label">Увек</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Visar en extra avisering när en enhet är ansluten. Detta låter dig dölja den permanenta aviseringen \"Inga enheter\" genom att inaktivera kanalen \"Enhetsstatus\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Behåll avisering efter frånkoppling</string>
     <string name="settings_keep_notification_after_disconnect_description">Fortsätt visa de senast kända batterinivåerna även efter att dina AirPods kopplas från</string>
-    <string name="settings_scanner_mode_label">Skannerläge</string>
-    <string name="settings_scanner_mode_description">Ska Bluetooth Low Energy-dataskannern prioritera prestanda eller spara energi?</string>
     <string name="settings_autopause_label">Automatisk paus</string>
     <string name="settings_autopause_description">Pausa ljudet när du tar bort enheten från örat.</string>
     <string name="settings_autopplay_label">Automatisk uppspelning</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Följande behörighet krävs:</string>
     <string name="permission_system_alert_window_label">Visa över andra appar</string>
     <string name="permission_system_alert_window_description">Tillåt CAPod att rita över andra appar för att möjliggöra funktionen \"Visa popup\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Låg effekt</string>
-    <string name="settings_scanner_mode_balanced_label">Balanserad</string>
-    <string name="settings_scanner_mode_lowlatency_label">Låg latens</string>
     <string name="settings_monitor_mode_manual_label">När appen är öppen</string>
     <string name="settings_monitor_mode_automatic_label">När enheten är ansluten</string>
     <string name="settings_monitor_mode_always_label">Alltid</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Inaonyesha arifa ya ziada wakati kifaa kimeunganishwa. Hii inakuwezesha kuficha arifa ya kudumu ya \"Hakuna vifaa\" kwa kuzima kituo cha \"Hali ya kifaa\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Weka arifa baada ya kukata muunganisho</string>
     <string name="settings_keep_notification_after_disconnect_description">Endelea kuonyesha viwango vya mwisho vya betri hata baada ya AirPods yako kukatika muunganisho</string>
-    <string name="settings_scanner_mode_label">Hali ya skana</string>
-    <string name="settings_scanner_mode_description">Je, skana ya data ya Bluetooth Low Energy itangulize utendakazi au ihifadhi nishati?</string>
     <string name="settings_autopause_label">Sitisha kiotomatiki</string>
     <string name="settings_autopause_description">Sitisha sauti unapotoa kifaa sikioni.</string>
     <string name="settings_autopplay_label">Cheza kiotomatiki</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Ruhusa ifuatayo inahitajika:</string>
     <string name="permission_system_alert_window_label">Dirisha la Arifa ya Mfumo</string>
     <string name="permission_system_alert_window_description">Ruhusu CAPod kuchora juu ya programu nyingine ili kuwezesha kipengele cha \"Onyesha Kidirisha\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Nishati ya chini</string>
-    <string name="settings_scanner_mode_balanced_label">Uwiano</string>
-    <string name="settings_scanner_mode_lowlatency_label">Ucheleweshaji mdogo</string>
     <string name="settings_monitor_mode_manual_label">Programu inapofunguliwa</string>
     <string name="settings_monitor_mode_automatic_label">Kifaa kinapounganishwa</string>
     <string name="settings_monitor_mode_always_label">Kila mara</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">ஒரு சாதனம் இணைக்கப்படும்போது கூடுதல் அறிவிப்பைக் காட்டுகிறது. \"சாதன நிலை\" சேனலை முடக்குவதன் மூலம் நிரந்தர \"சாதனங்கள் இல்லை\" அறிவிப்பை மறைக்க இது உங்களை அனுமதிக்கிறது.</string>
     <string name="settings_keep_notification_after_disconnect_label">துண்டிக்கப்பட்ட பிறகு அறிவிப்பை வைத்திரு</string>
     <string name="settings_keep_notification_after_disconnect_description">உங்கள் AirPods துண்டிக்கப்பட்ட பிறகும் கடைசியாக அறியப்பட்ட பேட்டரி நிலைகளைக் காட்டவும்</string>
-    <string name="settings_scanner_mode_label">ஸ்கேனர் முறை</string>
-    <string name="settings_scanner_mode_description">புளூடூத் குறைந்த ஆற்றல் தரவு ஸ்கேனர் செயல்திறனுக்கு முன்னுரிமை அளிக்க வேண்டுமா அல்லது ஆற்றலைச் சேமிக்க வேண்டுமா?</string>
     <string name="settings_autopause_label">தானியங்கு இடைநிறுத்தம்</string>
     <string name="settings_autopause_description">உங்கள் காதில் இருந்து சாதனத்தை அகற்றும்போது ஆடியோவை இடைநிறுத்தவும்.</string>
     <string name="settings_autopplay_label">தானியங்கு இயக்கம்</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">பின்வரும் அனுமதி தேவை:</string>
     <string name="permission_system_alert_window_label">கணினி எச்சரிக்கை சாளரம்</string>
     <string name="permission_system_alert_window_description">\"பாப்அப் காட்டு\" அம்சத்தை சாத்தியமாக்க CAPod-ஐ பிற ஆப்ஸ்களின் மேல் வரைய அனுமதிக்கவும்.</string>
-    <string name="settings_scanner_mode_lowpower_label">குறைந்த ஆற்றல்</string>
-    <string name="settings_scanner_mode_balanced_label">சமநிலை</string>
-    <string name="settings_scanner_mode_lowlatency_label">குறைந்த தாமதம்</string>
     <string name="settings_monitor_mode_manual_label">ஆப்ஸ் திறந்திருக்கும்போது</string>
     <string name="settings_monitor_mode_automatic_label">சாதனம் இணைக்கப்பட்டிருக்கும்போது</string>
     <string name="settings_monitor_mode_always_label">எப்போதும்</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">పరికరం కనెక్ట్ అయినప్పుడు అదనపు నోటిఫికేషన్‌ను చూపుతుంది. ఇది \"పరికర స్థితి\" ఛానెల్‌ను నిలిపివేయడం ద్వారా శాశ్వత \"పరికరం లేదు\" నోటిఫికేషన్‌ను దాచడానికి మిమ్మల్ని అనుమతిస్తుంది.</string>
     <string name="settings_keep_notification_after_disconnect_label">డిస్‌కనెక్ట్ తర్వాత నోటిఫికేషన్ ఉంచు</string>
     <string name="settings_keep_notification_after_disconnect_description">మీ AirPods డిస్‌కనెక్ట్ అయిన తర్వాత కూడా చివరిగా తెలిసిన బ్యాటరీ స్థాయిలను చూపించడం కొనసాగించు</string>
-    <string name="settings_scanner_mode_label">స్కానర్ మోడ్</string>
-    <string name="settings_scanner_mode_description">బ్లూటూత్ తక్కువ శక్తి డేటా స్కానర్ పనితీరుకు ప్రాధాన్యత ఇవ్వాలా లేదా శక్తిని ఆదా చేయాలా?</string>
     <string name="settings_autopause_label">ఆటో పాజ్</string>
     <string name="settings_autopause_description">మీ చెవి నుండి పరికరాన్ని తీసివేసినప్పుడు ఆడియోను పాజ్ చేయండి.</string>
     <string name="settings_autopplay_label">ఆటో ప్లే</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">కింది అనుమతి అవసరం:</string>
     <string name="permission_system_alert_window_label">సిస్టమ్ అలర్ట్ విండో</string>
     <string name="permission_system_alert_window_description">\"పాపప్ చూపించు\" ఫీచర్‌ను సాధ్యం చేయడానికి ఇతర యాప్‌ల మీద గీయడానికి CAPodను అనుమతించండి.</string>
-    <string name="settings_scanner_mode_lowpower_label">తక్కువ శక్తి</string>
-    <string name="settings_scanner_mode_balanced_label">సమతుల్యం</string>
-    <string name="settings_scanner_mode_lowlatency_label">తక్కువ జాప్యం</string>
     <string name="settings_monitor_mode_manual_label">యాప్ తెరిచి ఉన్నప్పుడు</string>
     <string name="settings_monitor_mode_automatic_label">పరికరం కనెక్ట్ అయినప్పుడు</string>
     <string name="settings_monitor_mode_always_label">ఎల్లప్పుడూ</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">แสดงการแจ้งเตือนเพิ่มเติมเมื่ออุปกรณ์เชื่อมต่อ ซึ่งช่วยให้คุณสามารถซ่อนการแจ้งเตือนถาวร \"ไม่มีอุปกรณ์\" โดยการปิดใช้งานช่อง \"สถานะอุปกรณ์\"</string>
     <string name="settings_keep_notification_after_disconnect_label">คงการแจ้งเตือนหลังตัดการเชื่อมต่อ</string>
     <string name="settings_keep_notification_after_disconnect_description">แสดงระดับแบตเตอรี่ล่าสุดที่ทราบต่อไปแม้ว่า AirPods ของคุณจะตัดการเชื่อมต่อแล้ว</string>
-    <string name="settings_scanner_mode_label">โหมดสแกนเนอร์</string>
-    <string name="settings_scanner_mode_description">เครื่องสแกนข้อมูล Bluetooth Low Energy ควรให้ความสำคัญกับประสิทธิภาพหรือประหยัดพลังงาน?</string>
     <string name="settings_autopause_label">หยุดชั่วคราวอัตโนมัติ</string>
     <string name="settings_autopause_description">หยุดเสียงชั่วคราวเมื่อถอดอุปกรณ์ออกจากหู</string>
     <string name="settings_autopplay_label">เล่นอัตโนมัติ</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">ต้องการสิทธิ์ต่อไปนี้:</string>
     <string name="permission_system_alert_window_label">หน้าต่างแจ้งเตือนระบบ</string>
     <string name="permission_system_alert_window_description">อนุญาตให้ CAPod วาดทับแอปอื่นเพื่อให้คุณสมบัติ \"แสดงป๊อปอัป\" ทำงานได้</string>
-    <string name="settings_scanner_mode_lowpower_label">ประหยัดพลังงาน</string>
-    <string name="settings_scanner_mode_balanced_label">สมดุล</string>
-    <string name="settings_scanner_mode_lowlatency_label">ความหน่วงต่ำ</string>
     <string name="settings_monitor_mode_manual_label">เมื่อเปิดแอป</string>
     <string name="settings_monitor_mode_automatic_label">เมื่ออุปกรณ์เชื่อมต่อ</string>
     <string name="settings_monitor_mode_always_label">เสมอ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Bir cihaz bağlandığında ek bir bildirim gösterir. Bu, \"Cihaz durumu\" kanalını devre dışı bırakarak kalıcı \"Cihaz yok\" bildirimini gizlemenizi sağlar.</string>
     <string name="settings_keep_notification_after_disconnect_label">Bağlantı kesildikten sonra bildirimi koru</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPods bağlantısı kesildikten sonra bile bilinen son pil seviyelerini göstermeye devam et</string>
-    <string name="settings_scanner_mode_label">Tarama modu</string>
-    <string name="settings_scanner_mode_description">Bluetooth Düşük Enerji veri tarayıcısının performansa mı yoksa enerji tasarrufuna mı öncelik versin?</string>
     <string name="settings_autopause_label">Otomatik duraklat</string>
     <string name="settings_autopause_description">Aygıtı kulağınızdan çıkarınca sesi duraklatır.</string>
     <string name="settings_autopplay_label">Otomatik oynat</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Aşağıdaki izin gereklidir:</string>
     <string name="permission_system_alert_window_label">Sistem Uyarı Penceresi</string>
     <string name="permission_system_alert_window_description">\"Açılır Pencere Göster\" özelliğini mümkün kılmak için CAPod\'un diğer uygulamaların üzerine çizmesine izin verin.</string>
-    <string name="settings_scanner_mode_lowpower_label">Düşük güç</string>
-    <string name="settings_scanner_mode_balanced_label">Dengeli</string>
-    <string name="settings_scanner_mode_lowlatency_label">Düşük gecikme</string>
     <string name="settings_monitor_mode_manual_label">Uygulama açıkken</string>
     <string name="settings_monitor_mode_automatic_label">Cihaz bağlıyken</string>
     <string name="settings_monitor_mode_always_label">Her zaman</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Показує додаткове сповіщення, коли пристрій підключено. Це дозволяє приховати постійне сповіщення \"Немає пристроїв\", вимкнувши канал \"Стан пристрою\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Залишати сповіщення після відключення</string>
     <string name="settings_keep_notification_after_disconnect_description">Продовжувати показувати останні відомі рівні заряду навіть після відключення AirPods</string>
-    <string name="settings_scanner_mode_label">Режим сканера</string>
-    <string name="settings_scanner_mode_description">Сканер даних Bluetooth Low Energy має зосередитися на продуктивності чи збереженні заряду батареї?</string>
     <string name="settings_autopause_label">Автопауза</string>
     <string name="settings_autopause_description">Зупинка відтворення аудіо, коли навушник прибрано з Вашого вуха.</string>
     <string name="settings_autopplay_label">Автовідтворення</string>
@@ -226,9 +224,6 @@
     <string name="permission_required_title">Потрібен наступний дозвіл:</string>
     <string name="permission_system_alert_window_label">Відображення поверх інших програм</string>
     <string name="permission_system_alert_window_description">Дозвольте CAPod відображатися поверх інших програм, щоб уможливити функцію \"Показувати спливаюче вікно\".</string>
-    <string name="settings_scanner_mode_lowpower_label">Енергозбереження</string>
-    <string name="settings_scanner_mode_balanced_label">Збалансований</string>
-    <string name="settings_scanner_mode_lowlatency_label">Низька затримка</string>
     <string name="settings_monitor_mode_manual_label">Коли програму відкрито</string>
     <string name="settings_monitor_mode_automatic_label">Коли пристрій підключено</string>
     <string name="settings_monitor_mode_always_label">Завжди</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">جب کوئی آلہ منسلک ہوتا ہے تو ایک اضافی اطلاع دکھاتا ہے۔ اس سے آپ \"آلہ کی حیثیت\" چینل کو غیر فعال کر کے مستقل \"کوئی آلہ نہیں\" اطلاع کو چھپا سکتے ہیں۔</string>
     <string name="settings_keep_notification_after_disconnect_label">منقطع ہونے کے بعد اطلاع رکھیں</string>
     <string name="settings_keep_notification_after_disconnect_description">آپ کے AirPods منقطع ہونے کے بعد بھی آخری معلوم بیٹری کی سطح دکھاتے رہیں</string>
-    <string name="settings_scanner_mode_label">اسکینر موڈ</string>
-    <string name="settings_scanner_mode_description">کیا بلوٹوتھ لو انرجی ڈیٹا اسکینر کو کارکردگی کو ترجیح دینی چاہئے یا توانائی بچانی چاہئے؟</string>
     <string name="settings_autopause_label">خودکار توقف</string>
     <string name="settings_autopause_description">آلہ کو کان سے ہٹاتے وقت آڈیو کو روکیں۔</string>
     <string name="settings_autopplay_label">خودکار پلے</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">درج ذیل اجازت درکار ہے:</string>
     <string name="permission_system_alert_window_label">سسٹم الرٹ ونڈو</string>
     <string name="permission_system_alert_window_description">\"پاپ اپ دکھائیں\" خصوصیت ممکن بنانے کے لئے CAPod کو دوسری ایپس کے اوپر ڈرا کرنے کی اجازت دیں۔</string>
-    <string name="settings_scanner_mode_lowpower_label">کم توانائی</string>
-    <string name="settings_scanner_mode_balanced_label">متوازن</string>
-    <string name="settings_scanner_mode_lowlatency_label">کم تاخیر</string>
     <string name="settings_monitor_mode_manual_label">جب ایپ کھلی ہو</string>
     <string name="settings_monitor_mode_automatic_label">جب آلہ منسلک ہو</string>
     <string name="settings_monitor_mode_always_label">ہمیشہ</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Qurilma ulanganda qo\'shimcha bildirishnoma ko\'rsatadi. Bu sizga \"Qurilma holati\" kanalini o\'chirib qo\'yish orqali doimiy \"Qurilmalar yo\'q\" bildirishnomasini yashirishga imkon beradi.</string>
     <string name="settings_keep_notification_after_disconnect_label">Uzilgandan keyin bildirishnomani saqlash</string>
     <string name="settings_keep_notification_after_disconnect_description">AirPods uzilgandan keyin ham oxirgi ma\'lum batareya darajalarini ko\'rsatishni davom ettiring</string>
-    <string name="settings_scanner_mode_label">Skaner rejimi</string>
-    <string name="settings_scanner_mode_description">Bluetooth Low Energy ma\'lumotlar skaneri samaradorlikni birinchi o\'ringa qo\'yishi kerakmi yoki energiyani tejashi kerakmi?</string>
     <string name="settings_autopause_label">Avtomatik pauza</string>
     <string name="settings_autopause_description">Qurilmani qulog\'ingizdan olib tashlaganingizda audioni pauza qiling.</string>
     <string name="settings_autopplay_label">Avtomatik ijro etish</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Quyidagi ruxsat talab qilinadi:</string>
     <string name="permission_system_alert_window_label">Tizim ogohlantirish oynasi</string>
     <string name="permission_system_alert_window_description">\"Qalqib chiquvchi oynani ko\'rsatish\" funksiyasini mumkin qilish uchun CAPod\'ga boshqa ilovalar ustida chizish ruxsatini bering.</string>
-    <string name="settings_scanner_mode_lowpower_label">Kam quvvat</string>
-    <string name="settings_scanner_mode_balanced_label">Muvozanatli</string>
-    <string name="settings_scanner_mode_lowlatency_label">Kam kechikish</string>
     <string name="settings_monitor_mode_manual_label">Ilova ochiq bo\'lganda</string>
     <string name="settings_monitor_mode_automatic_label">Qurilma ulanganda</string>
     <string name="settings_monitor_mode_always_label">Har doim</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Hiển thị thông báo bổ sung khi một thiết bị được kết nối. Điều này cho phép bạn ẩn thông báo cố định \"Không có thiết bị\" bằng cách tắt kênh \"Trạng thái thiết bị\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Giữ thông báo sau khi ngắt kết nối</string>
     <string name="settings_keep_notification_after_disconnect_description">Tiếp tục hiển thị mức pin đã biết gần nhất ngay cả sau khi AirPods của bạn ngắt kết nối</string>
-    <string name="settings_scanner_mode_label">Chế độ quét</string>
-    <string name="settings_scanner_mode_description">Máy quét dữ liệu Bluetooth Low Energy nên ưu tiên hiệu suất hay tiết kiệm năng lượng?</string>
     <string name="settings_autopause_label">Tự động tạm dừng</string>
     <string name="settings_autopause_description">Tạm dừng âm thanh khi tháo thiết bị khỏi tai bạn.</string>
     <string name="settings_autopplay_label">Tự động phát</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">Cần quyền sau:</string>
     <string name="permission_system_alert_window_label">Cửa sổ cảnh báo hệ thống</string>
     <string name="permission_system_alert_window_description">Cho phép CAPod hiển thị đè lên các ứng dụng khác để tính năng Show PopUp hoạt động.</string>
-    <string name="settings_scanner_mode_lowpower_label">Tiết kiệm pin</string>
-    <string name="settings_scanner_mode_balanced_label">Cân bằng</string>
-    <string name="settings_scanner_mode_lowlatency_label">Độ trễ thấp</string>
     <string name="settings_monitor_mode_manual_label">Khi ứng dụng đang mở</string>
     <string name="settings_monitor_mode_automatic_label">Khi thiết bị được kết nối</string>
     <string name="settings_monitor_mode_always_label">Luôn luôn</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">在设备连接时显示一条额外通知。这使您可以禁用“设备状态”通道来隐藏永久性的“无设备”通知。</string>
     <string name="settings_keep_notification_after_disconnect_label">断开连接后保持通知</string>
     <string name="settings_keep_notification_after_disconnect_description">即使您的 AirPods 断开连接，继续显示上次已知的电池电量水平</string>
-    <string name="settings_scanner_mode_label">扫描模式</string>
-    <string name="settings_scanner_mode_description">低功耗蓝牙数据扫描器应着重性能还是省电？</string>
     <string name="settings_autopause_label">自动暂停</string>
     <string name="settings_autopause_description">从耳中取出时自动暂停音频播放</string>
     <string name="settings_autopplay_label">自动播放</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">需要以下权限：</string>
     <string name="permission_system_alert_window_label">系统警告窗口</string>
     <string name="permission_system_alert_window_description">允许 CAPod 在其他应用的界面上方显示，以允许如“显示弹窗”功能。</string>
-    <string name="settings_scanner_mode_lowpower_label">低耗电</string>
-    <string name="settings_scanner_mode_balanced_label">平衡</string>
-    <string name="settings_scanner_mode_lowlatency_label">低延迟</string>
     <string name="settings_monitor_mode_manual_label">当应用程序打开时</string>
     <string name="settings_monitor_mode_automatic_label">设备连接时</string>
     <string name="settings_monitor_mode_always_label">总是</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">裝置連接時顯示額外通知。這讓您可以停用「裝置狀態」頻道來隱藏永久的「沒有裝置」通知。</string>
     <string name="settings_keep_notification_after_disconnect_label">斷線後保留通知</string>
     <string name="settings_keep_notification_after_disconnect_description">即使 AirPods 斷線後仍顯示上次的電量</string>
-    <string name="settings_scanner_mode_label">掃描模式</string>
-    <string name="settings_scanner_mode_description">低功耗藍牙掃描器應該優先考慮效能還是節能？</string>
     <string name="settings_autopause_label">自動暫停</string>
     <string name="settings_autopause_description">從耳中摘下時自動暫停。</string>
     <string name="settings_autopplay_label">自動播放</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">需要以下權限：</string>
     <string name="permission_system_alert_window_label">系統警示視窗</string>
     <string name="permission_system_alert_window_description">允許 CAPod 在其他應用程式上方顯示內容，以啟用「顯示彈出式視窗」功能。</string>
-    <string name="settings_scanner_mode_lowpower_label">低功耗</string>
-    <string name="settings_scanner_mode_balanced_label">平衡</string>
-    <string name="settings_scanner_mode_lowlatency_label">低延遲</string>
     <string name="settings_monitor_mode_manual_label">應用程式開啟時</string>
     <string name="settings_monitor_mode_automatic_label">裝置已連線時</string>
     <string name="settings_monitor_mode_always_label">一律</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">裝置連接時顯示額外通知。這讓您可以停用「裝置狀態」頻道來隱藏永久的「沒有裝置」通知。</string>
     <string name="settings_keep_notification_after_disconnect_label">斷線後保留通知</string>
     <string name="settings_keep_notification_after_disconnect_description">即使 AirPods 斷線後仍顯示上次的電量</string>
-    <string name="settings_scanner_mode_label">掃描模式</string>
-    <string name="settings_scanner_mode_description">低功耗藍牙掃描器應該優先考慮效能還是節能？</string>
     <string name="settings_autopause_label">自動暫停</string>
     <string name="settings_autopause_description">從耳中摘下時自動暫停。</string>
     <string name="settings_autopplay_label">自動播放</string>
@@ -220,9 +218,6 @@
     <string name="permission_required_title">可能要求下列權限：</string>
     <string name="permission_system_alert_window_label">系統警報視窗</string>
     <string name="permission_system_alert_window_description">允許 CAPod 在其他應用程式上繪圖，使「顯示彈出式視窗」功能成為可能。</string>
-    <string name="settings_scanner_mode_lowpower_label">低功耗</string>
-    <string name="settings_scanner_mode_balanced_label">平衡</string>
-    <string name="settings_scanner_mode_lowlatency_label">低延遲</string>
     <string name="settings_monitor_mode_manual_label">應用程式開啟時</string>
     <string name="settings_monitor_mode_automatic_label">裝置連線時</string>
     <string name="settings_monitor_mode_always_label">一律</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -46,8 +46,6 @@
     <string name="settings_monitor_connected_notification_description">Ibonisa isaziso esengeziwe lapho idivayisi ixhunyiwe. Lokhu kukuvumela ukuthi ufihle isaziso esihlala njalo esithi \"Awekho amadivayisi\" ngokukhubaza isiteshi \"Isimo sedivayisi\".</string>
     <string name="settings_keep_notification_after_disconnect_label">Gcina isaziso ngemva kokunqamuka</string>
     <string name="settings_keep_notification_after_disconnect_description">Qhubeka ubonise amazinga ebhethri okugcina aziwayo nangemva kokuthi ama-AirPods akho anqamuke</string>
-    <string name="settings_scanner_mode_label">Imodi yesithwebuli</string>
-    <string name="settings_scanner_mode_description">Ingabe isithwebuli sedatha ye-Bluetooth Low Energy kufanele sibeke phambili ukusebenza noma ukonga amandla?</string>
     <string name="settings_autopause_label">Misa kancane ngokuzenzakalela</string>
     <string name="settings_autopause_description">Misa kancane umsindo lapho ukhipha idivayisi endlebeni yakho.</string>
     <string name="settings_autopplay_label">Dlala ngokuzenzakalela</string>
@@ -222,9 +220,6 @@
     <string name="permission_required_title">Imvume elandelayo iyadingeka:</string>
     <string name="permission_system_alert_window_label">Iwindi Lesexwayiso Sohlelo</string>
     <string name="permission_system_alert_window_description">Vumela i-CAPod ukuthi idwebe phezu kwezinye izinhlelo zokusebenza ukwenza isici \"Bonisa isigelekeqe\" sikwazi ukusebenza.</string>
-    <string name="settings_scanner_mode_lowpower_label">Amandla aphansi</string>
-    <string name="settings_scanner_mode_balanced_label">Okulinganiswe</string>
-    <string name="settings_scanner_mode_lowlatency_label">Ukulibaziseka okuncane</string>
     <string name="settings_monitor_mode_manual_label">Uma uhlelo lokusebenza luvuliwe</string>
     <string name="settings_monitor_mode_automatic_label">Uma idivayisi ixhunyiwe</string>
     <string name="settings_monitor_mode_always_label">Njalo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,8 +50,6 @@
     <string name="settings_monitor_connected_notification_description">Shows an extra notification when a device is connected. This lets you hide the permanent \"No devices\" notification by disabling the \"Device status\" channel.</string>
     <string name="settings_keep_notification_after_disconnect_label">Keep notification after disconnect</string>
     <string name="settings_keep_notification_after_disconnect_description">Continue showing the last known battery levels even after your AirPods disconnect</string>
-    <string name="settings_scanner_mode_label">Scanner mode</string>
-    <string name="settings_scanner_mode_description">Should the Bluetooth Low Energy data scanner prioritize performance or conserve energy?</string>
     <string name="settings_autopause_label">Auto pause</string>
     <string name="settings_autopause_description">Pause audio when removing the device from your ear.</string>
     <string name="settings_autopplay_label">Auto play</string>
@@ -250,10 +248,6 @@
     <string name="permission_required_title">The following permission is required:</string>
     <string name="permission_system_alert_window_label">System Alert Window</string>
     <string name="permission_system_alert_window_description">Allow CAPod to draw over other apps to make the feature \"Show PopUp\" possible.</string>
-
-    <string name="settings_scanner_mode_lowpower_label">Low power</string>
-    <string name="settings_scanner_mode_balanced_label">Balanced</string>
-    <string name="settings_scanner_mode_lowlatency_label">Low latency</string>
 
     <string name="settings_monitor_mode_manual_label">When app is open</string>
     <string name="settings_monitor_mode_automatic_label">When device is connected</string>

--- a/app/src/test/java/eu/darken/capod/monitor/core/ble/BleScanModeControllerTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/ble/BleScanModeControllerTest.kt
@@ -1,0 +1,328 @@
+package eu.darken.capod.monitor.core.ble
+
+import eu.darken.capod.common.AppForegroundState
+import eu.darken.capod.common.bluetooth.BluetoothAddress
+import eu.darken.capod.common.bluetooth.BluetoothDevice2
+import eu.darken.capod.common.bluetooth.BluetoothManager2
+import eu.darken.capod.common.bluetooth.ScannerMode
+import eu.darken.capod.profiles.core.AppleDeviceProfile
+import eu.darken.capod.profiles.core.DeviceProfile
+import eu.darken.capod.profiles.core.DeviceProfilesRepo
+import eu.darken.capod.pods.core.apple.PodModel
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BleScanModeControllerTest : BaseTest() {
+
+    @Test
+    fun `temporary override wins`() {
+        resolveScannerMode(
+            overrideMode = ScannerMode.LOW_POWER,
+            isForeground = true,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = setOf(ADDRESS),
+        ) shouldBe ScannerMode.LOW_POWER
+    }
+
+    @Test
+    fun `connected paired profile uses low latency in foreground`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = true,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = setOf(ADDRESS),
+        ) shouldBe ScannerMode.LOW_LATENCY
+    }
+
+    @Test
+    fun `connected paired profile uses low latency in background`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = false,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = setOf(ADDRESS),
+        ) shouldBe ScannerMode.LOW_LATENCY
+    }
+
+    @Test
+    fun `foreground without connected paired profile uses balanced`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = true,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = emptySet(),
+        ) shouldBe ScannerMode.BALANCED
+    }
+
+    @Test
+    fun `background without connected paired profile uses low power`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = false,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = emptySet(),
+        ) shouldBe ScannerMode.LOW_POWER
+    }
+
+    @Test
+    fun `connected unprofiled device does not use low latency`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = true,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = setOf(OTHER_ADDRESS),
+        ) shouldBe ScannerMode.BALANCED
+    }
+
+    @Test
+    fun `connected unpaired profile does not use low latency`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = false,
+            profileAddresses = setOf(ADDRESS),
+            bondedAddresses = emptySet(),
+            connectedAddresses = setOf(ADDRESS),
+        ) shouldBe ScannerMode.LOW_POWER
+    }
+
+    @Test
+    fun `low latency requires the same address to be profiled bonded and connected`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = false,
+            profileAddresses = setOf(ADDRESS, OTHER_ADDRESS),
+            bondedAddresses = setOf(ADDRESS, THIRD_ADDRESS),
+            connectedAddresses = setOf(OTHER_ADDRESS, THIRD_ADDRESS),
+        ) shouldBe ScannerMode.LOW_POWER
+    }
+
+    @Test
+    fun `address matching is case insensitive`() {
+        resolveScannerMode(
+            overrideMode = null,
+            isForeground = false,
+            profileAddresses = setOf(ADDRESS.lowercase()),
+            bondedAddresses = setOf(ADDRESS),
+            connectedAddresses = setOf(ADDRESS.lowercase()),
+        ) shouldBe ScannerMode.LOW_LATENCY
+    }
+
+    @Test
+    fun `scannerMode emits even when connectedDevices never emits - regression guard`() = runTest {
+        val controller = createController(
+            isForeground = MutableStateFlow(true),
+            profiles = MutableStateFlow(listOf(profileWithAddress(ADDRESS))),
+            connectedDevices = MutableStateFlow(emptyList()),
+            bondedAddresses = MutableStateFlow(emptySet()),
+        )
+
+        controller.scannerMode.first() shouldBe ScannerMode.BALANCED
+    }
+
+    @Test
+    fun `scannerMode upgrades to LOW_LATENCY when bonded profile connects`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val connected = MutableStateFlow<List<BluetoothDevice2>>(emptyList())
+            val controller = createController(
+                isForeground = MutableStateFlow(true),
+                profiles = MutableStateFlow(listOf(profileWithAddress(ADDRESS))),
+                connectedDevices = connected,
+                bondedAddresses = MutableStateFlow(setOf(ADDRESS)),
+            )
+
+            val emissions = mutableListOf<ScannerMode>()
+            val job = backgroundScope.launch { controller.scannerMode.collect { emissions += it } }
+            runCurrent()
+
+            emissions.last() shouldBe ScannerMode.BALANCED
+
+            connected.value = listOf(deviceWithAddress(ADDRESS))
+            runCurrent()
+
+            emissions.last() shouldBe ScannerMode.LOW_LATENCY
+            job.cancel()
+        }
+
+    @Test
+    fun `withTemporaryOverride raises mode while active and releases on completion`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val controller = createController(
+                isForeground = MutableStateFlow(false),
+                profiles = MutableStateFlow(emptyList()),
+                connectedDevices = MutableStateFlow(emptyList()),
+                bondedAddresses = MutableStateFlow(emptySet()),
+            )
+
+            val emissions = mutableListOf<ScannerMode>()
+            val collector = backgroundScope.launch { controller.scannerMode.collect { emissions += it } }
+            runCurrent()
+
+            emissions.last() shouldBe ScannerMode.LOW_POWER
+
+            val gate = CompletableDeferred<Unit>()
+            val running = launch {
+                controller.withTemporaryOverride(ScannerMode.LOW_LATENCY) { gate.await() }
+            }
+            runCurrent()
+
+            emissions.last() shouldBe ScannerMode.LOW_LATENCY
+
+            gate.complete(Unit)
+            running.join()
+            runCurrent()
+
+            emissions.last() shouldBe ScannerMode.LOW_POWER
+            collector.cancel()
+        }
+
+    @Test
+    fun `overlapping withTemporaryOverride blocks both honored`() = runTest(UnconfinedTestDispatcher()) {
+        val controller = createController(
+            isForeground = MutableStateFlow(false),
+            profiles = MutableStateFlow(emptyList()),
+            connectedDevices = MutableStateFlow(emptyList()),
+            bondedAddresses = MutableStateFlow(emptySet()),
+        )
+
+        val emissions = mutableListOf<ScannerMode>()
+        val collector = backgroundScope.launch { controller.scannerMode.collect { emissions += it } }
+        runCurrent()
+
+        val gateA = CompletableDeferred<Unit>()
+        val gateB = CompletableDeferred<Unit>()
+
+        val a = launch { controller.withTemporaryOverride(ScannerMode.LOW_LATENCY) { gateA.await() } }
+        val b = launch { controller.withTemporaryOverride(ScannerMode.LOW_LATENCY) { gateB.await() } }
+        runCurrent()
+
+        emissions.last() shouldBe ScannerMode.LOW_LATENCY
+
+        gateA.complete(Unit)
+        a.join()
+        runCurrent()
+
+        emissions.last() shouldBe ScannerMode.LOW_LATENCY
+
+        gateB.complete(Unit)
+        b.join()
+        runCurrent()
+
+        emissions.last() shouldBe ScannerMode.LOW_POWER
+        collector.cancel()
+    }
+
+    @Test
+    fun `withTemporaryOverride releases on exception`() = runTest(UnconfinedTestDispatcher()) {
+        val controller = createController(
+            isForeground = MutableStateFlow(false),
+            profiles = MutableStateFlow(emptyList()),
+            connectedDevices = MutableStateFlow(emptyList()),
+            bondedAddresses = MutableStateFlow(emptySet()),
+        )
+
+        val emissions = mutableListOf<ScannerMode>()
+        val collector = backgroundScope.launch { controller.scannerMode.collect { emissions += it } }
+        runCurrent()
+
+        runCatching {
+            controller.withTemporaryOverride(ScannerMode.LOW_LATENCY) {
+                throw IllegalStateException("boom")
+            }
+        }
+        runCurrent()
+
+        emissions.last() shouldBe ScannerMode.LOW_POWER
+        collector.cancel()
+    }
+
+    @Test
+    fun `withTemporaryOverride releases on cancellation`() = runTest(UnconfinedTestDispatcher()) {
+        val controller = createController(
+            isForeground = MutableStateFlow(false),
+            profiles = MutableStateFlow(emptyList()),
+            connectedDevices = MutableStateFlow(emptyList()),
+            bondedAddresses = MutableStateFlow(emptySet()),
+        )
+
+        val emissions = mutableListOf<ScannerMode>()
+        val collector = backgroundScope.launch { controller.scannerMode.collect { emissions += it } }
+        runCurrent()
+
+        val gate = CompletableDeferred<Unit>()
+        val running = launch {
+            try {
+                controller.withTemporaryOverride(ScannerMode.LOW_LATENCY) { gate.await() }
+            } catch (_: CancellationException) {
+                // expected
+            }
+        }
+        runCurrent()
+
+        emissions.last() shouldBe ScannerMode.LOW_LATENCY
+
+        running.cancel()
+        running.join()
+        runCurrent()
+
+        emissions.last() shouldBe ScannerMode.LOW_POWER
+        collector.cancel()
+    }
+
+    private fun profileWithAddress(address: BluetoothAddress): DeviceProfile = AppleDeviceProfile(
+        label = "test",
+        model = PodModel.AIRPODS_PRO2_USBC,
+        address = address,
+    )
+
+    private fun deviceWithAddress(address: BluetoothAddress): BluetoothDevice2 = mockk {
+        every { this@mockk.address } returns address
+    }
+
+    private fun TestScope.createController(
+        isForeground: MutableStateFlow<Boolean>,
+        profiles: MutableStateFlow<List<DeviceProfile>>,
+        connectedDevices: MutableStateFlow<List<BluetoothDevice2>>,
+        bondedAddresses: MutableStateFlow<Set<BluetoothAddress>>,
+    ): BleScanModeController {
+        val foregroundState: AppForegroundState = mockk {
+            every { this@mockk.isForeground } returns isForeground
+        }
+        val profilesRepo: DeviceProfilesRepo = mockk {
+            every { this@mockk.profiles } returns profiles
+        }
+        val bluetoothManager: BluetoothManager2 = mockk {
+            every { this@mockk.connectedDevices } returns connectedDevices
+            every { this@mockk.bondedDeviceAddresses } returns bondedAddresses
+        }
+        return BleScanModeController(
+            appScope = backgroundScope,
+            appForegroundState = foregroundState,
+            profilesRepo = profilesRepo,
+            bluetoothManager = bluetoothManager,
+        )
+    }
+
+    private companion object {
+        const val ADDRESS = "AA:BB:CC:DD:EE:FF"
+        const val OTHER_ADDRESS = "11:22:33:44:55:66"
+        const val THIRD_ADDRESS = "22:33:44:55:66:77"
+    }
+}


### PR DESCRIPTION
## What changed

The app now picks the right Bluetooth scanning power automatically based on the situation:

- **Low Latency** when your AirPods are connected — fast updates while you're using them
- **Balanced** when the app is open and your headphones aren't connected — same as before
- **Low Power** when the app is in the background and no headphones are connected — saves battery

The "Scanner mode" setting in General Settings is gone — the app decides based on context. The TroubleShooter still bumps to Low Latency while it's actively scanning.

Also fixes a case where scanning could fail to start for users who hadn't granted the Bluetooth Connect permission, or where Android's headset profile took a while to come up.

Refs #41, #124, #137

## Technical Context

- **Critical regression fix**: the new `BleScanModeController.scannerMode` combine includes `bluetoothManager.connectedDevices`, which is `stateIn(initialValue = null).filterNotNull()` — it never emits if the HEADSET profile proxy stalls or `BLUETOOTH_CONNECT` is missing. The combine then never produced a mode and `BlePodMonitor.createBleScanner()` blocked forever. Wrapped that source with `.onStart { emit(emptyList()) }.catch { emit(emptyList()) }` so the controller emits within one tick and upgrades when real data arrives.
- **Refcounted override**: replaced `setTemporaryOverride / clearTemporaryOverride` with `suspend fun <T> withTemporaryOverride(mode, block): T`. Internal state is `MutableStateFlow<Map<ScannerMode, Int>>`; exposed mode picks the highest-priority active override (LOW_LATENCY > BALANCED > LOW_POWER). Eliminates the race where one caller's `finally` could clear another caller's override.
- **Reactive bonded set**: new `BluetoothManager2.bondedDeviceAddresses: Flow<Set<BluetoothAddress>>` driven by `ACTION_BOND_STATE_CHANGED`, replacing a one-shot `bondedDevices().first()` query inside `mapLatest`. Receiver-path query is wrapped in try/catch so a thrown `SecurityException` (e.g. permission revoked at runtime) doesn't escape `onReceive`.
- **TroubleShooter** uses `withTemporaryOverride(LOW_LATENCY) override@{ ... }`. `return@override` replaces the old `return@launch` to keep early-exit paths legal through the non-inline lambda.
- **Cleanup**: `ScannerMode.{identifier, labelRes}` removed (dead after UI deletion). Five `settings_scanner_mode_*` keys removed across all 76 locale files. The DataStore key `core.scanner.mode` retains stale values silently — no migration needed.
- **Out of scope**: TroubleShooter still creates addressless `AppleDeviceProfile`s, which the new policy can't match for LOW_LATENCY until the user links a paired address. Pre-existing behavior, deferred.

## Review checklist

- [ ] BLE scanning starts within ~1s of app launch even before `BLUETOOTH_CONNECT` is granted (regression guard)
- [ ] `Bluetooth/ScannerMode` log shows `BALANCED` in foreground without connected profile, `LOW_POWER` in background, `LOW_LATENCY` once profiled+bonded headphones connect
- [ ] TroubleShooter raises override on entry and clears it on completion / cancellation / exception
- [ ] No leftover references to `R.string.settings_scanner_mode_*` or `generalSettings.scannerMode`
