### PR TITLE
General: Make supporter status and debug logs more dependable

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
 import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
@@ -49,9 +48,11 @@ class UpgradeRepoFoss @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
-    fun openGithubSponsorsPage() = appScope.launch {
+    // Synchronous so the caller learns whether the page actually opened: the FOSS unlock heuristic
+    // only arms on a successful launch, and a fire-and-forget coroutine can't report that back.
+    fun openGithubSponsorsPage(): Boolean {
         log(TAG) { "openGithubSponsorsPage()" }
-        webpageTool.open(upgradeSite)
+        return webpageTool.open(upgradeSite)
     }
 
     // Writes capod's RETAINED persistence schema: existing supporter records are serialized with

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -95,6 +95,7 @@ fun UpgradeScreenHost(
         supporterSince = state?.supporterSince,
         snackbarHostState = snackbarHostState,
         onGithubSponsors = vm::goGithubSponsors,
+        onOpenSponsors = vm::openSponsors,
         onShowUpgradeOptions = vm::onShowUpgradeOptions,
         onNavigateUp = vm::navUp,
     )
@@ -106,6 +107,7 @@ internal fun UpgradeScreen(
     supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onGithubSponsors: () -> Unit = {},
+    onOpenSponsors: () -> Unit = {},
     onShowUpgradeOptions: () -> Unit = {},
     onNavigateUp: () -> Unit = {},
 ) {
@@ -140,7 +142,7 @@ internal fun UpgradeScreen(
             FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
                 paddingValues = paddingValues,
                 supporterSince = supporterSince,
-                onGithubSponsors = onGithubSponsors,
+                onOpenSponsors = onOpenSponsors,
             )
         }
     }
