### PR TITLE
Device: Fix AirPods showing up twice after opening the case

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/protocol/ProximityPairing.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/protocol/ProximityPairing.kt
@@ -2,7 +2,9 @@ package eu.darken.capod.pods.core.apple.ble.protocol
 
 import android.bluetooth.le.ScanFilter
 import dagger.Reusable
+import eu.darken.capod.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
 import javax.inject.Inject
 
 
@@ -13,6 +15,17 @@ object ProximityPairing {
         fun decode(message: ContinuityProtocol.Message): ProximityMessage? {
             if (message.type != CONTINUITY_PROTOCOL_MESSAGE_TYPE_PROXIMITY_PAIRING) {
                 log { "Not a proximity pairing message: $this" }
+                return null
+            }
+
+            // Pods also emit type 0x07 frames whose payload does not use the plaintext status
+            // format, e.g. prefix 0x07 from the identity address on connect (#603). Their bytes
+            // are garbage at the standard offsets and would create a ghost device.
+            if (message.data.firstOrNull() != PAIRING_MESSAGE_PREFIX) {
+                log(TAG, DEBUG) {
+                    val hex = message.data.joinToString(" ") { "%02X".format(it.toInt()) }
+                    "Dropping proximity pairing message with unsupported prefix: [$hex]"
+                }
                 return null
             }
 
@@ -49,4 +62,9 @@ object ProximityPairing {
 
     // This is the default message length among official Apple devices, clones may have different length
     internal const val PAIRING_MESSAGE_LENGTH = 25
+
+    // First payload byte of every known plaintext status broadcast, including pairing mode
+    internal val PAIRING_MESSAGE_PREFIX = 0x01.toUByte()
+
+    private val TAG = logTag("Pod", "Apple", "ProximityPairing")
 }

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/ble/devices/airpods/AirPodsGen4Test.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/ble/devices/airpods/AirPodsGen4Test.kt
@@ -1,6 +1,7 @@
 package eu.darken.capod.pods.core.apple.ble.devices.airpods
 
 import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.ble.BlePodSnapshot
 import eu.darken.capod.pods.core.apple.ble.devices.BaseBlePodsTest
 import eu.darken.capod.pods.core.apple.ble.devices.DualApplePods
 import eu.darken.capod.pods.core.apple.ble.devices.HasAppleColor
@@ -41,6 +42,16 @@ class AirPodsGen4Test : BaseBlePodsTest() {
             podStyle.identifier shouldBe HasAppleColor.DeviceColor.WHITE.name
 
             model shouldBe PodModel.AIRPODS_GEN4
+        }
+    }
+
+    @Test
+    fun `frame with unsupported payload prefix is rejected - #603`() = runTest {
+        // Captured from AirPods Gen4 on connect: sent from the identity address, payload prefix
+        // 0x07 instead of 0x01, model bytes match but battery/color bytes are not plaintext.
+        // Decoding it as a status frame created a duplicate device card.
+        create<BlePodSnapshot?>("07 19 07 19 20 35 DF DE 46 76 CE 66 5C F4 6E BA B6 AC 1B 69 4C A7 D8 09 BF 9A 04") {
+            this shouldBe null
         }
     }
 }


### PR DESCRIPTION
## What changed

Fixed AirPods appearing as two device cards for ~10–20 seconds when taking them out of the case. The duplicate showed wrong battery values and disappeared again on its own.

Closes #603

## Technical Context

- Root cause: on connect, AirPods Gen 4 emit a single proximity-pairing frame from their identity address whose payload prefix is `0x07` instead of `0x01`. The model bytes happen to sit at the usual offset so it passed model matching, but the rest of the payload is not the plaintext status format (battery nibbles 13/14, invalid color) — it minted a fresh device tracker that matched the same profile and rendered as a second card until the 20 s stale timeout.
- The guard sits at the decoder layer, before model dispatch, so every model — including the unknown-device catch-all — is protected; per-model validation would have left the catch-all exposed.
- Safe for pairing mode and clones: every real-device capture in the test suite (all AirPods, Beats, and fake variants) uses prefix `0x01`, and pairing/connection state is encoded in the payload suffix byte, not the prefix.
- Dropped frames are still logged with their full hex payload at DEBUG, so unrecognized variants stay visible in user debug logs.
