### PR TITLE
General: Clean up release-prepare step name and use client-id for App auth

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -60,7 +60,7 @@ bats tools/release/bump.bats
 
 Required org secrets (set on the d4rken-org organization, accessible to `capod`):
 
-- `RELEASE_APP_ID` — numeric ID of the `d4rken-org-releaser` GitHub App
+- `RELEASE_APP_CLIENT_ID` — Client ID of the `d4rken-org-releaser` GitHub App (visible on the App's settings page, format `Iv1.<hex>` or similar)
 - `RELEASE_APP_PRIVATE_KEY` — full `.pem` contents (including BEGIN/END lines)
 
 The App is installed on this repo and added as a bypass actor to:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -142,7 +142,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 #v3.1.1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Resolve bot identity
@@ -164,12 +164,12 @@ jobs:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Re-validate after approval wait
+      - name: Verify state still matches plan from Job 1
         run: |
           set -euo pipefail
           ./tools/release/bump.sh --mode=check --expected-current="${CURRENT_NAME_AT_PLAN}"
 
-      - name: Re-check tag collision (state may have moved during approval)
+      - name: Re-check tag collision (state may have moved between jobs)
         run: |
           set -euo pipefail
           if git rev-parse --verify "refs/tags/v${NEW_NAME}" >/dev/null 2>&1; then


### PR DESCRIPTION
## What changed

Two small follow-ups from the App-token rollout:

1. **Renamed the misleading "Re-validate after approval wait" step** → "Verify state still matches plan from Job 1". The approval gate this referred to was removed in #565, but the step name still implied one. Step body unchanged.
2. **Switched `app-id` → `client-id`** on `actions/create-github-app-token`. `app-id` is deprecated upstream (warning printed on every run); `client-id` is the supported input now.

## Action required before merging

The `client-id` swap requires a new org secret. Steps:

1. Open https://github.com/organizations/d4rken-org/settings/apps/d4rken-org-releaser (or whatever your App's name is)
2. Copy the **Client ID** value (it's in the "About" section near the App ID; format is `Iv1.<hex>` or similar)
3. Add an org Actions secret **`RELEASE_APP_CLIENT_ID`** with that value, scoped the same way as `RELEASE_APP_ID` (selected repos: `capod`, or all)
4. Then merge this PR
5. After successful first run, the old `RELEASE_APP_ID` secret can be deleted

## Technical Context

- `client-id` and `app-id` identify the same App but in different formats. The action accepts either; only `client-id` is non-deprecated.
- Renamed the adjacent "Re-check tag collision (state may have moved during approval)" step to drop the obsolete approval-wait reference too.
