### PR TITLE
Fix: Fix notification appearing lighter than system notifications in dark mode

### DIFF
--- a/app/src/main/res/drawable/notification_battery_progress.xml
+++ b/app/src/main/res/drawable/notification_battery_progress.xml
@@ -12,7 +12,7 @@
         <clip>
             <shape android:shape="rectangle">
                 <corners android:radius="4dp" />
-                <solid android:color="?android:attr/colorAccent" />
+                <solid android:color="@color/brand_primary" />
             </shape>
         </clip>
     </item>

--- a/app/src/main/res/layout/monitor_notification_dual_pods_big.xml
+++ b/app/src/main/res/layout/monitor_notification_dual_pods_big.xml
@@ -24,8 +24,6 @@
                 android:id="@+id/pod_left_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:tintMode="multiply"
-                android:tint="?android:attr/colorAccent"
                 android:src="@drawable/device_airpods_gen1_left" />
 
             <ProgressBar
@@ -58,8 +56,8 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="2dp"
-                    android:tintMode="multiply"
-                    android:tint="?android:attr/colorAccent"
+                    android:tint="@color/notification_icon_tint"
+                    android:tintMode="src_in"
                     android:src="@drawable/ic_baseline_power_24" />
 
                 <ImageView
@@ -67,8 +65,8 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="2dp"
-                    android:tintMode="multiply"
-                    android:tint="?android:attr/colorAccent"
+                    android:tint="@color/notification_icon_tint"
+                    android:tintMode="src_in"
                     android:src="@drawable/ic_baseline_hearing_24" />
 
             </LinearLayout>
@@ -88,8 +86,6 @@
                 android:id="@+id/pod_case_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:tintMode="multiply"
-                android:tint="?android:attr/colorAccent"
                 android:src="@drawable/device_airpods_gen1_case" />
 
             <ProgressBar
@@ -122,8 +118,8 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="2dp"
-                    android:tintMode="multiply"
-                    android:tint="?android:attr/colorAccent"
+                    android:tint="@color/notification_icon_tint"
+                    android:tintMode="src_in"
                     android:src="@drawable/ic_baseline_power_24" />
 
             </LinearLayout>
@@ -142,8 +138,6 @@
                 android:id="@+id/pod_right_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:tintMode="multiply"
-                android:tint="?android:attr/colorAccent"
                 android:src="@drawable/device_airpods_gen1_right" />
 
             <ProgressBar
@@ -176,8 +170,8 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="2dp"
-                    android:tintMode="multiply"
-                    android:tint="?android:attr/colorAccent"
+                    android:tint="@color/notification_icon_tint"
+                    android:tintMode="src_in"
                     android:src="@drawable/ic_baseline_power_24" />
 
                 <ImageView
@@ -185,8 +179,8 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="2dp"
-                    android:tintMode="multiply"
-                    android:tint="?android:attr/colorAccent"
+                    android:tint="@color/notification_icon_tint"
+                    android:tintMode="src_in"
                     android:src="@drawable/ic_baseline_hearing_24" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/monitor_notification_dual_pods_big.xml
+++ b/app/src/main/res/layout/monitor_notification_dual_pods_big.xml
@@ -24,6 +24,8 @@
                 android:id="@+id/pod_left_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/device_airpods_gen1_left" />
 
             <ProgressBar
@@ -86,6 +88,8 @@
                 android:id="@+id/pod_case_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/device_airpods_gen1_case" />
 
             <ProgressBar
@@ -138,6 +142,8 @@
                 android:id="@+id/pod_right_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/device_airpods_gen1_right" />
 
             <ProgressBar

--- a/app/src/main/res/layout/monitor_notification_dual_pods_small.xml
+++ b/app/src/main/res/layout/monitor_notification_dual_pods_small.xml
@@ -38,6 +38,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_power_24" />
 
             <ImageView
@@ -46,6 +48,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_hearing_24" />
         </LinearLayout>
 
@@ -76,6 +80,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_power_24" />
         </LinearLayout>
 
@@ -105,6 +111,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_power_24" />
 
             <ImageView
@@ -113,6 +121,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_hearing_24" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/monitor_notification_single_pods_big.xml
+++ b/app/src/main/res/layout/monitor_notification_single_pods_big.xml
@@ -24,6 +24,8 @@
                 android:id="@+id/headphones_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/twotone_headphones_24" />
 
             <TextView

--- a/app/src/main/res/layout/monitor_notification_single_pods_big.xml
+++ b/app/src/main/res/layout/monitor_notification_single_pods_big.xml
@@ -24,8 +24,6 @@
                 android:id="@+id/headphones_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:tintMode="multiply"
-                android:tint="?android:attr/colorAccent"
                 android:src="@drawable/twotone_headphones_24" />
 
             <TextView
@@ -71,8 +69,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
-                android:tintMode="multiply"
-                android:tint="?android:attr/colorAccent"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_power_24" />
 
             <ImageView
