### PR TITLE
General: Help fix devices that connect but show no data

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
@@ -61,6 +61,7 @@ import eu.darken.capod.main.ui.overview.cards.NoProfilesCard
 import eu.darken.capod.main.ui.overview.cards.PermissionCard
 import eu.darken.capod.main.ui.overview.cards.ReactionsMovedHintCard
 import eu.darken.capod.main.ui.overview.cards.SinglePodsCard
+import eu.darken.capod.main.ui.overview.cards.TroubleshootSuggestionCard
 import eu.darken.capod.main.ui.overview.cards.UnknownPodDeviceCard
 import eu.darken.capod.main.ui.overview.cards.UnmatchedDevicesCard
 import eu.darken.capod.monitor.core.PodDevice
@@ -172,6 +173,7 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
         },
         onManageDevices = { vm.goToDeviceManager() },
         onSettings = { vm.goToSettings() },
+        onTroubleShooter = { vm.goToTroubleShooter() },
         onUpgrade = { vm.onUpgrade() },
         onToggleUnmatched = { vm.toggleUnmatchedDevices() },
         onAncModeChange = { device, mode -> vm.setAncMode(device, mode) },
@@ -194,6 +196,7 @@ fun OverviewScreen(
     onBluetoothSettings: () -> Unit,
     onManageDevices: () -> Unit,
     onSettings: () -> Unit,
+    onTroubleShooter: () -> Unit = {},
     onUpgrade: () -> Unit,
     onToggleUnmatched: () -> Unit,
     onAncModeChange: (PodDevice, AapSetting.AncMode.Value) -> Unit = { _, _ -> },
@@ -348,6 +351,13 @@ fun OverviewScreen(
                             upgradeType = state.upgradeInfo.type,
                             onUpgrade = onUpgrade,
                         )
+                    }
+                }
+
+                // 4c. Troubleshooter suggestion — connected via audio but no live data is reaching us
+                if (state.showTroubleshootSuggestion) {
+                    item(key = "troubleshoot_suggestion") {
+                        TroubleshootSuggestionCard(onTroubleShooter = onTroubleShooter)
                     }
                 }
 

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -83,12 +84,45 @@ class OverviewViewModel @Inject constructor(
     private data class OverviewUiSettings(
         val reactionsHintDismissed: Boolean,
         val hideUnmatchedDevices: Boolean,
+        val showTroubleshootSuggestion: Boolean,
     )
+
+    /**
+     * True when a profile is connected to the system (audio) but CAPod has *no* live data for any
+     * device — the classic "broadcasts are being dropped by the ROM" symptom (e.g. some HyperOS
+     * phones, see #603). Surfaced as a hint pointing at the Troubleshooter, which can probe and
+     * persist a working compatibility combo. Debounced so it doesn't flash during the brief window
+     * between an audio connection and the first BLE broadcast. Suppressed whenever any pod is live,
+     * so it never claims "no data" while data is visibly arriving (incl. the #603 duplicate state).
+     */
+    private val troubleshootSuggestion = combineFlows(
+        profilesRepo.profiles,
+        bluetoothManager.connectedDevices.onStart { emit(emptyList()) },
+        deviceMonitor.devices,
+        permissionTool.missingScanPermissions,
+    ) { profiles, connectedDevices, devices, missingScanPermissions ->
+        val connectedAddresses = connectedDevices.mapTo(mutableSetOf()) { it.address }
+        val anyProfileConnected = profiles.any { it.address != null && it.address in connectedAddresses }
+        val anyLivePod = devices.any { it.isLive }
+        missingScanPermissions.isEmpty() && anyProfileConnected && !anyLivePod
+    }
+        .distinctUntilChanged()
+        .flatMapLatest { conditionMet ->
+            if (conditionMet) flow {
+                delay(TROUBLESHOOT_SUGGESTION_DELAY_MS)
+                emit(true)
+            } else flowOf(false)
+        }
+        .onStart { emit(false) }
+        .distinctUntilChanged()
 
     private val overviewUiSettings = combineFlows(
         generalSettings.reactionsHintDismissed.flow,
         generalSettings.hideUnmatchedDevices.flow,
-    ) { reactionsHintDismissed, hideUnmatched -> OverviewUiSettings(reactionsHintDismissed, hideUnmatched) }
+        troubleshootSuggestion,
+    ) { reactionsHintDismissed, hideUnmatched, showTroubleshootSuggestion ->
+        OverviewUiSettings(reactionsHintDismissed, hideUnmatched, showTroubleshootSuggestion)
+    }
 
     init {
         // When the persistent "hide unmatched" setting is enabled, reset the in-session expand
@@ -175,6 +209,7 @@ class OverviewViewModel @Inject constructor(
             userExpandedIds = prunedExpandedIds,
             showReactionsHint = hadLegacyReactionData && !uiSettings.reactionsHintDismissed,
             hideUnmatchedDevices = uiSettings.hideUnmatchedDevices,
+            showTroubleshootSuggestion = uiSettings.showTroubleshootSuggestion,
         )
     }.asLiveState()
 
