### PR TITLE
fix(navigation): Defer onNewIntent navCtrl call until Compose attaches

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.flow.SingleEventFlow
 import eu.darken.capod.common.navigation.LocalNavigationController
 import eu.darken.capod.common.navigation.Nav
 import eu.darken.capod.common.navigation.NavigationController
@@ -49,6 +50,11 @@ class MainActivity : Activity2() {
     @Inject lateinit var generalSettings: GeneralSettings
     @Inject lateinit var popUpWindow: PopUpWindow
     @Inject lateinit var upgradeRepo: UpgradeRepo
+
+    // Buffers warm-start intents (onNewIntent) so they are consumed from inside the Compose tree,
+    // after navCtrl.setup(backStack) has run. Calling navCtrl directly from onNewIntent races with
+    // the asynchronous Compose lambda and crashes if the back stack is not yet registered.
+    private val warmIntents = SingleEventFlow<Intent>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -80,7 +86,11 @@ class MainActivity : Activity2() {
             navCtrl.setup(backStack)
 
             LaunchedEffect(Unit) {
+                // Cold-start intent (the activity's launching intent).
                 consumeUpgradeExtra(intent)
+                // Warm-start intents delivered via onNewIntent. Consuming them here (instead of
+                // directly from onNewIntent) guarantees navCtrl.setup() has run.
+                warmIntents.collect { newIntent -> consumeUpgradeExtra(newIntent) }
             }
 
             CapodTheme(state = themeState) {
@@ -132,7 +142,9 @@ class MainActivity : Activity2() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        consumeUpgradeExtra(intent)
+        setIntent(intent)
+        // Defer to the Compose-side collector — navCtrl may not yet be set up here.
+        warmIntents.tryEmit(intent)
     }
 
     private fun consumeUpgradeExtra(intent: Intent?) {


### PR DESCRIPTION
## Summary

Latent twin of [d4rken-org/octi#284](https://github.com/d4rken-org/octi/pull/284) — same `NavigationController` design (`@Singleton` + nullable `_backStack` + strict `error("...not initialized")`), same Compose `setContent { }` registration pattern, same race surface.

`MainActivity.onNewIntent` calls `consumeUpgradeExtra(intent)`, which in turn calls `navCtrl.goTo(Nav.Main.Upgrade)`. If `onNewIntent` fires before the `setContent { }` lambda has run (e.g. during activity recreation from a config change, or `singleTask` warm intent delivery on a slow device), `_backStack` is still `null` and the `goTo` throws `IllegalStateException`.

This PR mirrors the fix shipped to Octi: defer the navigation step until a Compose-side collector picks it up.

## Changes

- New private `MainActivity.warmIntents: SingleEventFlow<Intent>` field
- `onNewIntent` now just calls `setIntent(intent)` and `warmIntents.tryEmit(intent)` — no `navCtrl` interaction
- The existing `LaunchedEffect(Unit)` inside `setContent` extends to also `warmIntents.collect { newIntent -> consumeUpgradeExtra(newIntent) }` after handling the cold-start intent
- `NavigationController` is unchanged — strict contract preserved

The race window is tight (it requires `onNewIntent` to fire between `setContent` returning and the Compose lambda running), so this is a latent crash with no Play Store report yet — but the same code path crashed Octi on Android 16 Beta. Fixing here pre-emptively.

## Test plan

- [x] `./gradlew :app:testFossDebugUnitTest` passes
- [x] `./gradlew :app:assembleFossDebug` compiles cleanly
- [ ] Manual: launch the upgrade flow via the existing pathway that fires `EXTRA_NAVIGATE_TO_UPGRADE` (e.g. via `EXTRA_UPGRADE_FOR_RESULT` flow or the link that triggers it) — confirm Upgrade screen still opens