### PR TITLE
Reaction: Fix AirPods buttons not working when the app is closed

### DIFF
--- a/app/src/main/java/eu/darken/capod/monitor/core/MonitorModeResolver.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/MonitorModeResolver.kt
@@ -26,8 +26,14 @@ class MonitorModeResolver @Inject constructor(
         profilesRepo.profiles,
         nudgeCapabilityStore.availability,
     ) { profiles, nudge ->
-        val primary = profiles.firstOrNull() ?: return@combine MonitorMode.MANUAL
-        primary.requiredMode(nudge)
+        // The mode is driven by the first *addressed* profile, not just the first profile. An
+        // address-less profile can neither host an AAP session (AapAutoConnect requires an address)
+        // nor auto-connect, so it can only ever resolve to MANUAL. Letting such a profile sit at the
+        // top of the list and force MANUAL would silently stop the foreground service that keeps the
+        // process — and thus background AAP/stem controls — alive for an addressed profile below it.
+        // No addressed profile at all => genuinely nothing to monitor => MANUAL.
+        profiles.firstOrNull { !it.address.isNullOrBlank() }?.requiredMode(nudge)
+            ?: MonitorMode.MANUAL
     }
         .distinctUntilChanged()
         .onEach { log(TAG, VERBOSE) { "effectiveMode = $it" } }

--- a/app/src/test/java/eu/darken/capod/monitor/core/MonitorModeResolverTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/MonitorModeResolverTest.kt
@@ -100,7 +100,7 @@ class MonitorModeResolverTest : BaseTest() {
     }
 
     @Test
-    fun `multi-profile primary-only - primary case 2 + secondary case 3 - AUTOMATIC`() = runTest {
+    fun `first addressed profile controls mode - addressed primary case 2 + addressed secondary case 3 - AUTOMATIC`() = runTest {
         profilesFlow.value = listOf(
             profile(id = "primary", autoConnect = false),
             profile(id = "secondary", autoConnect = true),
@@ -111,25 +111,59 @@ class MonitorModeResolverTest : BaseTest() {
     }
 
     @Test
-    fun `multi-profile primary-only - primary case 4 + secondary case 2 - MANUAL`() = runTest {
+    fun `unpaired primary is skipped when an addressed secondary exists - AUTOMATIC`() = runTest {
         profilesFlow.value = listOf(
             profile(id = "primary", address = null),
             profile(id = "secondary", address = "AA:BB:CC:DD:EE:FF"),
         )
 
+        resolver.effectiveMode.first() shouldBe MonitorMode.AUTOMATIC
+    }
+
+    @Test
+    fun `unpaired primary is skipped - addressed autoConnect secondary drives ALWAYS`() = runTest {
+        profilesFlow.value = listOf(
+            profile(id = "primary", address = null),
+            profile(id = "secondary", address = "AA:BB:CC:DD:EE:FF", autoConnect = true),
+        )
+        nudgeFlow.value = NudgeAvailability.AVAILABLE
+
+        resolver.effectiveMode.first() shouldBe MonitorMode.ALWAYS
+    }
+
+    @Test
+    fun `blank-address primary is skipped when an addressed secondary exists`() = runTest {
+        profilesFlow.value = listOf(
+            profile(id = "primary", address = "   "),
+            profile(id = "secondary", address = "AA:BB:CC:DD:EE:FF", autoConnect = true),
+        )
+        nudgeFlow.value = NudgeAvailability.AVAILABLE
+
+        resolver.effectiveMode.first() shouldBe MonitorMode.ALWAYS
+    }
+
+    @Test
+    fun `all profiles unpaired - MANUAL`() = runTest {
+        profilesFlow.value = listOf(
+            profile(id = "a", address = null, autoConnect = true),
+            profile(id = "b", address = "", autoConnect = true),
+        )
+        nudgeFlow.value = NudgeAvailability.AVAILABLE
+
         resolver.effectiveMode.first() shouldBe MonitorMode.MANUAL
     }
 
     @Test
-    fun `list reorder makes the secondary primary - mode flips`() = runTest {
-        val a = profile(id = "a", autoConnect = true)
-        val b = profile(id = "b", autoConnect = false)
+    fun `reorder among addressed profiles still flips the mode, unpaired stays ignored`() = runTest {
+        val unpaired = profile(id = "unpaired", address = null)
+        val addressedAuto = profile(id = "addressedAuto", autoConnect = true)
+        val addressedManual = profile(id = "addressedManual", autoConnect = false)
         nudgeFlow.value = NudgeAvailability.AVAILABLE
 
-        profilesFlow.value = listOf(a, b)
+        profilesFlow.value = listOf(unpaired, addressedAuto, addressedManual)
         resolver.effectiveMode.first() shouldBe MonitorMode.ALWAYS
 
-        profilesFlow.value = listOf(b, a)
+        profilesFlow.value = listOf(unpaired, addressedManual, addressedAuto)
         resolver.effectiveMode.first() shouldBe MonitorMode.AUTOMATIC
     }
 


### PR DESCRIPTION
## What changed

Fixed an issue where the physical controls on your AirPods (stem press / touch gestures) would stop working the moment you closed or left CAPod, and only worked again while the app was open on screen. This affected people who had an extra device profile with no AirPods assigned to it sitting at the top of their profile list — for example the empty "Default" profile the app creates on first launch.

## Technical Context

- Root cause: the monitor-mode resolver decided whether to run the foreground service based solely on the *first* profile in the list (`profiles.firstOrNull()`). An address-less profile at index 0 resolves to `MANUAL`, so the foreground service never starts. The AAP/stem-event read loop lives in process-lifetime `@AppScope` and is kept alive only by that foreground service, so once the backgrounded process was reclaimed the controls died. In the foreground the process stays resident, which is exactly why controls only worked there.
- Fix: resolve the mode from the first *addressed* profile instead of the first profile. An address-less profile can neither host an AAP session (auto-connect requires an address) nor auto-connect, so it can only ever yield `MANUAL` — letting it suppress monitoring for a properly-configured profile below it was never useful. Falls back to `MANUAL` only when no profile has an address.
- Reordering among addressed profiles still drives the mode exactly as before; only address-less profiles are skipped. The resolved `MonitorMode` flow is unchanged in shape, so no consumer changes were needed, and classic auto-connect primary-device selection is untouched.
