### PR TITLE
General: Improve the reliability of the upgrade and supporter screens

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -34,6 +34,10 @@ import eu.darken.capod.common.error.ErrorEventHandler
 import eu.darken.capod.common.navigation.NavigationEventHandler
 import eu.darken.capod.common.navigation.Nav
 import androidx.compose.ui.unit.dp
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 // Which presentation the FOSS upgrade screen shows: the classic support pitch, or one of the
 // status views behind the settings "upgrade status" entry.
@@ -54,7 +58,12 @@ fun UpgradeScreenHost(
 
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
-    val sponsorReturnTracker = remember { SponsorReturnTracker() }
+    // Seeded from the ViewModel's handle-backed pending launch: after a process death while the
+    // sponsor page was open, a blank tracker would swallow the very first return. The handle is the
+    // authority on whether a return is still expected, so it reconstructs the tracker's state.
+    val sponsorReturnTracker = remember(vm) {
+        SponsorReturnTracker(wentToBackground = vm.hasPendingSponsorLaunch())
+    }
 
     LaunchedEffect(Unit) {
         vm.snackbarEvents.collect { stringRes ->
@@ -77,12 +86,13 @@ fun UpgradeScreenHost(
         }
     }
 
-    val view by vm.state.collectAsStateWithLifecycle()
+    val state by vm.state.collectAsStateWithLifecycle()
 
     UpgradeScreen(
         // Until the route binding lands (one frame): the default route keeps rendering the pitch
         // exactly as before, only the manage route waits for the status decision.
-        view = view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        view = state?.view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        supporterSince = state?.supporterSince,
         snackbarHostState = snackbarHostState,
         onGithubSponsors = vm::goGithubSponsors,
         onShowUpgradeOptions = vm::onShowUpgradeOptions,
@@ -93,6 +103,7 @@ fun UpgradeScreenHost(
 @Composable
 internal fun UpgradeScreen(
     view: FossUpgradeView? = FossUpgradeView.PITCH,
+    supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onGithubSponsors: () -> Unit = {},
     onShowUpgradeOptions: () -> Unit = {},
@@ -104,7 +115,12 @@ internal fun UpgradeScreen(
         title = if (view == FossUpgradeView.PITCH) {
             AnnotatedString(stringResource(R.string.settings_upgrade_status_label))
         } else {
-            upgradeScreenTitle(upgraded = view == FossUpgradeView.STATUS_UPGRADED)
+            // "CAPod FOSS", not "CAPod Pro": on FOSS the flavor name IS the brand. The upgraded
+            // gate keeps the highlight for supporters only.
+            upgradeScreenTitle(
+                upgraded = view == FossUpgradeView.STATUS_UPGRADED,
+                nameRes = R.string.app_name_foss,
+            )
         },
         onNavigateUp = onNavigateUp,
         snackbarHostState = snackbarHostState,
@@ -123,6 +139,7 @@ internal fun UpgradeScreen(
 
             FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
                 paddingValues = paddingValues,
+                supporterSince = supporterSince,
                 onGithubSponsors = onGithubSponsors,
             )
         }
@@ -216,6 +233,7 @@ private fun UpgradeStatusFreeContent(
 @Composable
 private fun UpgradeStatusUpgradedContent(
     paddingValues: PaddingValues,
+    supporterSince: Instant? = null,
     onGithubSponsors: () -> Unit,
 ) {
     UpgradeScreenContent(
@@ -238,6 +256,15 @@ private fun UpgradeStatusUpgradedContent(
                 text = stringResource(R.string.upgrade_foss_supporter_thanks),
                 style = MaterialTheme.typography.bodyMedium,
             )
+            supporterSince?.let { since ->
+                val formatter = remember {
+                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+                }
+                Text(
+                    text = stringResource(R.string.upgrade_foss_supporter_since, formatter.format(since)),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
         }
 
         UpgradeSectionCard(
@@ -257,8 +284,9 @@ private fun UpgradeStatusUpgradedContent(
     }
 }
 
-internal class SponsorReturnTracker {
-    private var wentToBackground = false
+internal class SponsorReturnTracker(
+    private var wentToBackground: Boolean = false,
+) {
 
     fun onStop() {
         wentToBackground = true
@@ -294,6 +322,9 @@ private fun UpgradeScreenStatusFreePreview() {
 @Composable
 private fun UpgradeScreenStatusUpgradedPreview() {
     PreviewWrapper {
-        UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED)
+        UpgradeScreen(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.ofEpochMilli(1_700_000_000_000L),
+        )
     }
 }

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,20 +44,34 @@ class UpgradeViewModel @Inject constructor(
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
     // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
     // land on the upgraded status, not back on the ask. null until the route is bound.
-    internal val state: StateFlow<FossUpgradeView?> = combine(
+    internal val state: StateFlow<State?> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
         handle.getStateFlow(KEY_SHOW_UPGRADE_OPTIONS, false),
     ) { route, info, showOptions ->
-        when {
+        val view = when {
             route == null -> null
             route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }
+        // Derived in the same emission as the view on purpose: a sibling flow would let the
+        // upgraded status render for a frame without the date it is supposed to carry.
+        view?.let {
+            State(
+                view = it,
+                supporterSince = info.upgradedAt.takeIf { _ -> it == FossUpgradeView.STATUS_UPGRADED },
+            )
+        }
     }.safeStateIn(
         initialValue = null,
-        onError = { FossUpgradeView.PITCH },
+        onError = { State(view = FossUpgradeView.PITCH) },
+    )
+
+    // internal like FossUpgradeView: the view enum is a screen-local presentation detail.
+    internal data class State(
+        val view: FossUpgradeView,
+        val supporterSince: Instant? = null,
     )
 
     init {
@@ -97,20 +112,32 @@ class UpgradeViewModel @Inject constructor(
         upgradeRepo.openGithubSponsorsPage()
     }
 
+    /**
+     * Whether a sponsor-page launch is still awaiting its return.
+     *
+     * Handle-backed, so it survives process recreation while the browser is in front — the screen's
+     * in-memory return tracker does not, and gating on that alone drops the first return after a
+     * recreation.
+     */
+    fun hasPendingSponsorLaunch(): Boolean = handle.contains(KEY_SPONSOR_PRESSED_AT)
+
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+
+        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
+        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
+        // resetting the "supporter since" date the status screen shows them.
+        if (upgradeRepo.upgradeInfo.first().isPro) {
+            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+            return@launch
+        }
+
         val elapsed = SystemClock.elapsedRealtime() - pressedAt
         log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
         if (elapsed < SPONSOR_DELAY_MS) {
-            // The nudge belongs to the unlock heuristic. An already upgraded user (recurring
-            // donation button) has nothing to unlock — peeking at the page needs no feedback.
-            if (upgradeRepo.upgradeInfo.first().isPro) {
-                log(TAG) { "checkSponsorReturn(): Too quick, but already upgraded, staying quiet" }
-            } else {
-                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-                snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
-            }
+            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+            snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
         } else {
             log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
             upgradeRepo.persistUpgrade()

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/BillingCache.kt
@@ -12,24 +12,32 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.capod.common.datastore.basicReader
 import eu.darken.capod.common.datastore.basicWriter
 import eu.darken.capod.common.datastore.createValue
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// Retained legacy migration: installs that predate the DataStore move still carry their upgrade
+// state in the "settings_gplay" SharedPreferences file.
+private val Context.billingCacheDataStore by preferencesDataStore(
+    name = "settings_gplay",
+    produceMigrations = { ctx -> listOf(SharedPreferencesMigration(ctx, "settings_gplay")) },
+)
+
 @Singleton
-class BillingCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class BillingCache internal constructor(
+    private val dataStore: DataStore<Preferences>,
 ) {
 
-    // Retained legacy migration: installs that predate the DataStore move still carry their upgrade
-    // state in the "settings_gplay" SharedPreferences file.
-    private val Context.dataStore by preferencesDataStore(
-        name = "settings_gplay",
-        produceMigrations = { ctx -> listOf(SharedPreferencesMigration(ctx, "settings_gplay")) },
-    )
+    @Inject constructor(@ApplicationContext context: Context) : this(context.billingCacheDataStore)
 
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    // Test seam: the bounded reads/writes below run on real dispatchers, so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var cacheTimeoutMs: Long = CACHE_TIMEOUT_MS
 
     // Raw keys shared between the DataStoreValues and stampLastProState's transaction — one
     // source of truth for key name and encoding.
@@ -66,8 +74,15 @@ class BillingCache @Inject constructor(
         val proUnconfirmedSince: Long,
     )
 
+    // Bounded on purpose: a wedged DataStore file lock would otherwise hang the caller forever.
+    // A timeout must NOT fall back to the default snapshot -- that would report "never bought"
+    // for an install whose evidence merely couldn't be read, which is the exact distinction the
+    // debug-log header exists to make.
     suspend fun snapshot(): Snapshot {
-        val prefs = dataStore.data.first()
+        val prefs = withTimeoutOrNull(cacheTimeoutMs) { dataStore.data.first() } ?: run {
+            log(TAG, WARN) { "snapshot() timed out after ${cacheTimeoutMs}ms" }
+            throw IOException("BillingCache snapshot timed out after ${cacheTimeoutMs}ms")
+        }
         return Snapshot(
             lastProStateAt = prefs[lastProStateAtKey] ?: 0L,
             lastProStateSku = prefs[lastProStateSkuKey] ?: "",
@@ -83,11 +98,19 @@ class BillingCache @Inject constructor(
     // entitlement layer out of order) opened a still-valid episode that this older confirmation must
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
-        dataStore.edit { prefs ->
-            prefs[lastProStateSkuKey] = skuId
-            prefs[lastProStateAtKey] = at
-            val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-            if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-        }
+        // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
+        withTimeoutOrNull(cacheTimeoutMs) {
+            dataStore.edit { prefs ->
+                prefs[lastProStateSkuKey] = skuId
+                prefs[lastProStateAtKey] = at
+                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+            }
+        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+    }
+
+    companion object {
+        private const val CACHE_TIMEOUT_MS = 2_000L
+        private val TAG = logTag("Upgrade", "Gplay", "BillingCache")
     }
 }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -1,31 +1,63 @@
 package eu.darken.capod.common.upgrade.core
 
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.asLog
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.upgrade.UpgradeDiagnostics
+import eu.darken.capod.main.core.CurriculumVitae
+import kotlinx.coroutines.CancellationException
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Reports the local billing cache into the debug log header.
+ * Reports the local billing cache and the lifetime Pro-state history into the debug log header.
  *
  * `lastProStateAt > 0` is the "this install once confirmed a real Pro purchase" bit. It predates
  * the CurriculumVitae pro-state counters by years and lives in a DataStore that was never migrated
  * or renamed, so it survives update chains that the newer counters can't speak to. Without it in
  * the header, a purchase complaint can't be told apart from a never-bought install.
  *
- * Depends on [BillingCache] alone -- see [UpgradeDiagnostics] for why this must not pull in
- * UpgradeRepoGplay.
+ * Depends on [BillingCache] and [CurriculumVitae] alone -- see [UpgradeDiagnostics] for why this
+ * must not pull in UpgradeRepoGplay.
  */
 @Singleton
 class UpgradeDiagnosticsGplay @Inject constructor(
     private val billingCache: BillingCache,
+    private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
     override suspend fun debugInfo(): String {
-        val snapshot = billingCache.snapshot()
-        val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
-        val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
-        val unconfirmedSince = snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
-        return "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, proUnconfirmedSince=$unconfirmedSince)"
+        val cache = try {
+            val snapshot = billingCache.snapshot()
+            val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
+            val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
+            val unconfirmedSince =
+                snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
+            "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, " +
+                "proUnconfirmedSince=$unconfirmedSince)"
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Billing cache unavailable: ${e.asLog()}" }
+            "BillingCache=unavailable"
+        }
+        // Separate boundary from the cache read above on purpose: these are different DataStores,
+        // and the counters only cover installs new enough to have them. A failure to read one must
+        // not suppress the other's independent evidence.
+        val history = try {
+            curriculumVitae.proHistory().toString()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
+            "unavailable"
+        }
+        return "$cache, ProHistory=$history"
+    }
+
+    companion object {
+        private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -29,6 +30,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.capod.R
 import eu.darken.capod.common.compose.Preview2
@@ -49,8 +52,9 @@ fun UpgradeScreenHost(
     val context = LocalContext.current
     val activity = context as? android.app.Activity
 
-    // No screen-level resume refresh: MainActivity already refreshes the upgrade repo on every
-    // activity resume, which covers returning from Play after cancelling the subscription there.
+    // MainActivity's per-resume refresh only covers the entitlement, never the screen-local SKU
+    // query — so a transient Play outage would leave the retry card up until it's tapped by hand.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { vm.onResume() }
 
     // rememberSaveable, not remember: these are driven by one-shot events that are already consumed
     // from the flow, so a rotation while a dialog is up would drop it for good.
@@ -368,14 +372,24 @@ private fun UpgradeOffersBox(
         when (state) {
             GplayUpgradeUiState.Loading -> UpgradeActionCard { UpgradeLoadingBlock() }
             is GplayUpgradeUiState.Unavailable -> UpgradeInlineStateCard(
-                title = stringResource(R.string.upgrades_gplay_unavailable_error),
+                title = stringResource(R.string.upgrade_screen_offers_unavailable_title),
                 body = stringResource(R.string.upgrade_screen_offers_unavailable_message),
                 icon = Icons.TwoTone.WarningAmber,
             ) {
                 // Play can be slow rather than broken (cold store, first sign-in): let
                 // the user re-run the offer queries instead of leaving a dead screen.
+                // No reset needed: this composable unmounts the moment the state leaves Unavailable.
+                var retryTapped by remember { mutableStateOf(false) }
                 OutlinedButton(
-                    onClick = onRetry,
+                    // Guard inside the callback, not just via `enabled`: `enabled` only takes effect
+                    // after recomposition, so two taps in the same frame would both fire.
+                    onClick = {
+                        if (!retryTapped) {
+                            retryTapped = true
+                            onRetry()
+                        }
+                    },
+                    enabled = !retryTapped,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_RETRY),

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -266,6 +266,14 @@ class UpgradeViewModel @Inject constructor(
         retryTrigger.update { it + 1 }
     }
 
+    // Returning to the screen is the user's own "try again": a transient Play outage would
+    // otherwise leave the retry card up until it's tapped by hand. Only re-queries from the
+    // unavailable state — a loaded or still-loading screen has nothing to retry.
+    fun onResume() {
+        log(TAG) { "onResume()" }
+        if (state.value is GplayUpgradeUiState.Unavailable) retrySkuQuery()
+    }
+
     // Acquires the single action slot. Rejects while ANY other entitlement action of this ViewModel
     // runs, and while the repo reports a Play launch in flight (which may belong to another VM
     // instance — the repo CAS remains the authoritative gate, this only avoids the pointless tap).

--- a/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
@@ -20,15 +20,16 @@ import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.flow.DynamicStateFlow
 import eu.darken.capod.common.upgrade.UpgradeDiagnostics
-import eu.darken.capod.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -40,7 +41,6 @@ class RecorderModule @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val installId: InstallId,
     private val timeSource: TimeSource,
-    private val curriculumVitae: CurriculumVitae,
     private val upgradeDiagnostics: UpgradeDiagnostics,
 ) {
 
@@ -86,46 +86,38 @@ class RecorderModule @Inject constructor(
                         val newRecorder = Recorder(timeSource)
                         newRecorder.start(logFile)
 
-                        if (!isResume) {
-                            val startTime = timeSource.currentTimeMillis()
-                            writeTriggerFile(sessionDir, startTime)
-                            // The recorder is already live but not yet committed to the state: a
-                            // cancellation escaping the header would abandon it where stopRecorder()
-                            // can't reach it.
-                            try {
-                                logRecordingHeader()
-                            } catch (e: CancellationException) {
-                                newRecorder.stop()
-                                this@RecorderModule.currentLogDir = null
-                                throw e
-                            }
-
-                            this@RecorderModule.currentLogDir = sessionDir
-
-                            copy(
-                                recorder = newRecorder,
-                                currentLogDir = sessionDir,
-                                recordingStartedAt = startTime,
-                                persistedLogDir = null,
-                            )
-                        } else {
-                            try {
-                                logRecordingHeader()
-                            } catch (e: CancellationException) {
-                                newRecorder.stop()
-                                this@RecorderModule.currentLogDir = null
-                                throw e
-                            }
-
-                            this@RecorderModule.currentLogDir = sessionDir
-
-                            copy(
-                                recorder = newRecorder,
-                                currentLogDir = sessionDir,
-                                recordingStartedAt = if (recordingStartedAt > 0L) recordingStartedAt else timeSource.currentTimeMillis(),
-                                persistedLogDir = null,
-                            )
+                        val startTime = when {
+                            !isResume -> timeSource.currentTimeMillis()
+                            recordingStartedAt > 0L -> recordingStartedAt
+                            else -> timeSource.currentTimeMillis()
                         }
+
+                        try {
+                            if (!isResume) writeTriggerFile(sessionDir, startTime)
+
+                            logRecordingHeader()
+                        } catch (e: Exception) {
+                            // The recorder is already live but not yet committed to the state: an exception
+                            // escaping the header would abandon it where stopRecorder() can't reach it.
+                            withContext(NonCancellable) {
+                                try {
+                                    newRecorder.stop()
+                                } catch (stopError: Exception) {
+                                    e.addSuppressed(stopError)
+                                }
+                                this@RecorderModule.currentLogDir = null
+                            }
+                            throw e
+                        }
+
+                        this@RecorderModule.currentLogDir = sessionDir
+
+                        copy(
+                            recorder = newRecorder,
+                            currentLogDir = sessionDir,
+                            recordingStartedAt = startTime,
+                            persistedLogDir = null,
+                        )
                     } else if (!shouldRecord && isRecording) {
                         requireNotNull(recorder) { "Recorder is null despite isRecording" }.stop()
 
@@ -160,20 +152,7 @@ class RecorderModule @Inject constructor(
         log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
 
         try {
-            // Billing complaints usually arrive as debug logs: having the lifetime grace/Pro-loss
-            // history in the header saves a support round-trip.
-            log(TAG, INFO) { "Pro history: ${curriculumVitae.proHistory()}" }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            // Diagnostics only — a broken history read must not stop the recorder from starting.
-            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
-        }
-
-        // Separate boundary from the block above on purpose: these read different DataStores, and
-        // the counters above only cover installs new enough to have them. A failure to read one
-        // must not suppress the other's independent evidence.
-        try {
+            // Diagnostics only — a broken read must not stop the recorder from starting.
             upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
         } catch (e: CancellationException) {
             throw e

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -85,10 +85,14 @@ internal object UpgradeScreenTags {
 // Composed app title with the flavor postfix highlighted in the upgraded color while Pro is
 // active — the same treatment the dashboard title card uses.
 @Composable
-internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString {
+internal fun upgradeScreenTitle(
+    upgraded: Boolean,
+    @StringRes nameRes: Int = R.string.app_name_pro,
+): AnnotatedString {
     // capod ships the composed "CAPod Pro" as one translatable string so translations can reorder
-    // the words; the postfix is the trailing part and gets the upgraded highlight.
-    val parts = stringResource(R.string.app_name_pro).split(" ").filter { it.isNotEmpty() }
+    // the words; the postfix is the trailing part and gets the upgraded highlight. FOSS passes its
+    // own "CAPod FOSS" instead — the flavor name is the brand there, Pro is not a thing.
+    val parts = stringResource(nameRes).split(" ").filter { it.isNotEmpty() }
     val highlight = colorResource(R.color.brand_tertiary)
     return buildAnnotatedString {
         if (parts.size == 2) {
@@ -97,7 +101,7 @@ internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString {
             append(parts[1])
             if (upgraded) pop()
         } else {
-            append(stringResource(R.string.app_name_pro))
+            append(stringResource(nameRes))
         }
     }
 }

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -1,19 +1,26 @@
 package eu.darken.capod.common.debug.recording.core
 
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.common.BuildConfigWrap
 import eu.darken.capod.common.InstallId
 import eu.darken.capod.common.SystemTimeSource
 import eu.darken.capod.common.debug.logging.FileLogger
 import eu.darken.capod.common.debug.logging.Logging
 import eu.darken.capod.common.upgrade.UpgradeDiagnostics
-import eu.darken.capod.main.core.CurriculumVitae
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -27,18 +34,18 @@ import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
 
 /**
- * The recording header reads two independent diagnostics sources. Both reads happen AFTER the
- * recorder is already writing, so a failure in either must never abort the state update — that
+ * The recording header reads diagnostics that live outside the recorder. Those reads happen AFTER
+ * the recorder is already writing, so a guarded failure must never abort the state update — that
  * would leave a running recorder the module no longer knows about, i.e. a debug recording that
- * can't be stopped or collected.
+ * can't be stopped or collected. Failures that DO escape the header have to take the uncommitted
+ * recorder down with them.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
 class RecorderModuleDiagnosticsTest : BaseTest() {
 
     private fun buildModule(
-        scope: kotlinx.coroutines.CoroutineScope,
-        curriculumVitae: CurriculumVitae,
+        scope: CoroutineScope,
         upgradeDiagnostics: UpgradeDiagnostics,
     ) = RecorderModule(
         context = ApplicationProvider.getApplicationContext(),
@@ -46,116 +53,83 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         dispatcherProvider = TestDispatcherProvider(),
         installId = mockk<InstallId>(relaxed = true),
         timeSource = SystemTimeSource,
-        curriculumVitae = curriculumVitae,
         upgradeDiagnostics = upgradeDiagnostics,
     )
 
     @Test
-    fun `a failing pro-history read still leaves a tracked recording`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } throws IllegalStateException("history unreadable")
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        module.startRecorder().shouldNotBeNull()
-        module.state.first { it.isRecording }.currentLogDir.shouldNotBeNull()
-        // The other source is independent: its evidence must still be collected.
-        coVerify { diagnostics.debugInfo() }
-
-        module.stopRecorder().shouldNotBeNull()
-    }
-
-    @Test
     fun `a failing upgrade-diagnostics read still leaves a tracked recording`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } returns CurriculumVitae.ProHistory(
-            lastState = null,
-            graceEngagedCount = 0,
-            graceEngagedLast = null,
-            proLostCount = 0,
-            proLostLast = null,
-        )
         val diagnostics = mockk<UpgradeDiagnostics>()
         coEvery { diagnostics.debugInfo() } throws IllegalStateException("cache unreadable")
 
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        module.startRecorder().shouldNotBeNull()
-        module.state.first { it.isRecording }.currentLogDir.shouldNotBeNull()
-        coVerify { cv.proHistory() }
-
-        module.stopRecorder().shouldNotBeNull()
-    }
-
-    /**
-     * Cancellation is the one thing the header reads deliberately rethrow, so it is the one failure
-     * that can abort the state update. The recorder is already live at that point: it has to be
-     * stopped on the way out, or it keeps writing into a session the module no longer tracks.
-     *
-     * The start is launched, not awaited: an aborted update never flips isRecording, so
-     * startRecorder() stays suspended. The virtual-time delay is what lets the module's own
-     * background collectors run to completion.
-     */
-    @Test
-    fun `a cancelled pro-history read stops the recorder instead of leaking it`() = runTest {
-        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } throws CancellationException("scope died mid-read")
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        backgroundScope.launch { module.startRecorder() }
-        delay(1_000)
-
-        coVerify { cv.proHistory() }
-        module.state.first().isRecording shouldBe false
-        module.currentLogDir.shouldBeNull()
-        // The recorder that was already writing when the header aborted got stopped.
-        Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
-    }
-
-    @Test
-    fun `a cancelled upgrade-diagnostics read stops the recorder instead of leaking it`() = runTest {
-        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } returns CurriculumVitae.ProHistory(
-            lastState = null,
-            graceEngagedCount = 0,
-            graceEngagedLast = null,
-            proLostCount = 0,
-            proLostLast = null,
-        )
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } throws CancellationException("scope died mid-read")
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        backgroundScope.launch { module.startRecorder() }
-        delay(1_000)
-
-        coVerify { diagnostics.debugInfo() }
-        module.state.first().isRecording shouldBe false
-        module.currentLogDir.shouldBeNull()
-        Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
-    }
-
-    @Test
-    fun `both reads failing still leaves a tracked recording`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } throws IllegalStateException("history unreadable")
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } throws IllegalStateException("cache unreadable")
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
+        val module = buildModule(backgroundScope, diagnostics)
 
         val logDir = module.startRecorder()
         logDir.exists() shouldBe true
         module.state.first { it.isRecording }.currentLogDir shouldBe logDir
 
         module.stopRecorder().shouldNotBeNull()
+    }
+
+    /**
+     * Cancellation is the one thing the guarded header read deliberately rethrows, so it is one of
+     * the failures that can abort the state update. The recorder is already live at that point: it
+     * has to be stopped on the way out, or it keeps writing into a session the module no longer
+     * tracks.
+     *
+     * The start is launched, not awaited: an aborted update never flips isRecording, so
+     * startRecorder() stays suspended. The virtual-time delay is what lets the module's own
+     * background collectors run to completion.
+     */
+    @Test
+    fun `a cancelled upgrade-diagnostics read stops the recorder instead of leaking it`() = runTest {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } throws CancellationException("scope died mid-read")
+
+        val module = buildModule(backgroundScope, diagnostics)
+
+        backgroundScope.launch { module.startRecorder() }
+        delay(1_000)
+
+        coVerify { diagnostics.debugInfo() }
+        module.state.first().isRecording shouldBe false
+        module.currentLogDir.shouldBeNull()
+        // The recorder that was already writing when the header aborted got stopped: its file
+        // logger is no longer installed.
+        Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+    }
+
+    /**
+     * Same window as above, but for an ordinary failure instead of a cancellation. The header's
+     * injected sources are individually guarded, so the escape path is one of the unguarded first
+     * log lines — here the build description read.
+     */
+    @Test
+    fun `a failing header read stops the uncommitted recorder`() = runTest {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
+
+        mockkObject(BuildConfigWrap)
+        every { BuildConfigWrap.VERSION_DESCRIPTION } throws IllegalStateException("build info unreadable")
+
+        // Own scope: the escaping exception fails the collector, which must not fail the test's own
+        // scope. SupervisorJob keeps the module's state flow alive so it can be inspected after.
+        val moduleScope = CoroutineScope(coroutineContext + SupervisorJob() + CoroutineExceptionHandler { _, _ -> })
+        try {
+            val module = buildModule(moduleScope, diagnostics)
+
+            moduleScope.launch { module.startRecorder() }
+            delay(1_000)
+
+            module.state.first().isRecording shouldBe false
+            module.currentLogDir.shouldBeNull()
+            // Non-vacuity: without the guard's cleanup the started recorder's file logger would
+            // still be installed here.
+            Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+        } finally {
+            moduleScope.cancel()
+            unmockkObject(BuildConfigWrap)
+        }
     }
 }

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -1,0 +1,103 @@
+package eu.darken.capod.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.capod.common.compose.PreviewWrapper
+import eu.darken.capod.common.upgrade.core.UpgradeRepoFoss
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.time.Duration
+
+/**
+ * Host-level counterpart to the ViewModel's sponsor-return tests: those prove the ViewModel reacts,
+ * they cannot prove the screen actually bridges the lifecycle to it. Only a real STOP/RESUME
+ * round-trip catches a missing or mis-scoped lifecycle effect, or a tracker that isn't seeded from
+ * the handle after a recreation.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FossUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var persisted = 0
+
+    private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        coEvery { persistUpgrade() } answers { persisted++ }
+    }
+
+    private fun buildVm(
+        repo: UpgradeRepoFoss,
+        handle: SavedStateHandle = SavedStateHandle(),
+    ) = UpgradeViewModel(
+        handle = handle,
+        dispatcherProvider = TestDispatcherProvider(),
+        upgradeRepo = repo,
+    )
+
+    @Test
+    fun `a stop-resume round-trip after a sponsor launch runs the return check`() {
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve
+        // here. The default route binds via the host's own LaunchedEffect.
+        val vm = buildVm(mockRepo())
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        // CREATED, not STARTED: only that far down does the activity emit ON_STOP, which is what
+        // "the browser took the foreground" looks like to the return tracker.
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a recreated screen consumes the pending sponsor launch on the first resume`() {
+        // Process death while the browser was in front: the fresh screen's tracker never saw the
+        // ON_STOP, so it has to be seeded from the handle or the first return is swallowed.
+        val handle = SavedStateHandle()
+        buildVm(mockRepo(), handle).goGithubSponsors()
+
+        val recreatedVm = buildVm(mockRepo(), handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = recreatedVm)
+            }
+        }
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+}

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -15,6 +15,10 @@ import eu.darken.capod.common.compose.PreviewWrapper
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
@@ -60,7 +64,9 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
         }
 
-        composeRule.onAllNodesWithText(context.getString(R.string.app_name_pro)).assertCountEquals(1)
+        // "CAPod FOSS", not "CAPod Pro": the status views describe a FOSS install.
+        composeRule.onAllNodesWithText(context.getString(R.string.app_name_foss)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.app_name_pro)).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_FREE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
@@ -85,17 +91,37 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
     @Test
     fun `upgraded status view thanks the supporter and offers a recurring donation`() {
+        val since = Instant.ofEpochMilli(1_700_000_000_000L)
         composeRule.setUpgradeContent {
-            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED)
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
-        composeRule.onAllNodesWithText(context.getString(R.string.app_name_pro)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.app_name_foss)).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_supporter_thanks))
             .assertCountEquals(1)
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_foss_supporter_since, formatter.format(since))
+        ).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_DONATE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the supporter-since line stays away without a date`() {
+        // UpgradeRepoFoss can report an upgrade whose record predates the timestamp: no date line
+        // instead of a bogus one.
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = null)
+        }
+
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_foss_supporter_since, formatter.format(Instant.EPOCH))
+        ).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -76,37 +76,55 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `manage route shows the free status to non-upgraded users`() = runTest2(context = testDispatcher) {
         val vm = buildVm()
 
-        val view = async { vm.state.first { it != null } }
+        val view = async { vm.state.first { it != null }!! }
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.STATUS_FREE
+        view.await().view shouldBe FossUpgradeView.STATUS_FREE
+        // Only supporters have a supporter-since date.
+        view.await().supporterSince shouldBe null
     }
 
     @Test
     fun `manage route shows the upgraded status to supporters`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
 
-        val view = async { vm.state.first { it != null } }
+        val view = async { vm.state.first { it != null }!! }
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.STATUS_UPGRADED
+        view.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+    }
+
+    @Test
+    fun `supporterSince reflects the repo's upgradedAt`() = runTest2(context = testDispatcher) {
+        // Derived in the same emission as the view: the upgraded status must never render a frame
+        // without the date it is supposed to carry.
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val state = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        state.await() shouldBe UpgradeViewModel.State(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.EPOCH,
+        )
     }
 
     @Test
     fun `default and forced routes show the pitch`() = runTest2(context = testDispatcher) {
         val defaultVm = buildVm()
-        val defaultView = async { defaultVm.state.first { it != null } }
+        val defaultView = async { defaultVm.state.first { it != null }!! }
         defaultVm.bindRoute(Nav.Main.Upgrade())
 
         val forcedVm = buildVm()
-        val forcedView = async { forcedVm.state.first { it != null } }
+        val forcedView = async { forcedVm.state.first { it != null }!! }
         forcedVm.bindRoute(Nav.Main.Upgrade(forced = true))
         advanceUntilIdle()
 
-        defaultView.await() shouldBe FossUpgradeView.PITCH
-        forcedView.await() shouldBe FossUpgradeView.PITCH
+        defaultView.await().view shouldBe FossUpgradeView.PITCH
+        forcedView.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -114,15 +132,15 @@ class FossUpgradeViewModelTest : BaseTest() {
         val vm = buildVm()
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
 
-        val freeView = async { vm.state.first { it != null } }
+        val freeView = async { vm.state.first { it != null }!! }
         advanceUntilIdle()
-        freeView.await() shouldBe FossUpgradeView.STATUS_FREE
+        freeView.await().view shouldBe FossUpgradeView.STATUS_FREE
 
-        val pitchView = async { vm.state.first { it == FossUpgradeView.PITCH } }
+        val pitchView = async { vm.state.first { it?.view == FossUpgradeView.PITCH }!! }
         vm.onShowUpgradeOptions()
         advanceUntilIdle()
 
-        pitchView.await() shouldBe FossUpgradeView.PITCH
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -135,11 +153,11 @@ class FossUpgradeViewModelTest : BaseTest() {
 
         // Same handle, fresh ViewModel — as after the process was killed on the pitch.
         val recreatedVm = buildVm(handle = handle)
-        val view = async { recreatedVm.state.first { it != null } }
+        val view = async { recreatedVm.state.first { it != null }!! }
         recreatedVm.bindRoute(Nav.Main.Upgrade(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.PITCH
+        view.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -151,15 +169,15 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
         vm.onShowUpgradeOptions()
 
-        val pitchView = async { vm.state.first { it != null } }
+        val pitchView = async { vm.state.first { it != null }!! }
         advanceUntilIdle()
-        pitchView.await() shouldBe FossUpgradeView.PITCH
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
 
-        val upgradedView = async { vm.state.first { it == FossUpgradeView.STATUS_UPGRADED } }
+        val upgradedView = async { vm.state.first { it?.view == FossUpgradeView.STATUS_UPGRADED }!! }
         info.value = upgradedInfo()
         advanceUntilIdle()
 
-        upgradedView.await() shouldBe FossUpgradeView.STATUS_UPGRADED
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
     }
 
     @Test
@@ -236,5 +254,59 @@ class FossUpgradeViewModelTest : BaseTest() {
 
         thanks.await() shouldBe R.string.upgrade_foss_supporter_thanks
         coVerify(exactly = 1) { repo.persistUpgrade() }
+    }
+
+    @Test
+    fun `a recurring donation from the upgraded status keeps the supporter date`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The upgraded status screen's donate-again button runs the very same sponsor flow. A
+        // return past the delay must NOT persist again -- that would rewrite upgradedAt and
+        // visibly reset the "supporter since" date the screen shows.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val before = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+        before.await().supporterSince shouldBe Instant.EPOCH
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        vm.state.value!!.supporterSince shouldBe Instant.EPOCH
+    }
+
+    /**
+     * Process death between the sponsor launch and the return: the screen's in-memory return
+     * tracker is gone, so the handle-backed pending launch has to carry the state across. Without
+     * it the very first return after a recreation is dropped and the supporter never gets unlocked.
+     */
+    @Test
+    fun `a sponsor return after process recreation still persists the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val handle = SavedStateHandle()
+        val firstVm = buildVm(handle = handle)
+        firstVm.goGithubSponsors()
+        advanceUntilIdle()
+
+        // Same handle, fresh ViewModel — as after the process was killed while the browser was up.
+        val repo = mockRepo()
+        val recreatedVm = buildVm(repo = repo, handle = handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        val thanks = async { recreatedVm.toastEvents.first() }
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        recreatedVm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        thanks.await() shouldBe R.string.upgrade_foss_supporter_thanks
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        // Consumed: a later resume must not re-run the unlock.
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
     }
 }

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/SponsorReturnTrackerTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/SponsorReturnTrackerTest.kt
@@ -2,8 +2,9 @@ package eu.darken.capod.common.upgrade.ui
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
 
-class SponsorReturnTrackerTest {
+class SponsorReturnTrackerTest : BaseTest() {
 
     @Test
     fun `resume only counts after background transition`() {
@@ -12,6 +13,20 @@ class SponsorReturnTrackerTest {
         tracker.consumeResumeReturn() shouldBe false
 
         tracker.onStop()
+
+        tracker.consumeResumeReturn() shouldBe true
+        tracker.consumeResumeReturn() shouldBe false
+    }
+
+    /**
+     * The process can be killed while the sponsor page is in front, i.e. between the launch and the
+     * return. The recomposed screen gets a brand-new tracker that never saw the ON_STOP, so gating
+     * on in-memory state alone would swallow that first return for good. The handle-backed pending
+     * launch is the authority and seeds the tracker instead.
+     */
+    @Test
+    fun `a tracker seeded from a pending launch counts the first resume`() {
+        val tracker = SponsorReturnTracker(wentToBackground = true)
 
         tracker.consumeResumeReturn() shouldBe true
         tracker.consumeResumeReturn() shouldBe false

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/BillingCacheTest.kt
@@ -1,15 +1,25 @@
 package eu.darken.capod.common.upgrade.core
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.capod.common.datastore.value
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
+import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -17,53 +27,90 @@ class BillingCacheTest : BaseTest() {
 
     // One test method on purpose: BillingCache is a @Singleton in production, and DataStore
     // forbids two active instances on the same file — a second BillingCache in this process
-    // would crash, not exercise anything real.
+    // would crash, not exercise anything real. That includes the legacy-migration check below.
     @Test
     fun `stampLastProState round-trips through the DataStoreValues`() = runTest {
-        // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
-        // atomic stamp transaction writes and the keys/types the DataStoreValues read.
-        val cache = BillingCache(ApplicationProvider.getApplicationContext())
+        // Real time on purpose: the reads/writes below are bounded by cacheTimeoutMs, and the real
+        // DataStore does its I/O off the test scheduler -- under virtual time the bound would fire
+        // instantly while nothing else is scheduled.
+        withContext(Dispatchers.IO) {
+            val context = ApplicationProvider.getApplicationContext<Context>()
 
-        cache.lastProStateAt.value() shouldBe 0L
-        cache.lastProStateSku.value() shouldBe ""
+            // Installs that predate the DataStore move keep their upgrade state in the legacy
+            // "settings_gplay" SharedPreferences file. Seeded BEFORE the first DataStore access:
+            // dropping the migration would silently downgrade such an install to "never bought".
+            context.getSharedPreferences("settings_gplay", Context.MODE_PRIVATE).edit()
+                .putLong("gplay.cache.lastProAt", 1_000L)
+                .putString("gplay.cache.lastProSku", "legacy.sku")
+                .putLong("gplay.cache.proUnconfirmedAt", 2_000L)
+                .commit()
 
-        // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
-        // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
-        // install from one whose entitlement went missing.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 0L,
-            lastProStateSku = "",
-            proUnconfirmedSince = 0L,
-        )
+            // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
+            // atomic stamp transaction writes and the keys/types the DataStoreValues read.
+            val cache = BillingCache(context)
 
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+            cache.lastProStateAt.value() shouldBe 1_000L
+            cache.lastProStateSku.value() shouldBe "legacy.sku"
 
-        cache.lastProStateAt.value() shouldBe 1234L
-        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+            // The migrated triple has to surface through snapshot() too -- that is what the
+            // debug-log header reads, and it is the signal that separates a never-bought install
+            // from one whose entitlement went missing.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 1_000L,
+                lastProStateSku = "legacy.sku",
+                proUnconfirmedSince = 2_000L,
+            )
 
-        cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
 
-        cache.lastProStateAt.value() shouldBe 5678L
-        cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 1234L
+            cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
 
-        // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
-        // it, but must leave a NEWER episode intact — a connection failure that occurred after this
-        // confirmation but was processed out of order opened a still-valid episode.
-        cache.proUnconfirmedSince.value(4_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
-        cache.proUnconfirmedSince.value() shouldBe 0L
+            cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
 
-        cache.proUnconfirmedSince.value(9_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
-        cache.proUnconfirmedSince.value() shouldBe 9_000L
+            cache.lastProStateAt.value() shouldBe 5678L
+            cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
 
-        // snapshot() must agree with the individual reads. It exists so the debug-log header reads
-        // all three in ONE DataStore emission: three separate reads can straddle a concurrent
-        // stampLastProState and report a combination that never existed.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 8_000L,
-            lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-            proUnconfirmedSince = 9_000L,
-        )
+            // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
+            // it, but must leave a NEWER episode intact — a connection failure that occurred after this
+            // confirmation but was processed out of order opened a still-valid episode.
+            cache.proUnconfirmedSince.value(4_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
+            cache.proUnconfirmedSince.value() shouldBe 0L
+
+            cache.proUnconfirmedSince.value(9_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
+            cache.proUnconfirmedSince.value() shouldBe 9_000L
+
+            // snapshot() must agree with the individual reads. It exists so the debug-log header reads
+            // all three in ONE DataStore emission: three separate reads can straddle a concurrent
+            // stampLastProState and report a combination that never existed.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 8_000L,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 9_000L,
+            )
+        }
     }
+
+    @Test
+    fun `a wedged datastore is bounded, reads fail loudly and writes fail soft`() = runTest {
+        // Fake store, no file: a second real DataStore on the same file would crash this process.
+        val cache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L }
+
+        // A timeout must not masquerade as a default snapshot -- "never bought" and "couldn't read
+        // the evidence" are the two things the debug-log header exists to tell apart.
+        shouldThrow<IOException> { cache.snapshot() }
+
+        // The write only decorates the entitlement path, it must never block it.
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+    }
+}
+
+/** DataStore that never answers -- stands in for a wedged file lock. */
+internal class HangingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { awaitCancellation() }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        awaitCancellation()
 }

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -1,17 +1,33 @@
 package eu.darken.capod.common.upgrade.core
 
+import eu.darken.capod.main.core.CurriculumVitae
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class UpgradeDiagnosticsGplayTest : BaseTest() {
 
-    private fun create(snapshot: BillingCache.Snapshot) = UpgradeDiagnosticsGplay(
-        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } returns snapshot },
+    private val proHistory = CurriculumVitae.ProHistory(
+        lastState = CurriculumVitae.ProState.PURCHASED,
+        graceEngagedCount = 2,
+        graceEngagedLast = null,
+        proLostCount = 0,
+        proLostLast = null,
+    )
+
+    private fun create(
+        snapshot: () -> BillingCache.Snapshot,
+        history: () -> CurriculumVitae.ProHistory = { proHistory },
+    ) = UpgradeDiagnosticsGplay(
+        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } answers { snapshot() } },
+        curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } answers { history() } },
     )
 
     @Test
@@ -19,20 +35,104 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         // The whole point of this line in the log header is telling "never bought" apart from
         // "bought once, entitlement now missing". A raw 0 reads as a 1970 timestamp.
         val info = create(
-            BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+            { BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L) }
         ).debugInfo()
 
-        info shouldBe "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+        info shouldContain
+            "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+    }
+
+    @Test
+    fun `the pro history rides along so a complaint arrives with both records`() = runTest {
+        val info = create(
+            { BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L) }
+        ).debugInfo()
+
+        info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a broken history read still reports the billing cache`() = runTest {
+        // Different DataStores: one failing must not suppress the other's independent evidence.
+        val info = create(
+            snapshot = {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            history = { throw IllegalStateException("storage is full") },
+        ).debugInfo()
+
+        info shouldContain "lastProStateSku=${OurSku.Iap.PRO_UPGRADE.id}"
+        info shouldContain "ProHistory=unavailable"
+    }
+
+    @Test
+    fun `a broken billing cache read still reports the pro history`() = runTest {
+        // Mirror image of the above: the billing cache DataStore failing must not suppress the
+        // lifetime pro-state counters, which live in a different store.
+        var historyReads = 0
+        val info = create(
+            snapshot = { throw IllegalStateException("datastore is corrupt") },
+            history = { historyReads++; proHistory },
+        ).debugInfo()
+
+        historyReads shouldBe 1
+        info shouldContain "BillingCache=unavailable"
+        info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a cancelled billing cache read is not swallowed`() = runTest {
+        shouldThrow<CancellationException> {
+            create(
+                snapshot = { throw CancellationException("scope died") },
+            ).debugInfo()
+        }
+    }
+
+    @Test
+    fun `a cancelled history read is not swallowed`() = runTest {
+        // Symmetric to the cache read: cancellation is not a diagnostics failure, it means the
+        // caller's scope died and the header read must unwind with it.
+        shouldThrow<CancellationException> {
+            create(
+                snapshot = {
+                    BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+                },
+                history = { throw CancellationException("scope died") },
+            ).debugInfo()
+        }
+    }
+
+    @Test
+    fun `a wedged billing cache is reported as unavailable, not as a never-pro install`() = runTest {
+        // End-to-end over a real BillingCache whose store never answers: the bounded read throws,
+        // and the header must say the evidence is missing instead of claiming "never bought".
+        val diagnostics = UpgradeDiagnosticsGplay(
+            billingCache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L },
+            curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+        )
+
+        val info = diagnostics.debugInfo()
+
+        info shouldContain "BillingCache=unavailable"
+        info shouldNotContain "lastProStateAt=never"
+        info shouldContain "ProHistory=$proHistory"
     }
 
     @Test
     fun `a confirmed purchase reports an instant and the sku`() = runTest {
         val info = create(
-            BillingCache.Snapshot(
-                lastProStateAt = 1_700_000_000_000L,
-                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-                proUnconfirmedSince = 0L,
-            )
+            {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 0L,
+                )
+            }
         ).debugInfo()
 
         info shouldContain "lastProStateAt=2023-11-14T22:13:20Z"
@@ -43,11 +143,13 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
     @Test
     fun `an open unconfirmed episode is reported as an instant`() = runTest {
         val info = create(
-            BillingCache.Snapshot(
-                lastProStateAt = 1_700_000_000_000L,
-                lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
-                proUnconfirmedSince = 1_700_000_500_000L,
-            )
+            {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 1_700_000_500_000L,
+                )
+            }
         ).debugInfo()
 
         info shouldContain "proUnconfirmedSince=2023-11-14T22:21:40Z"

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -1,0 +1,76 @@
+package eu.darken.capod.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.capod.common.compose.PreviewWrapper
+import eu.darken.capod.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.capod.common.upgrade.core.billing.Sku
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Host-level counterpart to the ViewModel's `onResume` tests: those prove the ViewModel re-queries,
+ * they cannot prove the screen actually asks it to. Only a real lifecycle round-trip catches a
+ * missing or mis-scoped ON_RESUME effect.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null, isSettled = true))
+        every { wasEverPro } returns MutableStateFlow(false)
+        every { proUnconfirmedSince } returns MutableStateFlow(0L)
+        every { autoRestoreBusy } returns MutableStateFlow(false)
+        every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `returning to the screen re-runs a failed offers query`() {
+        val repo = mockRepo()
+        var queries = 0
+        coEvery { repo.querySkus(any()) } coAnswers {
+            queries++
+            throw GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        }
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(mapOf("forced" to false)),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve
+        // here. The default route binds via the host's own LaunchedEffect.
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+
+        composeRule.waitUntil { vm.state.value is GplayUpgradeUiState.Unavailable }
+        val baseline = queries
+
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { queries > baseline }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -152,6 +152,12 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_UNAVAILABLE).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_message)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
+        // The card is about the prices, not about Play as a whole -- the generic service-unavailable
+        // title contradicted its own body.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_title))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrades_gplay_unavailable_error))
+            .assertCountEquals(0)
     }
 
     @Test
@@ -301,6 +307,26 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // would silently miss the button.
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo().performClick()
         composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+    }
+
+    @Test
+    fun `the retry latches after the first tap`() {
+        var retryClicks = 0
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Unavailable(
+                    error = RuntimeException("Google Play services unavailable"),
+                ),
+                onRetry = { retryClicks++ },
+            )
+        }
+
+        val retry = composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo()
+        retry.performClick()
+        retry.performClick()
+
+        composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).assertIsNotEnabled()
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -139,6 +139,50 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `onResume retries the query after a failure`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // MainActivity's per-resume refresh only covers the entitlement -- coming back to the screen
+        // after a Play outage has to re-run the screen-local SKU query too.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        val vm = buildVm(repo)
+
+        val unavailable = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        advanceUntilIdle()
+
+        unavailable.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        coVerify(exactly = 1) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 1) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+    }
+
+    @Test
+    fun `onResume does not re-query when offers are already loaded`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val loaded = async { vm.state.first { it is GplayUpgradeUiState.Loaded } }
+        advanceUntilIdle()
+
+        loaded.await().shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+    }
+
+    @Test
     fun `a single failed product type keeps the screen loaded and surfaces the error once`() = runTest2(
         context = testDispatcher,
     ) {


### PR DESCRIPTION
## What changed

FOSS version: the supporter status screen now shows since when you've been supporting the project, titled "CAPod FOSS". Completing a GitHub Sponsors donation is no longer lost if Android killed the app in the background while the browser was open, and a supporter re-visiting the sponsors page from their status screen can no longer accidentally reset their supporter-since date.

Google Play version: if prices couldn't be loaded, returning to the upgrade screen now retries automatically, the error card says "Prices unavailable" instead of the generic services error, and the retry button can't be double-triggered.

For support: a slow or wedged billing cache can no longer hang debug-log recording or misreport a paying user as never-Pro — and a debug recording that fails while starting no longer leaves an invisible recorder running.

## Technical Context

- Continues the family-wide convergence on the shared canonical billing/upgrade implementation (follow-up to #655): this ports the latest canonical batch — bounded `BillingCache` snapshot/stamp (2s seam; a timed-out snapshot throws so the debug-log header reports `BillingCache=unavailable` instead of misreading a wedged cache as never-Pro), the pro-history fold into `UpgradeDiagnosticsGplay` with per-source failure isolation, the widened recorder start-failure guard (`catch(Exception)` + `NonCancellable` stop), the offers-unavailable polish (title, tap latch, ON_RESUME re-query — MainActivity's per-resume refresh only covers the entitlement, never the screen-local SKU query), and the `SponsorReturnTracker` seeding fix.
- The `BillingCache` constructor now takes the DataStore; the legacy `SharedPreferencesMigration("settings_gplay")` and all key names are preserved and now covered by a regression test that seeds the legacy prefs file.
- Supporter-since is derived in the same emission as the view state, so the upgraded status never renders without its date. Legacy supporter records have carried `upgradedAt` under the same wire name since the original 2022 schema — long-time supporters see their real date, no migration needed.
- Guarding that date: `checkSponsorReturn()` consumes the pending launch key and returns quietly when the install is already Pro, so the recurring-donation button can no longer rewrite `upgradedAt`.
- The FOSS title goes through a `@StringRes` parameter resolving the already-localized `app_name_foss` — a flavor resource override was rejected because `app_name_pro`'s ~76 locale variants would out-resolve it on non-English devices.
- Review guidance: new host-level lifecycle tests for both flavors (`createAndroidComposeRule`, real ViewModel, real lifecycle transitions) prove the ON_RESUME/ON_STOP wiring and the recreation seeding actually fire; the recorder guard tests assert cleanup via the installed `FileLogger` set and cover both cancellation and ordinary-exception escape paths.
