### PR TITLE
General: Add screenshots-only fastlane supply lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,6 +62,20 @@ platform :android do
     )
   end
 
+  lane :screenshots_only do
+    sh "bash ./remove_unsupported_languages.sh"
+    supply(
+        track: 'production',
+        package_name: 'eu.darken.capod',
+        skip_upload_apk: 'true',
+        skip_upload_aab: 'true',
+        skip_upload_metadata: 'true',
+        skip_upload_changelogs: 'true',
+        skip_upload_images: 'true',
+        skip_upload_screenshots: 'false',
+    )
+  end
+
   after_all do |lane|
     # This block is called, only if the executed lane was successful
 


### PR DESCRIPTION
## What changed

No user-facing behavior change. Adds a `fastlane screenshots_only` lane that pushes only the localized phone screenshots to the Play Store, without touching the AAB, metadata, listing images, or changelogs.

## Technical Context

- Mirrors the existing lane in `bluemusic` so the three apps share the same supply layout (`:beta`, `:production`, `:listing_only`, `:screenshots_only`)
- Targets the `production` track; `skip_upload_images: 'true'` excludes feature graphic / icon, only the `phoneScreenshots/` payload is uploaded
- Existing screenshots in `fastlane/metadata/android/*/images/phoneScreenshots/` are stale (e.g. `7_settings.png`, `8_reaction_settings.png` no longer match `SCREEN_MAP`); regenerate via `copy_screenshots.sh --clean` before invoking the new lane