### PR TITLE
General: Restore two-step release approval flow

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -12,7 +12,7 @@ gh workflow run release-prepare.yml -f bump_kind=build -f dry_run=true
 gh workflow run release-prepare.yml -f bump_kind=build -f dry_run=false
 ```
 
-After `dry_run=false`: Job 1 computes + writes the summary, Job 2 pauses for `foss-production` environment approval, then commits/tags/pushes/dispatches. `release-tag.yml` then runs `validate-tag` and the existing `release-github` + `release-gplay` jobs (both with their own environment approvals).
+After `dry_run=false`: Job 1 computes + writes the summary, then Job 2 immediately commits/tags/pushes/dispatches (no env gate — cancel the run between Job 1 and Job 2 if the summary looks wrong; you have ~seconds). `release-tag.yml` then runs `validate-tag` and the existing `release-github` (`foss-production` approval) + `release-gplay` (`gplay-production` approval) jobs — those are the two human checkpoints, matching the pre-migration UX.
 
 ## Inputs
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -133,7 +133,6 @@ jobs:
     needs: compute-and-validate
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-22.04
-    environment: foss-production
     permissions:
       contents: write
       actions: write


### PR DESCRIPTION
## What changed

No user-facing behavior change. Drops the `foss-production` environment gate from `release-prepare.yml`'s `push-and-dispatch` job so the bump/tag/push fires immediately after `compute-and-validate` completes. The downstream `release-tag.yml` jobs still gate on `foss-production` (`release-github`) and `gplay-production` (`release-gplay`) — those remain the two human checkpoints, matching the pre-migration approval flow.

## Technical Context

- The prepare-side gate added a third approval click on top of the existing two, with no real safety net beyond what Job 1's summary already shows. If the planned version looks wrong, cancel the run between Job 1 and Job 2 (the window is short but the summary is on screen by the time Job 2 starts).
- The atomicity guarantees inside Job 2 (atomic push, validate-tag in `release-tag.yml`) didn't depend on the env gate — they still hold.
- `validate-tag` in `release-tag.yml` continues to defend against hand-pushed `v*` tags or manual `gh workflow run release-tag.yml` invocations.
