### PR TITLE
fix: case-open popup re-appears after the case is closed

### DIFF
--- a/app/src/main/java/eu/darken/capod/reaction/core/popup/PopUpReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/popup/PopUpReaction.kt
@@ -242,8 +242,8 @@ class PopUpReaction @Inject constructor(
             DualApplePods.LidState.CLOSED -> CasePopUpDecision(
                 shouldShow = false,
                 shouldHide = true,
-                shouldResetCooldown = true,
-                reason = "Lid CLOSED, resetting cooldown",
+                shouldResetCooldown = false,
+                reason = "Lid CLOSED, refreshing cooldown",
             )
 
             else -> CasePopUpDecision(

--- a/app/src/test/java/eu/darken/capod/reaction/core/popup/PopUpReactionLogicTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/popup/PopUpReactionLogicTest.kt
@@ -33,10 +33,11 @@ class PopUpReactionLogicTest : BaseTest() {
         private fun evaluate(
             currentLidState: DualApplePods.LidState?,
             lastShownTime: Instant? = null,
+            at: Instant = now,
         ) = popUpReaction.evaluateCasePopUp(
             currentLidState = currentLidState,
             lastShownTime = lastShownTime,
-            now = now,
+            now = at,
             cooldownDuration = cooldown,
         )
 
@@ -78,11 +79,39 @@ class PopUpReactionLogicTest : BaseTest() {
         }
 
         @Test
-        fun `lid CLOSED - should NOT show, should hide, should reset cooldown`() {
+        fun `lid CLOSED - should NOT show, should hide, should NOT reset cooldown`() {
             val decision = evaluate(currentLidState = DualApplePods.LidState.CLOSED)
             decision.shouldShow shouldBe false
             decision.shouldHide shouldBe true
-            decision.shouldResetCooldown shouldBe true
+            decision.shouldResetCooldown shouldBe false
+        }
+
+        @Test
+        fun `lid CLOSED followed by residual OPEN within cooldown - should NOT show`() {
+            val closeDecision = evaluate(currentLidState = DualApplePods.LidState.CLOSED)
+            closeDecision.shouldHide shouldBe true
+            closeDecision.shouldResetCooldown shouldBe false
+
+            val residualOpenDecision = evaluate(
+                currentLidState = DualApplePods.LidState.OPEN,
+                lastShownTime = now,
+                at = now.plusMillis(500),
+            )
+            residualOpenDecision.shouldShow shouldBe false
+        }
+
+        @Test
+        fun `lid CLOSED then OPEN after cooldown elapsed - should show`() {
+            val closeDecision = evaluate(currentLidState = DualApplePods.LidState.CLOSED)
+            closeDecision.shouldHide shouldBe true
+            closeDecision.shouldResetCooldown shouldBe false
+
+            val reopenDecision = evaluate(
+                currentLidState = DualApplePods.LidState.OPEN,
+                lastShownTime = now,
+                at = now.plus(cooldown),
+            )
+            reopenDecision.shouldShow shouldBe true
         }
 
         @Test


### PR DESCRIPTION
## Summary

The case-open popup no longer re-appears after the case has been closed, fixing the inconsistency lilnug143 reported in #598. The popup decision logic in `PopUpReaction.kt` treated a case-close event as a full reset, so residual lid-state updates arriving after close could re-trigger the popup within the same session. Closing now hides the popup without resetting the cooldown, and the cooldown window has to genuinely elapse before a new open shows it again.

## Why this matters

#598 describes the popup randomly coming back after putting the AirPods case away, which makes the reaction feature feel broken precisely at the moment the user is done with it. The two-line logic change keeps the existing show-on-open behavior intact; only the close path changes.

## Testing

Extended `PopUpReactionLogicTest` with the residual-open-after-close case (popup stays hidden, cooldown preserved) and the cooldown-expiry case (a real re-open after the window shows the popup again). Gradle was not runnable on this host (no JVM); CI covers the build and the new tests.

AI was used for assistance.

Fixes #598
