### PR TITLE
Fix: Prevent app freezes on startup and during playback

### DIFF
--- a/app/src/main/java/eu/darken/capod/App.kt
+++ b/app/src/main/java/eu/darken/capod/App.kt
@@ -44,8 +44,11 @@ open class App : Application() {
     @Inject @AppScope lateinit var appScope: CoroutineScope
 
     override fun onCreate() {
-        super.onCreate()
+        // Must stay ABOVE super.onCreate(): that call performs the Hilt injection which constructs
+        // our singletons. Anything they log while being created is dropped if no logger is installed
+        // yet. Do not "tidy" this line back below super.onCreate().
         if (BuildConfig.DEBUG) Logging.install(LogCatLogger())
+        super.onCreate()
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(

--- a/app/src/main/java/eu/darken/capod/common/MediaControl.kt
+++ b/app/src/main/java/eu/darken/capod/common/MediaControl.kt
@@ -3,7 +3,9 @@ package eu.darken.capod.common
 import android.media.AudioManager
 import android.media.AudioPlaybackConfiguration
 import android.os.Build
+import android.os.Handler
 import android.view.KeyEvent
+import eu.darken.capod.common.dagger.AudioCallbackHandler
 import eu.darken.capod.common.debug.logging.Logging.Priority.INFO
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
 import eu.darken.capod.common.debug.logging.log
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 class MediaControl @Inject constructor(
     private val audioManager: AudioManager,
     private val timeSource: TimeSource,
+    @AudioCallbackHandler private val audioCallbackHandler: Handler,
 ) {
     /**
      * Set when [sendPause] dispatches a pause we expect to take effect, cleared when [sendPlay]
@@ -43,10 +46,25 @@ class MediaControl @Inject constructor(
     }
 
     init {
-        // Seed the active flag from current state so we won't miss the next inactive→active
-        // transition if music is already playing when MediaControl is constructed.
-        lastKnownMusicActive = audioManager.isMusicActive
-        audioManager.registerAudioPlaybackCallback(playbackCallback, null)
+        // Both calls below are binder transactions into AudioService. On the main thread they sat on
+        // the cold-start critical path (MediaControl is constructed during App.onCreate via Hilt) and
+        // produced ANRs.
+        //
+        // Register BEFORE seeding: both run on this handler's Looper, so any playback callback that
+        // fires during registration is queued behind this runnable and cannot execute until the seed
+        // is done. Seeding first would instead leave a gap in which a transition is neither delivered
+        // (not yet registered) nor reflected in the seed.
+        //
+        // Residual window: between construction and this runnable draining, no callback is live. That
+        // is one runnable-drain on an empty queue. If an auto-pause armed capPaused and the user
+        // manually resumed inside it, the inactive→active edge is missed and capPaused stays stale,
+        // costing one redundant (idempotent) MEDIA_PLAY on a later pod-in. Accepted deliberately;
+        // gating reactions on a readiness latch would risk auto-play/pause failing silently instead.
+        audioCallbackHandler.post {
+            audioManager.registerAudioPlaybackCallback(playbackCallback, audioCallbackHandler)
+            lastKnownMusicActive = audioManager.isMusicActive
+            log(TAG, INFO) { "Playback callback registered on ${Thread.currentThread().name}" }
+        }
     }
 
     val isPlaying: Boolean

--- a/app/src/main/java/eu/darken/capod/common/dagger/AndroidModule.kt
+++ b/app/src/main/java/eu/darken/capod/common/dagger/AndroidModule.kt
@@ -5,10 +5,13 @@ import android.app.NotificationManager
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.media.AudioManager
+import android.os.Handler
+import android.os.HandlerThread
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -34,4 +37,15 @@ class AndroidModule {
     fun audioManager(context: Context): AudioManager =
         context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
+    @Provides
+    @Singleton
+    @AudioCallbackHandler
+    fun audioCallbackHandler(): Handler =
+        Handler(HandlerThread("CAPod-MediaControl").apply { start() }.looper)
+
 }
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AudioCallbackHandler

--- a/app/src/test/java/eu/darken/capod/common/MediaControlTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/MediaControlTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.capod.common
 
 import android.media.AudioManager
+import android.os.Handler
 import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.clearMocks
@@ -9,6 +10,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -22,7 +24,9 @@ class MediaControlTest : BaseTest() {
     private lateinit var audioManager: AudioManager
     private lateinit var mediaControl: MediaControl
     private lateinit var timeSource: TestTimeSource
+    private lateinit var handler: Handler
     private lateinit var playbackCallbackSlot: CapturingSlot<AudioManager.AudioPlaybackCallback>
+    private lateinit var initRunnableSlot: CapturingSlot<Runnable>
 
     @BeforeEach
     fun setup() {
@@ -35,7 +39,15 @@ class MediaControlTest : BaseTest() {
         every { audioManager.isMusicActive } returns false
         playbackCallbackSlot = slot()
         every { audioManager.registerAudioPlaybackCallback(capture(playbackCallbackSlot), any()) } just Runs
-        mediaControl = MediaControl(audioManager, timeSource)
+        // The handler is captured, not inlined: registration and seeding now happen on a posted
+        // runnable, and an unconditionally-inline post would hide the window that exists between
+        // construction and that runnable draining.
+        handler = mockk()
+        initRunnableSlot = slot()
+        every { handler.post(capture(initRunnableSlot)) } returns true
+        mediaControl = MediaControl(audioManager, timeSource, handler)
+        // Drain the init runnable so `playbackCallbackSlot` is populated for `fireCallback()`.
+        initRunnableSlot.captured.run()
     }
 
     private fun fireCallback() {
@@ -227,5 +239,73 @@ class MediaControlTest : BaseTest() {
         // so the inactive→active reset clears the sticky flag — that's the correct outcome:
         // we don't want to claim our pause "stuck" when audio is playing.
         assertFalse(mediaControl.wasRecentlyPausedByCap)
+    }
+
+    @Test
+    fun `playback callback is registered on the injected background handler, not the main looper`() {
+        // Regression for the ANR cluster in onPlaybackConfigChanged: passing `null` here binds
+        // callback delivery to the main looper, and the callback body does a binder call.
+        verify { audioManager.registerAudioPlaybackCallback(any(), handler) }
+    }
+
+    @Test
+    fun `construction does no binder work on the calling thread`() {
+        // Regression for the ANR cluster in MediaControl's constructor: it runs during
+        // App.onCreate via Hilt, so nothing here may touch AudioService inline.
+        val freshAudioManager = mockk<AudioManager>(relaxed = true)
+        val freshHandler = mockk<Handler>()
+        every { freshHandler.post(any()) } returns true
+
+        MediaControl(freshAudioManager, timeSource, freshHandler)
+
+        verify(exactly = 0) { freshAudioManager.isMusicActive }
+        verify(exactly = 0) { freshAudioManager.registerAudioPlaybackCallback(any(), any()) }
+        verify(exactly = 1) { freshHandler.post(any()) }
+    }
+
+    @Test
+    fun `init registers the callback before seeding the active flag`() {
+        // Seeding first would leave a gap in which a transition is neither delivered (not yet
+        // registered) nor reflected in the seed.
+        val freshAudioManager = mockk<AudioManager>(relaxed = true)
+        every { freshAudioManager.isMusicActive } returns false
+        every { freshAudioManager.registerAudioPlaybackCallback(any(), any()) } just Runs
+        val freshHandler = mockk<Handler>()
+        val runnableSlot = slot<Runnable>()
+        every { freshHandler.post(capture(runnableSlot)) } returns true
+
+        MediaControl(freshAudioManager, timeSource, freshHandler)
+        runnableSlot.captured.run()
+
+        verifyOrder {
+            freshAudioManager.registerAudioPlaybackCallback(any(), freshHandler)
+            freshAudioManager.isMusicActive
+        }
+    }
+
+    @Test
+    fun `media control still works before the init runnable has drained`() = runTest {
+        // The window between construction and the posted runnable running: no callback is live
+        // yet, but the key-dispatch paths must behave normally.
+        val freshAudioManager = mockk<AudioManager>(relaxed = true)
+        every { freshAudioManager.isMusicActive } returns true
+        every { freshAudioManager.dispatchMediaKeyEvent(any()) } just Runs
+        every { freshAudioManager.registerAudioPlaybackCallback(any(), any()) } just Runs
+        val freshHandler = mockk<Handler>()
+        every { freshHandler.post(any()) } returns true
+
+        val undrained = MediaControl(freshAudioManager, timeSource, freshHandler)
+
+        assertFalse(undrained.wasRecentlyPausedByCap)
+
+        assertTrue(undrained.sendPause(rememberForResume = true))
+        assertTrue(undrained.wasRecentlyPausedByCap)
+        verify(exactly = 2) { freshAudioManager.dispatchMediaKeyEvent(any()) }
+
+        clearMocks(freshAudioManager, answers = false, recordedCalls = true)
+
+        undrained.sendPlay()
+        assertFalse(undrained.wasRecentlyPausedByCap)
+        verify(exactly = 2) { freshAudioManager.dispatchMediaKeyEvent(any()) }
     }
 }

--- a/app/src/test/java/eu/darken/capod/common/MediaControlTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/MediaControlTest.kt
@@ -242,9 +242,14 @@ class MediaControlTest : BaseTest() {
     }
 
     @Test
-    fun `playback callback is registered on the injected background handler, not the main looper`() {
+    fun `playback callback is registered with the injected handler rather than null`() {
         // Regression for the ANR cluster in onPlaybackConfigChanged: passing `null` here binds
         // callback delivery to the main looper, and the callback body does a binder call.
+        // Scope of this assertion: it only proves the injected handler is forwarded, not which
+        // Looper that handler is bound to — a JVM unit test cannot inspect a Looper here (this
+        // module does not use Robolectric). The Looper identity is covered instead by
+        // `AndroidModule.audioCallbackHandler()`, which is the single place that constructs it,
+        // and by the runtime QA check asserting the registration logs thread `CAPod-MediaControl`.
         verify { audioManager.registerAudioPlaybackCallback(any(), handler) }
     }
 


### PR DESCRIPTION
## What changed

Fixed two causes of the app freezing or becoming unresponsive: one during app startup, and one that could hit while music was starting or stopping. Both showed up in the Play Store's "app isn't responding" reports.

Also fixed a logging gap: messages written while the app was still starting up were being thrown away, so they never appeared in debug logs or bug reports.

## Technical Context

- Root cause for both ANR clusters is one line: `MediaControl` registered its audio playback callback with a `null` Handler, which binds callback delivery to the **main looper**, and the callback body then makes an `AudioManager.isMusicActive` binder call. Play flagged the callback cluster itself with its "Slow Binder call" potential-fix annotation.
- The constructor cluster is worse than its report count suggests: the traces run `App.onCreate` → Hilt `DoubleCheck` chain → `MediaControl.<init>` → `isMusicActive`, so every cold start paid for a binder round-trip to a possibly-contended `AudioService`.
- The `HandlerThread` is injected as a qualified `Handler` rather than constructed inside `MediaControl` because unit tests here run on plain JVM without Robolectric — a real `Looper` can't be instantiated, so the threading vehicle has to be a constructor seam. Note this does add a small synchronous cost at startup (thread start plus a latch wait for `getLooper()`), traded against a binder round-trip.
- Registration happens *before* the state seed inside the posted runnable, and the order is load-bearing: both run on the same Looper, so a playback callback firing during registration queues behind the init runnable. Seeding first would instead leave a gap where a transition is neither delivered (not yet registered) nor reflected in the seed.
- Accepted residual risk, documented in-code: between construction and that runnable draining, no callback is live. If an auto-pause armed `capPaused` and the user manually resumed inside that window, the missed edge costs one redundant — and idempotent — `MEDIA_PLAY` on a later pod-in. A readiness latch gating the reactions was considered and rejected: if readiness never arrived, auto-play/pause would fail *silently*, which is a worse failure than a stray play key.
- The `App.onCreate` logger-ordering change was found while verifying the above on a Pixel 8. `super.onCreate()` is `Hilt_App.onCreate()`, which runs `hiltInternalInject()` and constructs the singleton graph — but `Logging.install(LogCatLogger())` ran on the *next* line, so anything a singleton logged during construction was silently dropped. On fast hardware that discarded the new registration log entirely (0 matches in logcat, while 150 later `CAP:` lines from the same launch were present). Moving the install above `super.onCreate()` is safe: `Logging` is a plain object mutating a synchronized list, and `LogCatLogger` touches only `android.util.Log` and `Build.VERSION`.
- Two pre-existing `capPaused` defects surfaced while reviewing this change — a coalescing blind spot in the callback, and a lost-update race between `sendPlay` and a concurrent `sendPause` — are deliberately not addressed here. Fixing them means serializing the state machine, which would churn the tests that deliberately pin its current semantics. Tracked separately.

## Review checklist

- [ ] Register-before-seed ordering in `MediaControl.init` is preserved (a "tidy-up" back to seed-first reintroduces the gap)
- [ ] `Logging.install(...)` stays above `super.onCreate()` in `App.kt` — moving it back silently disables all logging emitted during Hilt singleton construction
- [ ] Verified on a real Pixel 8 (Android 17), not just an emulator: the `CAPod-MediaControl` thread is alive in-process, and its `voluntary_ctxt_switches` stepped 3 → 15 → 19 across two real playback-start transitions, with `utime`/`stime` still at 0 ticks. That is direct evidence `onPlaybackConfigChanged` is delivered on that Looper rather than `main`
- [ ] Not covered by automated testing: auto-pause on pod removal and auto-resume on pod insert. Ear detection needs the pods physically worn and removed, so it can't be driven over adb — worth a manual pass before release
- [ ] The new registration test asserts the handler is forwarded, not which Looper it's bound to; that distinction is called out in its comment so it isn't mistaken for main-looper coverage

Refs #647
