### PR TITLE
Fix: Avoid privileged endpoint when resolving release bot identity

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -154,12 +154,12 @@ jobs:
         id: bot
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
-          slug=$(gh api /app --jq .slug)
-          user_id=$(gh api "/users/${slug}%5Bbot%5D" --jq .id)
-          echo "user_name=${slug}[bot]" >> "$GITHUB_OUTPUT"
-          echo "user_email=${user_id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+          user_id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          echo "user_name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+          echo "user_email=${user_id}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
 
       - name: Checkout main with credentials
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2


### PR DESCRIPTION
## What changed

Fixes a 401 "JSON web token could not be decoded" error in the new App-token release flow. The `Resolve bot identity` step previously called `gh api /app` to fetch the App's slug, but that endpoint requires a GitHub App **JWT** (signed with the private key) — not the installation access token the workflow has. Switching to the action's own `app-slug` output avoids the privileged endpoint entirely.

## Technical Context

- The `actions/create-github-app-token` action exposes `app-slug` as a step output; using it removes the need to query the API for it
- The remaining `gh api /users/<slug>%5Bbot%5D` call is fine — that endpoint accepts installation tokens
- Verified by inspecting the action's `action.yml` outputs schema (`token`, `installation-id`, `app-slug`)

## Test plan

After merge, redispatch:

```
gh workflow run release-prepare.yml -f bump_kind=patch -f dry_run=false
```

Expect Job 2's `Resolve bot identity` step to print outputs cleanly and the rest of Job 2 to push the bump + tag through the bypass.
