### PR TITLE
General: Fix app freezes after the battery monitor starts

### DIFF
--- a/app/src/main/java/eu/darken/capod/CapodUncaughtExceptionHandler.kt
+++ b/app/src/main/java/eu/darken/capod/CapodUncaughtExceptionHandler.kt
@@ -1,73 +1,19 @@
 package eu.darken.capod
 
-import android.os.Looper
-import eu.darken.capod.common.debug.Bugs
 import eu.darken.capod.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
 import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.exitProcess
 
 internal class CapodUncaughtExceptionHandler(
     private val previousHandler: Thread.UncaughtExceptionHandler?,
-    private val mainThreadProvider: () -> Thread = { Looper.getMainLooper().thread },
-    private val loopMainThread: () -> Unit = { Looper.loop() },
-    private val reportForegroundServiceTimingException: (Throwable) -> Unit = { throwable ->
-        Bugs.report(
-            tag = App.TAG,
-            message = "Foreground service timing exception suppressed",
-            exception = throwable,
-        )
-    },
     private val cancelBeforeDelegate: (Throwable) -> Unit = {},
     private val exit: (Int) -> Unit = { exitProcess(it) },
 ) : Thread.UncaughtExceptionHandler {
 
-    private val foregroundExceptionHandled = AtomicBoolean(false)
-
     override fun uncaughtException(thread: Thread, throwable: Throwable) {
-        if (shouldSuppress(thread, throwable)) {
-            runCatching {
-                log(App.TAG, WARN) { "Suppressed foreground service timing exception: ${throwable.asLog()}" }
-                reportForegroundServiceTimingException(throwable)
-            }
-
-            val loopResult = runCatching { loopMainThread() }
-            if (loopResult.isSuccess) return
-
-            val loopFailure = loopResult.exceptionOrNull()!!
-            runCatching {
-                log(App.TAG, ERROR) {
-                    "Main loop failed after foreground service timing exception suppression: ${loopFailure.asLog()}"
-                }
-            }
-            delegate(thread, loopFailure)
-            return
-        }
-
         runCatching { log(App.TAG, ERROR) { "UNCAUGHT EXCEPTION: ${throwable.asLog()}" } }
-        delegate(thread, throwable)
-    }
-
-    private fun shouldSuppress(thread: Thread, throwable: Throwable): Boolean {
-        val isMainThread = runCatching { thread === mainThreadProvider() }.getOrDefault(false)
-        return throwable.isForegroundServiceTimingException() &&
-            isMainThread &&
-            foregroundExceptionHandled.compareAndSet(false, true)
-    }
-
-    private fun delegate(thread: Thread, throwable: Throwable) {
         runCatching { cancelBeforeDelegate(throwable) }
         previousHandler?.uncaughtException(thread, throwable) ?: exit(1)
     }
-}
-
-internal fun Throwable.isForegroundServiceTimingException(): Boolean {
-    var current: Throwable? = this
-    while (current != null) {
-        if (current.javaClass.simpleName == "ForegroundServiceDidNotStartInTimeException") return true
-        current = current.cause
-    }
-    return false
 }

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorControl.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorControl.kt
@@ -1,11 +1,15 @@
 package eu.darken.capod.monitor.core.worker
 
+import android.annotation.SuppressLint
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.capod.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.hasApiLevel
 import eu.darken.capod.common.permissions.Permission
 import eu.darken.capod.common.startServiceCompat
 import javax.inject.Inject
