### PR TITLE
General: Enable google-play and devtools Claude plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,8 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "support-investigator@claude-code-cafe": true
+    "support-investigator@claude-code-cafe": true,
+    "google-play@claude-code-cafe": true,
+    "devtools@claude-code-cafe": true
   }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Enables two additional Claude Code plugins in the checked-in `.claude/settings.json`: `google-play@claude-code-cafe` and `devtools@claude-code-cafe`.

## Technical Context

- Tooling config only — no app sources, build config, or resources are touched.