@@ -192,6 +227,7 @@ class OverviewViewModel @Inject constructor(
         val userExpandedIds: Set<String> = emptySet(),
         val showReactionsHint: Boolean = false,
         val hideUnmatchedDevices: Boolean = false,
+        val showTroubleshootSuggestion: Boolean = false,
     ) {
         val isScanBlocked: Boolean get() = permissions.any { it.isScanBlocking }
 
@@ -255,6 +291,11 @@ class OverviewViewModel @Inject constructor(
         navTo(Nav.Settings.Index)
     }
 
+    fun goToTroubleShooter() {
+        log(TAG, INFO) { "goToTroubleShooter()" }
+        navTo(Nav.Main.TroubleShooter)
+    }
+
     fun goToDeviceManager() {
         log(TAG, INFO) { "goToDeviceManager()" }
         navTo(Nav.Main.DeviceManager)
@@ -315,6 +356,14 @@ class OverviewViewModel @Inject constructor(
 
     companion object {
         private const val FREE_DEVICE_LIMIT = 1
+
+        /**
+         * How long the "connected but no live data" condition must hold before the troubleshooter
+         * hint appears, so it doesn't flash during the gap between an audio connection and the first
+         * BLE broadcast.
+         */
+        private const val TROUBLESHOOT_SUGGESTION_DELAY_MS = 15_000L
+
         private val TAG = logTag("Overview", "VM")
     }
 }

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/TroubleshootSuggestionCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/TroubleshootSuggestionCard.kt
@@ -1,0 +1,71 @@
+package eu.darken.capod.main.ui.overview.cards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Troubleshoot
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.Preview2
+import eu.darken.capod.common.compose.PreviewWrapper
+
+@Composable
+fun TroubleshootSuggestionCard(onTroubleShooter: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.TwoTone.Troubleshoot,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+                Text(
+                    text = stringResource(R.string.overview_troubleshoot_suggestion_label),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.overview_troubleshoot_suggestion_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = onTroubleShooter,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(text = stringResource(R.string.overview_troubleshoot_suggestion_action))
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun TroubleshootSuggestionCardPreview() = PreviewWrapper {
+    TroubleshootSuggestionCard(onTroubleShooter = {})
+}

--- a/app/src/main/java/eu/darken/capod/monitor/core/ble/BlePodMonitor.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/ble/BlePodMonitor.kt
@@ -60,6 +60,17 @@ class BlePodMonitor @Inject constructor(
     private val cacheLock = Mutex()
 
     /**
+     * Drops all cached observations. The troubleshooter calls this between probe attempts so a
+     * previous compat combo's cached devices (kept up to [STALE_DEVICE_TIMEOUT]) can't leak into
+     * the next attempt and falsely satisfy it — including via [preferCaseContextPod], which would
+     * otherwise hand back a stale snapshot whose timestamp predates the fresh scan.
+     */
+    suspend fun clearDeviceCache() = cacheLock.withLock {
+        log(TAG) { "clearDeviceCache()" }
+        deviceCache.clear()
+    }
+
+    /**
      * Ephemeral override that disables the proximity-pairing scan filter so
      * the troubleshooter can collect raw BLE broadcasts. Resets to false on
      * every process start; the troubleshooter is the only writer.
@@ -68,6 +79,40 @@ class BlePodMonitor @Inject constructor(
 
     fun setUnfilteredOverride(enabled: Boolean) {
         unfilteredOverride.value = enabled
+    }
+
+    /**
+     * Ephemeral override for the three BLE compatibility options. The troubleshooter uses this to
+     * probe combinations without writing the user's persisted settings: while set, it fully replaces
+     * the persisted compat values for the active scan. Resets to null on every process start; the
+     * troubleshooter is the only writer and always clears it when finished, so clearing it restores
+     * the user's original settings for free.
+     */
+    private val compatOverride = MutableStateFlow<CompatOverride?>(null)
+
+    fun setCompatOverride(override: CompatOverride?) {
+        log(TAG) { "setCompatOverride($override)" }
+        compatOverride.value = override
+    }
+
+    data class CompatOverride(
+        val offloadedFilteringDisabled: Boolean,
+        val offloadedBatchingDisabled: Boolean,
+        val indirectCallback: Boolean,
+    )
+
+    /** Persisted compat settings, transparently replaced by [compatOverride] while it is set. */
+    private val effectiveCompat: Flow<CompatOverride> = combine(
+        compatOverride,
+        generalSettings.isOffloadedFilteringDisabled.flow,
+        generalSettings.isOffloadedBatchingDisabled.flow,
+        generalSettings.useIndirectScanResultCallback.flow,
+    ) { override, filteringDisabled, batchingDisabled, indirectCallback ->
+        override ?: CompatOverride(
+            offloadedFilteringDisabled = filteringDisabled,
+            offloadedBatchingDisabled = batchingDisabled,
+            indirectCallback = indirectCallback,
+        )
     }
 
     val devices: Flow<List<BlePodSnapshot>> = combine(
@@ -145,22 +190,14 @@ class BlePodMonitor @Inject constructor(
     private fun createBleScanner() = combine(
         bleScanModeController.scannerMode,
         unfilteredOverride,
-        generalSettings.isOffloadedBatchingDisabled.flow,
-        generalSettings.isOffloadedFilteringDisabled.flow,
-        generalSettings.useIndirectScanResultCallback.flow,
-    ) {
-            scannermode,
-            showUnfiltered,
-            isOffloadedBatchingDisabled,
-            isOffloadedFilteringDisabled,
-            useIndirectScanResultCallback,
-        ->
+        effectiveCompat,
+    ) { scannermode, showUnfiltered, compat ->
         ScannerOptions(
             scannerMode = scannermode,
             showUnfiltered = showUnfiltered,
-            offloadedFilteringDisabled = isOffloadedFilteringDisabled,
-            offloadedBatchingDisabled = isOffloadedBatchingDisabled,
-            disableDirectCallback = useIndirectScanResultCallback,
+            offloadedFilteringDisabled = compat.offloadedFilteringDisabled,
+            offloadedBatchingDisabled = compat.offloadedBatchingDisabled,
+            disableDirectCallback = compat.indirectCallback,
         )
     }
         .throttleLatest(1000)

--- a/app/src/main/java/eu/darken/capod/troubleshooter/ui/TroubleShooterViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/troubleshooter/ui/TroubleShooterViewModel.kt
@@ -9,6 +9,7 @@ import eu.darken.capod.common.bluetooth.ScannerMode
 import eu.darken.capod.common.coroutine.DispatcherProvider
 import eu.darken.capod.common.datastore.valueBlocking
 import eu.darken.capod.common.debug.logging.Logging.Priority.INFO
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.uix.ViewModel4
@@ -22,14 +23,13 @@ import eu.darken.capod.pods.core.unknown.UnknownSnapshotBle
 import eu.darken.capod.profiles.core.AppleDeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfilesRepo
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.takeWhile
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
@@ -46,6 +46,9 @@ class TroubleShooterViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider) {
 
     private val _bleState = MutableStateFlow<BleState>(BleState.Intro())
+
+    /** Guards against re-entrant runs (e.g. a double tap on "Try again"). */
+    private val runLock = Mutex()
 
     data class State(val bleState: BleState)
 
@@ -82,167 +85,182 @@ class TroubleShooterViewModel @Inject constructor(
     }
 
     fun troubleShootBle() = launch(context = dispatcherProvider.IO) {
+        if (!runLock.tryLock()) {
+            log(TAG, WARN) { "troubleShootBle() ignored, a run is already in progress" }
+            return@launch
+        }
         log(TAG, INFO) { "troubleShootBle()" }
 
-        bleScanModeController.withTemporaryOverride(ScannerMode.LOW_LATENCY) override@{
-            try {
-            run {
-                progress("Checking for headphones...")
-                val mainDevice = withTimeoutOrNull(STEP_TIME) {
-                    deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
-                }
-                if (mainDevice != null) {
-                    success("Headphones found, nothing to troubleshoot.")
-                    return@override
-                } else {
-                    progress("Headphones not detected.\n")
-                }
-            }
+        try {
+            bleScanModeController.withTemporaryOverride(ScannerMode.LOW_LATENCY) override@{
+                // The combo under which supported headphones were detected (set in sweep 2).
+                var supportedCombo: BlePodMonitor.CompatOverride? = null
+                // Set only when the run reaches a terminal success. Persisted on exit; staying null
+                // (any failure, or cancellation) means we just clear the override, which restores the
+                // user's original — never-touched — settings.
+                var comboToPersist: BlePodMonitor.CompatOverride? = null
+                try {
+                    run {
+                        progress("Checking for headphones...")
+                        if (findLiveBleHeadphones()) {
+                            success("Headphones found, nothing to troubleshoot.")
+                            return@override
+                        } else {
+                            progress("Headphones not detected.\n")
+                        }
+                    }
 
-            val doScan: suspend (Boolean, Boolean, Boolean, Boolean) -> Collection<BlePodSnapshot> =
-                { hardwareFilteringDisabled,
-                  hardwareBatchingDisabled,
-                  indirectCallback,
-                  unfiltered ->
-                    val sb = StringBuilder("SCAN - Settings: ")
-                    sb.append("hardwareFilteringDisabled=$hardwareFilteringDisabled, ")
-                    sb.append("hardwareBatchingDisabled=$hardwareBatchingDisabled, ")
-                    sb.append("indirectCallback=$indirectCallback, ")
-                    sb.append("unfiltered=$unfiltered")
-                    progress(sb.toString())
-                    generalSettings.isOffloadedFilteringDisabled.valueBlocking = hardwareFilteringDisabled
-                    generalSettings.isOffloadedBatchingDisabled.valueBlocking = hardwareBatchingDisabled
-                    generalSettings.useIndirectScanResultCallback.valueBlocking = indirectCallback
-                    blePodMonitor.setUnfilteredOverride(unfiltered)
+                    val doScan: suspend (BlePodMonitor.CompatOverride, Boolean) -> Collection<BlePodSnapshot> =
+                        { combo, unfiltered ->
+                            progress(
+                                "SCAN - Settings: filteringDisabled=${combo.offloadedFilteringDisabled}, " +
+                                    "batchingDisabled=${combo.offloadedBatchingDisabled}, " +
+                                    "indirectCallback=${combo.indirectCallback}, unfiltered=$unfiltered"
+                            )
+                            blePodMonitor.setCompatOverride(combo)
+                            blePodMonitor.setUnfilteredOverride(unfiltered)
+                            val devices = collectFreshDevices()
+                            log(TAG) { "SCAN: Fresh BLE devices: $devices" }
+                            if (devices.isNotEmpty()) {
+                                progress("SCAN: Received data from ${devices.size} BLE devices")
+                            } else {
+                                progress("SCAN: No data received")
+                            }
+                            devices
+                        }
 
-                    val start = timeSource.elapsedRealtime()
-                    val devices = withTimeoutOrNull(STEP_TIME) {
-                        blePodMonitor.devices
-                            .take(10)
-                            .takeWhile { timeSource.elapsedRealtime() - start < STEP_TIME - 1000 }
-                            .toList()
-                            .flatten()
-                            .distinctBy { it.address }
-                    } ?: emptyList()
-                    log(TAG) { "SCAN: BLE Devices: $devices" }
-                    if (devices.isNotEmpty()) {
-                        progress("SCAN: Received data from ${devices.size} BLE devices")
-                        devices
-                    } else {
-                        progress("SCAN: No data received")
-                        devices
+                    run {
+                        progress("Checking if we can receive BLE data at all.")
+                        val gotData = COMPAT_COMBOS.any { combo -> doScan(combo, true).isNotEmpty() }
+                        if (!gotData) {
+                            failure("Phone is not receiving BLE data.", BleState.Result.Failure.Type.PHONE)
+                            return@override
+                        }
+                    }
+
+                    progress("We received at least some BLE data.\n")
+
+                    run {
+                        progress("Checking for supported headphones.")
+                        supportedCombo = COMPAT_COMBOS.firstOrNull { combo ->
+                            doScan(combo, false).any { it !is UnknownSnapshotBle }
+                        }
+                        if (supportedCombo == null) {
+                            failure("No compatible headphones found", BleState.Result.Failure.Type.HEADPHONES)
+                            return@override
+                        }
+                    }
+
+                    progress("Found some headphones that are supported by CAPod.\n")
+
+                    run {
+                        progress("Checking for your headphones with new BLE settings...")
+                        if (findLiveBleHeadphones()) {
+                            comboToPersist = supportedCombo
+                            success("Found your headphones, new BLE settings worked :)!")
+                            return@override
+                        }
+                    }
+
+                    progress("Still no headphones detected that count as yours.\n")
+
+                    run {
+                        progress("Checking all closeby headphones.")
+
+                        val otherDevices = collectFreshDevices()
+                        otherDevices.forEachIndexed { index, dev -> log(TAG) { "Device #$index: $dev" } }
+
+                        val candidate = otherDevices
+                            .filter { it !is UnknownSnapshotBle }
+                            .maxByOrNull { it.signalQuality }
+
+                        if (candidate == null) {
+                            failure(
+                                "No supported headphones found near your device.",
+                                BleState.Result.Failure.Type.HEADPHONES,
+                            )
+                            return@override
+                        }
+
+                        progress("Headphones found nearby, but not detected as yours.\n")
+                        progress("Creating profile for closest headphones.")
+                        log(TAG, INFO) { "Candidate is $candidate" }
+
+                        profilesRepo.addProfile(
+                            profile = AppleDeviceProfile(
+                                label = context.getString(R.string.troubleshooter_title),
+                                model = candidate.model,
+                            ),
+                            addFirst = true,
+                        )
+
+                        if (findLiveBleHeadphones()) {
+                            comboToPersist = supportedCombo
+                            success("Success! Detected your headphones.")
+                        } else {
+                            failure("No headphones detected near your device.", BleState.Result.Failure.Type.HEADPHONES)
+                        }
+                    }
+                } finally {
+                    blePodMonitor.setUnfilteredOverride(false)
+                    try {
+                        // Persist the winning combo before dropping the override so the effective scan
+                        // settings stay equal with no restart flicker. Done in its own try so the
+                        // override is still cleared (restoring originals) even if a write throws.
+                        comboToPersist?.let { persistCompat(it) }
+                    } finally {
+                        blePodMonitor.setCompatOverride(null)
                     }
                 }
-
-            run {
-                progress("Checking if we can receive BLE data at all.")
-                if (doScan(false, false, false, true).isNotEmpty()) return@run
-                if (doScan(false, false, true, true).isNotEmpty()) return@run
-                if (doScan(true, true, true, true).isNotEmpty()) return@run
-                if (doScan(true, true, false, true).isNotEmpty()) return@run
-                if (doScan(true, false, true, true).isNotEmpty()) return@run
-                if (doScan(true, false, false, true).isNotEmpty()) return@run
-                if (doScan(false, true, true, true).isNotEmpty()) return@run
-                if (doScan(false, true, false, true).isNotEmpty()) return@run
-
-                failure("Phone is not receiving BLE data.", BleState.Result.Failure.Type.PHONE)
-
-                generalSettings.isOffloadedFilteringDisabled.valueBlocking = false
-                generalSettings.isOffloadedBatchingDisabled.valueBlocking = false
-                generalSettings.useIndirectScanResultCallback.valueBlocking = false
-
-                return@override
             }
-
-            progress("We received at least some BLE data.\n")
-
-            run {
-                progress("Checking for supported headphones.")
-
-                if (doScan(false, false, false, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(false, false, true, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(true, true, true, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(true, true, false, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(true, false, true, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(true, false, false, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(false, true, true, false).any { it !is UnknownSnapshotBle }) return@run
-                if (doScan(false, true, false, false).any { it !is UnknownSnapshotBle }) return@run
-
-                failure("No compatible headphones found", BleState.Result.Failure.Type.HEADPHONES)
-
-                generalSettings.isOffloadedFilteringDisabled.valueBlocking = false
-                generalSettings.isOffloadedBatchingDisabled.valueBlocking = false
-                generalSettings.useIndirectScanResultCallback.valueBlocking = false
-
-                return@override
-            }
-
-            progress("Found some headphones that are supported by CAPod.\n")
-
-            run {
-                progress("Checking for your headphones with new BLE settings...")
-                val mainDevice = withTimeoutOrNull(STEP_TIME) {
-                    deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
-                }
-                if (mainDevice != null) {
-                    success("Found your headphones, new BLE settings worked :)!")
-                    return@override
-                }
-            }
-
-            progress("Still no headphones detected that count as yours.\n")
-
-            run {
-                progress("Checking all closeby headphones.")
-
-                val otherDevices = withTimeoutOrNull(STEP_TIME) {
-                    val start = timeSource.elapsedRealtime()
-                    blePodMonitor.devices
-                        .take(10)
-                        .takeWhile { timeSource.elapsedRealtime() - start < STEP_TIME - 1000 }
-                        .toList()
-                        .flatten()
-                        .distinctBy { it.address }
-                } ?: emptyList()
-
-                otherDevices.forEachIndexed { index, dev -> log(TAG) { "Device #$index: $dev" } }
-
-                if (otherDevices.isEmpty()) {
-                    failure("No supported headphones found near your device.", BleState.Result.Failure.Type.HEADPHONES)
-                    return@override
-                }
-
-                progress("Headphones found nearby, but not detected as yours.\n")
-                progress("Creating profile for closest headphones.")
-
-                val candidate = otherDevices
-                    .filter { it !is UnknownSnapshotBle }
-                    .maxBy { it.signalQuality }
-
-                log(TAG, INFO) { "Candidate is $candidate" }
-
-                profilesRepo.addProfile(
-                    profile = AppleDeviceProfile(
-                        label = context.getString(R.string.troubleshooter_title),
-                        model = candidate.model,
-                    ),
-                    addFirst = true,
-                )
-
-                val mainDevice = withTimeoutOrNull(STEP_TIME) {
-                    deviceMonitor.primaryDevice().filterNotNull().firstOrNull()
-                }
-
-                if (mainDevice != null) {
-                    success("Success! Detected your headphones.")
-                } else {
-                    failure("No headphones detected near your device.", BleState.Result.Failure.Type.HEADPHONES)
-                }
-            }
-            } finally {
-                blePodMonitor.setUnfilteredOverride(false)
-            }
+        } finally {
+            runLock.unlock()
         }
+    }
+
+    /**
+     * Waits up to [STEP_TIME] for the primary profile to be backed by a *fresh, live BLE*
+     * observation. A cached-only / AAP-only primary does not count — the troubleshooter is about
+     * whether BLE advertisements are actually reaching us. The freshness cutoff (snapshot seen at or
+     * after this call) means it reflects the currently-active scan settings and doesn't rely on the
+     * device cache having been cleared beforehand.
+     */
+    private suspend fun findLiveBleHeadphones(): Boolean {
+        val threshold = timeSource.now()
+        return withTimeoutOrNull(STEP_TIME) {
+            deviceMonitor.primaryDevice().firstOrNull { device ->
+                device?.ble != null && (device.seenLastAt?.let { it >= threshold } == true)
+            } != null
+        } ?: false
+    }
+
+    /**
+     * Collects BLE devices observed *after the current scan settings take effect*. Option changes
+     * restart the scan after a throttle, and [BlePodMonitor] keeps a 20s device cache, so without a
+     * freshness cutoff a stale observation from a previous combo could be mistaken for a "win".
+     */
+    private suspend fun collectFreshDevices(): List<BlePodSnapshot> {
+        // Drop anything cached under a previous combo so it can't satisfy this attempt.
+        blePodMonitor.clearDeviceCache()
+        val freshThreshold = timeSource.now().plusMillis(SCAN_SETTLE_MS)
+        val start = timeSource.elapsedRealtime()
+        val collected = mutableListOf<BlePodSnapshot>()
+        // Accumulate as we go: a timeout must not discard what we already observed. toList() only
+        // returns once the flow completes, which a quiet channel may never do within the window.
+        withTimeoutOrNull(STEP_TIME) {
+            blePodMonitor.devices
+                .takeWhile { timeSource.elapsedRealtime() - start < STEP_TIME - 1000 }
+                .collect { snapshots -> collected.addAll(snapshots) }
+        }
+        return collected
+            .filter { it.seenLastAt >= freshThreshold }
+            .distinctBy { it.address }
+    }
+
+    private fun persistCompat(combo: BlePodMonitor.CompatOverride) {
+        generalSettings.isOffloadedFilteringDisabled.valueBlocking = combo.offloadedFilteringDisabled
+        generalSettings.isOffloadedBatchingDisabled.valueBlocking = combo.offloadedBatchingDisabled
+        generalSettings.useIndirectScanResultCallback.valueBlocking = combo.indirectCallback
     }
 
     sealed class BleState {
@@ -294,6 +312,29 @@ class TroubleShooterViewModel @Inject constructor(
 
     companion object {
         const val STEP_TIME = 10 * 1000L
+
+        /**
+         * Grace period after switching compat settings before an observation counts as "fresh".
+         * Covers [BlePodMonitor]'s ~1s scan-option throttle plus the scanner restart.
+         */
+        const val SCAN_SETTLE_MS = 1500L
+
+        /**
+         * Compatibility combinations to probe, ordered fewest-disables-first so the first one that
+         * works (and gets persisted) is the *minimal* set of overrides — e.g. a phone that only
+         * needs batching disabled won't also get filtering disabled. Triple semantics:
+         * (offloadedFilteringDisabled, offloadedBatchingDisabled, indirectCallback).
+         */
+        val COMPAT_COMBOS: List<BlePodMonitor.CompatOverride> = listOf(
+            BlePodMonitor.CompatOverride(false, false, false), // baseline (no overrides)
+            BlePodMonitor.CompatOverride(false, true, false),  // batching only
+            BlePodMonitor.CompatOverride(true, false, false),  // filtering only
+            BlePodMonitor.CompatOverride(false, false, true),  // indirect callback only
+            BlePodMonitor.CompatOverride(false, true, true),   // batching + indirect
+            BlePodMonitor.CompatOverride(true, false, true),   // filtering + indirect
+            BlePodMonitor.CompatOverride(true, true, false),   // filtering + batching
+            BlePodMonitor.CompatOverride(true, true, true),    // everything
+        )
 
         val TAG = logTag("TroubleShooter", "VM")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth is disabled, enable it ;)</string>
     <string name="overview_monitoring_active_label">Monitoring for devices</string>
     <string name="overview_monitoring_active_description">Make sure your device is nearby and active.</string>
+    <string name="overview_troubleshoot_suggestion_label">Connected, but no data</string>
+    <string name="overview_troubleshoot_suggestion_description">Your device is connected, but CAPod isn\'t receiving any live data from it. Your phone may need a compatibility option — the troubleshooter can try to find one automatically.</string>
+    <string name="overview_troubleshoot_suggestion_action">Run troubleshooter</string>
     <string name="overview_unmatched_devices_label">Unmatched devices</string>
     <plurals name="overview_unmatched_devices_count">
         <item quantity="one">%d device without matching profile</item>

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
@@ -13,6 +13,8 @@ import eu.darken.capod.monitor.core.DeviceMonitor
 import eu.darken.capod.monitor.core.MonitorModeResolver
 import eu.darken.capod.monitor.core.PodDevice
 import eu.darken.capod.monitor.core.worker.MonitorControl
+import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.profiles.core.AppleDeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfilesRepo
 import io.kotest.matchers.shouldBe
@@ -25,6 +27,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -552,6 +555,88 @@ class OverviewViewModelTest : BaseTest() {
 
             val event = vm.requestPermissionEvent.first()
             event shouldBe Permission.BLUETOOTH
+        }
+    }
+
+    @Nested
+    inner class TroubleshootSuggestionTests {
+
+        private val connectedAddress = "AA:BB:CC:DD:EE:FF"
+
+        private fun connectedProfile(): DeviceProfile = AppleDeviceProfile(
+            label = "Test",
+            model = PodModel.AIRPODS_PRO2,
+            address = connectedAddress,
+        )
+
+        private fun connectedBtDevice() = mockk<BluetoothDevice2>(relaxed = true) {
+            every { address } returns connectedAddress
+        }
+
+        private fun setConnectedButNoLiveData() {
+            profilesFlow.value = listOf(connectedProfile())
+            connectedDevicesFlow.value = listOf(connectedBtDevice())
+            devicesFlow.value = emptyList()
+        }
+
+        @Test
+        fun `appears only after the debounce delay`() = runTest(testDispatcher) {
+            setConnectedButNoLiveData()
+            val vm = createViewModel()
+            var latest: OverviewViewModel.State? = null
+            backgroundScope.launch { vm.state.collect { latest = it } }
+
+            advanceTimeBy(14_000)
+            latest!!.showTroubleshootSuggestion shouldBe false
+
+            advanceTimeBy(2_000)
+            latest!!.showTroubleshootSuggestion shouldBe true
+        }
+
+        @Test
+        fun `suppressed while any pod is live even after the delay`() = runTest(testDispatcher) {
+            // #603 duplicate state: broadcasts ARE arriving (a live pod exists), so the card must
+            // not claim "no data" even though a profiled card may momentarily read as non-live.
+            profilesFlow.value = listOf(connectedProfile())
+            connectedDevicesFlow.value = listOf(connectedBtDevice())
+            devicesFlow.value = listOf(PodDevice(profileId = null, ble = mockk(relaxed = true), aap = null))
+
+            val vm = createViewModel()
+            var latest: OverviewViewModel.State? = null
+            backgroundScope.launch { vm.state.collect { latest = it } }
+
+            advanceTimeBy(20_000)
+            latest!!.showTroubleshootSuggestion shouldBe false
+        }
+
+        @Test
+        fun `not shown when no profile is system-connected`() = runTest(testDispatcher) {
+            profilesFlow.value = listOf(connectedProfile())
+            connectedDevicesFlow.value = emptyList()
+            devicesFlow.value = emptyList()
+
+            val vm = createViewModel()
+            var latest: OverviewViewModel.State? = null
+            backgroundScope.launch { vm.state.collect { latest = it } }
+
+            advanceTimeBy(20_000)
+            latest!!.showTroubleshootSuggestion shouldBe false
+        }
+
+        @Test
+        fun `hides immediately when live data returns before the delay`() = runTest(testDispatcher) {
+            setConnectedButNoLiveData()
+            val vm = createViewModel()
+            var latest: OverviewViewModel.State? = null
+            backgroundScope.launch { vm.state.collect { latest = it } }
+
+            advanceTimeBy(10_000)
+            latest!!.showTroubleshootSuggestion shouldBe false
+
+            // A broadcast arrives before the 15s window elapses — the pending suggestion is cancelled.
+            devicesFlow.value = listOf(PodDevice(profileId = null, ble = mockk(relaxed = true), aap = null))
+            advanceTimeBy(10_000)
+            latest!!.showTroubleshootSuggestion shouldBe false
         }
     }
 }

--- a/app/src/test/java/eu/darken/capod/troubleshooter/ui/TroubleShooterViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/troubleshooter/ui/TroubleShooterViewModelTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.capod.troubleshooter.ui
+
+import eu.darken.capod.monitor.core.ble.BlePodMonitor
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class TroubleShooterViewModelTest : BaseTest() {
+
+    private fun BlePodMonitor.CompatOverride.disabledCount() =
+        listOf(offloadedFilteringDisabled, offloadedBatchingDisabled, indirectCallback).count { it }
+
+    @Test
+    fun `compat combos cover every combination exactly once`() {
+        val combos = TroubleShooterViewModel.COMPAT_COMBOS
+        combos shouldHaveSize 8
+        combos.toSet() shouldHaveSize 8
+    }
+
+    @Test
+    fun `compat combos start with the no-override baseline`() {
+        TroubleShooterViewModel.COMPAT_COMBOS.first() shouldBe
+            BlePodMonitor.CompatOverride(false, false, false)
+    }
+
+    @Test
+    fun `compat combos are ordered fewest-disables-first`() {
+        val counts = TroubleShooterViewModel.COMPAT_COMBOS.map { it.disabledCount() }
+        counts shouldBe counts.sorted()
+    }
+
+    @Test
+    fun `batching-only is probed before any combo that also disables filtering`() {
+        // The #603 fix: a phone that only needs batching disabled must land on the minimal combo,
+        // not on "all off", so we don't needlessly disable hardware filtering too.
+        val combos = TroubleShooterViewModel.COMPAT_COMBOS
+        val batchingOnly = combos.indexOf(BlePodMonitor.CompatOverride(false, true, false))
+        val filteringAndBatching = combos.indexOf(BlePodMonitor.CompatOverride(true, true, false))
+        val everything = combos.indexOf(BlePodMonitor.CompatOverride(true, true, true))
+
+        batchingOnly shouldBeLessThan filteringAndBatching
+        batchingOnly shouldBeLessThan everything
+    }
+}


### PR DESCRIPTION
## What changed

When your headphones are connected (you hear audio) but CAPod's dashboard shows no connection, your phone's Bluetooth stack is usually dropping the broadcasts CAPod relies on — common on some Xiaomi/HyperOS ROMs (#603). Two improvements:

- The dashboard now shows a hint pointing to the Troubleshooter in exactly that situation, instead of leaving it buried in Settings → Support.
- The Troubleshooter now applies the *minimal* compatibility tweak that makes reception work, and only changes your settings when it actually succeeds — no leftover options toggled on, and nothing changed after a failed or cancelled run.

## Technical Context

- Probing now goes through a transient in-memory override on `BlePodMonitor` instead of writing the three compat settings on every attempt; only the winning combo is persisted, and only on terminal success. Failure/cancellation clears the override, restoring untouched settings.
- Combos are tried fewest-disables-first, so a phone that only needs batching disabled isn't also left with filtering disabled (ongoing CPU cost).
- Each probe clears the device cache and counts only observations past a settle cutoff, so a prior combo's cached devices (kept ~20s) can't be mistaken for the current one working. "Found" checks require a fresh live BLE observation, not cached/AAP state — so it can't exit early with "nothing to troubleshoot" for the devices that need it.
- The dashboard hint is debounced ~15s and suppressed whenever any pod is live, so it never flashes during connect→first-broadcast and never claims "no data" while data is arriving.
- Known limitation: during the ~1.5s scanner-restart window a lingering old-combo case-context frame can still mask a fresh non-case one via `preferCaseContextPod` — a rare, self-correcting false-negative left as-is to avoid touching shared monitoring behavior.
- Scope: addresses the discoverability/robustness half of #603. The separate "device shows twice when hardware batching is off" duplicate needs a verbose repro log and is not in this PR — hence `Refs`, not `Closes`.

## Review checklist

- [ ] In-memory override always cleared on every exit path (success, failure, cancellation, persist-throw)
- [ ] Only the minimal winning combo is persisted, only on terminal success
- [ ] `collectFreshDevices()` doesn't discard observations on timeout
- [ ] Dashboard hint stays hidden while any pod is live and during the debounce window

Refs #603
