### PR TITLE
Reaction: Keep media paused during pauses in a conversation

### DIFF
--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManager.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/AapConnectionManager.kt
@@ -75,10 +75,10 @@ class AapConnectionManager @Inject constructor(
     val sleepEvents: SharedFlow<BluetoothAddress> = _sleepEvents.asSharedFlow()
 
     /**
-     * Emits when a connected device reports a Conversational Awareness speaking transition
-     * (START/STOP, AAP command 0x4B). Paired with the origin address so the conversation
-     * reaction can gate on the primary device. Only the known 0x01/0x04 markers reach here —
-     * the engine drops unknown raw values (see [AapSessionEngine]).
+     * Emits when a connected device reports a Conversational Awareness transition (START / RESUME /
+     * HOLD / STOP, AAP command 0x4B). Paired with the origin address so the conversation reaction
+     * can gate on the primary device. Every well-formed frame is classified and emitted (unknown
+     * status bytes map to HOLD); only structurally malformed frames are dropped (see [AapSessionEngine]).
      */
     private val _conversationalAwarenessEvents =
         MutableSharedFlow<Pair<BluetoothAddress, ConversationAwarenessEvent>>(extraBufferCapacity = 16)

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngine.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngine.kt
@@ -323,8 +323,8 @@ internal class AapSessionEngine(
         }
 
         // Re-emit every (well-formed) Conversational Awareness frame as a classified event for the
-        // conversation reaction: START / STOP / HOLD (keep-alive). The decoder already dropped
-        // malformed frames (rawValue stays null only in that case). The raw payload remains logged.
+        // conversation reaction: START / RESUME / HOLD / STOP. The decoder already dropped malformed
+        // frames (rawValue stays null only in that case). The raw payload remains logged.
         if (value is AapSetting.ConversationalAwarenessState) {
             value.rawValue?.let { _conversationalAwarenessEvents.tryEmit(ConversationAwarenessEvent.fromStatus(it)) }
         }

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/AapSetting.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/AapSetting.kt
@@ -105,7 +105,7 @@ sealed class AapSetting {
      * [rawValue] is the status byte: the last byte of the 4-byte `02 00 01 XX` form (or the single
      * byte of the legacy form), preserved so consumers can classify it. [speaking] is `true` only
      * for the speaking-onset statuses (`1`, `2`); every other value (`0`, `3`, `4`, `5`, `0x0B`, …)
-     * is `false`. START/STOP/HOLD classification for the reaction lives in [ConversationAwarenessEvent].
+     * is `false`. START/RESUME/HOLD/STOP classification for the reaction lives in [ConversationAwarenessEvent].
      */
     data class ConversationalAwarenessState(
         val speaking: Boolean,

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/AapSetting.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/AapSetting.kt
@@ -103,9 +103,10 @@ sealed class AapSetting {
      * Push-only from device — reports speaking detection state (command 0x4B).
      *
      * [rawValue] is the status byte: the last byte of the 4-byte `02 00 01 XX` form (or the single
-     * byte of the legacy form), preserved so consumers can classify it. [speaking] is `true` only
-     * for the speaking-onset statuses (`1`, `2`); every other value (`0`, `3`, `4`, `5`, `0x0B`, …)
-     * is `false`. START/RESUME/HOLD/STOP classification for the reaction lives in [ConversationAwarenessEvent].
+     * byte of the legacy form), preserved so consumers can classify it. [speaking] is `true` while
+     * the wearer is talking — onset (`1`, `2`) or resumed after a pause (`5`); every other value
+     * (`0`, `3`, `4`, `0x0B`, …) is `false`. START/RESUME/HOLD/STOP classification for the reaction
+     * lives in [ConversationAwarenessEvent].
      */
     data class ConversationalAwarenessState(
         val speaking: Boolean,

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/ConversationAwarenessEvent.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/ConversationAwarenessEvent.kt
@@ -12,9 +12,10 @@ package eu.darken.capod.pods.core.apple.aap.protocol
  * - `5` → [RESUME] (speech resumed after a pause; the wind-down was aborted, CA stays engaged). In
  *   bursty speech the pod cycles `3,5,3,5,…`; `5` is NEVER a terminal. Misreading `5` as a stop was
  *   the root cause of the premature-resume bug — see [ConversationReaction].
- * - `8`, `9` → [STOP] (conversation ended → disengage). The terminal is always the `8`→`9` pair.
- *   Pod removal / case-close also emit `8`,`9` (sometimes with no prior `1`,`2`).
- * - any other value (`3` pause, `4` / `0x0B` wind-down, `7` abort, `6`, and anything unrecognised)
+ * - `6`, `8`, `9` → [STOP] (conversation ended → disengage). The usual terminal is the `8`→`9`
+ *   pair; `6` is a standalone terminal seen live on Pro 2 USB-C fw `…6814`. Pod removal / case-close
+ *   also emit `8`,`9` (sometimes with no prior `1`,`2`).
+ * - any other value (`3` pause, `4` / `0x0B` wind-down, `7` abort, and anything unrecognised)
  *   → [HOLD]: a transitional "possible/real wind-down" frame. The real wind-down runs `3→0x0B→4`
  *   then the `8,9` terminal; `7` precedes an aborted terminal. Unknown values are deliberately
  *   classified as HOLD (arm the safety fuse, never resume immediately) rather than guessed at.
@@ -37,7 +38,7 @@ enum class ConversationAwarenessEvent {
     companion object {
         val SPEAKING_STATUSES = setOf(1, 2)
         val RESUME_STATUSES = setOf(5)
-        val STOPPED_STATUSES = setOf(8, 9)
+        val STOPPED_STATUSES = setOf(6, 8, 9)
 
         fun fromStatus(status: Int): ConversationAwarenessEvent = when (status) {
             in SPEAKING_STATUSES -> START

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/ConversationAwarenessEvent.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/ConversationAwarenessEvent.kt
@@ -3,36 +3,45 @@ package eu.darken.capod.pods.core.apple.aap.protocol
 /**
  * Classified Conversational Awareness signal derived from the status byte of a `0x4B` frame.
  *
- * Status-byte mapping (from live AirPods Pro 3 + Pro 2 USB-C captures — both models share one
- * firmware train and a byte-identical protocol — plus the librepods project):
- * - `1`, `2` → [START] (wearer started / is speaking → engage the reaction)
- * - `5`, `6`, `8`, `9` → [STOP] (wearer stopped → disengage). All four confirmed live on Pro 2
- *   USB-C fw `…6814`; which one terminates a given flurry varies with how speech ended.
- * - any other value (`0`, `3`, `4`, `7`, `0x0B`, … and anything unrecognised) → [HOLD]: a
- *   transitional wind-down frame (`7` was only discovered on fw `…6814` — the set is open-ended,
- *   so unknown values are deliberately classified as HOLD rather than guessed at).
+ * Status-byte mapping, derived from a labelled capture set across AirPods Pro 3 and Pro 2 USB-C
+ * (`protocol-research/conversationalawareness/` — both models share one firmware train and emit
+ * byte-identical sequences). Each scenario was captured with a known action (normal talking,
+ * bursty talking, single-pod, volume-up abort, pod removal/case):
+ * - `1`, `2` → [START] (conversation onset / wind-up → engage the reaction). A conversation always
+ *   opens `1` then `2`; re-onset only ever happens after a terminal.
+ * - `5` → [RESUME] (speech resumed after a pause; the wind-down was aborted, CA stays engaged). In
+ *   bursty speech the pod cycles `3,5,3,5,…`; `5` is NEVER a terminal. Misreading `5` as a stop was
+ *   the root cause of the premature-resume bug — see [ConversationReaction].
+ * - `8`, `9` → [STOP] (conversation ended → disengage). The terminal is always the `8`→`9` pair.
+ *   Pod removal / case-close also emit `8`,`9` (sometimes with no prior `1`,`2`).
+ * - any other value (`3` pause, `4` / `0x0B` wind-down, `7` abort, `6`, and anything unrecognised)
+ *   → [HOLD]: a transitional "possible/real wind-down" frame. The real wind-down runs `3→0x0B→4`
+ *   then the `8,9` terminal; `7` precedes an aborted terminal. Unknown values are deliberately
+ *   classified as HOLD (arm the safety fuse, never resume immediately) rather than guessed at.
  *
  * The pod sends NO frames during active speech — it stays engaged (and silent) for as long as it
  * hears nearby voices, 20-30s+ observed. So frame-silence must NOT be read as "speaking ended".
- * Conversely, any non-START frame means the wind-down has begun: a short flurry of transitional
- * and terminal frames (e.g. `3,0xB,4,8,9` or `3,5,7,8,9`). With only ONE pod worn (other in
- * case/disconnected) the terminal is deterministically dropped — the flurry ends on a transitional
- * `4` (#608; reproduced on Pro 3 and Pro 2 alike) — so [ConversationReaction] treats a HOLD as
- * "terminal imminent" and arms a short fuse, with a long stale backstop for a fully-dropped flurry.
- * A flurry's trailing frames may arrive after its terminal; they are ignored once disengaged.
+ * A HOLD means the wind-down may have begun; with only ONE pod worn the `8,9` terminal is
+ * deterministically dropped — the flurry ends on `4` (#608, reproduced on Pro 3 and Pro 2) — so
+ * [ConversationReaction] treats a HOLD as "terminal imminent" and arms a short fuse, with a long
+ * stale backstop for a fully-dropped flurry. A RESUME (`5`) cancels that fuse and re-arms the long
+ * backstop; trailing frames after a terminal are ignored once disengaged.
  */
 enum class ConversationAwarenessEvent {
     START,
+    RESUME,
     HOLD,
     STOP,
     ;
 
     companion object {
         val SPEAKING_STATUSES = setOf(1, 2)
-        val STOPPED_STATUSES = setOf(5, 6, 8, 9)
+        val RESUME_STATUSES = setOf(5)
+        val STOPPED_STATUSES = setOf(8, 9)
 
         fun fromStatus(status: Int): ConversationAwarenessEvent = when (status) {
             in SPEAKING_STATUSES -> START
+            in RESUME_STATUSES -> RESUME
             in STOPPED_STATUSES -> STOP
             else -> HOLD
         }

--- a/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/DefaultAapDeviceProfile.kt
+++ b/app/src/main/java/eu/darken/capod/pods/core/apple/aap/protocol/DefaultAapDeviceProfile.kt
@@ -197,8 +197,11 @@ class DefaultAapDeviceProfile(
                     p[3].toInt() and 0xFF
                 else -> return null
             }
-            // speaking = the "started/active speaking" statuses (1,2); see ConversationAwarenessEvent.
-            val speaking = status in ConversationAwarenessEvent.SPEAKING_STATUSES
+            // speaking = the wearer is currently speaking: onset (1,2) or resumed after a pause (5).
+            // See ConversationAwarenessEvent. (Consumers read rawValue for full classification; this
+            // bool just exposes "is talking now", so a resume must count as speaking too.)
+            val speaking = status in ConversationAwarenessEvent.SPEAKING_STATUSES ||
+                status in ConversationAwarenessEvent.RESUME_STATUSES
             return AapSetting.ConversationalAwarenessState::class to
                 AapSetting.ConversationalAwarenessState(speaking, rawValue = status)
         }

--- a/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -92,9 +91,25 @@ class ConversationReaction @Inject constructor(
         val at: Long,
     )
 
+    /** What the single pending [disengageJob] is currently waiting for. */
+    private enum class TimerPhase {
+        /** Long backstop while only START/RESUME seen — inferred end if it fires. */
+        STALE_BACKSTOP,
+
+        /** Short fuse armed by a wind-down HOLD — terminal imminent (or dropped, #608). */
+        WIND_DOWN_FUSE,
+
+        /** Brief wait on an uncorroborated cold terminal to see if a pod-removal ear change follows. */
+        STOP_SETTLE,
+    }
+
     private val mutex = Mutex()
     private var active: Active? = null
-    private var staleJob: Job? = null
+    private var disengageJob: Job? = null
+    private var timerPhase: TimerPhase? = null
+    // Bumped on every (re)arm. A timer job captures its generation and only acts if still current —
+    // guards against a stale job that already passed its delay being re-armed to the SAME phase.
+    private var timerGeneration = 0L
     private var idCounter = 0L
 
     // Per-owner AAP ear-detection tracking, so a CA terminal that lands right after a pod
@@ -134,13 +149,17 @@ class ConversationReaction @Inject constructor(
             val current = active
             if (current != null && current.owner == address) {
                 // Duplicate START for the same speaker — don't re-act, just keep the session alive.
-                // A START also cancels a pending wind-down fuse: the wearer is speaking again.
-                armDisengageTimer(current, STALE_TIMEOUT)
+                // A START also cancels a pending wind-down fuse / settle: the wearer is speaking again.
+                armTimer(current, TimerPhase.STALE_BACKSTOP)
                 log(TAG) { "START from $address — already active ($action), keep-alive" }
                 return
             }
-            // A different device started speaking while we were active — undo the old one first.
-            if (current != null) revert(current, "superseded by $address")
+            // A different device started speaking while we were active — undo the old one first and
+            // cancel its pending timer (the no-op engage paths below would otherwise leak it).
+            if (current != null) {
+                revert(current, "superseded by $address")
+                clearActive()
+            }
 
             when (action) {
                 ConversationAction.PAUSE -> {
@@ -148,7 +167,7 @@ class ConversationReaction @Inject constructor(
                     if (paused) {
                         val record = Active(nextId(), address, Kind.Paused, timeSource.elapsedRealtime())
                         active = record
-                        armDisengageTimer(record, STALE_TIMEOUT)
+                        armTimer(record, TimerPhase.STALE_BACKSTOP)
                         log(TAG, INFO) { "START on $address → paused media" }
                     } else {
                         active = null
@@ -171,7 +190,7 @@ class ConversationReaction @Inject constructor(
                             timeSource.elapsedRealtime(),
                         )
                         active = record
-                        armDisengageTimer(record, STALE_TIMEOUT)
+                        armTimer(record, TimerPhase.STALE_BACKSTOP)
                         log(TAG, INFO) { "START on $address → ducked volume ${duck.priorVolume}→${duck.appliedVolume}" }
                     } else {
                         active = null
@@ -194,7 +213,7 @@ class ConversationReaction @Inject constructor(
     private suspend fun onSpeakingResume(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
         if (current.owner != address) return
-        armDisengageTimer(current, STALE_TIMEOUT)
+        armTimer(current, TimerPhase.STALE_BACKSTOP)
         log(TAG) { "RESUME from $address — speech resumed, keep-alive" }
     }
 
@@ -207,7 +226,7 @@ class ConversationReaction @Inject constructor(
     private suspend fun onSpeakingHold(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
         if (current.owner != address) return
-        armDisengageTimer(current, WIND_DOWN_TIMEOUT)
+        armTimer(current, TimerPhase.WIND_DOWN_FUSE)
     }
 
     private suspend fun onSpeakingStop(address: BluetoothAddress) {
@@ -218,21 +237,31 @@ class ConversationReaction @Inject constructor(
                 log(TAG) { "STOP from $address ignored — owner is ${current.owner}" }
                 return
             }
-            // Pulling/inserting a pod makes the firmware tear down and re-key CA — it emits a terminal
-            // (8,9) then a fresh onset (1,2) around the physical change, even though the conversation
-            // is still going. So a terminal that lands right after an ear-detection transition is not
-            // a real end: defer to the short wind-down fuse instead of disengaging. A genuine re-onset
-            // cancels it (no resume/restore churn — fixes the PAUSE strand and the LOWER_VOLUME blip on
-            // removal); if the conversation really ended, the fuse disengages within seconds.
-            if (isRecentEarTransition(address)) {
-                armDisengageTimer(current, WIND_DOWN_TIMEOUT)
-                log(TAG) { "STOP from $address during ear transition — deferring to fuse, not disengaging" }
-                return@withLock
+            // The 0x06 ear-detection frame may have arrived but not yet been processed by the
+            // allStates collector — fold the latest snapshot in before deciding (in-app ordering race).
+            refreshEarTransition(address)
+
+            // Pulling/inserting a pod makes the firmware re-key CA — a terminal (8,9) then a fresh
+            // onset (1,2) around the physical change, even though the conversation continues.
+            when {
+                // Ear change already seen → re-key artifact. Defer to the fuse; a re-onset cancels it.
+                isRecentEarTransition(address) -> {
+                    armTimer(current, TimerPhase.WIND_DOWN_FUSE)
+                    log(TAG) { "STOP from $address during ear transition — deferring to fuse" }
+                }
+                // Corroborated by a preceding wind-down (3,0xB,4 / abort 7): a real end → resume now.
+                timerPhase == TimerPhase.WIND_DOWN_FUSE -> {
+                    clearActive()
+                    disengage(current, primary, "STOP on $address", applyAgeGuard = false)
+                }
+                // Cold terminal with no wind-down and no ear change yet. On primary-pod removal the
+                // firmware sends the terminal a few ms BEFORE the ear-detection frame, so wait a short
+                // settle to see if an ear change lands before treating it as a real end.
+                else -> {
+                    armTimer(current, TimerPhase.STOP_SETTLE)
+                    log(TAG) { "STOP from $address — uncorroborated, settling" }
+                }
             }
-            clearActive()
-            // An explicit terminal frame is positive evidence CA ended now → resume regardless of how
-            // long ago we engaged. The age guard is only for inferred (stale-backstop) ends.
-            disengage(current, primary, "STOP on $address", applyAgeGuard = false)
         }
     }
 
@@ -272,15 +301,7 @@ class ConversationReaction @Inject constructor(
 
     private suspend fun onStatesUpdated(states: Map<BluetoothAddress, AapPodState>) = mutex.withLock {
         // Record when each device's AAP ear-detection last changed (pod removed/inserted/cased).
-        // The very first observation of a device only seeds the baseline — it is not a transition.
-        val now = timeSource.elapsedRealtime()
-        for ((address, state) in states) {
-            val ear = state.aapEarDetection
-            if (lastEarDetection.containsKey(address) && lastEarDetection[address] != ear) {
-                earTransitionAt[address] = now
-            }
-            lastEarDetection[address] = ear
-        }
+        for ((address, state) in states) recordEarIfChanged(address, state.aapEarDetection)
         lastEarDetection.keys.retainAll(states.keys)
         earTransitionAt.keys.retainAll(states.keys)
 
@@ -289,6 +310,22 @@ class ConversationReaction @Inject constructor(
             clearActive()
             revert(current, "owner ${current.owner} gone")
         }
+    }
+
+    /**
+     * Must be called under [mutex]. Notes an AAP ear-detection transition for [address]. The very
+     * first observation of a device only seeds the baseline — it is not counted as a transition.
+     */
+    private fun recordEarIfChanged(address: BluetoothAddress, ear: AapSetting.EarDetection?) {
+        if (lastEarDetection.containsKey(address) && lastEarDetection[address] != ear) {
+            earTransitionAt[address] = timeSource.elapsedRealtime()
+        }
+        lastEarDetection[address] = ear
+    }
+
+    /** Must be called under [mutex]. Folds the latest allStates snapshot in for [address]. */
+    private fun refreshEarTransition(address: BluetoothAddress) {
+        recordEarIfChanged(address, aapManager.allStates.value[address]?.aapEarDetection)
     }
 
     private suspend fun onMonitorCompleted() = mutex.withLock {
@@ -316,36 +353,60 @@ class ConversationReaction @Inject constructor(
         mediaControl.restoreMusicVolume(kind.priorVolume)
     }
 
-    /** Must be called under [mutex]. Clears the active slot and cancels its stale timer. */
+    /** Must be called under [mutex]. Clears the active slot and cancels its pending timer. */
     private fun clearActive() {
-        staleJob?.cancel()
-        staleJob = null
+        disengageJob?.cancel()
+        disengageJob = null
+        timerPhase = null
         active = null
     }
 
     /**
-     * Must be called under [mutex]. (Re)arms the disengage timer for [record] — every frame picks
-     * the fuse matching its meaning: START / RESUME → [STALE_TIMEOUT] (active speech, frames cease
-     * for its whole duration), HOLD → [WIND_DOWN_TIMEOUT] (wind-down begun, terminal imminent). On
-     * expiry the session is force-ended. Identity-checked so a late timer can't disengage a newer
-     * session. The age guard ([PAUSE_RESUME_WINDOW]) is applied only when the long [STALE_TIMEOUT]
-     * fires — that is the purely-inferred "we lost track" end; the short wind-down fuse is driven by a
-     * recent HOLD and should resume even after a long conversation (dropped-terminal #608 recovery).
+     * Must be called under [mutex]. (Re)arms the single disengage timer for [record] in [phase],
+     * replacing whatever was pending. On expiry [onTimerExpired] decides per phase. Guarded on both
+     * [Active.id] and [phase] so a late timer can't act on a newer session or a re-armed phase.
      */
-    private fun armDisengageTimer(record: Active, timeout: Duration) {
-        val applyAgeGuard = timeout == STALE_TIMEOUT
-        staleJob?.cancel()
-        staleJob = appScope.launch {
+    private fun armTimer(record: Active, phase: TimerPhase) {
+        disengageJob?.cancel()
+        timerPhase = phase
+        val generation = ++timerGeneration
+        val timeout = when (phase) {
+            TimerPhase.STALE_BACKSTOP -> STALE_TIMEOUT
+            TimerPhase.WIND_DOWN_FUSE -> WIND_DOWN_TIMEOUT
+            TimerPhase.STOP_SETTLE -> STOP_SETTLE_DELAY
+        }
+        disengageJob = appScope.launch {
             delay(timeout)
             val primary = deviceMonitor.primaryDevice().first()
             mutex.withLock {
-                if (active?.id == record.id) {
-                    val current = active!!
-                    clearActive()
-                    disengage(current, primary, "no terminal frame within $timeout", applyAgeGuard = applyAgeGuard)
-                }
+                // generation guards against a stale job re-armed to the same phase for the same record.
+                if (active?.id == record.id && timerGeneration == generation) onTimerExpired(record, phase, primary)
             }
         }
+    }
+
+    /**
+     * Must be called under [mutex] from inside the firing timer job. Detaches the slot WITHOUT
+     * cancelling (we ARE that job — self-cancel could abort a following suspension), then acts:
+     * - STOP_SETTLE + an ear change appeared meanwhile → re-key artifact, hand off to the fuse.
+     * - otherwise force-end the session. The age guard applies only to the inferred STALE backstop;
+     *   the wind-down fuse and a settled cold terminal carry real/recent end evidence → resume regardless.
+     */
+    private suspend fun onTimerExpired(record: Active, phase: TimerPhase, primary: PodDevice?) {
+        disengageJob = null
+        timerPhase = null
+        if (phase == TimerPhase.STOP_SETTLE && isRecentEarTransition(record.owner)) {
+            armTimer(record, TimerPhase.WIND_DOWN_FUSE)
+            log(TAG) { "STOP settle elapsed for ${record.owner} — ear transition appeared, deferring to fuse" }
+            return
+        }
+        active = null
+        val reason = when (phase) {
+            TimerPhase.STALE_BACKSTOP -> "no terminal within backstop"
+            TimerPhase.WIND_DOWN_FUSE -> "no terminal within wind-down fuse"
+            TimerPhase.STOP_SETTLE -> "cold terminal settled"
+        }
+        disengage(record, primary, reason, applyAgeGuard = phase == TimerPhase.STALE_BACKSTOP)
     }
 
     /** Must be called under [mutex]. True if [address] had an AAP ear-detection change very recently. */
@@ -395,5 +456,15 @@ class ConversationReaction @Inject constructor(
          * seconds away. Kept well under that gap so genuine terminals aren't deferred to the fuse.
          */
         private val EAR_TRANSITION_WINDOW = 2.seconds
+
+        /**
+         * How long to wait on an *uncorroborated cold* terminal (no preceding wind-down HOLD, no ear
+         * change yet) before treating it as a real end. Covers the reverse frame-ordering on
+         * primary-pod removal, where the firmware sends the terminal a few ms BEFORE the ear-detection
+         * frame — too early for the backward-looking check. Only cold terminals settle; a normal end
+         * (`…3,0xB,4,8`) and an abort (`7,8`) are already corroborated by the fuse and resume instantly,
+         * so this adds no latency to genuine conversation ends.
+         */
+        private val STOP_SETTLE_DELAY = 250.milliseconds
     }
 }

--- a/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
@@ -40,17 +40,23 @@ import kotlin.time.Duration.Companion.seconds
  * volume or pausing, per the primary device's [ReactionConfig.conversationAction], and reverts when
  * speaking stops. On Android the pod firmware does not duck audio itself, so CAPod performs it.
  *
- * Disengage is driven by the pod's explicit end-of-speech frame ([ConversationAwarenessEvent.STOP]).
- * The pod sends NO frames during active speech — it stays engaged for as long as it hears nearby
- * voices (observed: CA held engaged 21-32s with zero `0x4B` frames, indefinitely against ambient
- * noise). So frame-silence must NOT be read as "speaking ended"; after a START only the long
- * [STALE_TIMEOUT] backstop applies, and a link drop is handled by the owner-disconnect revert.
+ * Disengage is driven by the pod's explicit end-of-speech frame ([ConversationAwarenessEvent.STOP],
+ * status `8,9`). The pod sends NO frames during active speech — it stays engaged for as long as it
+ * hears nearby voices (observed: CA held engaged 21-32s with zero `0x4B` frames, indefinitely
+ * against ambient noise). So frame-silence must NOT be read as "speaking ended"; after a START only
+ * the long [STALE_TIMEOUT] backstop applies, and a link drop is handled by the owner-disconnect revert.
  *
- * Because the pod is silent while engaged, any non-START frame is evidence the wind-down has begun.
- * The wind-down is a short flurry of transitional ([ConversationAwarenessEvent.HOLD]) and terminal
- * frames — but the terminal is sometimes dropped entirely (fw `…6589` emitted `3,0xB,4` then nothing,
- * stranding the volume low — #608). So a HOLD frame re-arms the timer with the short
- * [WIND_DOWN_TIMEOUT] fuse: if no terminal follows, speech is treated as ended anyway.
+ * A [ConversationAwarenessEvent.HOLD] frame (`3` pause, `0x0B`/`4` wind-down, `7` abort) is evidence
+ * the wind-down may have begun. The real wind-down is a short flurry `3→0x0B→4` then the `8,9`
+ * terminal — but the terminal is sometimes dropped entirely (single-pod wear: fw `…6589`/`…6861`
+ * emitted `3,0xB,4` then nothing, stranding the volume low — #608). So a HOLD frame re-arms the
+ * timer with the short [WIND_DOWN_TIMEOUT] fuse: if no terminal (or resume) follows, speech is
+ * treated as ended anyway.
+ *
+ * A [ConversationAwarenessEvent.RESUME] frame (`5`) means speech resumed after a pause — in bursty
+ * talking the pod cycles `3,5,3,5,…` while CA stays engaged. It is NOT a terminal: it cancels any
+ * armed wind-down fuse and re-arms the long backstop, so media stays paused/ducked through the whole
+ * conversation. (Treating `5` as a stop was the premature-resume + stuck bug.)
  *
  * State is a single global slot (media volume / playback is system-wide, not per-device) guarded by
  * a [Mutex] — events, AAP-state-removal, the stale timer, and monitor completion all mutate it.
@@ -96,6 +102,7 @@ class ConversationReaction @Inject constructor(
 
     private suspend fun onEvent(address: BluetoothAddress, event: ConversationAwarenessEvent) = when (event) {
         ConversationAwarenessEvent.START -> onSpeakingStart(address)
+        ConversationAwarenessEvent.RESUME -> onSpeakingResume(address)
         ConversationAwarenessEvent.HOLD -> onSpeakingHold(address)
         ConversationAwarenessEvent.STOP -> onSpeakingStop(address)
     }
@@ -164,9 +171,24 @@ class ConversationReaction @Inject constructor(
     }
 
     /**
-     * Transitional wind-down frame. The pod is silent during active speech, so this frame means the
-     * wind-down has begun and a terminal frame is imminent — but firmware sometimes drops it (#608).
-     * Arm the short fuse: if no terminal (or fresh START) follows, disengage anyway.
+     * Speech resumed (status `5`) after a pause — the wind-down was aborted, the wearer is talking
+     * again. Cancel any armed wind-down fuse and re-arm the long [STALE_TIMEOUT] backstop, exactly
+     * like a duplicate-START keep-alive, so media stays paused/ducked through the conversation. Does
+     * NOT engage from scratch: a RESUME with no active session is ignored (a conversation always
+     * opens with a START, and a stray `5` should never start a pause/duck on its own).
+     */
+    private suspend fun onSpeakingResume(address: BluetoothAddress) = mutex.withLock {
+        val current = active ?: return
+        if (current.owner != address) return
+        armDisengageTimer(current, STALE_TIMEOUT)
+        log(TAG) { "RESUME from $address — speech resumed, keep-alive" }
+    }
+
+    /**
+     * Transitional wind-down frame (`3` pause, `0x0B`/`4` wind-down, `7` abort). The pod is silent
+     * during active speech, so this frame means the wind-down may have begun and a terminal frame is
+     * imminent — but firmware sometimes drops it (#608, single-pod wear). Arm the short fuse: if no
+     * terminal (or a fresh START / RESUME) follows, disengage anyway.
      */
     private suspend fun onSpeakingHold(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
@@ -258,9 +280,10 @@ class ConversationReaction @Inject constructor(
 
     /**
      * Must be called under [mutex]. (Re)arms the disengage timer for [record] — every frame picks
-     * the fuse matching its meaning: START → [STALE_TIMEOUT] (active speech, frames cease for its
-     * whole duration), HOLD → [WIND_DOWN_TIMEOUT] (wind-down begun, terminal imminent). On expiry
-     * the session is force-ended. Identity-checked so a late timer can't disengage a newer session.
+     * the fuse matching its meaning: START / RESUME → [STALE_TIMEOUT] (active speech, frames cease
+     * for its whole duration), HOLD → [WIND_DOWN_TIMEOUT] (wind-down begun, terminal imminent). On
+     * expiry the session is force-ended. Identity-checked so a late timer can't disengage a newer
+     * session.
      */
     private fun armDisengageTimer(record: Active, timeout: Duration) {
         staleJob?.cancel()
@@ -283,7 +306,7 @@ class ConversationReaction @Inject constructor(
         private val TAG = logTag("Reaction", "Conversation")
 
         /**
-         * Backstop fuse while engaged with no wind-down evidence yet (only START frames seen).
+         * Backstop fuse while engaged with no wind-down evidence yet (START/RESUME frames seen).
          * Must stay LONG: the pod sends zero frames during active speech and stays engaged against
          * ambient noise, so a short timeout here resumes media mid-conversation (the original 12s
          * value did exactly that). Only recovers a session whose entire wind-down flurry was lost
@@ -299,7 +322,7 @@ class ConversationReaction @Inject constructor(
          * pod deterministically drops the terminal (#608, reproduced on Pro 3 and Pro 2) — this
          * fuse disengages instead of stranding the volume low for [STALE_TIMEOUT]. Must be ≥ ~5s:
          * gaps up to 2.8s were observed between consecutive wind-down frames, and each HOLD re-arms
-         * this fuse. A fresh START re-arms the long fuse (speaking resumed).
+         * this fuse. A fresh START or RESUME (`5`, speech resumed) re-arms the long fuse instead.
          */
         private val WIND_DOWN_TIMEOUT = 6.seconds
 

--- a/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
@@ -12,6 +12,8 @@ import eu.darken.capod.monitor.core.DeviceMonitor
 import eu.darken.capod.monitor.core.PodDevice
 import eu.darken.capod.monitor.core.primaryDevice
 import eu.darken.capod.pods.core.apple.aap.AapConnectionManager
+import eu.darken.capod.pods.core.apple.aap.AapPodState
+import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import eu.darken.capod.pods.core.apple.aap.protocol.ConversationAwarenessEvent
 import eu.darken.capod.profiles.core.ReactionConfig
 import kotlinx.coroutines.CoroutineScope
@@ -58,6 +60,12 @@ import kotlin.time.Duration.Companion.seconds
  * armed wind-down fuse and re-arms the long backstop, so media stays paused/ducked through the whole
  * conversation. (Treating `5` as a stop was the premature-resume + stuck bug.)
  *
+ * Removing/inserting a pod makes the firmware re-key CA — it emits a terminal then a fresh onset
+ * around the physical change even though the conversation continues. A terminal arriving within
+ * [EAR_TRANSITION_WINDOW] of an AAP ear-detection change is therefore treated as a re-key artifact:
+ * it defers to the wind-down fuse instead of disengaging, so a brief pod removal mid-conversation
+ * neither strands a pause nor causes a duck→restore→re-duck volume blip.
+ *
  * State is a single global slot (media volume / playback is system-wide, not per-device) guarded by
  * a [Mutex] — events, AAP-state-removal, the stale timer, and monitor completion all mutate it.
  * Volume ducks are additionally reverted on owner-disconnect and monitor completion so a dropped
@@ -89,11 +97,17 @@ class ConversationReaction @Inject constructor(
     private var staleJob: Job? = null
     private var idCounter = 0L
 
+    // Per-owner AAP ear-detection tracking, so a CA terminal that lands right after a pod
+    // removal/insertion can be recognised as a re-key artifact rather than a real conversation end.
+    private val lastEarDetection = mutableMapOf<BluetoothAddress, AapSetting.EarDetection?>()
+    private val earTransitionAt = mutableMapOf<BluetoothAddress, Long>()
+
     fun monitor(): Flow<Unit> = merge(
         aapManager.conversationalAwarenessEvents.onEach { (address, event) -> onEvent(address, event) },
-        // Reverts a stranded duck when the owning device leaves the AAP state map for any reason
-        // (intentional or not) — disconnectEvents only fires for unintentional drops.
-        aapManager.allStates.onEach { states -> onActiveDevicesChanged(states.keys) },
+        // Tracks ear-detection transitions (for terminal-artifact suppression) and reverts a stranded
+        // duck when the owning device leaves the AAP state map for any reason (intentional or not) —
+        // disconnectEvents only fires for unintentional drops.
+        aapManager.allStates.onEach { states -> onStatesUpdated(states) },
     )
         .map { }
         // Service stop / scope cancellation: undo any active duck so we don't leave volume lowered.
@@ -204,6 +218,17 @@ class ConversationReaction @Inject constructor(
                 log(TAG) { "STOP from $address ignored — owner is ${current.owner}" }
                 return
             }
+            // Pulling/inserting a pod makes the firmware tear down and re-key CA — it emits a terminal
+            // (8,9) then a fresh onset (1,2) around the physical change, even though the conversation
+            // is still going. So a terminal that lands right after an ear-detection transition is not
+            // a real end: defer to the short wind-down fuse instead of disengaging. A genuine re-onset
+            // cancels it (no resume/restore churn — fixes the PAUSE strand and the LOWER_VOLUME blip on
+            // removal); if the conversation really ended, the fuse disengages within seconds.
+            if (isRecentEarTransition(address)) {
+                armDisengageTimer(current, WIND_DOWN_TIMEOUT)
+                log(TAG) { "STOP from $address during ear transition — deferring to fuse, not disengaging" }
+                return@withLock
+            }
             clearActive()
             // An explicit terminal frame is positive evidence CA ended now → resume regardless of how
             // long ago we engaged. The age guard is only for inferred (stale-backstop) ends.
@@ -245,9 +270,22 @@ class ConversationReaction @Inject constructor(
         }
     }
 
-    private suspend fun onActiveDevicesChanged(addresses: Set<BluetoothAddress>) = mutex.withLock {
+    private suspend fun onStatesUpdated(states: Map<BluetoothAddress, AapPodState>) = mutex.withLock {
+        // Record when each device's AAP ear-detection last changed (pod removed/inserted/cased).
+        // The very first observation of a device only seeds the baseline — it is not a transition.
+        val now = timeSource.elapsedRealtime()
+        for ((address, state) in states) {
+            val ear = state.aapEarDetection
+            if (lastEarDetection.containsKey(address) && lastEarDetection[address] != ear) {
+                earTransitionAt[address] = now
+            }
+            lastEarDetection[address] = ear
+        }
+        lastEarDetection.keys.retainAll(states.keys)
+        earTransitionAt.keys.retainAll(states.keys)
+
         val current = active ?: return
-        if (current.owner !in addresses) {
+        if (current.owner !in states.keys) {
             clearActive()
             revert(current, "owner ${current.owner} gone")
         }
@@ -310,6 +348,12 @@ class ConversationReaction @Inject constructor(
         }
     }
 
+    /** Must be called under [mutex]. True if [address] had an AAP ear-detection change very recently. */
+    private fun isRecentEarTransition(address: BluetoothAddress): Boolean {
+        val at = earTransitionAt[address] ?: return false
+        return (timeSource.elapsedRealtime() - at).milliseconds <= EAR_TRANSITION_WINDOW
+    }
+
     private fun nextId(): Long = ++idCounter
 
     companion object {
@@ -343,5 +387,13 @@ class ConversationReaction @Inject constructor(
          * resumes regardless of age — those carry real/recent evidence the conversation just ended.
          */
         private val PAUSE_RESUME_WINDOW = 2.minutes
+
+        /**
+         * A CA terminal landing within this window of an AAP ear-detection change is treated as a pod
+         * removal/insertion re-key artifact (firmware emits 8,9 then 1,2 around the physical change),
+         * not a real end. The artifact terminal arrives ~40ms after the ear change; a real end is
+         * seconds away. Kept well under that gap so genuine terminals aren't deferred to the fuse.
+         */
+        private val EAR_TRANSITION_WINDOW = 2.seconds
     }
 }

--- a/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
@@ -121,7 +121,7 @@ class ConversationReaction @Inject constructor(
             if (current != null && current.owner == address) {
                 // Duplicate START for the same speaker — don't re-act, just keep the session alive.
                 // A START also cancels a pending wind-down fuse: the wearer is speaking again.
-                armDisengageTimer(current, STALE_TIMEOUT)
+                keepAlive(current, STALE_TIMEOUT)
                 log(TAG) { "START from $address — already active ($action), keep-alive" }
                 return
             }
@@ -180,7 +180,7 @@ class ConversationReaction @Inject constructor(
     private suspend fun onSpeakingResume(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
         if (current.owner != address) return
-        armDisengageTimer(current, STALE_TIMEOUT)
+        keepAlive(current, STALE_TIMEOUT)
         log(TAG) { "RESUME from $address — speech resumed, keep-alive" }
     }
 
@@ -193,7 +193,7 @@ class ConversationReaction @Inject constructor(
     private suspend fun onSpeakingHold(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
         if (current.owner != address) return
-        armDisengageTimer(current, WIND_DOWN_TIMEOUT)
+        keepAlive(current, WIND_DOWN_TIMEOUT)
     }
 
     private suspend fun onSpeakingStop(address: BluetoothAddress) {
@@ -276,6 +276,20 @@ class ConversationReaction @Inject constructor(
         staleJob?.cancel()
         staleJob = null
         active = null
+    }
+
+    /**
+     * Must be called under [mutex]. Keep-alive for the ongoing session [current]: refresh its
+     * activity timestamp and (re)arm the disengage timer. The timestamp refresh makes
+     * [PAUSE_RESUME_WINDOW] measure "time since the last frame" rather than "since engage" — without
+     * it a conversation longer than the window would fail the resume guard and strand media paused
+     * when its terminal finally arrives. A genuinely back-stopped session (no frames for the whole
+     * [STALE_TIMEOUT]) is unaffected: its timestamp is never refreshed, so it still won't auto-resume.
+     */
+    private fun keepAlive(current: Active, timeout: Duration) {
+        val refreshed = current.copy(at = timeSource.elapsedRealtime())
+        active = refreshed
+        armDisengageTimer(refreshed, timeout)
     }
 
     /**

--- a/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
@@ -121,7 +121,7 @@ class ConversationReaction @Inject constructor(
             if (current != null && current.owner == address) {
                 // Duplicate START for the same speaker — don't re-act, just keep the session alive.
                 // A START also cancels a pending wind-down fuse: the wearer is speaking again.
-                keepAlive(current, STALE_TIMEOUT)
+                armDisengageTimer(current, STALE_TIMEOUT)
                 log(TAG) { "START from $address — already active ($action), keep-alive" }
                 return
             }
@@ -180,7 +180,7 @@ class ConversationReaction @Inject constructor(
     private suspend fun onSpeakingResume(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
         if (current.owner != address) return
-        keepAlive(current, STALE_TIMEOUT)
+        armDisengageTimer(current, STALE_TIMEOUT)
         log(TAG) { "RESUME from $address — speech resumed, keep-alive" }
     }
 
@@ -193,7 +193,7 @@ class ConversationReaction @Inject constructor(
     private suspend fun onSpeakingHold(address: BluetoothAddress) = mutex.withLock {
         val current = active ?: return
         if (current.owner != address) return
-        keepAlive(current, WIND_DOWN_TIMEOUT)
+        armDisengageTimer(current, WIND_DOWN_TIMEOUT)
     }
 
     private suspend fun onSpeakingStop(address: BluetoothAddress) {
@@ -205,12 +205,19 @@ class ConversationReaction @Inject constructor(
                 return
             }
             clearActive()
-            disengage(current, primary, "STOP on $address")
+            // An explicit terminal frame is positive evidence CA ended now → resume regardless of how
+            // long ago we engaged. The age guard is only for inferred (stale-backstop) ends.
+            disengage(current, primary, "STOP on $address", applyAgeGuard = false)
         }
     }
 
-    /** Graceful disengage (STOP event or stale timeout). Must be called under [mutex]. */
-    private suspend fun disengage(record: Active, primary: PodDevice?, reason: String) {
+    /**
+     * Graceful disengage (STOP event or timer expiry). Must be called under [mutex]. [applyAgeGuard]
+     * gates resume on [PAUSE_RESUME_WINDOW]: `true` only for the inferred stale-backstop end (we lost
+     * track and timed out — surprise-resuming long after is worse than a stranded pause); `false` for
+     * an explicit terminal or the wind-down fuse, where a recent/real end signal makes resume correct.
+     */
+    private suspend fun disengage(record: Active, primary: PodDevice?, reason: String, applyAgeGuard: Boolean) {
         when (val kind = record.kind) {
             is Kind.Paused -> {
                 // Resume the pause WE caused, regardless of the current action setting. Gating on
@@ -219,7 +226,7 @@ class ConversationReaction @Inject constructor(
                 // surprising behaviour. The remaining guards are about real device/playback state.
                 val age = timeSource.elapsedRealtime() - record.at
                 when {
-                    age.milliseconds > PAUSE_RESUME_WINDOW ->
+                    applyAgeGuard && age.milliseconds > PAUSE_RESUME_WINDOW ->
                         log(TAG) { "$reason — resume skipped (stale, ${age}ms)" }
                     primary?.address != record.owner ->
                         log(TAG) { "$reason — resume skipped (primary switched)" }
@@ -279,27 +286,16 @@ class ConversationReaction @Inject constructor(
     }
 
     /**
-     * Must be called under [mutex]. Keep-alive for the ongoing session [current]: refresh its
-     * activity timestamp and (re)arm the disengage timer. The timestamp refresh makes
-     * [PAUSE_RESUME_WINDOW] measure "time since the last frame" rather than "since engage" — without
-     * it a conversation longer than the window would fail the resume guard and strand media paused
-     * when its terminal finally arrives. A genuinely back-stopped session (no frames for the whole
-     * [STALE_TIMEOUT]) is unaffected: its timestamp is never refreshed, so it still won't auto-resume.
-     */
-    private fun keepAlive(current: Active, timeout: Duration) {
-        val refreshed = current.copy(at = timeSource.elapsedRealtime())
-        active = refreshed
-        armDisengageTimer(refreshed, timeout)
-    }
-
-    /**
      * Must be called under [mutex]. (Re)arms the disengage timer for [record] — every frame picks
      * the fuse matching its meaning: START / RESUME → [STALE_TIMEOUT] (active speech, frames cease
      * for its whole duration), HOLD → [WIND_DOWN_TIMEOUT] (wind-down begun, terminal imminent). On
      * expiry the session is force-ended. Identity-checked so a late timer can't disengage a newer
-     * session.
+     * session. The age guard ([PAUSE_RESUME_WINDOW]) is applied only when the long [STALE_TIMEOUT]
+     * fires — that is the purely-inferred "we lost track" end; the short wind-down fuse is driven by a
+     * recent HOLD and should resume even after a long conversation (dropped-terminal #608 recovery).
      */
     private fun armDisengageTimer(record: Active, timeout: Duration) {
+        val applyAgeGuard = timeout == STALE_TIMEOUT
         staleJob?.cancel()
         staleJob = appScope.launch {
             delay(timeout)
@@ -308,7 +304,7 @@ class ConversationReaction @Inject constructor(
                 if (active?.id == record.id) {
                     val current = active!!
                     clearActive()
-                    disengage(current, primary, "no terminal frame within $timeout")
+                    disengage(current, primary, "no terminal frame within $timeout", applyAgeGuard = applyAgeGuard)
                 }
             }
         }
@@ -340,7 +336,12 @@ class ConversationReaction @Inject constructor(
          */
         private val WIND_DOWN_TIMEOUT = 6.seconds
 
-        /** A pause older than this no longer auto-resumes — unexpected late playback is worse. */
+        /**
+         * For an *inferred* end only (the [STALE_TIMEOUT] backstop fired — we lost track of the
+         * conversation), a pause older than this no longer auto-resumes: surprise playback long after
+         * is worse than a stranded pause. An explicit terminal frame, or the short wind-down fuse,
+         * resumes regardless of age — those carry real/recent evidence the conversation just ended.
+         */
         private val PAUSE_RESUME_WINDOW = 2.minutes
     }
 }

--- a/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
+++ b/app/src/main/java/eu/darken/capod/reaction/core/conversation/ConversationReaction.kt
@@ -284,7 +284,7 @@ class ConversationReaction @Inject constructor(
                         log(TAG) { "$reason — resume skipped (stale, ${age}ms)" }
                     primary?.address != record.owner ->
                         log(TAG) { "$reason — resume skipped (primary switched)" }
-                    primary.isBeingWorn == false ->
+                    wornForResume(primary) == false ->
                         log(TAG) { "$reason — resume skipped (not worn)" }
                     mediaControl.isPlaying ->
                         log(TAG) { "$reason — resume skipped (already playing)" }
@@ -408,6 +408,17 @@ class ConversationReaction @Inject constructor(
         }
         disengage(record, primary, reason, applyAgeGuard = phase == TimerPhase.STALE_BACKSTOP)
     }
+
+    /**
+     * Whether the pod is worn enough to resume into, honoring One-Pod Mode (mirrors
+     * [eu.darken.capod.reaction.core.autoconnect.AutoConnect]): with One-Pod Mode on, a single pod
+     * in ear counts as worn, falling back to the both-pods reading only when the single-pod signal is
+     * unknown. Returns `null` when ear state is genuinely unknown — the caller treats only an explicit
+     * `false` as not-worn, so an unknown stays lenient (resumes).
+     */
+    private fun wornForResume(device: PodDevice): Boolean? =
+        if (device.reactions.onePodMode) device.isEitherPodInEar ?: device.isBeingWorn
+        else device.isBeingWorn
 
     /** Must be called under [mutex]. True if [address] had an AAP ear-detection change very recently. */
     private fun isRecentEarTransition(address: BluetoothAddress): Boolean {

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/aap/devices/DefaultAapDeviceProfileTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/aap/devices/DefaultAapDeviceProfileTest.kt
@@ -412,6 +412,8 @@ class DefaultAapDeviceProfileTest : BaseAapSessionTest() {
     @Nested
     inner class ConversationAwarenessStateTests {
         @Test fun `speaking start`() { decodeSetting<AapSetting.ConversationalAwarenessState>(aapMessage("04 00 04 00 4B 00 01")).speaking shouldBe true }
+        @Test fun `speaking resume`() { decodeSetting<AapSetting.ConversationalAwarenessState>(aapMessage("04 00 04 00 4B 00 05")).speaking shouldBe true }
+        @Test fun `speaking pause`() { decodeSetting<AapSetting.ConversationalAwarenessState>(aapMessage("04 00 04 00 4B 00 03")).speaking shouldBe false }
         @Test fun `speaking stop`() { decodeSetting<AapSetting.ConversationalAwarenessState>(aapMessage("04 00 04 00 4B 00 04")).speaking shouldBe false }
         @Test fun `empty payload returns null`() { profile.decodeSetting(aapMessage("04 00 04 00 4B 00")).shouldBeNull() }
     }

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngineTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngineTest.kt
@@ -562,21 +562,32 @@ class AapSessionEngineTest : BaseTest() {
         }
 
         @Test
-        fun `terminal statuses 5, 6, 8, 9 emit STOP`() = runTest(UnconfinedTestDispatcher()) {
-            // 5 is the terminal wind-down value on fw …6861 (never reaches 6/8/9); 6/8/9 on fw …6503.
-            firstEventFor(5) shouldBe ConversationAwarenessEvent.STOP
-            firstEventFor(6) shouldBe ConversationAwarenessEvent.STOP
+        fun `status 5 emits RESUME`() = runTest(UnconfinedTestDispatcher()) {
+            // 5 = speech resumed after a pause (bursty talking cycles 3,5,3,5,…); NOT a terminal.
+            // Labelled captures across Pro 3 + Pro 2 USB-C show 5 only ever inside an active
+            // conversation, never ending one. Misreading it as STOP was the premature-resume bug.
+            firstEventFor(5) shouldBe ConversationAwarenessEvent.RESUME
+        }
+
+        @Test
+        fun `terminal statuses 8 and 9 emit STOP`() = runTest(UnconfinedTestDispatcher()) {
+            // The conversation terminal is always the 8→9 pair (both pods); also emitted by pod
+            // removal / case-close. 6 is never observed as a terminal, so it falls through to HOLD.
             firstEventFor(8) shouldBe ConversationAwarenessEvent.STOP
             firstEventFor(9) shouldBe ConversationAwarenessEvent.STOP
         }
 
         @Test
         fun `transitional and unknown statuses emit HOLD (stay engaged)`() = runTest(UnconfinedTestDispatcher()) {
-            // Must never disengage on these — only an explicit terminal STOP does.
+            // Must never resume immediately on these — they arm the short wind-down fuse instead.
+            // 3 = pause, 0x0B/4 = wind-down, 7 = abort; 6 and any unknown value default to HOLD.
             firstEventFor(3) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(4) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(0x0B) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(7) shouldBe ConversationAwarenessEvent.HOLD
+            firstEventFor(6) shouldBe ConversationAwarenessEvent.HOLD
+            firstEventFor(0) shouldBe ConversationAwarenessEvent.HOLD
+            firstEventFor(0xFF) shouldBe ConversationAwarenessEvent.HOLD
         }
     }
 

--- a/app/src/test/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngineTest.kt
+++ b/app/src/test/java/eu/darken/capod/pods/core/apple/aap/engine/AapSessionEngineTest.kt
@@ -570,9 +570,10 @@ class AapSessionEngineTest : BaseTest() {
         }
 
         @Test
-        fun `terminal statuses 8 and 9 emit STOP`() = runTest(UnconfinedTestDispatcher()) {
-            // The conversation terminal is always the 8→9 pair (both pods); also emitted by pod
-            // removal / case-close. 6 is never observed as a terminal, so it falls through to HOLD.
+        fun `terminal statuses 6, 8 and 9 emit STOP`() = runTest(UnconfinedTestDispatcher()) {
+            // The usual terminal is the 8→9 pair (both pods; also emitted by pod removal / case-close).
+            // 6 is a standalone terminal seen live on Pro 2 USB-C fw …6814.
+            firstEventFor(6) shouldBe ConversationAwarenessEvent.STOP
             firstEventFor(8) shouldBe ConversationAwarenessEvent.STOP
             firstEventFor(9) shouldBe ConversationAwarenessEvent.STOP
         }
@@ -580,12 +581,11 @@ class AapSessionEngineTest : BaseTest() {
         @Test
         fun `transitional and unknown statuses emit HOLD (stay engaged)`() = runTest(UnconfinedTestDispatcher()) {
             // Must never resume immediately on these — they arm the short wind-down fuse instead.
-            // 3 = pause, 0x0B/4 = wind-down, 7 = abort; 6 and any unknown value default to HOLD.
+            // 3 = pause, 0x0B/4 = wind-down, 7 = abort; any unknown value defaults to HOLD.
             firstEventFor(3) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(4) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(0x0B) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(7) shouldBe ConversationAwarenessEvent.HOLD
-            firstEventFor(6) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(0) shouldBe ConversationAwarenessEvent.HOLD
             firstEventFor(0xFF) shouldBe ConversationAwarenessEvent.HOLD
         }

--- a/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
@@ -6,6 +6,7 @@ import eu.darken.capod.monitor.core.DeviceMonitor
 import eu.darken.capod.monitor.core.PodDevice
 import eu.darken.capod.pods.core.apple.aap.AapConnectionManager
 import eu.darken.capod.pods.core.apple.aap.AapPodState
+import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import eu.darken.capod.pods.core.apple.aap.protocol.ConversationAwarenessEvent
 import eu.darken.capod.profiles.core.ReactionConfig
 import io.mockk.coEvery
@@ -30,6 +31,9 @@ class ConversationReactionTest : BaseTest() {
 
     private val primaryAddress: BluetoothAddress = "AA:BB:CC:DD:EE:FF"
     private val otherAddress: BluetoothAddress = "11:22:33:44:55:66"
+
+    private val inEar = AapSetting.EarDetection.PodPlacement.IN_EAR
+    private val outOfEar = AapSetting.EarDetection.PodPlacement.NOT_IN_EAR
 
     // Mirrors of ConversationReaction's private timing constants. STALE_TIMEOUT: long backstop
     // while only START frames were seen. WIND_DOWN_TIMEOUT: short fuse armed by a HOLD frame
@@ -92,6 +96,16 @@ class ConversationReactionTest : BaseTest() {
 
     private suspend fun TestScope.emit(address: BluetoothAddress, event: ConversationAwarenessEvent) {
         eventsFlow.emit(address to event)
+        runCurrent()
+    }
+
+    /** Simulates an AAP ear-detection transition (pod removed/inserted) for the primary device. */
+    private fun TestScope.changeEarDetection(primary: AapSetting.EarDetection.PodPlacement, secondary: AapSetting.EarDetection.PodPlacement) {
+        statesFlow.value = mapOf(
+            primaryAddress to mockk(relaxed = true) {
+                every { aapEarDetection } returns AapSetting.EarDetection(primary, secondary)
+            },
+        )
         runCurrent()
     }
 
@@ -539,6 +553,74 @@ class ConversationReactionTest : BaseTest() {
         verify(exactly = 0) { mediaControl.restoreMusicVolume(any()) }
         job.cancel()
     }
+
+    @Test
+    fun `PAUSE pod removal mid-conversation does not strand media paused`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Pulling a pod re-keys CA (terminal then fresh onset) while the conversation continues.
+            // The terminal lands right after the ear-detection change → defer to the fuse, the re-onset
+            // cancels it, media stays paused and the session alive. The real end later resumes.
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+            changeEarDetection(inEar, outOfEar)                       // pod pulled
+            emit(primaryAddress, ConversationAwarenessEvent.STOP)     // re-key terminal
+            emit(primaryAddress, ConversationAwarenessEvent.START)    // re-onset, still talking
+            advanceTimeBy(windDownTimeoutMs * 2)                      // fuse would have fired — but was cancelled
+            runCurrent()
+            coVerify(exactly = 0) { mediaControl.sendPlay() }         // still paused, not stranded-resumed early
+
+            timeSource.advanceBy(java.time.Duration.ofSeconds(3))     // past EAR_TRANSITION_WINDOW
+            advanceTimeBy(3_000)
+            runCurrent()
+            emit(primaryAddress, ConversationAwarenessEvent.STOP)     // genuine end, no recent ear change
+            coVerify(exactly = 1) { mediaControl.sendPlay() }         // resumes
+            job.cancel()
+        }
+
+    @Test
+    fun `LOWER_VOLUME pod removal mid-conversation does not blip the volume`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // The re-key terminal must not restore (which the immediate re-onset would then re-duck —
+            // an audible 5→10→5 jump). Defer to the fuse; the re-onset keeps it ducked.
+            val job = launchReaction() // default LOWER_VOLUME
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            verify(exactly = 1) { mediaControl.duckMusicVolume(any()) }
+
+            changeEarDetection(inEar, outOfEar)                       // pod pulled
+            emit(primaryAddress, ConversationAwarenessEvent.STOP)     // re-key terminal
+            verify(exactly = 0) { mediaControl.restoreMusicVolume(any()) } // no restore → no blip
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)    // re-onset
+            verify(exactly = 1) { mediaControl.duckMusicVolume(any()) } // not re-ducked (keep-alive only)
+            verify(exactly = 0) { mediaControl.restoreMusicVolume(any()) }
+            job.cancel()
+        }
+
+    @Test
+    fun `terminal during ear transition still disengages via the fuse if no re-onset follows`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Removed a pod AND the conversation actually ended (no re-onset): the deferred terminal's
+            // fuse must still disengage within seconds rather than waiting for the long backstop.
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+            changeEarDetection(inEar, outOfEar)
+            emit(primaryAddress, ConversationAwarenessEvent.STOP)     // deferred to fuse
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            advanceTimeBy(windDownTimeoutMs + 500)
+            runCurrent()
+            coVerify(exactly = 1) { mediaControl.sendPlay() }         // fuse disengaged
+            job.cancel()
+        }
 
     @Test
     fun `STOP from a non-owner does not disengage the active owner`() = runTest(UnconfinedTestDispatcher()) {

--- a/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
@@ -449,6 +449,32 @@ class ConversationReactionTest : BaseTest() {
         }
 
     @Test
+    fun `PAUSE resumes on the terminal even after a conversation longer than the resume window`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Each keep-alive frame refreshes the activity timestamp, so PAUSE_RESUME_WINDOW is
+            // measured from the last frame — not from engage. Without that refresh a 3-minute
+            // conversation would fail the age guard and strand media paused on its real terminal.
+            // Advance BOTH clocks so the window is genuinely exercised (the TestTimeSource drives age).
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+            repeat(3) {
+                timeSource.advanceBy(java.time.Duration.ofSeconds(60))
+                advanceTimeBy(60_000) // < STALE_TIMEOUT, so the backstop never fires
+                runCurrent()
+                emit(primaryAddress, ConversationAwarenessEvent.RESUME) // keep-alive, refreshes `at`
+            }
+            coVerify(exactly = 0) { mediaControl.sendPlay() } // 3 min in, still paused
+
+            emit(primaryAddress, ConversationAwarenessEvent.STOP) // terminal right after last activity
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+            job.cancel()
+        }
+
+    @Test
     fun `RESUME without a prior start is a no-op`() = runTest(UnconfinedTestDispatcher()) {
         devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
         val job = launchReaction()

--- a/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
@@ -451,10 +451,10 @@ class ConversationReactionTest : BaseTest() {
     @Test
     fun `PAUSE resumes on the terminal even after a conversation longer than the resume window`() =
         runTest(UnconfinedTestDispatcher()) {
-            // Each keep-alive frame refreshes the activity timestamp, so PAUSE_RESUME_WINDOW is
-            // measured from the last frame — not from engage. Without that refresh a 3-minute
-            // conversation would fail the age guard and strand media paused on its real terminal.
-            // Advance BOTH clocks so the window is genuinely exercised (the TestTimeSource drives age).
+            // A bursty conversation that runs past PAUSE_RESUME_WINDOW: the explicit STOP must still
+            // resume. The age guard applies only to the inferred stale backstop, not to a real
+            // terminal. Advance BOTH clocks so the window is genuinely exercised (TestTimeSource
+            // drives `age`).
             devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
             val job = launchReaction()
 
@@ -465,12 +465,53 @@ class ConversationReactionTest : BaseTest() {
                 timeSource.advanceBy(java.time.Duration.ofSeconds(60))
                 advanceTimeBy(60_000) // < STALE_TIMEOUT, so the backstop never fires
                 runCurrent()
-                emit(primaryAddress, ConversationAwarenessEvent.RESUME) // keep-alive, refreshes `at`
+                emit(primaryAddress, ConversationAwarenessEvent.RESUME)
             }
             coVerify(exactly = 0) { mediaControl.sendPlay() } // 3 min in, still paused
 
-            emit(primaryAddress, ConversationAwarenessEvent.STOP) // terminal right after last activity
+            emit(primaryAddress, ConversationAwarenessEvent.STOP) // explicit terminal
             coVerify(exactly = 1) { mediaControl.sendPlay() }
+            job.cancel()
+        }
+
+    @Test
+    fun `PAUSE resumes on a direct STOP after long frame silence`() = runTest(UnconfinedTestDispatcher()) {
+        // Continuous speech sends no frames; then a direct terminal (no preceding wind-down) arrives
+        // past PAUSE_RESUME_WINDOW but before STALE_TIMEOUT. An explicit STOP is positive evidence CA
+        // ended now, so it must resume regardless of engage-age. (Fails if the age guard is applied to
+        // explicit terminals.)
+        devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+        val job = launchReaction()
+
+        emit(primaryAddress, ConversationAwarenessEvent.START)
+        coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+        timeSource.advanceBy(java.time.Duration.ofSeconds(150)) // > 2-min window, < 5-min backstop
+        advanceTimeBy(150_000)
+        runCurrent()
+        coVerify(exactly = 0) { mediaControl.sendPlay() } // still paused, no frames yet
+
+        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        coVerify(exactly = 1) { mediaControl.sendPlay() }
+        job.cancel()
+    }
+
+    @Test
+    fun `PAUSE does not resume when the stale backstop fires past the resume window`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // The inferred end (5-min backstop, no terminal ever) keeps the age guard: a long-stale
+            // pause must NOT surprise-resume.
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+            timeSource.advanceBy(java.time.Duration.ofMinutes(5))
+            advanceTimeBy(5L * 60 * 1000 + 500) // STALE_TIMEOUT fires
+            runCurrent()
+
+            coVerify(exactly = 0) { mediaControl.sendPlay() } // inferred stale end → not resumed
             job.cancel()
         }
 

--- a/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
@@ -56,14 +56,18 @@ class ConversationReactionTest : BaseTest() {
         action: ConversationAction,
         reduction: Int = 50,
         worn: Boolean = true,
+        onePodMode: Boolean = false,
+        eitherInEar: Boolean? = worn,
     ): PodDevice = mockk(relaxed = true) {
         every { profileId } returns address
         every { this@mockk.address } returns address
         every { reactions } returns ReactionConfig(
             conversationAction = action,
             conversationVolumeReduction = reduction,
+            onePodMode = onePodMode,
         )
         every { isBeingWorn } returns worn
+        every { isEitherPodInEar } returns eitherInEar
     }
 
     @BeforeEach
@@ -285,6 +289,81 @@ class ConversationReactionTest : BaseTest() {
         coVerify(exactly = 0) { mediaControl.sendPlay() }
         job.cancel()
     }
+
+    @Test
+    fun `PAUSE one-pod mode resumes via wind-down fuse when the single worn pod drops the terminal`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // #608 single-pod wear: both-pods isBeingWorn is false, but One-Pod Mode means the single
+            // in-ear pod counts as worn, so the fuse-driven resume must fire. Was skipped as "not worn"
+            // because the guard read isBeingWorn (both pods) instead of honoring One-Pod Mode.
+            devicesFlow.value = listOf(
+                mockPodDevice(
+                    primaryAddress,
+                    ConversationAction.PAUSE,
+                    worn = false,
+                    onePodMode = true,
+                    eitherInEar = true,
+                ),
+            )
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD) // wind-down begins, terminal dropped
+
+            advanceTimeBy(windDownTimeoutMs + 500)
+            runCurrent()
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+            job.cancel()
+        }
+
+    @Test
+    fun `PAUSE one-pod mode stays paused via fuse when no pod is worn`() = runTest(UnconfinedTestDispatcher()) {
+        // One-Pod Mode on, but neither pod in ear (both isBeingWorn and isEitherPodInEar false) — the
+        // single-pod leniency must NOT resume into pods that are out.
+        devicesFlow.value = listOf(
+            mockPodDevice(
+                primaryAddress,
+                ConversationAction.PAUSE,
+                worn = false,
+                onePodMode = true,
+                eitherInEar = false,
+            ),
+        )
+        val job = launchReaction()
+
+        emit(primaryAddress, ConversationAwarenessEvent.START)
+        emit(primaryAddress, ConversationAwarenessEvent.HOLD)
+        advanceTimeBy(windDownTimeoutMs + 500)
+        runCurrent()
+
+        coVerify(exactly = 0) { mediaControl.sendPlay() }
+        job.cancel()
+    }
+
+    @Test
+    fun `PAUSE one-pod mode resumes on terminal after wind-down with a single worn pod`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // The timerPhase==WIND_DOWN_FUSE branch disengages immediately on the explicit terminal
+            // (no STOP_SETTLE). Verify the One-Pod Mode worn check applies on that shared path too.
+            devicesFlow.value = listOf(
+                mockPodDevice(
+                    primaryAddress,
+                    ConversationAction.PAUSE,
+                    worn = false,
+                    onePodMode = true,
+                    eitherInEar = true,
+                ),
+            )
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD) // wind-down → fuse armed
+            emit(primaryAddress, ConversationAwarenessEvent.STOP)  // real terminal → immediate disengage
+            runCurrent()
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+            job.cancel()
+        }
 
     @Test
     fun `PAUSE stop does not resume when something is already playing`() = runTest(UnconfinedTestDispatcher()) {

--- a/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
@@ -338,9 +338,9 @@ class ConversationReactionTest : BaseTest() {
     @Test
     fun `PAUSE stays paused through frame silence, resumes only on explicit STOP, then re-engages`() =
         runTest(UnconfinedTestDispatcher()) {
-            // Regression for the fw …6861 bug: the pod sends an onset, then NO frames for ~20s while
-            // the wearer keeps talking, then a terminal STOP. The old 12s stale timeout resumed media
-            // mid-speech; the backstop must not, and a fresh talk must re-arm.
+            // The pod sends NO frames during continuous speech (29s silent gaps observed), then a
+            // terminal STOP. The old 12s stale timeout resumed media mid-speech; the long backstop
+            // must not, and a fresh talk must re-arm.
             devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
             val job = launchReaction()
 
@@ -374,6 +374,102 @@ class ConversationReactionTest : BaseTest() {
 
         emit(primaryAddress, ConversationAwarenessEvent.STOP) // 8
         coVerify(exactly = 1) { mediaControl.sendPlay() }
+        job.cancel()
+    }
+
+    @Test
+    fun `RESUME keeps media paused through a bursty conversation, resumes only at the real terminal`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Regression for the fw …6861 status-5 bug. Bursty talking emits 1,2 then 3,5 (pause,
+            // resume) pairs while CA stays engaged, ending with the real wind-down 3,0xB,4,8,9.
+            // Status 5 was misclassified as a terminal STOP, so media resumed on the first burst
+            // pause and — with no fresh 1/2 onset mid-conversation — never paused again. RESUME must
+            // keep media paused until the genuine terminal.
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START) // 1
+            emit(primaryAddress, ConversationAwarenessEvent.START) // 2
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3 pause
+            emit(primaryAddress, ConversationAwarenessEvent.RESUME) // 5 resume
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3 pause
+            emit(primaryAddress, ConversationAwarenessEvent.RESUME) // 5 resume
+            coVerify(exactly = 0) { mediaControl.sendPlay() }       // stayed paused through the bursts
+
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 0x0B
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 4
+            emit(primaryAddress, ConversationAwarenessEvent.STOP)   // 8 terminal
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+            job.cancel()
+        }
+
+    @Test
+    fun `RESUME cancels the wind-down fuse`() = runTest(UnconfinedTestDispatcher()) {
+        // A pause (3) arms the short fuse; a resume (5) must cancel it and switch back to the long
+        // backstop — otherwise media resumes ~6s into renewed speech.
+        devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+        val job = launchReaction()
+
+        emit(primaryAddress, ConversationAwarenessEvent.START)
+        emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3 — wind-down fuse armed
+        advanceTimeBy(windDownTimeoutMs * 2 / 3)
+        runCurrent()
+        emit(primaryAddress, ConversationAwarenessEvent.RESUME) // 5 — speech resumed, cancel fuse
+        advanceTimeBy(windDownTimeoutMs * 2)                    // well past the original fuse
+        runCurrent()
+
+        coVerify(exactly = 0) { mediaControl.sendPlay() }
+        job.cancel()
+    }
+
+    @Test
+    fun `wind-down after a RESUME still disengages via the fuse (dropped terminal)`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // After a resume re-arms the long backstop, a later genuine wind-down (0xB,4 with the
+            // 8,9 terminal dropped — single-pod) must still disengage via the short fuse. Proves the
+            // RESUME keep-alive doesn't permanently disable #608 recovery.
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3 pause
+            emit(primaryAddress, ConversationAwarenessEvent.RESUME) // 5 resume → long backstop
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3 pause again
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 0x0B wind-down
+            emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 4 — terminal dropped
+            coVerify(exactly = 0) { mediaControl.sendPlay() }
+
+            advanceTimeBy(windDownTimeoutMs + 500)
+            runCurrent()
+            coVerify(exactly = 1) { mediaControl.sendPlay() }
+            job.cancel()
+        }
+
+    @Test
+    fun `RESUME without a prior start is a no-op`() = runTest(UnconfinedTestDispatcher()) {
+        devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+        val job = launchReaction()
+
+        emit(primaryAddress, ConversationAwarenessEvent.RESUME) // stray 5, nothing engaged
+
+        coVerify(exactly = 0) { mediaControl.sendPause(any()) }
+        coVerify(exactly = 0) { mediaControl.sendPlay() }
+        job.cancel()
+    }
+
+    @Test
+    fun `LOWER_VOLUME RESUME keeps the volume ducked`() = runTest(UnconfinedTestDispatcher()) {
+        // Same status-5 bug seen on the default action: it restored volume on the first 3→5 pause.
+        val job = launchReaction() // devicesFlow default = LOWER_VOLUME
+
+        emit(primaryAddress, ConversationAwarenessEvent.START)
+        verify(exactly = 1) { mediaControl.duckMusicVolume(any()) }
+        emit(primaryAddress, ConversationAwarenessEvent.HOLD)   // 3
+        emit(primaryAddress, ConversationAwarenessEvent.RESUME) // 5
+        verify(exactly = 0) { mediaControl.restoreMusicVolume(any()) }
         job.cancel()
     }
 

--- a/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
+++ b/app/src/test/java/eu/darken/capod/reaction/core/conversation/ConversationReactionTest.kt
@@ -37,9 +37,11 @@ class ConversationReactionTest : BaseTest() {
 
     // Mirrors of ConversationReaction's private timing constants. STALE_TIMEOUT: long backstop
     // while only START frames were seen. WIND_DOWN_TIMEOUT: short fuse armed by a HOLD frame
-    // (wind-down begun, terminal imminent — but sometimes dropped, #608).
+    // (wind-down begun, terminal imminent — but sometimes dropped, #608). STOP_SETTLE_DELAY: brief
+    // wait on an uncorroborated cold terminal (no preceding HOLD) before treating it as a real end.
     private val staleTimeoutMs = 5L * 60 * 1000
     private val windDownTimeoutMs = 6_000L
+    private val stopSettleMs = 250L
 
     private lateinit var eventsFlow: MutableSharedFlow<Pair<BluetoothAddress, ConversationAwarenessEvent>>
     private lateinit var statesFlow: MutableStateFlow<Map<BluetoothAddress, AapPodState>>
@@ -117,7 +119,9 @@ class ConversationReactionTest : BaseTest() {
         verify(exactly = 1) { mediaControl.duckMusicVolume(50) }
         verify(exactly = 0) { mediaControl.restoreMusicVolume(any()) }
 
-        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
         verify(exactly = 1) { mediaControl.restoreMusicVolume(10) }
         job.cancel()
     }
@@ -130,7 +134,9 @@ class ConversationReactionTest : BaseTest() {
         val job = launchReaction()
 
         emit(primaryAddress, ConversationAwarenessEvent.START)
-        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
 
         verify(exactly = 1) { mediaControl.restoreMusicVolume(10) }
         job.cancel()
@@ -259,7 +265,9 @@ class ConversationReactionTest : BaseTest() {
         emit(primaryAddress, ConversationAwarenessEvent.START)
         coVerify(exactly = 1) { mediaControl.sendPause(false) }
 
-        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
         coVerify(exactly = 1) { mediaControl.sendPlay() }
         job.cancel()
     }
@@ -271,6 +279,8 @@ class ConversationReactionTest : BaseTest() {
 
         emit(primaryAddress, ConversationAwarenessEvent.START)
         emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
 
         coVerify(exactly = 0) { mediaControl.sendPlay() }
         job.cancel()
@@ -284,6 +294,8 @@ class ConversationReactionTest : BaseTest() {
         emit(primaryAddress, ConversationAwarenessEvent.START)
         every { mediaControl.isPlaying } returns true // user/app restarted playback during the talk
         emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
 
         coVerify(exactly = 0) { mediaControl.sendPlay() }
         job.cancel()
@@ -299,7 +311,9 @@ class ConversationReactionTest : BaseTest() {
 
         // User changes the action mid-conversation; we must still undo the pause WE caused.
         devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.LOWER_VOLUME))
-        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
 
         coVerify(exactly = 1) { mediaControl.sendPlay() }
         job.cancel()
@@ -366,7 +380,9 @@ class ConversationReactionTest : BaseTest() {
             runCurrent()
             coVerify(exactly = 0) { mediaControl.sendPlay() } // NOT resumed mid-speech
 
-            emit(primaryAddress, ConversationAwarenessEvent.STOP) // wearer stopped → pod's terminal frame
+            emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+            advanceTimeBy(stopSettleMs + 50)
+            runCurrent()
             coVerify(exactly = 1) { mediaControl.sendPlay() }
 
             emit(primaryAddress, ConversationAwarenessEvent.START) // a fresh talk re-arms
@@ -483,7 +499,9 @@ class ConversationReactionTest : BaseTest() {
             }
             coVerify(exactly = 0) { mediaControl.sendPlay() } // 3 min in, still paused
 
-            emit(primaryAddress, ConversationAwarenessEvent.STOP) // explicit terminal
+            emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+            advanceTimeBy(stopSettleMs + 50)
+            runCurrent()
             coVerify(exactly = 1) { mediaControl.sendPlay() }
             job.cancel()
         }
@@ -505,7 +523,9 @@ class ConversationReactionTest : BaseTest() {
         runCurrent()
         coVerify(exactly = 0) { mediaControl.sendPlay() } // still paused, no frames yet
 
-        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
         coVerify(exactly = 1) { mediaControl.sendPlay() }
         job.cancel()
     }
@@ -577,7 +597,35 @@ class ConversationReactionTest : BaseTest() {
             advanceTimeBy(3_000)
             runCurrent()
             emit(primaryAddress, ConversationAwarenessEvent.STOP)     // genuine end, no recent ear change
+            advanceTimeBy(stopSettleMs + 50)                          // cold terminal → settles briefly
+            runCurrent()
             coVerify(exactly = 1) { mediaControl.sendPlay() }         // resumes
+            job.cancel()
+        }
+
+    @Test
+    fun `PAUSE primary-pod removal where the terminal precedes the ear change is caught by the settle`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // On primary-pod removal the firmware sends the terminal a few ms BEFORE the 0x06 ear
+            // frame, so the backward-looking check misses it. The settle catches it: the ear change
+            // lands during the settle window, so on expiry the cold terminal is treated as a re-key
+            // artifact (deferred to the fuse), not a resume.
+            devicesFlow.value = listOf(mockPodDevice(primaryAddress, ConversationAction.PAUSE))
+            val job = launchReaction()
+
+            emit(primaryAddress, ConversationAwarenessEvent.START)
+            coVerify(exactly = 1) { mediaControl.sendPause(false) }
+
+            emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal — ear frame not here yet
+            changeEarDetection(outOfEar, inEar)                   // ear change arrives ~ms later, during settle
+            advanceTimeBy(stopSettleMs + 50)                      // settle expires
+            runCurrent()
+            coVerify(exactly = 0) { mediaControl.sendPlay() }     // deferred to fuse, NOT resumed
+
+            emit(primaryAddress, ConversationAwarenessEvent.START) // re-onset on remaining pod
+            advanceTimeBy(windDownTimeoutMs * 2)                   // fuse cancelled by the re-onset
+            runCurrent()
+            coVerify(exactly = 0) { mediaControl.sendPlay() }      // still paused, session alive
             job.cancel()
         }
 
@@ -640,7 +688,9 @@ class ConversationReactionTest : BaseTest() {
         val job = launchReaction()
 
         emit(primaryAddress, ConversationAwarenessEvent.START)
-        emit(primaryAddress, ConversationAwarenessEvent.STOP)
+        emit(primaryAddress, ConversationAwarenessEvent.STOP) // cold terminal → settles briefly
+        advanceTimeBy(stopSettleMs + 50)
+        runCurrent()
         coVerify(exactly = 1) { mediaControl.sendPlay() }
 
         advanceTimeBy(staleTimeoutMs + 500) // backstop would fire if STOP hadn't cancelled it


### PR DESCRIPTION
## What changed

Fixes Conversational Awareness so media no longer comes back while you're still in a conversation, resumes correctly at the real end (now including single-pod wear), and reduces the playback/volume glitch when you briefly remove a pod mid-conversation — across both Pause and Lower-volume modes, on AirPods Pro 3 and Pro 2 USB-C.

## Technical Context

- **Root cause (main bug):** the pods emit status `5` when speech *resumes* after a pause (bursty talking cycles `3,5,3,5,…`); CAPod treated `5` as a terminal stop, so it resumed on the first pause and — since the pods don't re-send an onset `1,2` mid-conversation — never re-engaged. Fix: `5` is now a `RESUME` keep-alive. Taxonomy derived from 18 labelled captures + on-device verification (`1,2`=onset, `3`=pause, `5`=resume, `0x0B,4`=wind-down, `7`=abort, `6/8,9`=terminal); both models identical, no model-gating.
- **`6` is a terminal** (live fw `…6814` shows it ending a conversation): `STOPPED = {6,8,9}`. Only `5` was misclassified.
- **Resume age-guard** now applies only to the inferred 5-min stale backstop; an explicit terminal or the wind-down fuse resumes regardless of engage-age (fixes >2-min conversations and direct terminals after long speech).
- **Single-pod resume (PAUSE) — found in on-device testing:** the disengage worn-guard gated resume on `isBeingWorn` (= *both* pods in ear), so with One-Pod Mode and a single worn pod the #608 fuse fired but the resume was suppressed → media stranded paused (the duck path escaped this via its unconditional restore, which is why the original #608 looked fixed). Now honors One-Pod Mode — `if (onePodMode) isEitherPodInEar ?: isBeingWorn else isBeingWorn`, mirroring `AutoConnect`; only a true unknown stays lenient. Verified on Pixel 9 Pro + Pro 3.
- **Pod removal/insertion re-key:** pulling a pod makes the firmware emit a terminal then a fresh onset around the physical change. The reaction tracks AAP ear-detection (`0x06`) transitions and treats a terminal near one as a re-key artifact, deferring to the wind-down fuse (a re-onset cancels it).
- **Frame-ordering race:** on-device, *secondary*-pod removal sends the ear frame ~40ms **before** the terminal (caught by the backward-looking check), but *primary*-pod removal sends the terminal ~5ms **before** the ear frame. So a single timer now carries an explicit phase (`STALE_BACKSTOP` / `WIND_DOWN_FUSE` / `STOP_SETTLE`): an *uncorroborated cold* terminal (no preceding wind-down, no ear change yet) waits a ~250ms settle to catch a trailing ear change. Normal ends (`…3,0xB,4,8`) and aborts (`7,8`) are already corroborated by the fuse and resume instantly — **no latency added to genuine conversation ends.** A monotonic generation token guards the single timer slot against stale-job races (Codex review).
- **Removal re-key without `0x06` (known residual):** the artifact suppression depends on the firmware emitting an ear-detection (`0x06`) frame. On-device, AirPods Pro 3 was observed to re-key CA on pod removal *without* emitting any `0x06` during an active session, so a ~0.5s volume blip / playback flicker still slips through (the 250ms settle only catches re-keys faster than itself). Strictly better than pre-#617 (which restored on every removal with no settle), and the suppression works where `0x06` does fire (Pro 2 USB-C). A fully ear-detection-independent re-key suppression (detect `8,9`→`1,2` directly) is tracked as follow-up.
- `ConversationalAwarenessState.speaking` now `true` for `5` (display-state correctness only).
- #608 (single-pod dropped `8,9` terminal) preserved: `0x0B,4` still arms the short fuse.

## Review checklist

- [x] On-device verified (Pixel 9 Pro + Pro 3): status-`5` bursts keep media paused through a bursty conversation, resume only at the real `8,9`; single-pod #608 PAUSE now resumes via the fuse (One-Pod Mode worn-guard fix).
- [x] Taxonomy confirmed on Doug's fw `…6861` (genuine end `1,2 → 3 → 0B → 4 → 8 → 9`, no `5`).
- [x] AirPods Pro 1 (H1) emits no `0x4B` at all — never enters the CA path, so the no-model-gating decision carries no H1 risk.
- [ ] Known residual (follow-up): pod-removal re-key with no `0x06` still produces a ~0.5s blip on Pro 3; pause/duck otherwise correct.
- [ ] Residual (by design): a true inferred end (last frame `5`, link up, no terminal ever) keeps a PAUSE paused until the 5-min backstop; ducking restores unconditionally.
