### PR TITLE
Fix: Ongoing notification stuck showing "Unknown"

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -26,7 +26,7 @@ import eu.darken.capod.monitor.core.PodDevice
 import eu.darken.capod.monitor.core.battery.BatteryEstimate
 import eu.darken.capod.monitor.core.battery.BatteryEstimator
 import eu.darken.capod.monitor.core.battery.estimateFor
-import eu.darken.capod.monitor.core.tierRank
+import eu.darken.capod.monitor.core.podDeviceTierComparator
 import eu.darken.capod.monitor.core.worker.MonitorControl
 import eu.darken.capod.pods.core.apple.aap.AapConnectionManager
 import eu.darken.capod.pods.core.apple.aap.protocol.AapCommand
@@ -256,10 +256,7 @@ class OverviewViewModel @Inject constructor(
         }
 
         val profiledDevices: List<PodDevice> by lazy {
-            devices.filter { it.profileId != null }.sortedWith(
-                compareBy<PodDevice> { it.tierRank() }
-                    .thenBy { profileOrder[it.profileId] ?: Int.MAX_VALUE }
-            )
+            devices.filter { it.profileId != null }.sortedWith(podDeviceTierComparator(profileOrder))
         }
 
         /**

--- a/app/src/main/java/eu/darken/capod/monitor/core/PodDevice.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/PodDevice.kt
@@ -65,7 +65,22 @@ data class PodDevice(
     /** True when the profile's BR/EDR address is in the system's connected Bluetooth devices. */
     val isSystemConnected: Boolean = false,
 ) {
-    val model: PodModel get() = ble?.model ?: profileModel ?: cached?.model ?: PodModel.UNKNOWN
+    /**
+     * A profile's model is never null — it defaults to [PodModel.UNKNOWN] — so a profile that never
+     * learned a model would otherwise mask a perfectly good model sitting in the cache, and
+     * everything downstream ([hasCase], [hasDualPods], [hasEarDetection], the notification layout,
+     * the widget) would degrade to the unknown-device shape for the device's whole lifetime.
+     *
+     * Only the profile step skips UNKNOWN. A live snapshot reporting UNKNOWN is a real decoder
+     * result for an unrecognised model, not a missing answer, and must stay authoritative — its
+     * label says "Unknown device", so overriding it with a stale profile/cache model would pair a
+     * known-model layout with an unknown-model label.
+     */
+    val model: PodModel
+        get() = ble?.model
+            ?: profileModel?.takeUnless { it == PodModel.UNKNOWN }
+            ?: cached?.model
+            ?: PodModel.UNKNOWN
     /** Bonded BR/EDR address (from profile). Used for AAP commands. */
     val address: BluetoothAddress? get() = ble?.meta?.profile?.address ?: profileAddress ?: cached?.address
     /**

--- a/app/src/main/java/eu/darken/capod/monitor/core/PodDeviceTier.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/PodDeviceTier.kt
@@ -20,12 +20,19 @@ fun PodDevice.tierRank(): Int = when {
 }
 
 /**
- * Picks the user-perceived primary profiled device: lowest [tierRank], with
- * the user's profile-list order as the tiebreaker.
+ * Sort order for the user-perceived primary profiled device: lowest [tierRank] first, then the
+ * user's profile-list order, which `profiles_priority_hint` promises is authoritative.
+ *
+ * Shared by [primaryByTier] and the dashboard's device list so the notification, the popup, the
+ * quick-settings tile and the dashboard card can never disagree about which device is primary.
+ */
+fun podDeviceTierComparator(profileOrder: Map<String, Int>): Comparator<PodDevice> =
+    compareBy<PodDevice> { it.tierRank() }
+        .thenBy { profileOrder[it.profileId] ?: Int.MAX_VALUE }
+
+/**
+ * Picks the user-perceived primary profiled device, per [podDeviceTierComparator].
  */
 fun List<PodDevice>.primaryByTier(profileOrder: Map<String, Int>): PodDevice? =
     filter { it.profileId != null }
-        .minWithOrNull(
-            compareBy<PodDevice> { it.tierRank() }
-                .thenBy { profileOrder[it.profileId] ?: Int.MAX_VALUE }
-        )
+        .minWithOrNull(podDeviceTierComparator(profileOrder))

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -98,6 +98,7 @@ class MonitorService : Service() {
     @Volatile private var monitorGeneration = 0
     private var foregroundStartFailed = false
     private var injectionComplete = false
+    @Volatile private var destroyed = false
 
     @Volatile private var lastNotification: Notification? = null
 
@@ -137,6 +138,10 @@ class MonitorService : Service() {
      * re-satisfy the foreground obligation with the notification the user is currently seeing.
      */
     internal fun postPrimaryNotification(notification: Notification) {
+        if (destroyed) {
+            log(TAG, VERBOSE) { "Skipping notification post, service is being destroyed." }
+            return
+        }
         lastNotification = notification
         notificationManager.notify(MonitorNotifications.NOTIFICATION_ID, notification)
     }
@@ -412,6 +417,10 @@ class MonitorService : Service() {
 
     override fun onDestroy() {
         log(TAG, VERBOSE) { "onDestroy()" }
+        // Set before cancelling: cancellation doesn't await the collectors, so one already past its
+        // suspension point can still reach postPrimaryNotification() and re-post what we just took
+        // down. The flag makes that post a no-op instead.
+        destroyed = true
         monitorScope.cancel("Service destroyed")
 
         if (injectionComplete) {
@@ -427,6 +436,15 @@ class MonitorService : Service() {
                 } catch (e: Exception) {
                     log(TAG, WARN) { "Failed to cancel connected notification: ${e.message}" }
                 }
+            }
+            // The FGS notification can outlive stopSelf(), leaving whatever content was last posted
+            // stuck in the shade. notificationManager.cancel() alone is not enough while the
+            // notification is still bound to the foreground service, so detach it first.
+            try {
+                stopForeground(Service.STOP_FOREGROUND_REMOVE)
+                notificationManager.cancel(MonitorNotifications.NOTIFICATION_ID)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to cancel monitor notification: ${e.message}" }
             }
         } else {
             log(TAG, WARN) { "onDestroy: Skipping notification cleanup, injection was incomplete." }

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -190,8 +190,11 @@ class MonitorService : Service() {
         // would re-post the previous session's last content under its original timestamp — which is
         // how a stale "unknown device" frame survives a teardown/restart cycle. Rebuilding is not an
         // option here: this has to stay cheap enough to satisfy the obligation before DI is ready.
+        //
+        // Deliberately does NOT clear the cache here: a collector on Dispatchers.Default can post
+        // between the read below and any write, so clearing would discard a frame that is actually
+        // current. Invalidation happens where a new session is launched instead.
         val reusable = lastNotification?.takeIf { monitoringJob?.isActive == true }
-        if (reusable == null) lastNotification = null
         if (!promoteToForeground(reusable ?: MonitorNotifications.createEarlyNotification(this))) {
             stopSelf(startId)
             return START_NOT_STICKY
@@ -214,6 +217,10 @@ class MonitorService : Service() {
 
         val generation = ++monitorGeneration
         monitorScope.coroutineContext.cancelChildren()
+        // A new session starts here, so the previous session's last frame must not be re-promoted
+        // into it. Safe at this point: the old collectors are cancelled and the new ones haven't run,
+        // so there is no current notification to discard.
+        lastNotification = null
 
         monitoringJob = monitorScope.launch {
             try {
@@ -445,9 +452,11 @@ class MonitorService : Service() {
                     log(TAG, WARN) { "Failed to cancel connected notification: ${e.message}" }
                 }
             }
-            // The FGS notification can outlive stopSelf(), leaving whatever content was last posted
-            // stuck in the shade. notificationManager.cancel() alone is not enough while the
-            // notification is still bound to the foreground service, so detach it first.
+            // Defence in depth: AOSP reaps the FGS notification on destroy by itself (verified on
+            // API 36), but reports of a stuck ongoing notification on Samsung suggest that is not
+            // universal. Retract it explicitly. cancel() alone is not the foreground-service
+            // lifecycle operation and can be ignored while the notification is still bound, so
+            // detach first. Both calls are idempotent.
             try {
                 stopForeground(Service.STOP_FOREGROUND_REMOVE)
                 notificationManager.cancel(MonitorNotifications.NOTIFICATION_ID)

--- a/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
+++ b/app/src/main/java/eu/darken/capod/monitor/core/worker/MonitorService.kt
@@ -184,7 +184,15 @@ class MonitorService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // Every startForegroundService() re-arms the startForeground() obligation,
         // so every onStartCommand has to satisfy it again, no matter how it exits.
-        if (!promoteToForeground(lastNotification ?: MonitorNotifications.createEarlyNotification(this))) {
+        //
+        // Only reuse the cached notification while a monitor session is actually live. It is a fully
+        // built object whose `when` is frozen at build time, so re-promoting it to open a NEW session
+        // would re-post the previous session's last content under its original timestamp — which is
+        // how a stale "unknown device" frame survives a teardown/restart cycle. Rebuilding is not an
+        // option here: this has to stay cheap enough to satisfy the obligation before DI is ready.
+        val reusable = lastNotification?.takeIf { monitoringJob?.isActive == true }
+        if (reusable == null) lastNotification = null
+        if (!promoteToForeground(reusable ?: MonitorNotifications.createEarlyNotification(this))) {
             stopSelf(startId)
             return START_NOT_STICKY
         }

--- a/app/src/test/java/eu/darken/capod/monitor/core/PodDeviceTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/PodDeviceTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.monitor.core
 
+import eu.darken.capod.monitor.core.cache.CachedDeviceState
 import eu.darken.capod.pods.core.apple.ble.BlePodSnapshot
 import eu.darken.capod.pods.core.apple.ble.devices.HasCase
 import eu.darken.capod.pods.core.apple.ble.devices.HasChargeDetectionDual
@@ -97,6 +98,57 @@ class PodDeviceTest : BaseTest() {
         val device = PodDevice(profileId = null, ble = null, aap = null)
         device.model shouldBe PodModel.UNKNOWN
     }
+
+    /**
+     * A profile's model defaults to UNKNOWN and is never null, so treating it as an answer would
+     * let a profile that never learned a model shadow the cache for the whole device's lifetime.
+     */
+    @Test
+    fun `UNKNOWN profile model falls through to the cache`() {
+        val device = PodDevice(
+            profileId = "a",
+            ble = null,
+            aap = null,
+            profileModel = PodModel.UNKNOWN,
+            cached = cachedState(model = PodModel.AIRPODS_PRO2_USBC),
+        )
+        device.model shouldBe PodModel.AIRPODS_PRO2_USBC
+    }
+
+    @Test
+    fun `known profile model wins over the cache`() {
+        val device = PodDevice(
+            profileId = "a",
+            ble = null,
+            aap = null,
+            profileModel = PodModel.AIRPODS_PRO3,
+            cached = cachedState(model = PodModel.AIRPODS_PRO2_USBC),
+        )
+        device.model shouldBe PodModel.AIRPODS_PRO3
+    }
+
+    /**
+     * An UNKNOWN from a live snapshot is a real decoder verdict on an unrecognised model, not a
+     * missing answer — overriding it would pair a known-model layout with "Unknown device" as the
+     * label, since getLabel() keeps preferring the BLE snapshot.
+     */
+    @Test
+    fun `live UNKNOWN model is not overridden by profile or cache`() {
+        val device = PodDevice(
+            profileId = "a",
+            ble = mockk(relaxed = true) { every { model } returns PodModel.UNKNOWN },
+            aap = null,
+            profileModel = PodModel.AIRPODS_PRO3,
+            cached = cachedState(model = PodModel.AIRPODS_PRO2_USBC),
+        )
+        device.model shouldBe PodModel.UNKNOWN
+    }
+
+    private fun cachedState(model: PodModel) = CachedDeviceState(
+        profileId = "a",
+        model = model,
+        lastSeenAt = Instant.EPOCH,
+    )
 
     @Test
     fun `identifier delegates to BLE`() {

--- a/app/src/test/java/eu/darken/capod/monitor/core/PodDeviceTierTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/PodDeviceTierTest.kt
@@ -12,6 +12,7 @@ class PodDeviceTierTest : BaseTest() {
         profileId: String?,
         isSystemConnected: Boolean = false,
         isLive: Boolean = false,
+        profileModel: PodModel = PodModel.AIRPODS_PRO,
     ): PodDevice {
         // isLive is derived from ble != null || aap != null. Use a minimal AapPodState so we
         // don't need to fabricate a BLE snapshot for the live case.
@@ -20,7 +21,7 @@ class PodDeviceTierTest : BaseTest() {
             profileId = profileId,
             ble = null,
             aap = aap,
-            profileModel = PodModel.AIRPODS_PRO,
+            profileModel = profileModel,
             isSystemConnected = isSystemConnected,
         )
     }
@@ -80,5 +81,17 @@ class PodDeviceTierTest : BaseTest() {
         val withoutOrder = device(profileId = "z", isLive = true)
         val devices = listOf(withoutOrder, withOrder)
         devices.primaryByTier(profileOrder = mapOf("a" to 0)) shouldBe withOrder
+    }
+
+    /**
+     * `profiles_priority_hint` promises profile order is authoritative once tier is equal — no
+     * model- or data-based reordering may creep in ahead of it.
+     */
+    @Test
+    fun `primaryByTier keeps profile order for a device with no known model`() {
+        val blankButFirst = device(profileId = "a", profileModel = PodModel.UNKNOWN)
+        val known = device(profileId = "b")
+        val devices = listOf(known, blankButFirst)
+        devices.primaryByTier(profileOrder = mapOf("a" to 0, "b" to 1)) shouldBe blankButFirst
     }
 }

--- a/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
@@ -126,6 +126,28 @@ class MonitorServiceTest {
     }
 
     /**
+     * A built Notification's `when` is frozen, so re-promoting the previous session's last frame to
+     * open a new one re-posts stale content under its original timestamp — the way an "unknown
+     * device" placeholder survives a teardown/restart cycle.
+     */
+    @Test
+    fun `a start with no live monitor does not reuse the previous notification`() {
+        val service = createService()
+        service.readyForMonitoring()
+
+        val stale = notification("stale")
+        service.postPrimaryNotification(stale)
+
+        // Monitor session has ended — the cached frame no longer reflects anything current.
+        service.setField("monitoringJob", null)
+
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
+
+        shadowOf(service).lastForegroundNotification shouldNotBeSameInstanceAs stale
+        service.getField("lastNotification") shouldNotBeSameInstanceAs stale
+    }
+
+    /**
      * The FGS notification can outlive `stopSelf()`. Leaving it up strands whatever content was last
      * posted — including the unknown-device placeholder built before the first BLE scan batch landed.
      *

--- a/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
@@ -6,9 +6,12 @@ import android.app.NotificationManager
 import android.app.Service
 import androidx.core.app.NotificationCompat
 import eu.darken.capod.monitor.ui.MonitorNotifications
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Job
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,6 +38,9 @@ class MonitorServiceTest {
     private fun MonitorService.setField(name: String, value: Any?) {
         MonitorService::class.java.getDeclaredField(name).apply { isAccessible = true }.set(this, value)
     }
+
+    private fun MonitorService.getField(name: String): Any? =
+        MonitorService::class.java.getDeclaredField(name).apply { isAccessible = true }.get(this)
 
     private fun notification(title: String): Notification =
         NotificationCompat.Builder(context, MonitorNotifications.NOTIFICATION_CHANNEL_ID)
@@ -117,5 +123,55 @@ class MonitorServiceTest {
 
         shadowOf(service).lastForegroundNotification shouldBeSameInstanceAs dynamic
         shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+    }
+
+    /**
+     * The FGS notification can outlive `stopSelf()`. Leaving it up strands whatever content was last
+     * posted — including the unknown-device placeholder built before the first BLE scan batch landed.
+     *
+     * Asserted as an interaction, not as shadow end-state: Robolectric's `ShadowService.onDestroy()`
+     * tears the foreground notification down by itself, so an end-state check passes either way.
+     */
+    @Test
+    fun `onDestroy retracts the monitor notification`() {
+        val service = createService()
+        service.readyForMonitoring()
+        val manager = mockk<NotificationManager>(relaxed = true)
+        service.notificationManager = manager
+
+        service.onDestroy()
+
+        verify { manager.cancel(MonitorNotifications.NOTIFICATION_ID) }
+    }
+
+    /**
+     * Scope cancellation doesn't await the collectors, so one already past its suspension point can
+     * still post — re-creating the very notification onDestroy just took down.
+     */
+    @Test
+    fun `a post that lands after onDestroy is dropped`() {
+        val service = createService()
+        service.readyForMonitoring()
+        service.onDestroy()
+
+        val manager = mockk<NotificationManager>(relaxed = true)
+        service.notificationManager = manager
+
+        service.postPrimaryNotification(notification("late"))
+
+        verify(exactly = 0) { manager.notify(any<Int>(), any()) }
+        service.getField("lastNotification").shouldBeNull()
+    }
+
+    @Test
+    fun `onDestroy skips notification cleanup when injection never completed`() {
+        val service = createService()
+        service.setField("injectionComplete", false)
+        val manager = mockk<NotificationManager>(relaxed = true)
+        service.notificationManager = manager
+
+        service.onDestroy()
+
+        verify(exactly = 0) { manager.cancel(any<Int>()) }
     }
 }

--- a/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
+++ b/app/src/test/java/eu/darken/capod/monitor/core/worker/MonitorServiceTest.kt
@@ -138,13 +138,32 @@ class MonitorServiceTest {
         val stale = notification("stale")
         service.postPrimaryNotification(stale)
 
-        // Monitor session has ended — the cached frame no longer reflects anything current.
-        service.setField("monitoringJob", null)
+        // Monitor session has ended. Production never nulls monitoringJob, it leaves the completed
+        // job in place, so a finished Job is the faithful state here.
+        service.setField("monitoringJob", Job().apply { complete() })
 
         service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
 
         shadowOf(service).lastForegroundNotification shouldNotBeSameInstanceAs stale
         service.getField("lastNotification") shouldNotBeSameInstanceAs stale
+    }
+
+    /**
+     * Invalidation is deliberately at session launch, not next to the promote: a collector on
+     * Dispatchers.Default can post between the read and a write there, so clearing at promote time
+     * could discard a frame that is genuinely current.
+     */
+    @Test
+    fun `launching a new session drops the previous session's notification`() {
+        val service = createService()
+        service.readyForMonitoring()
+        service.postPrimaryNotification(notification("previous"))
+
+        // forceStart bypasses the "already monitoring" early return, so a new session is launched.
+        service.onStartCommand(MonitorService.intent(context, forceStart = true), 0, 1) shouldBe
+            Service.START_STICKY
+
+        service.getField("lastNotification").shouldBeNull()
     }
 
     /**


### PR DESCRIPTION
## What changed

The ongoing notification could get stuck showing "Unknown" while the app's dashboard showed
correct AirPods details right next to it. The notification was non-dismissible and kept its
original timestamp, so it stayed wrong indefinitely.

Three things are fixed:

- A stale notification is no longer re-posted when monitoring restarts. Previously the app reused
  the previous session's last notification, so an out-of-date reading could reappear.
- When monitoring stops, the notification is now explicitly taken down instead of being left
  stranded in the shade with whatever it last showed.
- A device whose profile never learned which AirPods model it is now falls back to the last
  known model instead of displaying as an unknown device.

## Technical Context

- **Root cause, "Unknown" content:** `DeviceProfile.model` is non-null and defaults to
  `PodModel.UNKNOWN`, and `DeviceMonitor` passes it as `profileModel`. The old chain
  `ble?.model ?: profileModel ?: cached?.model` therefore short-circuited on `UNKNOWN` and could
  never reach a good cached model — so `MonitorNotificationViewFactory` picked the unknown-device
  layout, whose text is `PodModel.UNKNOWN`'s hardcoded "Unknown" label. **This is the out-of-box
  state**: `DeviceProfilesRepo` auto-creates a profile with only `label` set, so every fresh install
  starts with "My Headphones" / model `UNKNOWN` / no address until the user assigns a paired device.
  Verified on an emulator. The profile state itself is not addressed here — see #658.
- **Only the profile step skips UNKNOWN.** A live snapshot reporting `UNKNOWN` is a real decoder
  verdict on an unrecognised model (`UnknownAppleSnapshotBle`), not a missing answer. IRK matching
  does not check model, so a live unknown snapshot can attach to a known-model profile; overriding
  it there would pair a known-model layout with `getLabel()`'s "Unknown device" text.
- **Root cause, stale frame surviving a restart:** `onStartCommand` re-promoted the cached
  `lastNotification` *object*. A built `Notification` has a frozen `when`, so opening a new session
  with it re-posted the previous session's content under its original timestamp. It is now only
  reused while `monitoringJob` is actually live; otherwise the service promotes a fresh startup
  notification. Rebuilding from device state is not viable at that point — the promotion has to
  happen before DI is ready, per the FGS-ANR constraint from #653.
- **Cache invalidation sits at session launch, not next to the promote.** Clearing it beside the
  promote is a check-then-act across threads: a collector on `Dispatchers.Default` can post between
  the read and the write, so the clear would discard a frame that is genuinely current *and* the
  early notification would be promoted over it — and because the "already monitoring" path returns
  early, `distinctUntilChanged` need not emit again, leaving "Starting up…" displayed. Clearing
  after `cancelChildren()` and before the new `launch` avoids that: old collectors are cancelled,
  new ones have not run, so there is no current frame to lose.
- **Teardown is defence in depth, not a proven fix.** Nothing ever cancelled
  `MonitorNotifications.NOTIFICATION_ID`; `onDestroy()` only
  cancelled `NOTIFICATION_ID_CONNECTED`. An ID-based cancel is also not the foreground-service
  lifecycle operation and can be ignored while the notification is still bound to an active FGS, so
  the service now detaches with `stopForeground(STOP_FOREGROUND_REMOVE)` first.
- **Why the `destroyed` flag:** `onDestroy()` cancels the monitor scope but does not await it, and
  collectors run on `Dispatchers.Default`. One already past its suspension point could reach
  `postPrimaryNotification()` after teardown and re-create the notification just removed.
- **The comparator hoist is behaviour-neutral.** `primaryByTier` and `OverviewViewModel.profiledDevices`
  carried byte-identical duplicated comparators; they are now one `podDeviceTierComparator()`, also
  used by `AncTileStateStore`. An earlier draft demoted data-less devices ahead of profile order —
  dropped, because `profiles_priority_hint` explicitly promises profile order is authoritative, and
  it would have changed which single device a free-tier user sees.

## Verification and its limits

- Build + `testFossDebugUnitTest` + `testGplayDebugUnitTest` green.
- Driven on an API 36 emulator: the reporter's precondition reproduces exactly on a fresh install
  (profile "My Headphones", model Unknown, no paired device → `effectiveMode = MANUAL`). The real
  teardown path was exercised end to end (`Monitor mode: MANUAL` → `Monitor finished, stopping
  service.` → `onDestroy()`); `stopForeground(STOP_FOREGROUND_REMOVE)` + `cancel()` ran with no
  exception, no crash and no ANR, process still alive.
- **The stranded-notification symptom does not reproduce on stock AOSP.** A pre-fix build also had
  the notification removed after `onDestroy()`, so the teardown change could not be A/B-validated
  there; its benefit is reasoned, not measured. The report is from a Samsung SM-S9370, so the
  persistence appears to be OEM-specific.
- Not tested against real AirPods hardware.
- The reporter confirmed that assigning a paired Bluetooth device to the profile resolves the symptom
  on their device, which corroborates the root-cause chain. It does not distinguish which of the two
  notification mechanisms was at fault, and that is now unanswerable: once monitoring runs
  continuously it overwrites `NOTIFICATION_ID`, so the stale frame is gone either way.

- **Not addressed here, tracked in #658:** a profile with no paired Bluetooth device resolves to
  `MonitorMode.MANUAL`, so the service stops ~1s after each start and the notification only ever
  receives its first frame. That is current design, and the auto-created default profile ships in
  exactly that state.
- **Also not addressed, and not filed:** pre-`a4ba3022` users could manually select `ALWAYS`; that
  override is gone and the derived mode cannot reach `ALWAYS` without an addressed profile. The old
  `AUTOMATIC` default would also have stopped for an address-less profile, so what was lost is
  specifically the user-selectable override, not the default behaviour — and restoring it would mean
  reinstating the `settings_monitor_mode_*` strings that commit deleted across ~90 locales. No
  confirmed user has been affected by it: the reporter here had pairable AirPods all along and had
  simply not assigned them.

## Review checklist

- [ ] `stopForeground(STOP_FOREGROUND_REMOVE)` in `onDestroy()` does not interfere with the #653 FGS
      start-trigger work (no exception or ANR observed on API 36, but not verified on a real device)
- [ ] Gating notification reuse on `monitoringJob?.isActive` cannot leave a restart without a
      notification (`createEarlyNotification` is the fallback, and the obligation is still satisfied
      on every exit path)
- [ ] `PodDevice.model` falling through to cache is correct for a fuzzy-matched profile. Note a
      keyless `UNKNOWN`-model profile is promiscuous by construction (`AppleFactory.kt:110` filters on
      `it.model == UNKNOWN || it.model == tempDevice.model`, and the first branch matches anything),
      so in a crowded environment such a profile can cache a stranger's model and now display it
      where it previously showed "Unknown"
## Accepted limitation

Neither the `destroyed` flag nor the cache gate is atomic with collector posts: a collector on
`Dispatchers.Default` that is already past its check can still `notify()` afterwards, so both guards
narrow the window rather than closing it. This is pre-existing, and it is **deliberately accepted
rather than deferred** — there is no follow-up planned.

Closing it properly would mean giving notification posts generation ownership and serialising the
check/cache-write/`notify()` sequence on the main dispatcher, which reaches into the #653 FGS
lifecycle work. That was weighed and rejected: the race was found by inspection with no observed
victim, the window is narrow, and every change to this service carries ANR risk that cannot be
validated on an emulator (the symptom this PR started from does not even reproduce there). If a real
report ever matches this signature, revisit it then.




