### PR TITLE
Device: Fix AirPods Max 2 wear detection

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/devices/airpods/AirPodsMax2.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/devices/airpods/AirPodsMax2.kt
@@ -44,8 +44,18 @@ data class AirPodsMax2(
             return pubFlags.isBitSet(0)
         }
 
+    // Aggregate "any wear sensor active" — NOT "both earcups worn".
+    // Observed on A3454: bit 5 of pubStatus is always set while advertising and
+    // no longer carries the wear flag (unlike Max gen 1). Bits 1 and 3 of
+    // pubStatus reflect the two earcup sensors (same byte positions used by
+    // DualApplePods, but without the primary/flip semantics).
+    //
+    // We OR them because some Android pairings only see one of the two bits
+    // reliably (issue #548: "both worn" advertises as 0x23 — bit 1 only —
+    // while macOS sees 0x2B with both bits set). AND-ing would falsely report
+    // "not worn" during normal use on those phones.
     override val isBeingWorn: Boolean
-        get() = pubStatus.isBitSet(5)
+        get() = pubStatus.isBitSet(1) || pubStatus.isBitSet(3)
 
     class Factory @Inject constructor(
         private val repo: PodHistoryRepo,

--- a/app/src/test/java/eu/darken/capod/monitor/core/PodDeviceTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/PodDeviceTest.kt
@@ -12,6 +12,7 @@ import eu.darken.capod.pods.core.apple.ble.devices.DualApplePods
 import eu.darken.capod.pods.core.apple.aap.AapPodState
 import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import eu.darken.capod.pods.core.apple.ble.devices.ApplePods
+import eu.darken.capod.pods.core.apple.ble.devices.SingleApplePods
 import eu.darken.capod.pods.core.apple.ble.protocol.ProximityPayload
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -198,6 +199,23 @@ class PodDeviceTest : BaseTest() {
         device.isRightInEar shouldBe false
         device.isBeingWorn shouldBe false
         device.isEitherPodInEar shouldBe true
+    }
+
+    @Test
+    fun `BLE isBeingWorn delegates to HasEarDetection on single-pod devices`() {
+        val mock = mockk<SingleApplePods>(relaxed = true, moreInterfaces = arrayOf(HasEarDetection::class)) {
+            every { model } returns PodModel.AIRPODS_MAX2
+            every { (this@mockk as HasEarDetection).isBeingWorn } returns true
+        }
+        val device = PodDevice(profileId = null, ble = mock, aap = null)
+        device.isBeingWorn shouldBe true
+
+        val mockNotWorn = mockk<SingleApplePods>(relaxed = true, moreInterfaces = arrayOf(HasEarDetection::class)) {
+            every { model } returns PodModel.AIRPODS_MAX2
+            every { (this@mockk as HasEarDetection).isBeingWorn } returns false
+        }
+        val deviceNotWorn = PodDevice(profileId = null, ble = mockNotWorn, aap = null)
+        deviceNotWorn.isBeingWorn shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/ble/devices/airpods/AirPodsMax2Test.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/ble/devices/airpods/AirPodsMax2Test.kt
@@ -24,6 +24,7 @@ class AirPodsMax2Test : BaseBlePodsTest() {
             batteryHeadsetPercent shouldBe 0.6f
 
             isHeadsetBeingCharged shouldBe false
+            isBeingWorn shouldBe true
 
             model shouldBe PodModel.AIRPODS_MAX2
         }
@@ -35,6 +36,7 @@ class AirPodsMax2Test : BaseBlePodsTest() {
             pubStatus shouldBe 0x20.toUByte()
             batteryHeadsetPercent shouldBe 0.6f
             isHeadsetBeingCharged shouldBe false
+            isBeingWorn shouldBe false
             model shouldBe PodModel.AIRPODS_MAX2
         }
 
@@ -42,6 +44,7 @@ class AirPodsMax2Test : BaseBlePodsTest() {
             pubStatus shouldBe 0x21.toUByte()
             batteryHeadsetPercent shouldBe 0.6f
             isHeadsetBeingCharged shouldBe false
+            isBeingWorn shouldBe false
             model shouldBe PodModel.AIRPODS_MAX2
         }
 
@@ -49,6 +52,17 @@ class AirPodsMax2Test : BaseBlePodsTest() {
             pubStatus shouldBe 0x23.toUByte()
             batteryHeadsetPercent shouldBe 0.6f
             isHeadsetBeingCharged shouldBe false
+            isBeingWorn shouldBe true
+            model shouldBe PodModel.AIRPODS_MAX2
+        }
+
+        // Synthetic: one earcup off, the other on (issue #548 sees 0x29 in this state on
+        // both macOS and Android; we don't claim left vs right side semantics here).
+        create<AirPodsMax2>("07 19 01 2D 20 29 F6 8F 03 14 04 E1 8B 99 98 20 0B C3 C1 12 2D B0 43 98 94 D6 A0") {
+            pubStatus shouldBe 0x29.toUByte()
+            batteryHeadsetPercent shouldBe 0.6f
+            isHeadsetBeingCharged shouldBe false
+            isBeingWorn shouldBe true
             model shouldBe PodModel.AIRPODS_MAX2
         }
     }


### PR DESCRIPTION
## What changed

Fixes wear detection on AirPods Max 2. The app used to show "in-ear" all the time — even when the headphones were sitting on a desk — so auto play/pause never triggered. Now the dashboard reflects whether the headphones are actually being worn, and auto play/pause works as expected when both earcups come off.

## Technical Context

- Root cause: Max 2 reused Max gen 1's BLE advertisement decoding, which reads bit 5 of the status byte. On A3454 bit 5 is always set while advertising; the actual ear-wear state is encoded in bits 1 and 3 (the per-earcup sensors). Reading bit 5 always returned `true`.
- The two earcup bits are OR'd into a single boolean. AND-ing would match macOS UX (one earcup off ⇒ pause) but breaks Android: phones without the L2CAP/AAP-derived keys only see one of the two bits reliably (the reporter observed `0x23` for "both worn" and `0x21` for "neither" — bit 1 only). AND would falsely report "not worn" during normal use on those phones.
- Side effect: removing only one earcup will not pause media — both earcups need to come off. This is a deliberate trade-off that fixes the reporter's primary complaint without breaking the Android-only path.
- Scope: Max 2 (A3454) only. Max gen 1 (A2096) has different bit semantics with shipping tests; left unchanged. Max USB-C (A3184) only has a `0x2B` sample where old and new logic both return worn; cannot determine its layout without an unworn sample, so left unchanged pending a follow-up.

## Review checklist

- [ ] Confirm dashboard `In ear` flag toggles between worn/unworn states on a real Max 2
- [ ] Confirm auto play/pause triggers when both earcups come off
- [ ] Confirm the value flowing through the dashboard is BLE-derived, not AAP-derived (debug overlay should show `pubStatus` toggling `0x21 ↔ 0x23`)

Closes #548
