### PR TITLE
Device: Fix battery card flickering near other people's AirPods

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/history/KnownDevice.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/history/KnownDevice.kt
@@ -16,6 +16,12 @@ data class KnownDevice(
     val seenCounter: Int,
     val history: List<ApplePods>,
     val lastCaseBattery: Float?,
+    /**
+     * Profile id this device has ever IRK-resolved to, or null if it has only ever been seen as a
+     * keyless device. Durable — kept even when [history] is trimmed — so the weak history-recovery
+     * paths can reliably refuse to hand an IRK-backed identity to a foreign same-model frame.
+     */
+    val boundProfileId: String? = null,
 ) {
     val lastPayload: ProximityPayload
         get() = history.last().payload

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/ble/history/PodHistoryRepo.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/ble/history/PodHistoryRepo.kt
@@ -76,7 +76,8 @@ class PodHistoryRepo @Inject constructor(
         val caseIgnored = if (current is DualApplePods) {
             val target = current.getCaseMatchMarkings()
             knownDevices.values.filter { known ->
-                known.history.filterIsInstance<DualApplePods>().any { it.getCaseMatchMarkings() == target }
+                known.history.filterIsInstance<DualApplePods>().any { it.getCaseMatchMarkings() == target } &&
+                    known.isIrkConsistentWith(current)
             }
         } else {
             emptySet()
@@ -143,7 +144,7 @@ class PodHistoryRepo @Inject constructor(
         if (recognizedDevice == null) {
             val currentMarkers = payload.getFuzzyIdentifier()
             recognizedDevice = knownDevices.values
-                .firstOrNull { it.lastPayload.getFuzzyIdentifier() == currentMarkers }
+                .firstOrNull { it.lastPayload.getFuzzyIdentifier() == currentMarkers && it.isIrkConsistentWith(current) }
                 ?.also { log(TAG, DEBUG) { "search1: Similarity match for device=${current.model}" } }
         }
 
@@ -154,6 +155,24 @@ class PodHistoryRepo @Inject constructor(
         return recognizedDevice
     }
 
+    /**
+     * The weak history paths (fuzzy markers, case-ignored markings) match on low-entropy broadcast
+     * data — model + battery nibbles + colour — which a stranger's same-model AirPods at a similar
+     * battery satisfies. Those paths must not let a foreign frame inherit the identity of one of OUR
+     * keyed (IRK-backed) devices, or the foreign snapshot poisons that device's cache slot and the
+     * dashboard card glitches (Symptom B).
+     *
+     * A [KnownDevice] is "IRK-backed" if it has ever resolved against a profile's IRK
+     * ([KnownDevice.boundProfileId], latched durably so history trimming can't erode it). Such a
+     * device may only be claimed via the strong address/IRK paths, or by a current frame that
+     * resolved to the SAME profile. Keyless devices (never IRK-backed) are unaffected — fuzzy
+     * recovery still works for them exactly as before.
+     */
+    private fun KnownDevice.isIrkConsistentWith(current: ApplePods): Boolean {
+        val bound = boundProfileId ?: return true // not IRK-backed -> keyless, weak match allowed
+        return current.meta.profile?.id == bound
+    }
+
     fun updateHistory(device: ApplePods) {
         val existing = knownDevices[device.identifier]
 
@@ -162,12 +181,16 @@ class PodHistoryRepo @Inject constructor(
             .mapNotNull { it.batteryCasePercent }
             .lastOrNull()
 
+        // Latch the IRK-resolved profile id (never cleared by an unbound frame), so it survives history trimming.
+        val boundProfileId = device.meta.profile?.id?.takeIf { device.meta.isIRKMatch }
+
         knownDevices[device.identifier] = if (existing != null) {
             val history = existing.history.plus(device)
             existing.copy(
                 seenCounter = existing.seenCounter + 1,
                 history = history,
-                lastCaseBattery = history.determineLatestCaseBattery() ?: existing.lastCaseBattery
+                lastCaseBattery = history.determineLatestCaseBattery() ?: existing.lastCaseBattery,
+                boundProfileId = boundProfileId ?: existing.boundProfileId,
             )
         } else {
             log(TAG, DEBUG) { "Creating new history for ${device.logSummary()}" }
@@ -177,7 +200,8 @@ class PodHistoryRepo @Inject constructor(
                 seenFirstAt = device.seenFirstAt,
                 seenCounter = 1,
                 history = history,
-                lastCaseBattery = history.determineLatestCaseBattery()
+                lastCaseBattery = history.determineLatestCaseBattery(),
+                boundProfileId = boundProfileId,
             )
         }
     }

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManagerTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManagerTest.kt
@@ -146,12 +146,12 @@ class AapConnectionManagerTest : BaseTest() {
             val closeCalls = AtomicInteger(0)
             val blockingInput = object : InputStream() {
                 override fun read(): Int {
-                    readBlocked.await(2, TimeUnit.SECONDS)
+                    readBlocked.await(5, TimeUnit.SECONDS)
                     return -1
                 }
 
                 override fun read(b: ByteArray): Int {
-                    readBlocked.await(2, TimeUnit.SECONDS)
+                    readBlocked.await(5, TimeUnit.SECONDS)
                     return -1
                 }
             }
@@ -180,9 +180,12 @@ class AapConnectionManagerTest : BaseTest() {
 
             // disconnect() runs engine.reset() before closing the socket, so awaiting the close latch
             // guarantees the state has already flipped to DISCONNECTED.
-            readBlocked.await(2, TimeUnit.SECONDS) shouldBe true
+            readBlocked.await(5, TimeUnit.SECONDS) shouldBe true
             connection.state.value.connectionState shouldBe AapPodState.ConnectionState.DISCONNECTED
-            closeCalls.get() shouldBe 1
+            // The socket must be closed (this unblocks the wedged read). It may be closed more than
+            // once — the watchdog's disconnect() and the read loop's finally both run cleanupSocket()
+            // and can race — so assert "at least once" rather than an exact, timing-dependent count.
+            (closeCalls.get() >= 1) shouldBe true
         }
 
         @Test

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManagerTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManagerTest.kt
@@ -16,6 +16,11 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -34,6 +39,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class AapConnectionManagerTest : BaseTest() {
 
@@ -139,19 +145,23 @@ class AapConnectionManagerTest : BaseTest() {
         }
 
         @Test
-        fun `handshake timeout disconnects a silent session`() = testScope.runTest {
+        fun `handshake timeout disconnects a silent session`() = runBlocking {
             // Socket connects and the handshake is sent, but the peer never replies: read() blocks
-            // forever. The handshake watchdog must time out and tear the session down.
+            // until the socket is closed. The handshake watchdog must time out and tear the session
+            // down. This exercises real dispatchers + a real socket close, so it runs on REAL time
+            // with generous bounds — mixing runTest's virtual time with Dispatchers.IO made it flaky.
             val readBlocked = CountDownLatch(1)
             val closeCalls = AtomicInteger(0)
             val blockingInput = object : InputStream() {
+                // Block well past the test's own wait so the watchdog (not a read self-timeout) is
+                // always what ends the read.
                 override fun read(): Int {
-                    readBlocked.await(5, TimeUnit.SECONDS)
+                    readBlocked.await(30, TimeUnit.SECONDS)
                     return -1
                 }
 
                 override fun read(b: ByteArray): Int {
-                    readBlocked.await(5, TimeUnit.SECONDS)
+                    readBlocked.await(30, TimeUnit.SECONDS)
                     return -1
                 }
             }
@@ -170,22 +180,27 @@ class AapConnectionManagerTest : BaseTest() {
                 profile = AapDeviceProfile.forModel(PodModel.AIRPODS_PRO3),
                 socketFactory = socketFactory,
                 timeSource = timeSource,
-                connectTimeout = 50.milliseconds,
-                handshakeTimeout = 100.milliseconds,
+                connectTimeout = 1.seconds,
+                handshakeTimeout = 200.milliseconds,
             )
 
-            connection.connect(testScope)
-            // Fire the 100ms handshake watchdog.
-            advanceUntilIdle()
+            val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+            try {
+                connection.connect(scope)
 
-            // disconnect() runs engine.reset() before closing the socket, so awaiting the close latch
-            // guarantees the state has already flipped to DISCONNECTED.
-            readBlocked.await(5, TimeUnit.SECONDS) shouldBe true
-            connection.state.value.connectionState shouldBe AapPodState.ConnectionState.DISCONNECTED
-            // The socket must be closed (this unblocks the wedged read). It may be closed more than
-            // once — the watchdog's disconnect() and the read loop's finally both run cleanupSocket()
-            // and can race — so assert "at least once" rather than an exact, timing-dependent count.
-            (closeCalls.get() >= 1) shouldBe true
+                // The 200ms watchdog tears the silent session down: disconnect() resets the engine to
+                // DISCONNECTED and THEN closes the socket (the close mock increments before counting
+                // the latch down). Awaiting that latch is the unambiguous "watchdog fired" signal and
+                // sidesteps any reset-vs-close ordering race. Generous real-time bound for loaded CI.
+                readBlocked.await(15, TimeUnit.SECONDS) shouldBe true
+                connection.state.value.connectionState shouldBe AapPodState.ConnectionState.DISCONNECTED
+                // close() may run once (watchdog) or twice (watchdog + read-loop finally race on
+                // cleanupSocket before socket is nulled) — both are correct, so assert "at least once".
+                (closeCalls.get() >= 1) shouldBe true
+            } finally {
+                readBlocked.countDown()
+                scope.cancel()
+            }
         }
 
         @Test

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/ble/history/PodHistoryFuzzyCollisionTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/ble/history/PodHistoryFuzzyCollisionTest.kt
@@ -1,0 +1,90 @@
+package eu.darken.capod.pods.core.apple.ble.history
+
+import eu.darken.capod.common.fromHex
+import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.ble.devices.BaseBlePodsTest
+import eu.darken.capod.pods.core.apple.ble.devices.airpods.AirPodsPro2Usbc
+import eu.darken.capod.profiles.core.AppleDeviceProfile
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Reproduces Symptom B (the dashboard-card glitch): a FOREIGN same-model AirPods, whose BLE address
+ * does not resolve against our IRK, gets recovered as OUR device's stable identity purely via the
+ * fuzzy/case-ignored history fallback ([PodHistoryRepo.baseSearch]). The foreign snapshot carries
+ * `meta.profile == null` (IRK failed) but adopts our identifier, so it overwrites our BLE cache slot
+ * keyed by that identifier — and the merged device flaps to `ble = null` (cached-only) until our next
+ * real frame re-binds.
+ *
+ * The two frames use the SAME advertisement payload (so the low-entropy fuzzy markers — model bits,
+ * pod/case battery nibbles, colour — are identical) but DIFFERENT BLE addresses, mimicking another
+ * person's same-model AirPods at a similar battery level in a crowded environment.
+ */
+class PodHistoryFuzzyCollisionTest : BaseBlePodsTest() {
+
+    // IRK + a resolvable RPA pair lifted from RPACheckerTest.
+    private val irkHex = "79-04-65-1E-E2-CC-D9-26-F2-6E-20-EE-3E-CC-DE-79"
+    private val myRpa = "5A:16:2B:91:D1:CD"        // resolves against irkHex
+    private val foreignAddress = "77:49:4C:D8:25:0C" // does NOT resolve against irkHex
+
+    // A valid AirPods Pro 2 (USB-C) proximity advertisement (model 0x2420), reused for both frames.
+    private val payload = "07 19 01 24 20 0B 99 8F 11 00 04 BD A7 3B FF 2D 8A 3C AF 9B 1A 7C 74 B7 A9 D1 C3"
+
+    @Test
+    fun `foreign same-model frame must not adopt a keyed device's identity`() = runTest {
+        profileList.add(
+            AppleDeviceProfile(
+                label = "Mine",
+                model = PodModel.AIRPODS_PRO2_USBC,
+                identityKey = irkHex.fromHex(),
+                address = "AA:BB:CC:DD:EE:FF",
+            )
+        )
+
+        // 1) Our own frame: address resolves against our IRK -> IRK-bound, registers history.
+        lateinit var mine: AirPodsPro2Usbc
+        create<AirPodsPro2Usbc>(payload, address = myRpa) { mine = this }
+        mine.meta.isIRKMatch shouldBe true
+        mine.meta.profile shouldNotBe null
+
+        // 2) A foreign device's frame: same payload (identical fuzzy markers), different address.
+        lateinit var foreign: AirPodsPro2Usbc
+        create<AirPodsPro2Usbc>(payload, address = foreignAddress) { foreign = this }
+
+        // The foreign frame is correctly NOT IRK-bound...
+        foreign.meta.isIRKMatch shouldBe false
+        foreign.meta.profile shouldBe null
+
+        // ...and therefore must NOT inherit our stable identity. Before the gate this FAILED: the
+        // case-ignored/fuzzy fallback recovered our KnownDevice for the foreign frame, so it adopted
+        // our identifier and poisoned our cache slot -> the merged device glitched to ble=null.
+        foreign.identifier shouldNotBe mine.identifier
+    }
+
+    @Test
+    fun `our own keyed device keeps its identity across an RPA rotation`() = runTest {
+        // Guard: narrowing the weak paths must not fragment our own identity — across an RPA
+        // rotation our device is still recovered via the strong IRK path.
+        profileList.add(
+            AppleDeviceProfile(
+                label = "Mine",
+                model = PodModel.AIRPODS_PRO2_USBC,
+                identityKey = irkHex.fromHex(),
+                address = "AA:BB:CC:DD:EE:FF",
+            )
+        )
+        val myRotatedRpa = "45:23:51:E3:40:6E" // also resolves against irkHex (computed)
+
+        lateinit var first: AirPodsPro2Usbc
+        create<AirPodsPro2Usbc>(payload, address = myRpa) { first = this }
+        first.meta.isIRKMatch shouldBe true
+
+        lateinit var second: AirPodsPro2Usbc
+        create<AirPodsPro2Usbc>(payload, address = myRotatedRpa) { second = this }
+        second.meta.isIRKMatch shouldBe true
+        // Same physical device across rotation -> same stable identity (recovered via IRK).
+        second.identifier shouldBe first.identifier
+    }
+}


### PR DESCRIPTION
## What changed

Fixed the battery/status card flickering — signal bars, in-ear and "worn" state briefly dropping
out — that could happen in busy places (a gym, a train) where other people nearby have the **same
model** of AirPods. Your own AirPods stay rock-solid on the card now.

## Technical Context

- Root cause: identity tracking has two independent steps per BLE advertisement — the IRK-based
  binding to your profile, and a separate "stable id" recovery that survives address rotation. The
  stable-id recovery has weak fallbacks (case-ignored markings, fuzzy markers) that match on
  low-entropy broadcast data only — model + battery nibbles + colour. A **stranger's** same-model
  AirPods at a similar battery level satisfies those fallbacks, so its frame (which fails your IRK,
  so it carries no profile) was recovered as *your* device's id. It then overwrote your device's BLE
  cache slot, and the merged device flapped to cached-only (`ble = null`) until your next real frame
  re-bound — the visible flicker. Confirmed deterministically by the new test (a foreign frame
  adopting the keyed device's exact identity).
- Fix: the two weak recovery paths now refuse to hand an **IRK-backed** (keyed) device's identity to
  a frame that didn't resolve to the same profile. The strong address/IRK recovery paths are
  untouched, so your device's identity still survives RPA rotation.
- Keyless profiles (users who can't obtain IRK/ENC keys and rely on fuzzy matching) are deliberately
  left exactly as before — their devices were never IRK-backed, so the gate is a no-op for them.
  This does **not** fix the same flicker for keyless setups; without a key there's no strong identity
  to disambiguate two same-model devices, which is inherent.
- The "is this device keyed" signal is latched durably on the known-device record (not re-derived
  from the trimmed history window), so it can't erode over a long session.
- Also stabilizes a flaky AAP handshake-timeout test inherited from the previous change (it asserted
  an exact socket-close count that races between two cleanup paths, and used a tight latch timeout) —
  it was failing intermittently on loaded CI runners, unrelated to this fix.

## Review checklist

- [ ] Gate applies only to the weak paths (fuzzy `baseSearch`, case-ignored `search`); strong
      address/IRK recovery unchanged
- [ ] `boundProfileId` is latched on any IRK-matched frame and never cleared by a later unbound frame
- [ ] Keyless devices (`boundProfileId == null`) keep identical fuzzy-matching behaviour
- [ ] A rejected foreign frame mints its own id (no unbounded `knownDevices` growth beyond the 30s prune)
