### PR TITLE
Fix: Drop redundant explicit release-tag dispatch (App-token fires push trigger)

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -12,7 +12,7 @@ gh workflow run release-prepare.yml -f bump_kind=build -f dry_run=true
 gh workflow run release-prepare.yml -f bump_kind=build -f dry_run=false
 ```
 
-After `dry_run=false`: Job 1 computes + writes the summary, then Job 2 immediately commits/tags/pushes/dispatches (no env gate — cancel the run between Job 1 and Job 2 if the summary looks wrong; you have ~seconds). `release-tag.yml` then runs `validate-tag` and the existing `release-github` (`foss-production` approval) + `release-gplay` (`gplay-production` approval) jobs — those are the two human checkpoints, matching the pre-migration UX.
+After `dry_run=false`: Job 1 computes + writes the summary, then Job 2 immediately commits/tags/pushes (no env gate — cancel the run between Job 1 and Job 2 if the summary looks wrong; you have ~seconds). The tag push naturally triggers `release-tag.yml` (the App-token push fires `on: push:` workflows; only `GITHUB_TOKEN`-pushes are suppressed). `release-tag.yml` then runs `validate-tag` and the existing `release-github` (`foss-production` approval) + `release-gplay` (`gplay-production` approval) jobs — those are the two human checkpoints, matching the pre-migration UX.
 
 ## Inputs
 
@@ -75,4 +75,4 @@ Other apps in the org can reuse the same App + secrets — just install the App 
 
 ## Stuck-dispatch recovery
 
-If Job 2's atomic push lands but `gh workflow run release-tag.yml` fails (rare — Job 1's auth precheck should prevent it), the tag is public but no pipeline runs. Re-dispatch: `gh workflow run release-tag.yml --ref v<new> -f dry_run=false`.
+If Job 2's atomic push lands but the natural `on: push:` trigger doesn't fire `release-tag.yml` (rare — would mean GitHub dropped the event), the tag is public but no pipeline runs. Re-dispatch manually: `gh workflow run release-tag.yml --ref v<new> -f dry_run=false`.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -39,13 +39,11 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      actions: read
     outputs:
       new_name: ${{ steps.plan.outputs.new_name }}
       new_code: ${{ steps.plan.outputs.new_code }}
       current_name: ${{ steps.plan.outputs.current_name }}
     env:
-      GH_TOKEN: ${{ github.token }}
       INPUT_BUMP_KIND: ${{ inputs.bump_kind }}
       INPUT_VERSION_TYPE: ${{ inputs.version_type }}
       INPUT_VERSION_OVERRIDE: ${{ inputs.version_override }}
@@ -64,9 +62,6 @@ jobs:
           ref: main
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Verify gh auth and dispatch capability
-        run: gh workflow view release-tag.yml > /dev/null
 
       - name: Compute and validate
         id: plan
@@ -222,13 +217,6 @@ jobs:
         run: |
           set -euo pipefail
           git push --atomic origin "HEAD:refs/heads/main" "refs/tags/v${NEW_NAME}"
-
-      - name: Dispatch release-tag.yml
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          gh workflow run release-tag.yml --ref "v${NEW_NAME}" -f dry_run=false
 
       - name: Write step summary
         run: |


### PR DESCRIPTION
## What changed

Drops the explicit `gh workflow run release-tag.yml` step from `release-prepare.yml`. Since the prepare job now pushes with a GitHub App token (not `GITHUB_TOKEN`), the natural `on: push: tags: ['v*']` trigger fires `release-tag.yml` automatically — the explicit dispatch was originally a workaround for `GITHUB_TOKEN`'s trigger suppression and is now redundant.

Without this, every release dispatched two duplicate `release-tag.yml` runs (one from the natural push trigger, one from the explicit dispatch), queued back-to-back via the concurrency group. The first release run (#25205749266) triggered exactly this.

## Technical Context

- App-token pushes do fire `on: push` workflow triggers — only `GITHUB_TOKEN`-driven pushes are suppressed by GitHub
- Removed Job 1's `Verify gh auth and dispatch capability` step — its sole purpose was sanity-checking that the now-removed dispatch step would work
- Tightened Job 1 permissions from `contents: read, actions: read` to just `contents: read`; dropped Job 1's job-level `GH_TOKEN` env (no `gh` calls remain in Job 1)
- Job 2's existing concurrency on `release-tag.yml` (`group: release-${{ github.ref_name }}`) still protects against accidental duplicates if anyone manually dispatches the workflow at the same ref