@@ -16,6 +20,7 @@ class MonitorControl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
+    @SuppressLint("NewApi")
     fun startMonitor(
         forceStart: Boolean = false,
     ) {
@@ -32,9 +37,13 @@ class MonitorControl @Inject constructor(
             context.startServiceCompat(MonitorService.intent(context, forceStart))
             log(TAG) { "Monitor start request sent." }
         } catch (e: IllegalStateException) {
-            log(TAG, WARN) { "Failed to start monitor service: ${e.message}" }
+            if (hasApiLevel(31) && e is ForegroundServiceStartNotAllowedException) {
+                log(TAG, WARN) { "Start rejected, app is not allowed to start a FGS from the background: ${e.asLog()}" }
+            } else {
+                log(TAG, WARN) { "Failed to start monitor service: ${e.asLog()}" }
+            }
         } catch (e: SecurityException) {
-            log(TAG, WARN) { "Failed to start monitor service, permission issue: ${e.message}" }
+            log(TAG, WARN) { "Failed to start monitor service, permission issue: ${e.asLog()}" }
         }
     }
 

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -99,6 +99,8 @@ class MonitorService : Service() {
     private var foregroundStartFailed = false
     private var injectionComplete = false
 
+    @Volatile private var lastNotification: Notification? = null
+
     @Volatile
     private var latestNotificationSettings: NotificationSettings =
         NotificationSettings(useExtraNotification = false, keepAfterDisconnect = false)
@@ -128,6 +130,15 @@ class MonitorService : Service() {
             log(TAG, WARN) { "Foreground service start denied (security): ${e.message}" }
             false
         }
+    }
+
+    /**
+     * Posts the primary monitor notification and remembers it, so a later [onStartCommand] can
+     * re-satisfy the foreground obligation with the notification the user is currently seeing.
+     */
+    internal fun postPrimaryNotification(notification: Notification) {
+        lastNotification = notification
+        notificationManager.notify(MonitorNotifications.NOTIFICATION_ID, notification)
     }
 
     override fun onCreate() {
@@ -160,10 +171,19 @@ class MonitorService : Service() {
 
         // Replace early notification with the full one from injected MonitorNotifications.
         // Failure here is non-fatal — the service is already foreground from the early call.
-        promoteToForeground(notifications.getStartupNotification())
+        val startupNotification = notifications.getStartupNotification()
+        lastNotification = startupNotification
+        promoteToForeground(startupNotification)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Every startForegroundService() re-arms the startForeground() obligation,
+        // so every onStartCommand has to satisfy it again, no matter how it exits.
+        if (!promoteToForeground(lastNotification ?: MonitorNotifications.createEarlyNotification(this))) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
         log(TAG, VERBOSE) { "onStartCommand(intent=$intent, flags=$flags, startId=$startId)" }
 
         if (foregroundStartFailed) {
@@ -250,13 +270,12 @@ class MonitorService : Service() {
             .onEach { (currentDevice, settings, estimate) ->
                 latestNotificationSettings = settings
 
-                notificationManager.notify(
-                    MonitorNotifications.NOTIFICATION_ID,
+                postPrimaryNotification(
                     notifications.getNotification(
                         currentDevice,
                         estimate = estimate,
                         showHint = settings.useExtraNotification,
-                    ),
+                    )
                 )
 
                 when (val action = decideExtraNotificationAction(currentDevice, settings)) {

--- a/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/ui/MonitorNotifications.kt
@@ -170,6 +170,7 @@ class MonitorNotifications @Inject constructor(
                 setContentIntent(openPi)
                 setSmallIcon(R.drawable.device_earbuds_generic_both)
                 setContentTitle(context.getString(R.string.app_name))
+                setContentText(context.getString(R.string.monitor_notification_starting))
                 setPriority(NotificationCompat.PRIORITY_LOW)
                 setOngoing(true)
             }.build()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="notification_channel_device_status_label">Device status</string>
     <string name="notification_channel_device_status_connected_label">Connected device</string>
     <string name="monitor_notification_extra_enabled_hint">You can disable this notification in system settings.</string>
+    <string name="monitor_notification_starting">Starting up…</string>
 
     <string name="support_debuglog_label">Debug log</string>
     <string name="support_debuglog_desc">Record everything the app is doing into a text file that you can share.</string>

--- a/app/src/test/java/eu/darken/capod/CapodUncaughtExceptionHandlerTest.kt
+++ b/app/src/test/java/eu/darken/capod/CapodUncaughtExceptionHandlerTest.kt
@@ -7,66 +7,16 @@ import testhelpers.BaseTest
 class CapodUncaughtExceptionHandlerTest : BaseTest() {
 
     @Test
-    fun `suppresses first main thread foreground service timing exception`() {
+    fun `delegates foreground service timing exception`() {
         val mainThread = Thread.currentThread()
         val previousHandler = RecordingHandler()
-        val reports = mutableListOf<Throwable>()
-        var loopCalls = 0
         val handler = CapodUncaughtExceptionHandler(
             previousHandler = previousHandler,
-            mainThreadProvider = { mainThread },
-            loopMainThread = { loopCalls++ },
-            reportForegroundServiceTimingException = { reports += it },
             exit = { throw AssertionError("exitProcess($it)") },
         )
         val throwable = ForegroundServiceDidNotStartInTimeException()
 
         handler.uncaughtException(mainThread, throwable)
-
-        loopCalls shouldBe 1
-        reports shouldBe listOf(throwable)
-        previousHandler.throwables shouldBe emptyList()
-    }
-
-    @Test
-    fun `delegates repeated main thread foreground service timing exception`() {
-        val mainThread = Thread.currentThread()
-        val previousHandler = RecordingHandler()
-        val reports = mutableListOf<Throwable>()
-        var loopCalls = 0
-        val handler = CapodUncaughtExceptionHandler(
-            previousHandler = previousHandler,
-            mainThreadProvider = { mainThread },
-            loopMainThread = { loopCalls++ },
-            reportForegroundServiceTimingException = { reports += it },
-            exit = { throw AssertionError("exitProcess($it)") },
-        )
-        val first = ForegroundServiceDidNotStartInTimeException()
-        val second = ForegroundServiceDidNotStartInTimeException()
-
-        handler.uncaughtException(mainThread, first)
-        handler.uncaughtException(mainThread, second)
-
-        loopCalls shouldBe 1
-        reports shouldBe listOf(first)
-        previousHandler.throwables shouldBe listOf(second)
-    }
-
-    @Test
-    fun `delegates foreground service timing exception from non-main thread`() {
-        val mainThread = Thread.currentThread()
-        val workerThread = Thread()
-        val previousHandler = RecordingHandler()
-        val handler = CapodUncaughtExceptionHandler(
-            previousHandler = previousHandler,
-            mainThreadProvider = { mainThread },
-            loopMainThread = { throw AssertionError("loopMainThread should not run") },
-            reportForegroundServiceTimingException = { throw AssertionError("report should not run") },
-            exit = { throw AssertionError("exitProcess($it)") },
-        )
-        val throwable = ForegroundServiceDidNotStartInTimeException()
-
-        handler.uncaughtException(workerThread, throwable)
 
         previousHandler.throwables shouldBe listOf(throwable)
     }
@@ -77,9 +27,6 @@ class CapodUncaughtExceptionHandlerTest : BaseTest() {
         val previousHandler = RecordingHandler()
         val handler = CapodUncaughtExceptionHandler(
             previousHandler = previousHandler,
-            mainThreadProvider = { mainThread },
-            loopMainThread = { throw AssertionError("loopMainThread should not run") },
-            reportForegroundServiceTimingException = { throw AssertionError("report should not run") },
             exit = { throw AssertionError("exitProcess($it)") },
         )
         val throwable = IllegalStateException("boom")
@@ -101,9 +48,6 @@ class CapodUncaughtExceptionHandlerTest : BaseTest() {
         val throwable = IllegalStateException("boom")
         val handler = CapodUncaughtExceptionHandler(
             previousHandler = previousHandler,
-            mainThreadProvider = { mainThread },
-            loopMainThread = { throw AssertionError("loopMainThread should not run") },
-            reportForegroundServiceTimingException = { throw AssertionError("report should not run") },
             cancelBeforeDelegate = { events += "cancel" },
             exit = { throw AssertionError("exitProcess($it)") },
         )
@@ -114,21 +58,19 @@ class CapodUncaughtExceptionHandlerTest : BaseTest() {
     }
 
     @Test
-    fun `delegates loop failure after suppression`() {
+    fun `delegates even when cancelBeforeDelegate throws`() {
         val mainThread = Thread.currentThread()
         val previousHandler = RecordingHandler()
-        val loopFailure = IllegalStateException("loop failed")
+        val throwable = IllegalStateException("boom")
         val handler = CapodUncaughtExceptionHandler(
             previousHandler = previousHandler,
-            mainThreadProvider = { mainThread },
-            loopMainThread = { throw loopFailure },
-            reportForegroundServiceTimingException = {},
+            cancelBeforeDelegate = { throw IllegalStateException("shutdown failed") },
             exit = { throw AssertionError("exitProcess($it)") },
         )
 
-        handler.uncaughtException(mainThread, ForegroundServiceDidNotStartInTimeException())
+        handler.uncaughtException(mainThread, throwable)
 
-        previousHandler.throwables shouldBe listOf(loopFailure)
+        previousHandler.throwables shouldBe listOf(throwable)
     }
 
     private class RecordingHandler : Thread.UncaughtExceptionHandler {

--- a/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorControlTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorControlTest.kt
@@ -1,0 +1,92 @@
+package eu.darken.capod.monitor.core.worker
+
+import android.Manifest
+import android.app.Application
+import android.app.ForegroundServiceStartNotAllowedException
+import android.content.Context
+import eu.darken.capod.common.debug.logging.Logging
+import eu.darken.capod.common.startServiceCompat
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * A start rejection must never escape, but it also must not disappear into a message-only log line
+ * — the stack tells us which caller tried to start the service from the background.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34], application = Application::class)
+class MonitorControlTest {
+
+    private val context: Application get() = RuntimeEnvironment.getApplication()
+
+    private val logLines = mutableListOf<Triple<Logging.Priority, String, String>>()
+
+    private val testLogger = object : Logging.Logger {
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            logLines.add(Triple(priority, tag, message))
+        }
+    }
+
+    @Before
+    fun setup() {
+        shadowOf(context).grantPermissions(Manifest.permission.BLUETOOTH)
+        logLines.clear()
+        Logging.install(testLogger)
+        mockkStatic("eu.darken.capod.common.ContextExtensionsKt")
+    }
+
+    @After
+    fun teardown() {
+        Logging.remove(testLogger)
+        unmockkAll()
+    }
+
+    private fun warnings(): List<String> = logLines
+        .filter { it.first == Logging.Priority.WARN }
+        .map { it.third }
+
+    @Test
+    fun `background start rejections are logged as such`() {
+        val failure = ForegroundServiceStartNotAllowedException("not allowed from background")
+        every { any<Context>().startServiceCompat(any()) } throws failure
+
+        MonitorControl(context).startMonitor()
+
+        val warning = warnings().single { it.contains("Start rejected") }
+        warning shouldContain ForegroundServiceStartNotAllowedException::class.java.name
+    }
+
+    @Test
+    fun `other illegal states are logged generically`() {
+        val failure = IllegalStateException("something else")
+        every { any<Context>().startServiceCompat(any()) } throws failure
+
+        MonitorControl(context).startMonitor()
+
+        val warning = warnings().single { it.contains("Failed to start monitor service") }
+        warning shouldContain IllegalStateException::class.java.name
+        warning shouldNotContain "Start rejected"
+    }
+
+    @Test
+    fun `security exceptions are logged with their stack`() {
+        val failure = SecurityException("missing permission")
+        every { any<Context>().startServiceCompat(any()) } throws failure
+
+        MonitorControl(context).startMonitor()
+
+        val warning = warnings().single { it.contains("Failed to start monitor service") }
+        warning shouldContain SecurityException::class.java.name
+    }
+}

--- a/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
@@ -1,0 +1,121 @@
+package eu.darken.capod.monitor.core.worker
+
+import android.app.Application
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.Service
+import androidx.core.app.NotificationCompat
+import eu.darken.capod.monitor.ui.MonitorNotifications
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import kotlinx.coroutines.Job
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Every `startForegroundService()` re-arms the `startForeground()` obligation, so each
+ * `onStartCommand()` has to satisfy it again — on every exit path.
+ *
+ * NOTE: `create()` already runs the real `onCreate()` (early promotion + failing Hilt injection),
+ * so shadow state is non-trivial before a test acts. Assertions are deltas against the state
+ * captured right before the call under test, never absolutes.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34], application = Application::class)
+class MonitorServiceTest {
+
+    private val context: Application get() = RuntimeEnvironment.getApplication()
+
+    private fun MonitorService.setField(name: String, value: Any?) {
+        MonitorService::class.java.getDeclaredField(name).apply { isAccessible = true }.set(this, value)
+    }
+
+    private fun notification(title: String): Notification =
+        NotificationCompat.Builder(context, MonitorNotifications.NOTIFICATION_CHANNEL_ID)
+            .setContentTitle(title)
+            .build()
+
+    private fun createService(): MonitorService {
+        val service = Robolectric.buildService(MonitorService::class.java).create().get()
+        // Hilt injection fails on a plain Application, so wire what the tests need by hand and
+        // reset the flags onCreate() left behind.
+        service.notificationManager = context.getSystemService(NotificationManager::class.java)
+        service.setField("foregroundStartFailed", false)
+        service.setField("injectionComplete", false)
+        service.setField("monitoringJob", null)
+        service.setField("lastNotification", null)
+        return service
+    }
+
+    private fun MonitorService.readyForMonitoring() {
+        setField("injectionComplete", true)
+        setField("monitoringJob", Job())
+        setField("foregroundStartFailed", false)
+    }
+
+    @Test
+    fun `repeated non-force starts promote to foreground every time`() {
+        val service = createService()
+        service.readyForMonitoring()
+
+        val first = notification("first")
+        service.setField("lastNotification", first)
+
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
+        shadowOf(service).lastForegroundNotification shouldBeSameInstanceAs first
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+
+        val second = notification("second")
+        service.setField("lastNotification", second)
+
+        service.onStartCommand(MonitorService.intent(context), 0, 2) shouldBe Service.START_STICKY
+        shadowOf(service).lastForegroundNotification shouldBeSameInstanceAs second
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+    }
+
+    @Test
+    fun `foreground-denied start still satisfies the obligation before stopping`() {
+        val service = createService()
+        service.setField("foregroundStartFailed", true)
+        service.setField("lastNotification", null)
+        val beforeCall = shadowOf(service).lastForegroundNotification
+
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_NOT_STICKY
+
+        shadowOf(service).lastForegroundNotification shouldNotBeSameInstanceAs beforeCall
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+    }
+
+    @Test
+    fun `re-promotion falls back to the early notification when nothing was posted`() {
+        val service = createService()
+        service.readyForMonitoring()
+        service.setField("lastNotification", null)
+        val beforeCall = shadowOf(service).lastForegroundNotification
+
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
+
+        shadowOf(service).lastForegroundNotification shouldNotBeSameInstanceAs beforeCall
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+    }
+
+    @Test
+    fun `re-promotion uses the notification posted by the monitor flow`() {
+        val service = createService()
+        service.readyForMonitoring()
+
+        val dynamic = notification("dynamic")
+        service.postPrimaryNotification(dynamic)
+
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
+
+        shadowOf(service).lastForegroundNotification shouldBeSameInstanceAs dynamic
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+    }
+}

--- a/app/src/test/java/eu/darken/capod/monitor/ui/MonitorNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/ui/MonitorNotificationsTest.kt
@@ -1,0 +1,28 @@
+package eu.darken.capod.monitor.ui
+
+import android.app.Application
+import android.app.Notification
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34], application = Application::class)
+class MonitorNotificationsTest {
+
+    @Test
+    fun `early notification is user presentable`() {
+        // It can be the notification the user sees for the whole lifetime of a service that never
+        // finishes starting up, so it has to stand on its own.
+        val notification = MonitorNotifications.createEarlyNotification(RuntimeEnvironment.getApplication())
+
+        notification.extras.getString(Notification.EXTRA_TITLE).isNullOrBlank() shouldBe false
+        notification.extras.getString(Notification.EXTRA_TEXT).isNullOrBlank() shouldBe false
+        notification.smallIcon shouldNotBe null
+        notification.contentIntent shouldNotBe null
+    }
+}


### PR DESCRIPTION
## What changed

Fixed a bug where the app could silently freeze in the background after the battery monitor started. Instead of showing an error, the app would hang invisibly and rack up "app isn't responding" reports — this was the single most common stability issue in Play Store diagnostics, affecting roughly a third of users who experienced any error. The monitor now also keeps working reliably when the system restarts it repeatedly (e.g. on Bluetooth connect/disconnect).

## Technical Context

- Root cause: every `startForegroundService()` call re-arms the 10-second `startForeground()` obligation even when the service is already in the foreground. The monitor service only promoted itself in `onCreate()`, so any start request that hit the already-running service (Bluetooth connect/disconnect, dashboard entry) left an unsatisfied obligation that timed out. It now re-promotes as the first statement of every `onStartCommand()`, reusing the most recently posted notification.
- The uncaught-exception handler suppressed the resulting `ForegroundServiceDidNotStartInTimeException` and parked the main thread in a nested `Looper.loop()`, converting each crash into a zombie process that accumulated repeated, unattributable "main thread idle" ANRs. The suppression is removed so residual failures surface as real, attributable crashes.
- Foreground-service start rejections (`ForegroundServiceStartNotAllowedException`) previously logged only the bare message; they now log distinctly with the full stack, making the formerly opaque crash clusters diagnosable.
- The early foreground notification now carries content text — some Android 16 builds reject content-poor foreground notifications.
- This ports the fix validated in d4rken-org/bluemusic#244. Verified on-device (Pixel 9 Pro, Android 16): repeated Bluetooth-triggered start deliveries to the already-running service promote cleanly with zero foreground-service timeout errors across all observation windows.
