### PR TITLE
Fix: Hide settings consistently when AirPods can't be controlled

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/DeviceSettingsScreen.kt
@@ -386,7 +386,7 @@ fun DeviceSettingsScreen(
                 val showSoundSection =
                     (features.hasPersonalizedVolume && personalizedVol != null) ||
                             (features.hasToneVolume && toneVol != null) ||
-                            features.hasMicrophoneMode
+                            (features.hasMicrophoneMode && device.microphoneMode != null)
                 if (showSoundSection) {
                     item("sound_section") {
                         SoundCard(
@@ -404,7 +404,7 @@ fun DeviceSettingsScreen(
                 }
 
                 // ── Controls ─────────────────────────────────
-                val showControlsSection = features.hasStemConfig ||
+                val showControlsSection = (features.hasStemConfig && device.stemConfig != null) ||
                         (features.hasEndCallMuteMic && device.endCallMuteMic != null) ||
                         (features.hasPressSpeed && device.pressSpeed != null) ||
                         (features.hasPressHoldDuration && device.pressHoldDuration != null) ||

--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/ControlsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/ControlsCard.kt
@@ -29,10 +29,10 @@ internal fun ControlsCard(
     val volSwipe = device.volumeSwipe
     val volSwipeLen = device.volumeSwipeLength
 
-    val showPressControlsNav = features.hasStemConfig ||
-            features.hasPressSpeed ||
-            features.hasPressHoldDuration ||
-            features.hasEndCallMuteMic
+    val showPressControlsNav = (features.hasStemConfig && device.stemConfig != null) ||
+            (features.hasPressSpeed && device.pressSpeed != null) ||
+            (features.hasPressHoldDuration && device.pressHoldDuration != null) ||
+            (features.hasEndCallMuteMic && device.endCallMuteMic != null)
 
     SettingsSection(title = stringResource(R.string.device_settings_category_controls_label)) {
         if (showPressControlsNav) {

--- a/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/SoundCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/devicesettings/cards/SoundCard.kt
@@ -81,7 +81,7 @@ internal fun SoundCard(
                 )
             }
         }
-        if (features.hasMicrophoneMode) {
+        if (features.hasMicrophoneMode && device.microphoneMode != null) {
             if (isPro) {
                 val micMode = device.microphoneMode
                     ?: AapSetting.MicrophoneMode(AapSetting.MicrophoneMode.Mode.AUTO)


### PR DESCRIPTION
## What changed

When CAPod could see your AirPods over Bluetooth but couldn't take full control of them (for example because another app or your Mac was holding the AirPods connection), the device settings screen mixed two different "unavailable" states: most settings disappeared, but the **Microphone** selector and the **Press controls** entry stayed on screen as greyed-out items. That made it look as if those two settings had a separate problem from the rest.

They now hide together with the other settings whenever the AirPods aren't responding to commands, so the screen reads consistently: a setting is shown when it can be used, and hidden when it can't.

## Technical Context

- Root cause: visibility for `Sound > Microphone` and `Controls > Press controls` was gated only on the static `Model.Features` flag, while every other AAP-dependent row in the same screen used `features.hasX && device.X != null`. When AAP is in `aap != null && connectionState != READY` (e.g. socket connects then stalls in `HANDSHAKING`), the live setting values are null but `Model.Features` flags are static, so the two outliers kept rendering and got `enabled = device.isAapReady` (false).
- Fix is a one-line addition of the missing data-presence check in each spot (parent `showSoundSection` / `showControlsSection` gates plus the inner `SoundCard` / `ControlsCard` rows). No new pattern introduced — just brings the outliers in line with ANC, Tone Volume, Volume Swipe, etc.
- `PressControlsScreen` already auto-navigates back when AAP drops mid-session (`PressControlsScreen.kt:74-84`), so hiding the entry point on the parent screen makes the destination's behaviour consistent in both directions.