@@ -80,8 +78,8 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginStart="2dp"
-                android:tintMode="multiply"
-                android:tint="?android:attr/colorAccent"
+                android:tint="@color/notification_icon_tint"
+                android:tintMode="src_in"
                 android:src="@drawable/ic_baseline_hearing_24" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/monitor_notification_single_pods_small.xml
+++ b/app/src/main/res/layout/monitor_notification_single_pods_small.xml
@@ -30,6 +30,8 @@
             android:id="@+id/headphones_battery_icon"
             style="@style/PodInfoItemIcon.Notification"
             android:layout_marginStart="12dp"
+            android:tint="@color/notification_icon_tint"
+            android:tintMode="src_in"
             android:src="@drawable/ic_baseline_battery_unknown_24" />
 
         <TextView
@@ -46,6 +48,8 @@
             android:layout_width="16dp"
             android:layout_height="16dp"
             android:layout_marginStart="2dp"
+            android:tint="@color/notification_icon_tint"
+            android:tintMode="src_in"
             android:src="@drawable/ic_baseline_power_24" />
 
         <ImageView
@@ -54,6 +58,8 @@
             android:layout_width="16dp"
             android:layout_height="16dp"
             android:layout_marginStart="2dp"
+            android:tint="@color/notification_icon_tint"
+            android:tintMode="src_in"
             android:src="@drawable/ic_baseline_hearing_24" />
 
     </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="notification_icon_tint">#EEEEEE</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,4 +60,6 @@
     <color name="brand_primary">#3f7aff</color>
     <color name="brand_secondary">#ffd83c</color>
     <color name="brand_tertiary">#41eb8e</color>
+
+    <color name="notification_icon_tint">#757575</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,6 +18,8 @@
     <style name="PodInfoItemIcon.Notification" parent="TextAppearance.Compat.Notification.Title">
         <item name="android:layout_height">20dp</item>
         <item name="android:layout_width">20dp</item>
+        <item name="android:tintMode">src_in</item>
+        <item name="android:tint">@color/notification_icon_tint</item>
     </style>
 
     <style name="PodInfoItemIcon.Notification.Large" parent="PodInfoItemIcon.Notification">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,15 +13,11 @@
 
     <style name="Notification.Container">
         <!--        <item name="android:background">?android:attr/colorBackground</item>-->
-        <item name="android:theme">@style/Theme.Material3.DynamicColors.DayNight</item>
     </style>
 
     <style name="PodInfoItemIcon.Notification" parent="TextAppearance.Compat.Notification.Title">
         <item name="android:layout_height">20dp</item>
         <item name="android:layout_width">20dp</item>
-        <item name="android:tintMode">multiply</item>
-        <item name="android:tint">?android:attr/colorAccent</item>
-        <item name="tint">?android:attr/colorAccent</item>
     </style>
 
     <style name="PodInfoItemIcon.Notification.Large" parent="PodInfoItemIcon.Notification">
@@ -32,7 +28,6 @@
     <style name="PodInfoItemText.Notification" parent="TextAppearance.Compat.Notification.Title">
         <item name="android:singleLine">true</item>
         <item name="android:ellipsize">end</item>
-        <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
     <style name="PodInfoItemIcon" parent="TextAppearance.Material3.BodyMedium">


### PR DESCRIPTION
## What changed

The status notification no longer appears lighter or more transparent than other system notifications in dark mode on Samsung One UI 8.5 / Android 16.

## Technical Context

- Root cause: `Theme.Material3.DynamicColors.DayNight` was applied as `android:theme` on the notification container. RemoteViews inflate in the notification host process (SystemUI), where `DynamicColors` is never called — so the theme fell back to light-mode Material3 defaults even in dark mode, causing light-colored icons and text on dark backgrounds
- Fixed by removing the broken theme override and replacing all `?attr/colorAccent` / `?android:attr/textColorPrimary` usages in notification layouts with explicit day/night color resources (`notification_icon_tint`: `#757575` light / `#EEEEEE` dark); text views use `TextAppearance.Compat.Notification.Title` which resolves correctly in the notification context
- Status glyph icons (charging, in-ear) switched from `tintMode="multiply"` × `?colorAccent` to `tintMode="src_in"` × `@color/notification_icon_tint` — more predictable for vector glyphs and avoids the wrong-color feedback loop
- Product PNG icons (AirPods photos) also receive `src_in` × `notification_icon_tint`; without any tint, the white-on-transparent PNGs would be invisible on light notification backgrounds
- Battery progress bar fill replaced with `@color/brand_primary` to eliminate the last `?attr` reference in the notification rendering path
- Confirmed build+run on Pixel 8; One UI 8.5 confirmation outstanding — cannot reproduce without a paired device near the test hardware

Closes #613

## Review checklist

- [ ] Notification displays correctly in dark mode on stock Android
- [ ] Notification displays correctly in light mode (product icons visible, not invisible)
- [ ] One UI 8.5 reporter confirms fix — tag in issue #613