@@ -234,7 +236,7 @@ private fun UpgradeStatusFreeContent(
 private fun UpgradeStatusUpgradedContent(
     paddingValues: PaddingValues,
     supporterSince: Instant? = null,
-    onGithubSponsors: () -> Unit,
+    onOpenSponsors: () -> Unit,
 ) {
     UpgradeScreenContent(
         paddingValues = paddingValues,
@@ -273,7 +275,7 @@ private fun UpgradeStatusUpgradedContent(
         ) {
             UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_recurring_body))
             OutlinedButton(
-                onClick = onGithubSponsors,
+                onClick = onOpenSponsors,
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag(UpgradeScreenTags.FOSS_DONATE),

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -106,9 +106,28 @@ class UpgradeViewModel @Inject constructor(
         handle[KEY_SHOW_UPGRADE_OPTIONS] = true
     }
 
+    /** Armed variant: the pitch's sponsor button, which starts the return-after-5s unlock heuristic. */
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
+        if (hasPendingSponsorLaunch()) {
+            log(TAG) { "A sponsor launch is already awaiting its return" }
+            return
+        }
+        // Only arm the heuristic if the page actually opened; otherwise an unrelated later
+        // background/foreground round-trip would grant supporter status with no page ever shown.
+        if (!upgradeRepo.openGithubSponsorsPage()) {
+            log(TAG) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            return
+        }
         handle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
+    }
+
+    /**
+     * Unarmed variant: the status view's donate button. An existing supporter re-visiting the page
+     * must not re-arm the unlock heuristic — there is nothing left to unlock.
+     */
+    fun openSponsors() {
+        log(TAG) { "openSponsors()" }
         upgradeRepo.openGithubSponsorsPage()
     }
 

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Borg ontwikkeling</string>
     <string name="upgrade_foss_sponsor_subtitle">Geen advertensies. Geen opsporing. Geen Google Play-binding.</string>
     <string name="upgrade_foss_sponsor_returned_early">Alreeds terug? U ondersteuning hou CAPod aan die lewe.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Ondersteuner sedert %s</string>
     <string name="upgrade_foss_supporter_thanks">Dankie dat jy CAPod se ontwikkeling ondersteun!</string>
     <string name="upgrade_foss_sponsor_again_action">Maak borgblad oop</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">ልማትን ይደግፉ</string>
     <string name="upgrade_foss_sponsor_subtitle">ምንም ማስታወቂያ የሉም። ምንም ክትትል የሉም። ምንም Google Play ቆለፋ የሉም።</string>
     <string name="upgrade_foss_sponsor_returned_early">ቀድሞ ተመለሱ፡ ድጋፏዎ CAPodን ህያው ያቆይላል።</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">ደጋፊ ከ%s ጀምሮ</string>
     <string name="upgrade_foss_supporter_thanks">የCAPod ልማትን ስለደገፉ እናመሰግናለን!</string>
     <string name="upgrade_foss_sponsor_again_action">የስፖንሰር ገጽን ክፈት</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">دعم التطوير</string>
     <string name="upgrade_foss_sponsor_subtitle">لا إعلانات. لا تتبع. لا قيود من جوجل بلاي.</string>
     <string name="upgrade_foss_sponsor_returned_early">هل عدت بالفعل؟ دعمك يبقي كابود حيًّا.</string>
-    <string name="upgrade_badge_label">البرمجيات الحرة والمفتوحة المصدر</string>
     <string name="upgrade_foss_supporter_since">داعم منذ %s</string>
     <string name="upgrade_foss_supporter_thanks">شكرًا لدعمك تطوير CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">فتح صفحة الرعاية</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">İnkişafı sponsor edin</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklam yoxdur. İzləmə yoxdur. Google Play bağlılığı yoxdur.</string>
     <string name="upgrade_foss_sponsor_returned_early">Artıq geri qayıtdınız? Dəstəyiniz CAPod-u yaşadır.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s tarixindən bəri dəstəkçi</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-un inkişafını dəstəklədiyiniz üçün təşəkkürlər!</string>
     <string name="upgrade_foss_sponsor_again_action">Sponsor səhifəsini aç</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Падтрымаць распрацоўку</string>
     <string name="upgrade_foss_sponsor_subtitle">Ніякай рэкламы. Ніякай адсочкі. Ніякай залежнасці ад Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Ужо вяртаецеся? Ваша падтрымка трымае CAPod ў жывых.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Спонсар з %s</string>
     <string name="upgrade_foss_supporter_thanks">Дзякуй за падтрымку развіцця CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Адкрыць старонку спонсарства</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Спонсорирайте разработката</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклами. Без следене. Без заключване в Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Вече ли? Вашата подкрепа поддържа CAPod жив.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Поддържник от %s</string>
     <string name="upgrade_foss_supporter_thanks">Благодарим ви, че подкрепяте развитието на CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Отвори страницата за спонсорство</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">স্পনসর ডেভলপমেন্ট</string>
     <string name="upgrade_foss_sponsor_subtitle">কোনো বিজ্ঞাপন নেই। কোনো ট্র্যাকিং নেই। Google Play-এর সাথে বাঁধানো নেই।</string>
     <string name="upgrade_foss_sponsor_returned_early">ইতোমধ্যে ফিরে গেলেন? আপনার সমর্থন CAPodকে বাঁচিয়ে রাখে।</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s থেকে সমর্থক</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-এর উন্নয়নে সমর্থন করার জন্য আপনাকে ধন্যবাদ!</string>
     <string name="upgrade_foss_sponsor_again_action">স্পনসর পৃষ্ঠা খুলুন</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Patrocina el desenvolupament</string>
     <string name="upgrade_foss_sponsor_subtitle">Sense anuncis. Sense seguiment. Sense dependència del Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Ja heu tornat? El vostre suport manté viu el CAPod.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Col·laborador des de %s</string>
     <string name="upgrade_foss_supporter_thanks">Gràcies per donar suport al desenvolupament del CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Obre la pàgina del patrocinador</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponzorovat vývoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Žádné reklamy. Žádné sledování. Žádná závislost na Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Už jste zpět? Vaše podpora udržuje CAPod naživu.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Podporovatel od %s</string>
     <string name="upgrade_foss_supporter_thanks">Děkujeme za podporu vývoje CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Otevřít stránku sponzora</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsorudvikling</string>
     <string name="upgrade_foss_sponsor_subtitle">Ingen annoncer. Ingen sporing. Ingen Google Play-lås.</string>
     <string name="upgrade_foss_sponsor_returned_early">Allerede tilbage? Din støtte holder CAPod i live.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Støtte siden %s</string>
     <string name="upgrade_foss_supporter_thanks">Tak fordi du støtter udviklingen af CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Åbn sponsorside</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Fördere Entwicklung</string>
     <string name="upgrade_foss_sponsor_subtitle">Keine Werbung. Kein Tracking. Keine Google-Play-Bindung.</string>
     <string name="upgrade_foss_sponsor_returned_early">Schon zurück? Deine Unterstützung hält CAPod am Leben.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Unterstützer seit %s</string>
     <string name="upgrade_foss_supporter_thanks">Vielen Dank, dass du die Entwicklung von CAPod unterstützt!</string>
     <string name="upgrade_foss_sponsor_again_action">Sponsoring-Seite öffnen</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Χορηγήστε την ανάπτυξη</string>
     <string name="upgrade_foss_sponsor_subtitle">Χωρίς διαφημίσεις. Χωρίς παρακολούθηση. Χωρίς δέσμευση στο Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Επιστρέψατε ήδη; Η υποστήριξή σας κρατά το CAPod ζωντανό.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Υποστηρικτής από %s</string>
     <string name="upgrade_foss_supporter_thanks">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη του CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Άνοιγμα σελίδας χορηγίας</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsorear el desarrollo</string>
     <string name="upgrade_foss_sponsor_subtitle">Sin publicidad. Sin rastreo. Sin dependencia de Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">¿Ya te vas? Tu apoyo mantiene CAPod vivo.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">¡Gracias por apoyar el desarrollo de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocinio</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Patrocinar el desarrollo</string>
     <string name="upgrade_foss_sponsor_subtitle">Sin anuncios. Sin rastreo. Sin dependencia de Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">¿Ya de vuelta? Tu apoyo mantiene CAPod con vida.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">¡Gracias por apoyar el desarrollo de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocinio</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Patrocinadores</string>
     <string name="upgrade_foss_sponsor_subtitle">Sin anuncios. Sin rastreo. Sin dependencia de Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">¿Ya de vuelta? Tu apoyo mantiene CAPod vivo.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">¡Gracias por apoyar el desarrollo de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocinio</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Rahasta arendamist</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklaami pole. Jälgimist pole. Google Play lukustust pole.</string>
     <string name="upgrade_foss_sponsor_returned_early">Juba tagasi? Sinu toetus hoiab CAPodi elus.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Toetaja alates %s</string>
     <string name="upgrade_foss_supporter_thanks">Täname, et toetad CAPodi arendust!</string>
     <string name="upgrade_foss_sponsor_again_action">Ava sponsorlehekülg</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Garapena babestu</string>
     <string name="upgrade_foss_sponsor_subtitle">Iragarkirik ez. Jarraipenik ez. Google Play-ren lotura ez.</string>
     <string name="upgrade_foss_sponsor_returned_early">Dagoeneko itzuli? Zure laguntzak CAPod bizirik mantentzen du.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Laguntzaile %s(e)tik aurrera</string>
     <string name="upgrade_foss_supporter_thanks">Eskerrik asko CAPod-en garapena babesten duzulako!</string>
     <string name="upgrade_foss_sponsor_again_action">Ireki babesle-orria</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">حامی توسعه دهنده</string>
     <string name="upgrade_foss_sponsor_subtitle">بدون تبلیغ. بدون ردیابی. بدون وابستگی به Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">زود برگشتیدی؟ حمایت شما CAPod را زنده نگه می‌دارد.</string>
-    <string name="upgrade_badge_label">منبع‌آزاد</string>
     <string name="upgrade_foss_supporter_since">حامی از %s</string>
     <string name="upgrade_foss_supporter_thanks">از حمایت شما از توسعه CAPod سپاسگزاریم!</string>
     <string name="upgrade_foss_sponsor_again_action">باز کردن صفحه حمایت مالی</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsoroi kehitystä</string>
     <string name="upgrade_foss_sponsor_subtitle">Ei mainoksia. Ei seurantaa. Ei Google Play -riippuvuutta.</string>
     <string name="upgrade_foss_sponsor_returned_early">Jo takaisin? Tukesi pitää CAPod-sovelluksen hengissä.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Tukija %s lähtien</string>
     <string name="upgrade_foss_supporter_thanks">Kiitos, että tuet CAPodin kehitystä!</string>
     <string name="upgrade_foss_sponsor_again_action">Avaa sponsorisivu</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Mag-sponsor ng development</string>
     <string name="upgrade_foss_sponsor_subtitle">Walang ads. Walang tracking. Walang Google Play lock-in.</string>
     <string name="upgrade_foss_sponsor_returned_early">Bumalik na? Ang iyong suporta ay nagpapanatiling buhay ng CAPod.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Tagasuporta simula %s</string>
     <string name="upgrade_foss_supporter_thanks">Salamat sa pagsuporta sa development ng CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Buksan ang sponsor page</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Soutenir le développement</string>
     <string name="upgrade_foss_sponsor_subtitle">Pas de publicités. Pas de suivi à la trace. Pas de dépendance à Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Déjà de retour ? Votre soutien maintient CAPod en vie.</string>
-    <string name="upgrade_badge_label">Logiciel libre</string>
     <string name="upgrade_foss_supporter_since">Soutien depuis %s</string>
     <string name="upgrade_foss_supporter_thanks">Merci de soutenir le développement de CAPod !</string>
     <string name="upgrade_foss_sponsor_again_action">Ouvrir la page de parrainage</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Patrocinar desenvolvemento</string>
     <string name="upgrade_foss_sponsor_subtitle">Sen anuncios. Sen rastrexo. Sen dependencia de Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">És rápido/a! O teu apoio mantén CAPod vivo.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">Grazas por apoiar o desenvolvemento de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir a páxina de patrocinio</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">विकास को प्रायोजक करें</string>
     <string name="upgrade_foss_sponsor_subtitle">कोई विज्ञापन नहीं। कोई ट्रैकिंग नहीं। Google Play पर निर्भरता नहीं।</string>
     <string name="upgrade_foss_sponsor_returned_early">अभी वापस? आपका समर्थन CAPod को जीवित रखता है।</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s से समर्थक</string>
     <string name="upgrade_foss_supporter_thanks">CAPod के विकास का समर्थन करने के लिए धन्यवाद!</string>
     <string name="upgrade_foss_sponsor_again_action">स्पॉन्सर पेज खोलें</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Podržite razvoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Bez oglasa. Bez praćenja. Bez zaključanosti na Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Već se vraćate? Vaša podrška čuva CAPod na životu.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Podržavatelj od %s</string>
     <string name="upgrade_foss_supporter_thanks">Hvala vam što podržavate razvoj CAPoda!</string>
     <string name="upgrade_foss_sponsor_again_action">Otvori stranicu za sponzoriranje</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Szponzori fejlesztés</string>
     <string name="upgrade_foss_sponsor_subtitle">Nincs hirdetés. Nincs nyomkövetés. Nincs Google Play-függőség.</string>
     <string name="upgrade_foss_sponsor_returned_early">Már visszamész? A támogatásodnak köszönhetően él tovább a CAPod.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Támogató %s óta</string>
     <string name="upgrade_foss_supporter_thanks">Köszönjük, hogy támogatod a CAPod fejlesztését!</string>
     <string name="upgrade_foss_sponsor_again_action">Támogatói oldal megnyitása</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Հովանավորել զարգացումը</string>
     <string name="upgrade_foss_sponsor_subtitle">Լրատնություն չկա: հետքխկություն չկա: Google Play-ի կապվածություն չկա:</string>
     <string name="upgrade_foss_sponsor_returned_early">Արդևն հետ? ձևր աիկտակցությունը CAPod-ին կենդանի պահում:</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Հովանավոր է %s-ից</string>
     <string name="upgrade_foss_supporter_thanks">Շնորհակալություն CAPod-ի զարգացումն աջակցելու համար!</string>
     <string name="upgrade_foss_sponsor_again_action">Բացել հովանավորության էջը</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Pengembangan sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Tanpa iklan. Tanpa pelacakan. Tanpa ketergantungan Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Sudah kembali? Dukungan Anda menjaga CAPod tetap hidup.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Pendukung sejak %s</string>
     <string name="upgrade_foss_supporter_thanks">Terima kasih karena telah mendukung pengembangan CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Buka halaman sponsor</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Styrkja þróun</string>
     <string name="upgrade_foss_sponsor_subtitle">Engar auglysíngar. Engin rakning. Ekkert Google Play-lás.</string>
     <string name="upgrade_foss_sponsor_returned_early">Aftur þegar? Styðjað þít heldur CAPod lifandi.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Styrktaraðili síðan %s</string>
     <string name="upgrade_foss_supporter_thanks">Takk fyrir að styðja þróun CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Opna styrktarsíðu</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Finanzia lo sviluppo</string>
     <string name="upgrade_foss_sponsor_subtitle">Nessuna pubblicità. Nessun tracciamento. Nessun vincolo con Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Già via? Il tuo supporto mantiene CAPod in vita.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Sostenitore dal %s</string>
     <string name="upgrade_foss_supporter_thanks">Grazie per supportare lo sviluppo di CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Apri la pagina sponsor</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">פיתוח חסות</string>
     <string name="upgrade_foss_sponsor_subtitle">אין פרסומות. אין מעקב. אין תלות ב-Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">כבר חוזר? התמיכה שלך שומרת את CAPod בחיים.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">תומך מאז %s</string>
     <string name="upgrade_foss_supporter_thanks">תודה שאתה תומך בפיתוח של CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">פתח את דף התמיכה</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">開発支援者</string>
     <string name="upgrade_foss_sponsor_subtitle">広告なし。追跡なし。Google Play依存なし。</string>
     <string name="upgrade_foss_sponsor_returned_early">もう戻りますか？あなたのサポートがCAPodを支えています。</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%sからのサポーター</string>
     <string name="upgrade_foss_supporter_thanks">CAPodの開発を支援していただきありがとうございます!</string>
     <string name="upgrade_foss_sponsor_again_action">スポンサーページを開く</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">სპონსორის განვითარება</string>
     <string name="upgrade_foss_sponsor_subtitle">რეკლამა არა. თვალთვალება არა. Google Play-ზე დამოკიდება არა.</string>
     <string name="upgrade_foss_sponsor_returned_early">უკვე დაბრუნდით? თქვენი მხარდაჯერა CAPod-ს გადარჩენებას ეხმარება.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">მხარდამჭერი %s-დან</string>
     <string name="upgrade_foss_supporter_thanks">მადლობა CAPod-ის განვითარების მხარდაჭერისთვის!</string>
     <string name="upgrade_foss_sponsor_again_action">სპონსორის გვერდის გახსნა</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">ឧបត្ថម្ភការអភិវឌ្ឍន៍</string>
     <string name="upgrade_foss_sponsor_subtitle">គ្មានការផ្សាយពាណិជ្ជកម្ម។ គ្មានការតាមដាន។ គ្មានការចាក់សោ Google Play។</string>
     <string name="upgrade_foss_sponsor_returned_early">ត្រលប់មកវិញហើយ។? ការគាំទ្ររបស់អ្នកចិញ្ចឹម CAPod ឥ្សរិយនៅរស់។</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">អ្នកគាំទ្រតាំងពី %s</string>
     <string name="upgrade_foss_supporter_thanks">សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍ CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">បើកទំព័រឧបត្ថម្ភ</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Pêşdebiriyê teref bike</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklam tune. Śopandin tune. Girêdana Google Play tune.</string>
     <string name="upgrade_foss_sponsor_returned_early">Zirû vegeriya? Piştgiriya we CAPod sax dihêle.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Piştgir ji %s ve</string>
     <string name="upgrade_foss_supporter_thanks">Spas ji bo piştgiriya te ya pêşxistina CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Rûpela piştgiriyê veke</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">ಅಭಿವೃದ್ಧಿಗೆ ಪ್ರಾಯೋಜಕತ್ವ ನೀಡಿ</string>
     <string name="upgrade_foss_sponsor_subtitle">ಜಾಹೀರಾತುಗಳಿಲ್ಲ. ಭಕ್ಷಣೆ ಇಲ್ಲ. Google Play ಲಾಕ್-ಇನ್ ಇಲ್ಲ.</string>
     <string name="upgrade_foss_sponsor_returned_early">ಇಷ್ಟೇ ಹಿಂದಿರುಗಿದಿರಿ? ನಿಮ್ಮ ಬೆಂಬಲ CAPod ಅನ್ನು ಜೀವಂತವಾಗಿಡುತ್ತದೆ.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s ರಿಂದ ಬೆಂಬಲಿಗ</string>
     <string name="upgrade_foss_supporter_thanks">CAPod ಅಭಿವೃದ್ಧಿಗೆ ಬೆಂಬಲ ನೀಡಿದ್ದಕ್ಕಾಗಿ ಧನ್ಯವಾದಗಳು!</string>
     <string name="upgrade_foss_sponsor_again_action">ಪ್ರಾಯೋಜಕ ಪುಟ ತೆರೆಯಿರಿ</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">개발 후원하기</string>
     <string name="upgrade_foss_sponsor_subtitle">광고 없음. 추적 없음. Google Play 의존 없음.</string>
     <string name="upgrade_foss_sponsor_returned_early">벌써 돌아가세요? 여러분의 지원이 CAPod를 유지합니다.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s부터 후원자</string>
     <string name="upgrade_foss_supporter_thanks">CAPod 개발을 후원해 주셔서 감사합니다!</string>
     <string name="upgrade_foss_sponsor_again_action">후원 페이지 열기</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Иштелеп чыгууну колдоо</string>
     <string name="upgrade_foss_sponsor_subtitle">Жарнама. Кадалоолоо жок. Google Playга байланма.</string>
     <string name="upgrade_foss_sponsor_returned_early">Артка кайттыңызбы? Сиздин колдооңуз CAPodты тирүү сактайт.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s\'дан бери колдоочу</string>
     <string name="upgrade_foss_supporter_thanks">CAPod\'дун өнүгүшүн колдогонуңуз үчүн рахмат!</string>
     <string name="upgrade_foss_sponsor_again_action">Демөөрчүлүк баракчасын ачуу</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">ສະໜັບສະໜູນການພັດທະນາ</string>
     <string name="upgrade_foss_sponsor_subtitle">ບໍ່ມີໂຄສະນາ. ບໍ່ມີການຕິດຕາມ. ບໍ່ຕິດ Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">ກັບມາແລ້ວ? ການສະໜັບສະໜູນຂອງທ່ານຮັກສາ CAPod ໃຫ້ດຳເນີນຕໍ່ໄປ.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">ຜູ້ສະໜັບສະໜູນຕັ້ງແຕ່ %s</string>
     <string name="upgrade_foss_supporter_thanks">ຂອບຊູ່ສຳລັບການສະໜັບສະໜູນການພັດທະນາຂອງ CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">ເປິດໝ້າສະໜັບສະໜູນ</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Remti plėtrą</string>
     <string name="upgrade_foss_sponsor_subtitle">Jokių reklamų. Jokio sekimo. Jokio „Google Play“ priklausomybės.</string>
     <string name="upgrade_foss_sponsor_returned_early">Jau grįžte? Jūsų parama palaiko CAPod gyvybę.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Rėmėjas nuo %s</string>
     <string name="upgrade_foss_supporter_thanks">Ačiū, kad remiate CAPod kūrimą!</string>
     <string name="upgrade_foss_sponsor_again_action">Atidaryti rėmėjo puslapį</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsorēt attīstību</string>
     <string name="upgrade_foss_sponsor_subtitle">Bez reklamām. Bez izsekošanas. Bez Google Play saistībām.</string>
     <string name="upgrade_foss_sponsor_returned_early">Jau atpakaļ? Tavs atbalsts uztur CAPod esamību.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Atbalstītājs kopš %s</string>
     <string name="upgrade_foss_supporter_thanks">Paldies, ka atbalsti CAPod izstrādi!</string>
     <string name="upgrade_foss_sponsor_again_action">Atvērt sponsorēšanas lapu</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Спонзорирај развој</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклами. Без пратење. Без зависност од Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Веќе се вративте? Вашата поддршка го одржува CAPod жив.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Поддржувач од %s</string>
     <string name="upgrade_foss_supporter_thanks">Ти благодариме што го поддржуваш развојот на CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Отвори ја страницата за спонзорство</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">വികസനം സ്പോൺസർ ചെയ്യുക</string>
     <string name="upgrade_foss_sponsor_subtitle">പരസ്യങ്ങൾ ഇല്ല. ട്രാക്കിംഗ് ഇല്ല. Google Play ലോക്ക്-ഇൻ ഇല്ല.</string>
     <string name="upgrade_foss_sponsor_returned_early">ഇത്ര പെട്ടെന്ന് തിരിച്ചു പോകുന്നോ? നിങ്ങളുടെ പിന്തുണ CAPod നിലനിർത്തുന്നു.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s മുതൽ പിന്തുണക്കാൻ</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-ന്റെ വികസനത്തെ പിന്തുണച്ചതിന് നന്ദി!</string>
     <string name="upgrade_foss_sponsor_again_action">സ്പോൺസർ പേജ് തുറക്കുക</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Хөгжлийг дэмжих</string>
     <string name="upgrade_foss_sponsor_subtitle">Реклам байхгүй. Хяналт байхгүй. Google Play-д хамааралгүй.</string>
     <string name="upgrade_foss_sponsor_returned_early">Аль хэдэйн буцаж ирлээ? Таны дэмжлэг CAPod-ийг амьд байлгадаг.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s-с хойш дэмжигч</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-ын хөгжлийг дэмжсэнд баярлалаа!</string>
     <string name="upgrade_foss_sponsor_again_action">Дэмжигчийн хуудсыг нээх</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">विकासास प्रायोजित करा</string>
     <string name="upgrade_foss_sponsor_subtitle">कोणत्याही जाहिराती नाहीत. कोणतेही ट्रॅकिंग नाही. Google Play चे बंधन नाही.</string>
     <string name="upgrade_foss_sponsor_returned_early">आधीच परत? तुमचा पाठिंबा CAPod जिवंत ठेवतो.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s पासून समर्थक</string>
     <string name="upgrade_foss_supporter_thanks">CAPod च्या विकासाला पाठिंबा दिल्याबद्दल धन्यवाद!</string>
     <string name="upgrade_foss_sponsor_again_action">प्रायोजक पृष्ठ उघडा</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Pembangunan penaja</string>
     <string name="upgrade_foss_sponsor_subtitle">Tiada iklan. Tiada penjejakan. Tiada ikatan Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Sudah kembali? Sokongan anda mengekalkan CAPod.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Penyokong sejak %s</string>
     <string name="upgrade_foss_supporter_thanks">Terima kasih kerana menyokong pembangunan CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Buka halaman penaja</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးရန်</string>
     <string name="upgrade_foss_sponsor_subtitle">ကြောင်ညာမရှိ။ ခြေရာမခံ။ Google Play ချုပ်ချယ်မြုမရှိ။</string>
     <string name="upgrade_foss_sponsor_returned_early">ပြန်သွားပြီးလါ? သင်၏ ပံ့ပိုးမှု CAPod ကို ရှင်သန်ဆက်လက်ကေစေသည်။</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s မှစ၍ ပံ့ပိုးသူ</string>
     <string name="upgrade_foss_supporter_thanks">CAPod ၏ ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည်!</string>
     <string name="upgrade_foss_sponsor_again_action">ပံ့ပိုးသူစာမျက်နှာကို ဖွင့်ပါ</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Støtt utviklingen</string>
     <string name="upgrade_foss_sponsor_subtitle">Ingen reklame. Ingen sporing. Ingen Google Play-avhengighet.</string>
     <string name="upgrade_foss_sponsor_returned_early">Allerede tilbake? Din støtte holder CAPod i live.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Støttespiller siden %s</string>
     <string name="upgrade_foss_supporter_thanks">Takk for at du støtter utviklingen av CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Åpne sponsorside</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">विकासलाई प्रायोजन गर्नुहोस्</string>
     <string name="upgrade_foss_sponsor_subtitle">कुनै विज्ञापन छैन। कुनै ट्रैकिङ छैन। Google Playमा बाँधिएको छैन।</string>
     <string name="upgrade_foss_sponsor_returned_early">पहिले नै फिर्नुभयो? तपाईंको सहयोगले CAPod जीवित राख्छ।</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s देखि समर्थक</string>
     <string name="upgrade_foss_supporter_thanks">CAPod को विकासलाई समर्थन गर्नुभएकोमा धन्यवाद!</string>
     <string name="upgrade_foss_sponsor_again_action">प्रायोजक पृष्ठ खोल्नुहोस्</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsor ontwikkeling</string>
     <string name="upgrade_foss_sponsor_subtitle">Geen advertenties. Geen tracking. Geen Google Play-vergrendeling.</string>
     <string name="upgrade_foss_sponsor_returned_early">Alweer terug? Jouw steun houdt CAPod in leven.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Supporter sinds %s</string>
     <string name="upgrade_foss_supporter_thanks">Bedankt voor je steun aan de ontwikkeling van CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Open de sponsorpagina</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Wesprzyj rozwój</string>
     <string name="upgrade_foss_sponsor_subtitle">Bez reklam. Bez śledzenia. Bez uzależnienia od Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Już wróciłeś? Twoje wsparcie utrzymuje CAPod przy życiu.</string>
-    <string name="upgrade_badge_label">Foss</string>
     <string name="upgrade_foss_supporter_since">Wspierający od %s</string>
     <string name="upgrade_foss_supporter_thanks">Dziękuję za wsparcie rozwoju CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Otwórz stronę wspierającego</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Patrocinador do desenvolvimento</string>
     <string name="upgrade_foss_sponsor_subtitle">Sem anúncios. Sem rastreamento. Sem dependência do Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Já voltou? Seu apoio mantém o CAPod vivo.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Apoiador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">Obrigado por apoiar o desenvolvimento do CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocínio</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Patrocine o desenvolvimento</string>
     <string name="upgrade_foss_sponsor_subtitle">Sem anúncios. Sem rastreamento. Sem dependência do Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Já está a sair? O seu apoio mantém o CAPod ativo.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Apoiante desde %s</string>
     <string name="upgrade_foss_supporter_thanks">Obrigado por apoiares o desenvolvimento do CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocínio</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsurisar il sviluppament</string>
     <string name="upgrade_foss_sponsor_subtitle">Nagins annunzis. Nagin tracking. Nagin blocadi da Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Gia enavos? Tes sustegn mantegn CAPod viv.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Sustegnider dapi %s</string>
     <string name="upgrade_foss_supporter_thanks">Grazia per sustegnair il svilup da CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Avrir la pagina da sponsurisaziun</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsorizează dezvoltarea</string>
     <string name="upgrade_foss_sponsor_subtitle">Fara reclame. Fara urmarire. Fara dependenta de Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Ati revenit deja? Sprijinul dvs. mentine CAPod in viata.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Susținător din %s</string>
     <string name="upgrade_foss_supporter_thanks">Mulțumim că sprijini dezvoltarea CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Deschide pagina de sponsorizare</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Поддержать разработку</string>
     <string name="upgrade_foss_sponsor_subtitle">Без рекламы. Без слежки. Без привязки к Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Вернулись? Ваша поддержка помогает CAPod жить.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Спонсор с %s</string>
     <string name="upgrade_foss_supporter_thanks">Спасибо за поддержку разработки CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Открыть страницу спонсорства</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsoriza s\'isvilupu</string>
     <string name="upgrade_foss_sponsor_subtitle">Peroe publicidade. Peroe trachiamentu. Peroe dipendentzia de Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Zas torradas giai? Su sostegnu tuyu mantenet CAPod in vida.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Sustentadore dae su %s</string>
     <string name="upgrade_foss_supporter_thanks">Gràtzias pro sustènnere s\'isvilupu de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Aberi sa pàgina de sponsorizatzione</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">සංවර්ධනයට අනුග්‍රහය දෙන්න</string>
     <string name="upgrade_foss_sponsor_subtitle">අළු නැත. ට්‍රැකිං නැත. Google Play සලක඾ත්වය නැත.</string>
     <string name="upgrade_foss_sponsor_returned_early">එක්බේන්මට පළ්ට? ඔබ෪් සහය් CAPod ක්‍රියාත්මකව තබා ගෙනයි.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s සිට අනුග්‍රාහකයෙකි</string>
     <string name="upgrade_foss_supporter_thanks">CAPod හි සංවර්ධනයට සහාය දැක්වූ ඔබට ස්තූතියි!</string>
     <string name="upgrade_foss_sponsor_again_action">අනුග්‍රාහක පිටුව විවෘත කරන්න</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponzorovaný vývoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Žiadne reklamy. Žiadne sledovanie. Žiadna závislosť od Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Už späť? Vaša podpora udržiava CAPod pri živote.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Podporovateľ od %s</string>
     <string name="upgrade_foss_supporter_thanks">Ďakujeme, že podporujete vývoj CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Otvoriť stránku sponzorstva</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Podpri razvoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Brez oglasov. Brez sledenja. Brez vezave na Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Že nazaj? Vaša podpora ohranja CAPod pri življenju.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Podpornik od %s</string>
     <string name="upgrade_foss_supporter_thanks">Hvala, ker podpirate razvoj CAPod-a!</string>
     <string name="upgrade_foss_sponsor_again_action">Odpri stran za sponzorstvo</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Zhvillimi i sponsorëve</string>
     <string name="upgrade_foss_sponsor_subtitle">Pa reklama. Pa gjurmim. Pa varësi nga Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Ktheheni tashmjë? Mbështjetja juaj e mban CAPod gjallë.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Mbështetës që nga %s</string>
     <string name="upgrade_foss_supporter_thanks">Faleminderit për mbështetjen e zhvillimit të CAPod-it!</string>
     <string name="upgrade_foss_sponsor_again_action">Hap faqen e sponsorizimit</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Спонзориши развој</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклама. Без праћења. Без зависности од Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Већ одлазите? Ваша подршка чува CAPod живим.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Подржавалац од %s</string>
     <string name="upgrade_foss_supporter_thanks">Хвала вам што подржавате развој CAPod-а!</string>
     <string name="upgrade_foss_sponsor_again_action">Отворите страницу за спонзорство</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsra utvecklingen</string>
     <string name="upgrade_foss_sponsor_subtitle">Inga annonser. Ingen spårning. Ingen bindning till Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Redan tillbaka? Ditt stöd håller CAPod vid liv.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Supporter sedan %s</string>
     <string name="upgrade_foss_supporter_thanks">Tack för att du stödjer utvecklingen av CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Öppna sponsorsidan</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Faidhi maendeleo</string>
     <string name="upgrade_foss_sponsor_subtitle">Hakuna matangazo. Hakuna ufuatiliaji. Hakuna kufungwa kwa Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Unarudi tayari? Msaada wako unaweka CAPod iwe hai.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Msaidizi tangu %s</string>
     <string name="upgrade_foss_supporter_thanks">Asante kwa kuunga mkono maendeleo ya CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Fungua ukurasa wa udhamini</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்</string>
     <string name="upgrade_foss_sponsor_subtitle">ஐவிளம்பரம் இல்லை. கண்காணிப்பு இல்லை. Google Play கட்டுப்பாட்டு இல்லை.</string>
     <string name="upgrade_foss_sponsor_returned_early">இத்தனை இருக்கிறீரகளா? உங்கள் ஆதரவு CAPodஐ உயிருடன் வைத்திருக்கிறது.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s முதல் ஆதரவாளர்</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-இன் மேம்பாட்டை ஆதரித்ததற்கு நன்றி!</string>
     <string name="upgrade_foss_sponsor_again_action">ஸ்பான்சர் பக்கத்தைத் திற</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">అభివృద్ధిని స్పాన్సర్ చేయండి</string>
     <string name="upgrade_foss_sponsor_subtitle">జాహీరాతులు లేవు. ట్రాకింగ్ లేదు. Google Play ఒక్కటికి పరిమితం కాదు.</string>
     <string name="upgrade_foss_sponsor_returned_early">ఇర్వై వెనక్కి వెళ్ళారా? మీ మద్దతు CAPodను సజీవంగా ఉంచుతుంది.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s నుండి సపోర్టర్</string>
     <string name="upgrade_foss_supporter_thanks">CAPod అభివృద్ధికి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు!</string>
     <string name="upgrade_foss_sponsor_again_action">స్పాన్సర్ పేజీని తెరవండి</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">สปอนเซอร์การพัฒนา</string>
     <string name="upgrade_foss_sponsor_subtitle">ไม่มีโฆษณา ไม่ติดตาม ไม่ผูกขาด Google Play</string>
     <string name="upgrade_foss_sponsor_returned_early">กลับมาแล้ว? การสนับสนุนของคุณช่วยให้ CAPod ดำเนินต่อไป</string>
-    <string name="upgrade_badge_label">บังคับ</string>
     <string name="upgrade_foss_supporter_since">ผู้สนับสนุนตั้งแต่ %s</string>
     <string name="upgrade_foss_supporter_thanks">ขอบคุณที่สนับสนุนการพัฒนา CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">เปิดหน้าสนับสนุน</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Geliştirmeyi destekleyin</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklam yok. Takip yok. Google Play sınırlaması yok.</string>
     <string name="upgrade_foss_sponsor_returned_early">Şimdiden döndün mü? Desteğin CAPod\'u ayakta tutuyor.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s tarihinden beri destekçi</string>
     <string name="upgrade_foss_supporter_thanks">CAPod\'un geliştirilmesini desteklediğin için teşekkürler!</string>
     <string name="upgrade_foss_sponsor_again_action">Sponsor sayfasını aç</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Розвиток спонсорів</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклами. Без стеження. Без прив\'язки до Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Вже повертаєтеся? Ваша підтримка зберігає CAPod.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Підтримує з %s</string>
     <string name="upgrade_foss_supporter_thanks">Дякуємо за підтримку розробки CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Відкрити сторінку спонсорства</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">ترقی کو اسپانسر کریں</string>
     <string name="upgrade_foss_sponsor_subtitle">کوئی اشتہار نہیں۔ کوئی ٹریکنگ نہیں۔ کوئی Google Play کی قید نہیں۔</string>
     <string name="upgrade_foss_sponsor_returned_early">پہلے ہی واپس؟ آپ کی مدد CAPod کو زندہ رکھتی ہے۔</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s سے سپورٹر</string>
     <string name="upgrade_foss_supporter_thanks">CAPod کی ترقی کی حمایت کرنے کا شکریہ!</string>
     <string name="upgrade_foss_sponsor_again_action">سپانسر پیج کھولیں</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Rivojlanishni sponsorlik qilish</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklamasiz. Kuzatishsiz. Google Play cheklovlarisiz.</string>
     <string name="upgrade_foss_sponsor_returned_early">Allaqachon qaytdingizmi? Sizning yordamingiz CAPod\'ni tirik saqlaydi.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">%s dan beri homiy</string>
     <string name="upgrade_foss_supporter_thanks">CAPod rivojlanishini qo\'llab-quvvatlaganingiz uchun rahmat!</string>
     <string name="upgrade_foss_sponsor_again_action">Homiylik sahifasini ochish</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Tài trợ nhà phát triển</string>
     <string name="upgrade_foss_sponsor_subtitle">Không quảng cáo. Không theo dõi. Không phụ thuộc Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Quay lại rồi sao? Sự ủng hộ của bạn giúp CAPod tiếp tục tồn tại.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Người ủng hộ từ %s</string>
     <string name="upgrade_foss_supporter_thanks">Cảm ơn bạn đã ủng hộ sự phát triển của CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Mở trang tài trợ</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">赞助开发</string>
     <string name="upgrade_foss_sponsor_subtitle">无广告。无追踪。无 Google Play 绑定。</string>
     <string name="upgrade_foss_sponsor_returned_early">已经回去了？您的支持是 CAPod 生存的动力。</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">自 %s 起成为支持者</string>
     <string name="upgrade_foss_supporter_thanks">感谢您支持 CAPod 的开发!</string>
     <string name="upgrade_foss_sponsor_again_action">打开赞助页面</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">贊助開發</string>
     <string name="upgrade_foss_sponsor_subtitle">沒有廣告。沒有追蹤。沒有 Google Play 鎖定。</string>
     <string name="upgrade_foss_sponsor_returned_early">這麼快就要離開？您的支持讓 CAPod 繼續存活。</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">自 %s 起成為贊助者</string>
     <string name="upgrade_foss_supporter_thanks">感謝你支持 CAPod 的開發！</string>
     <string name="upgrade_foss_sponsor_again_action">開啟贊助頁面</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">贊助開發</string>
     <string name="upgrade_foss_sponsor_subtitle">無廣告。無追蹤。無 Google Play 鎖定。</string>
     <string name="upgrade_foss_sponsor_returned_early">已經回容了？您的支持讓 CAPod 繼續運行。</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">自 %s 起成為贊助者</string>
     <string name="upgrade_foss_supporter_thanks">感謝您支持 CAPod 的開發！</string>
     <string name="upgrade_foss_sponsor_again_action">開啟贊助頁面</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_foss_sponsor_action">Xhasa ukuthuthukiswa</string>
     <string name="upgrade_foss_sponsor_subtitle">Azikho izibhangeli. Akunakulandelelwa. Ayikho ukuvinjwa kwe-Google Play.</string>
     <string name="upgrade_foss_sponsor_returned_early">Ubuyile? Ukwesekwa kwakho kugcina i-CAPod iphila.</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_foss_supporter_since">Umsekeli kusukela ngo-%s</string>
     <string name="upgrade_foss_supporter_thanks">Ngiyabonga ngokusekela ukuthuthukiswa kwe-CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Vula ikhasi lomxhasi</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="upgrade_foss_sponsor_action">Sponsor development</string>
     <string name="upgrade_foss_sponsor_subtitle">No ads. No tracking. No Google Play lock-in.</string>
     <string name="upgrade_foss_sponsor_returned_early">Back already? Your support keeps CAPod alive.</string>
-    <string name="upgrade_badge_label">FOSS</string>
+    <string name="upgrade_badge_label" translatable="false">FOSS</string>
     <string name="upgrade_foss_supporter_since">Supporter since %s</string>
     <string name="upgrade_foss_supporter_thanks">Thank you for supporting CAPod\'s development!</string>
     <string name="upgrade_foss_sponsor_again_action">Open sponsor page</string>

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/BillingCache.kt
@@ -13,8 +13,10 @@ import eu.darken.capod.common.datastore.basicReader
 import eu.darken.capod.common.datastore.basicWriter
 import eu.darken.capod.common.datastore.createValue
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
@@ -99,14 +101,24 @@ class BillingCache internal constructor(
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
         // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
-        withTimeoutOrNull(cacheTimeoutMs) {
-            dataStore.edit { prefs ->
-                prefs[lastProStateSkuKey] = skuId
-                prefs[lastProStateAtKey] = at
-                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-            }
-        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        // A wedged file lock (timeout) and a broken write (IOException, corrupt file, no disk space)
+        // are the same to the caller — the stamp is lost, the bookkeeping around it carries on.
+        try {
+            withTimeoutOrNull(cacheTimeoutMs) {
+                dataStore.edit { prefs ->
+                    prefs[lastProStateSkuKey] = skuId
+                    prefs[lastProStateAtKey] = at
+                    val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                    if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+                }
+            } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        } catch (e: CancellationException) {
+            // Caught before the general case on purpose: our caller going away is not a write
+            // failure, and swallowing it would break their structured concurrency.
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "stampLastProState($skuId, $at) failed, write skipped: ${e.asLog()}" }
+        }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -7,6 +7,7 @@ import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.upgrade.UpgradeDiagnostics
 import eu.darken.capod.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,6 +29,10 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
+    // Test seam: the bounded read below runs on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var historyTimeoutMs: Long = HISTORY_TIMEOUT_MS
+
     override suspend fun debugInfo(): String {
         val cache = try {
             val snapshot = billingCache.snapshot()
@@ -47,7 +52,12 @@ class UpgradeDiagnosticsGplay @Inject constructor(
         // and the counters only cover installs new enough to have them. A failure to read one must
         // not suppress the other's independent evidence.
         val history = try {
-            curriculumVitae.proHistory().toString()
+            // Bounded like the cache read above: a wedged DataStore file lock would otherwise hold
+            // the debug-log header - and with it the start of the recording - forever.
+            withTimeoutOrNull(historyTimeoutMs) { curriculumVitae.proHistory().toString() } ?: run {
+                log(TAG, WARN) { "Pro history timed out after ${historyTimeoutMs}ms" }
+                "unavailable"
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -58,6 +68,7 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     }
 
     companion object {
+        private const val HISTORY_TIMEOUT_MS = 2_000L
         private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/main/java/eu/darken/capod/common/WebpageTool.kt
+++ b/app/src/main/java/eu/darken/capod/common/WebpageTool.kt
@@ -15,14 +15,18 @@ class WebpageTool @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    fun open(address: String) {
+    // Returns whether an activity was actually started, so callers that gate behaviour on the page
+    // having opened (e.g. the FOSS sponsor unlock heuristic) don't fire when no browser handled it.
+    fun open(address: String): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, address.toUri()).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        try {
+        return try {
             context.startActivity(intent)
+            true
         } catch (e: Exception) {
             log(ERROR) { "Failed to launch: ${e.asLog()}" }
+            false
         }
     }
 

--- a/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -43,6 +44,10 @@ class RecorderModule @Inject constructor(
     private val timeSource: TimeSource,
     private val upgradeDiagnostics: UpgradeDiagnostics,
 ) {
+
+    // Test seam: the header read below is bounded on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
     @Volatile
     internal var currentLogDir: File? = null
@@ -152,14 +157,31 @@ class RecorderModule @Inject constructor(
         log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
 
         try {
-            // Diagnostics only — a broken read must not stop the recorder from starting.
-            upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
+            // Diagnostics only — a broken read must not stop the recorder from starting. Bounded on
+            // top of that: debug recording is what a user reaches for when the app is ALREADY
+            // misbehaving, so a source that never answers (a stuck DataStore file lock, a billing
+            // store that doesn't respond) must not hold up the start of the recording either.
+            val read = withTimeoutOrNull(headerReadTimeoutMs) { HeaderRead(upgradeDiagnostics.debugInfo()) }
+            when {
+                read == null -> log(TAG, WARN) {
+                    "Upgrade diagnostics unavailable, read did not finish within ${headerReadTimeoutMs}ms"
+                }
+                // Completion is tracked separately from the value: a flavor that legitimately has
+                // nothing to report (FOSS) returns null and gets no line at all, not an "unavailable".
+                read.value != null -> log(TAG, INFO) { "Upgrade diagnostics: ${read.value}" }
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "Upgrade diagnostics unavailable: ${e.asLog()}" }
         }
     }
+
+    /**
+     * Completion marker for a header read: tells a source that legitimately has nothing to report
+     * (no diagnostics on FOSS) apart from one that never answered within the deadline.
+     */
+    private class HeaderRead<T>(val value: T)
 
     private fun createSessionDir(): File {
         val timestamp = timeSource.now().atZone(java.time.ZoneOffset.UTC)
@@ -267,6 +289,9 @@ class RecorderModule @Inject constructor(
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "capod_force_debug_run"
         private const val MIN_RECORDING_MS = 5_000L
+
+        // Budget for the header's diagnostics read.
+        private const val HEADER_READ_TIMEOUT_MS = 5_000L
 
         @VisibleForTesting
         internal fun parseTriggerContent(

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Fout</string>
     <string name="general_grant_permission_action">Gee toestemming</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">አይገኝም</string>
     <string name="general_error_label">ስህተት</string>
     <string name="general_grant_permission_action">ፈቃድ ስጥ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">كابود</string>
     <string name="app_name_pro">كابود – النسخة الاحترافية</string>
-    <string name="app_name_foss">كابود – البرمجيات الحرة والمفتوحة المصدر</string>
     <string name="general_value_not_available_label">غ/م</string>
     <string name="general_error_label">خطأ</string>
     <string name="general_grant_permission_action">منح الإذن</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Mövcud deyil</string>
     <string name="general_error_label">Xəta</string>
     <string name="general_grant_permission_action">İcazə ver</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Памылка</string>
     <string name="general_grant_permission_action">Даць дазвол</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Н/П</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_grant_permission_action">Дай разрешение</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">প্রযোজ্য নয়</string>
     <string name="general_error_label">ত্রুটি</string>
     <string name="general_grant_permission_action">অনুমতি দিন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Concedeix el permís</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_grant_permission_action">Udělit oprávnění</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">I/T</string>
     <string name="general_error_label">Fejl</string>
     <string name="general_grant_permission_action">Giv tilladelse</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">K.A.</string>
     <string name="general_error_label">Fehler</string>
     <string name="general_grant_permission_action">Berechtigungen erteilen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Μ/Δ</string>
     <string name="general_error_label">Σφάλμα</string>
     <string name="general_grant_permission_action">Παραχώρηση άδειας</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">No disponible</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Conceder el permiso</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">No disponible</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Conceder el permiso</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">No disponible</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Conceder el permiso</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">Tasuline CAPod</string>
-    <string name="app_name_foss">CAPod – tasuta ja vabavaraline</string>
     <string name="general_value_not_available_label">Pole saadaval</string>
     <string name="general_error_label">Viga</string>
     <string name="general_grant_permission_action">Anna õigus</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">E/E</string>
     <string name="general_error_label">Errorea</string>
     <string name="general_grant_permission_action">Eman baimena</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">ندارد</string>
     <string name="general_error_label">خطا</string>
     <string name="general_grant_permission_action">اعطای مجوز</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Ei saatavilla</string>
     <string name="general_error_label">Virhe</string>
     <string name="general_grant_permission_action">Myönnä lupa</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Hindi Available</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Ibigay ang pahintulot</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod version libre</string>
     <string name="general_value_not_available_label">N.D.</string>
     <string name="general_error_label">Erreur</string>
     <string name="general_grant_permission_action">Accorder l’autorisation</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Erro</string>
     <string name="general_grant_permission_action">Conceder permiso</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">उपलब्ध नहीं</string>
     <string name="general_error_label">त्रुटि</string>
     <string name="general_grant_permission_action">अनुमति दें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Pogreška</string>
     <string name="general_grant_permission_action">Odobri dozvolu</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Hiba</string>
     <string name="general_grant_permission_action">Engedély megadása</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Հասանելի չէ</string>
     <string name="general_error_label">Սխալ</string>
     <string name="general_grant_permission_action">Տալ թույլտվություն</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Tidak Tersedia</string>
     <string name="general_error_label">Kesalahan</string>
     <string name="general_grant_permission_action">Berikan izin</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Ekki tiltækt</string>
     <string name="general_error_label">Villa</string>
     <string name="general_grant_permission_action">Veita heimild</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Errore</string>
     <string name="general_grant_permission_action">Concedi permesso</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">לא זמין</string>
     <string name="general_error_label">שגיאה</string>
     <string name="general_grant_permission_action">הענק הרשאה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">該当なし</string>
     <string name="general_error_label">エラー</string>
     <string name="general_grant_permission_action">権限を付与</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">მიუწვდომელი</string>
     <string name="general_error_label">შეცდომა</string>
     <string name="general_grant_permission_action">ნებართვის მინიჭება</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">មិនមាន</string>
     <string name="general_error_label">កំហុស</string>
     <string name="general_grant_permission_action">ផ្តល់ការអនុញ្ញាត</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Xeletî</string>
     <string name="general_grant_permission_action">Destûr bide</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">ಲಭ್ಯವಿಲ್ಲ</string>
     <string name="general_error_label">ದೋಷ</string>
     <string name="general_grant_permission_action">ಅನುಮತಿ ನೀಡಿ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">값 없음</string>
     <string name="general_error_label">오류</string>
     <string name="general_grant_permission_action">권한 부여</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Жок</string>
     <string name="general_error_label">Ката</string>
     <string name="general_grant_permission_action">Уруксат берүү</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">ຜິດພາດ</string>
     <string name="general_grant_permission_action">ອະນຸຍາດ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Nėra</string>
     <string name="general_error_label">Klaida</string>
     <string name="general_grant_permission_action">Suteikti leidimą</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Kļūda</string>
     <string name="general_grant_permission_action">Piešķirt atļauju</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_grant_permission_action">Дозволи дозвола</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">ലഭ്യമല്ല</string>
     <string name="general_error_label">പിശക്</string>
     <string name="general_grant_permission_action">അനുമതി നൽകുക</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Байхгүй</string>
     <string name="general_error_label">Алдаа</string>
     <string name="general_grant_permission_action">Зөвшөөрөл олгох</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">उपलब्ध नाही</string>
     <string name="general_error_label">त्रुटी</string>
     <string name="general_grant_permission_action">परवानगी द्या</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Tidak tersedia</string>
     <string name="general_error_label">Ralat</string>
     <string name="general_grant_permission_action">Beri kebenaran</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">အမှား</string>
     <string name="general_grant_permission_action">ခွင့်ပြုချက်ပေးရန်</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Feil</string>
     <string name="general_grant_permission_action">Gi tillatelse</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">उपलब्ध छैन</string>
     <string name="general_error_label">त्रुटि</string>
     <string name="general_grant_permission_action">अनुमति दिनुहोस्</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Fout</string>
     <string name="general_grant_permission_action">Toestemming verlenen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -185,7 +185,6 @@ K4r0lSz;</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod Foss</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Błąd</string>
     <string name="general_grant_permission_action">Udziel uprawnień</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Erro</string>
     <string name="general_grant_permission_action">Conceder permissão</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Erro</string>
     <string name="general_grant_permission_action">Conceder permissão</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Errur</string>
     <string name="general_grant_permission_action">Conceder permissiun</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Eroare</string>
     <string name="general_grant_permission_action">Acordă permisiunea</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -184,7 +184,6 @@ AL_Cool_T</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Недоступно</string>
     <string name="general_error_label">Ошибка</string>
     <string name="general_grant_permission_action">Предоставить разрешение</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -182,7 +182,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Errore</string>
     <string name="general_grant_permission_action">Cuntze permissu</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">ලබා ගත නොහැක</string>
     <string name="general_error_label">දෝෂය</string>
     <string name="general_grant_permission_action">අවසරය ලබා දෙන්න</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Nedostupné</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_grant_permission_action">Udeliť povolenie</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Ni podatka</string>
     <string name="general_error_label">Napaka</string>
     <string name="general_grant_permission_action">Odobri dovoljenje</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Gabim</string>
     <string name="general_grant_permission_action">Jep lejen</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_grant_permission_action">Дај дозволу</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Ej tillgängligt</string>
     <string name="general_error_label">Fel</string>
     <string name="general_grant_permission_action">Bevilja behörighet</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Haipatikani</string>
     <string name="general_error_label">Hitilafu</string>
     <string name="general_grant_permission_action">Toa ruhusa</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">கிடைக்கவில்லை</string>
     <string name="general_error_label">பிழை</string>
     <string name="general_grant_permission_action">அனுமதி வழங்கு</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">అందుబాటులో లేదు</string>
     <string name="general_error_label">లోపం</string>
     <string name="general_grant_permission_action">అనుమతి ఇవ్వు</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">ไม่พร้อมใช้งาน</string>
     <string name="general_error_label">ข้อผิดพลาด</string>
     <string name="general_grant_permission_action">ให้สิทธิ์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Hata</string>
     <string name="general_grant_permission_action">İzin ver</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Помилка</string>
     <string name="general_grant_permission_action">Надати дозвіл</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">دستیاب نہیں</string>
     <string name="general_error_label">خرابی</string>
     <string name="general_grant_permission_action">اجازت دیں</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Xato</string>
     <string name="general_grant_permission_action">Ruxsat berish</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Không có</string>
     <string name="general_error_label">Lỗi</string>
     <string name="general_grant_permission_action">Cấp quyền</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">错误</string>
     <string name="general_grant_permission_action">授予权限</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">不適用</string>
     <string name="general_error_label">錯誤</string>
     <string name="general_grant_permission_action">授予權限</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">不適用</string>
     <string name="general_error_label">錯誤</string>
     <string name="general_grant_permission_action">授予權限</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -183,7 +183,6 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
     <string name="general_value_not_available_label">Ayitholakali</string>
     <string name="general_error_label">Iphutha</string>
     <string name="general_grant_permission_action">Nika imvume</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,7 +209,7 @@
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
     <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss">CAPod FOSS</string>
+    <string name="app_name_foss" translatable="false">CAPod FOSS</string>
 
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Error</string>

--- a/app/src/test/java/eu/darken/capod/common/WebpageToolTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/WebpageToolTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.capod.common
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The return value is a contract, not a convenience: the FOSS sponsor unlock heuristic only arms
+ * when the page actually opened. Every swallow point has to report the failure back.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WebpageToolTest : BaseTest() {
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a launched page reports success`() {
+        WebpageTool(application).open(URL) shouldBe true
+
+        shadowOf(application).nextStartedActivity!!.data shouldBe URL.toUri()
+    }
+
+    @Test
+    fun `a missing browser reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw ActivityNotFoundException("No browser")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    @Test
+    fun `a denied launch reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw SecurityException("Permission Denial")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    companion object {
+        private const val URL = "https://github.com/sponsors/d4rken"
+    }
+}

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -4,9 +4,11 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.capod.common.BuildConfigWrap
 import eu.darken.capod.common.InstallId
 import eu.darken.capod.common.SystemTimeSource
+import eu.darken.capod.common.coroutine.DispatcherProvider
 import eu.darken.capod.common.debug.logging.FileLogger
 import eu.darken.capod.common.debug.logging.Logging
 import eu.darken.capod.common.upgrade.UpgradeDiagnostics
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -19,12 +21,17 @@ import io.mockk.unmockkObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -32,6 +39,8 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.system.measureTimeMillis
 
 /**
  * The recording header reads diagnostics that live outside the recorder. Those reads happen AFTER
@@ -44,17 +53,56 @@ import testhelpers.coroutine.TestDispatcherProvider
 @Config(sdk = [33], application = TestApplication::class)
 class RecorderModuleDiagnosticsTest : BaseTest() {
 
+    private val logLines = CopyOnWriteArrayList<String>()
+    private val logCapture = object : Logging.Logger {
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            logLines.add(message)
+        }
+    }
+
+    @Before
+    fun installLogCapture() {
+        Logging.install(logCapture)
+    }
+
+    @After
+    fun removeLogCapture() {
+        Logging.remove(logCapture)
+    }
+
     private fun buildModule(
         scope: CoroutineScope,
         upgradeDiagnostics: UpgradeDiagnostics,
+        dispatcherProvider: DispatcherProvider = TestDispatcherProvider(),
     ) = RecorderModule(
         context = ApplicationProvider.getApplicationContext(),
         appScope = scope,
-        dispatcherProvider = TestDispatcherProvider(),
+        dispatcherProvider = dispatcherProvider,
         installId = mockk<InstallId>(relaxed = true),
         timeSource = SystemTimeSource,
         upgradeDiagnostics = upgradeDiagnostics,
     )
+
+    /**
+     * Real dispatchers on purpose: the header's read deadline is wall-clock, so a virtual-time test
+     * would skip past it instead of exercising it — an ignored seam has to fail this, not pass after
+     * the full production budget. The seam is set before [RecorderModule.startRecorder] so no header
+     * read can run against the production bound.
+     */
+    private fun withRealtimeModule(
+        upgradeDiagnostics: UpgradeDiagnostics,
+        headerTimeoutMs: Long = 300L,
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val module = buildModule(moduleScope, upgradeDiagnostics, TestDispatcherProvider(Dispatchers.IO))
+            module.headerReadTimeoutMs = headerTimeoutMs
+            runBlocking { block(module) }
+        } finally {
+            moduleScope.cancel()
+        }
+    }
 
     @Test
     fun `a failing upgrade-diagnostics read still leaves a tracked recording`() = runTest {
@@ -130,6 +178,40 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         } finally {
             moduleScope.cancel()
             unmockkObject(BuildConfigWrap)
+        }
+    }
+
+    /**
+     * Debug recording is what a user reaches for when the app is ALREADY misbehaving, so a
+     * diagnostics source that never answers must not be the thing that denies them the log.
+     */
+    @Test
+    fun `a wedged upgrade diagnostics read does not hold up the recording`() {
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } coAnswers { awaitCancellation() }
+
+        withRealtimeModule(diagnostics, headerTimeoutMs = 300L) { module ->
+            val elapsed = measureTimeMillis { module.startRecorder() }
+
+            module.state.first().isRecording shouldBe true
+            logLines.any { it.startsWith("Upgrade diagnostics unavailable") } shouldBe true
+            // Non-vacuity: without the bound this would sit on the wedged read forever.
+            elapsed shouldBeLessThan 1_500L
+        }
+    }
+
+    @Test
+    fun `a flavor without diagnostics is not reported as unavailable`() {
+        // FOSS has nothing to report and returns null: no diagnostics line at all, and above all
+        // not one claiming the read failed or timed out.
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns null
+
+        withRealtimeModule(diagnostics) { module ->
+            module.startRecorder()
+
+            module.state.first().isRecording shouldBe true
+            logLines.any { it.startsWith("Upgrade diagnostics") } shouldBe false
         }
     }
 }

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -39,6 +39,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
 
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        every { openGithubSponsorsPage() } returns true
         coEvery { persistUpgrade() } answers { persisted++ }
     }
 

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.compose.ui.semantics.SemanticsActions
 import eu.darken.capod.R
 import eu.darken.capod.common.compose.PreviewWrapper
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
@@ -127,9 +128,16 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     @Test
     fun `recurring donation button invokes the sponsors callback`() {
         var clicked = false
+        // The armed pitch callback must stay untouched here: a supporter donating again has nothing
+        // left to unlock, so the donate button goes through the unarmed callback.
+        var armed = false
 
         composeRule.setUpgradeContent {
-            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, onGithubSponsors = { clicked = true })
+            UpgradeScreen(
+                view = FossUpgradeView.STATUS_UPGRADED,
+                onGithubSponsors = { armed = true },
+                onOpenSponsors = { clicked = true },
+            )
         }
 
         composeRule.onNodeWithTag(UpgradeScreenTags.FOSS_DONATE)
@@ -137,6 +145,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.runOnIdle {
             assertTrue(clicked)
+            assertFalse(armed)
         }
     }
 }

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -61,6 +62,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         info: MutableStateFlow<UpgradeRepoFoss.Info> = MutableStateFlow(UpgradeRepoFoss.Info()),
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
+        every { openGithubSponsorsPage() } returns true
     }
 
     private fun buildVm(
@@ -308,5 +310,70 @@ class FossUpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 1) { repo.persistUpgrade() }
         // Consumed: a later resume must not re-run the unlock.
         recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // A silently failed launch must not leave the heuristic armed: an unrelated later
+        // background round-trip would otherwise hand out supporter status for free.
+        val repo = mockRepo()
+        every { repo.openGithubSponsorsPage() } returns false
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // And the failure must not brick the button either — the next working attempt arms as usual.
+        every { repo.openGithubSponsorsPage() } returns true
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+    }
+
+    @Test
+    fun `a second sponsor tap while a launch is pending opens the page only once`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+    }
+
+    @Test
+    fun `a long donate visit from the status view does not re-persist the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
+        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val state = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+        state.await().supporterSince shouldBe Instant.EPOCH
+
+        vm.openSponsors()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        vm.state.value!!.supporterSince shouldBe Instant.EPOCH
     }
 }

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/BillingCacheTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.capod.common.datastore.value
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
@@ -105,6 +106,28 @@ class BillingCacheTest : BaseTest() {
         // The write only decorates the entitlement path, it must never block it.
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
     }
+
+    @Test
+    fun `a failing datastore write does not abort the entitlement bookkeeping`() = runTest {
+        // A broken write (corrupt file, no disk space) is not the same failure as a wedged lock, and
+        // the timeout alone doesn't cover it -- the exception would propagate straight through the
+        // stamp into the caller that was only decorating its entitlement work.
+        val cache = BillingCache(ThrowingPreferencesDataStore())
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+
+        // Reads stay loud: a snapshot that can't be read must not look like "never bought".
+        shouldThrow<IOException> { cache.snapshot() }
+    }
+
+    @Test
+    fun `a cancelled stamp still cancels`() = runTest {
+        // Fail-soft must not extend to cancellation -- swallowing it would break the structured
+        // concurrency of whatever entitlement work is being torn down.
+        val cache = BillingCache(CancellingPreferencesDataStore())
+
+        shouldThrow<CancellationException> { cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L) }
+    }
 }
 
 /** DataStore that never answers -- stands in for a wedged file lock. */
@@ -113,4 +136,20 @@ internal class HangingPreferencesDataStore : DataStore<Preferences> {
 
     override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
         awaitCancellation()
+}
+
+/** DataStore whose I/O fails -- stands in for a corrupt file or a full disk. */
+internal class ThrowingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw IOException("Preferences file is broken") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw IOException("Preferences file is broken")
+}
+
+/** DataStore whose write is cancelled from the outside. */
+internal class CancellingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw CancellationException("Torn down") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw CancellationException("Torn down")
 }

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -8,7 +8,10 @@ import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
@@ -121,6 +124,33 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         info shouldContain "BillingCache=unavailable"
         info shouldNotContain "lastProStateAt=never"
         info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a wedged history is reported as unavailable`() = runTest {
+        // Counterpart to the wedged cache above: a never-answering CurriculumVitae store would hold
+        // the debug-log header -- and with it the start of the recording -- forever.
+        // Real time on purpose: under virtual time the bound would fire instantly while nothing else
+        // is scheduled, so an ignored seam would still pass.
+        withContext(Dispatchers.IO) {
+            val diagnostics = UpgradeDiagnosticsGplay(
+                billingCache = mockk<BillingCache>().apply {
+                    coEvery { snapshot() } returns BillingCache.Snapshot(
+                        lastProStateAt = 0L,
+                        lastProStateSku = "",
+                        proUnconfirmedSince = 0L,
+                    )
+                },
+                curriculumVitae = mockk<CurriculumVitae>().apply {
+                    coEvery { proHistory() } coAnswers { awaitCancellation() }
+                },
+            ).apply { historyTimeoutMs = 50L }
+
+            val info = diagnostics.debugInfo()
+
+            info shouldContain "BillingCache(lastProStateAt=never"
+            info shouldContain "ProHistory=unavailable"
+        }
     }
 
     @Test


### PR DESCRIPTION
## What changed

FOSS version: supporter status is now only granted when the GitHub Sponsors page actually opened — if no browser could handle the link, returning to the app later no longer counts as a donation visit, and a second tap while a visit is pending doesn't fire twice. The "donate again" button on the supporter status screen now simply opens the page without re-running the unlock logic. And the "FOSS" badge and the "CAPod FOSS" title are no longer translatable: a few languages had them translated into regular words (the Thai badge meant "compulsory", and French/Estonian/Arabic phrasings silently dropped the FOSS branding from the Overview toolbar entirely).

For support: debug-log recording now starts even when the billing storage is wedged — the log header's diagnostics read is bounded instead of waiting forever, exactly for the moment a user is trying to report a problem. A failed write to the purchase cache also no longer interrupts the surrounding entitlement bookkeeping.

## Technical Context

- Propagates the latest canonical billing/upgrade batch (follow-up to #657): `WebpageTool.open()` returns whether an activity was started (capod's single broad catch returns false — the upstream stub-handler machinery was deliberately not imported); `openGithubSponsorsPage()` is synchronous so `goGithubSponsors()` can arm the return-after-5s unlock heuristic only on a successful launch, behind a single-flight guard; the status view's donate button routes through a new unarmed `openSponsors()`.
- The already-Pro return guard from the previous batch stays as defense-in-depth; its regression test is unchanged.
- `stampLastProState()` was fail-soft for timeouts only; thrown write exceptions now degrade to a logged skip (cancellation rethrown, covered by dedicated fakes/tests). Reads stay loud.
- The recorder's single header read is bounded by a 5s seam with a completion marker distinguishing "timed out" from "legitimately nothing to report" (FOSS has no upgrade diagnostics and must stay silent, not log "unavailable"). The GPlay diagnostics' pro-history read gets the same 2s bound its billing-cache read already had.
- Resources: `upgrade_badge_label` (foss) and `app_name_foss` are `translatable="false"` with all 150 locale entries removed (capod's lint does not flag stray translations of non-translatable strings, so completeness was verified by occurrence checks — each id now exists exactly once). The GPlay "Pro" badge translations are intentional and untouched.
- Review guidance: the wedge tests run on real dispatchers with short timeout seams and elapsed ceilings (an implementation that ignores the seam fails the ceiling; one without the bound hangs); relaxed-mock repos now stub the Boolean launch explicitly, since MockK's relaxed default of `false` would otherwise silently disarm every sponsor test.
