### PR TITLE
General: Show when background monitoring is off

### DIFF
--- a/app/src/debug/java/eu/darken/capod/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/capod/screenshots/ScreenshotContent.kt
@@ -19,6 +19,7 @@ import eu.darken.capod.common.compose.PreviewWrapper
 import eu.darken.capod.common.compose.preview.MOCK_NOW
 import eu.darken.capod.common.compose.preview.MockPodDataProvider
 import eu.darken.capod.common.theming.CapodTheme
+import eu.darken.capod.main.core.MonitorMode
 import eu.darken.capod.main.ui.overview.OverviewScreen
 import eu.darken.capod.main.ui.overview.OverviewViewModel
 import eu.darken.capod.monitor.core.battery.BatteryEstimate
@@ -85,6 +86,7 @@ internal fun DashboardContent(showAap: Boolean = false) = PreviewWrapper {
             devices = devices,
             isDebug = false,
             isBluetoothEnabled = true,
+            effectiveMode = MonitorMode.AUTOMATIC,
             profiles = listOf(
                 MockPodDataProvider.profile("My AirPods Pro", PodModel.AIRPODS_PRO2),
                 MockPodDataProvider.profile("AirPods Max", PodModel.AIRPODS_MAX),

--- a/app/src/main/java/eu/darken/capod/common/compose/preview/MockPodDataProvider.kt
+++ b/app/src/main/java/eu/darken/capod/common/compose/preview/MockPodDataProvider.kt
@@ -149,9 +149,14 @@ object MockPodDataProvider {
 
     // --- Profile helpers ---
 
-    fun profile(label: String, model: PodModel): AppleDeviceProfile = AppleDeviceProfile(
+    fun profile(
+        label: String,
+        model: PodModel,
+        address: String? = "AA:BB:CC:DD:EE:FF",
+    ): AppleDeviceProfile = AppleDeviceProfile(
         label = label,
         model = model,
+        address = address,
     )
 
     // --- Dual pod with Apple keys ---

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
@@ -53,6 +53,8 @@ import eu.darken.capod.common.error.ErrorEventHandler
 import eu.darken.capod.common.navigation.NavigationEventHandler
 import eu.darken.capod.common.permissions.Permission
 import eu.darken.capod.common.upgrade.UpgradeRepo
+import eu.darken.capod.main.core.MonitorMode
+import eu.darken.capod.main.ui.overview.cards.BackgroundMonitoringOffCard
 import eu.darken.capod.main.ui.overview.cards.BluetoothDisabledCard
 import eu.darken.capod.main.ui.overview.cards.DeviceLimitUpgradeCard
 import eu.darken.capod.main.ui.overview.cards.DualPodsCard
@@ -186,6 +188,9 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
         onToggleDeviceExpansion = { device ->
             device.profileId?.let { vm.toggleDeviceExpansion(it) }
         },
+        onSetupPairedDevice = {
+            currentState.soleProfileId?.let { vm.goToEditProfile(it) } ?: vm.goToDeviceManager()
+        },
     )
 }
 
@@ -204,6 +209,7 @@ fun OverviewScreen(
     onDeviceSettings: (PodDevice) -> Unit = {},
     onEditProfile: (PodDevice) -> Unit = {},
     onToggleDeviceExpansion: (PodDevice) -> Unit = {},
+    onSetupPairedDevice: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -308,6 +314,12 @@ fun OverviewScreen(
 
             // 4. Profiled device cards (limited to 1 for free users)
             if (!state.isScanBlocked && state.isBluetoothEnabled) {
+                if (state.monitoringStatus == OverviewViewModel.MonitoringStatus.BACKGROUND_OFF) {
+                    item(key = "monitoring_off") {
+                        BackgroundMonitoringOffCard(onSetupPairedDevice = onSetupPairedDevice)
+                    }
+                }
+
                 if (state.showReactionsHint && state.visibleProfiledDevices.isNotEmpty()) {
                     item(key = "reactions_hint") {
                         ReactionsMovedHintCard()
@@ -362,7 +374,7 @@ fun OverviewScreen(
                 }
 
                 // 5. Monitoring active card
-                if (state.profiles.isNotEmpty() && state.profiledDevices.isEmpty() && !state.shouldShowUnmatchedSection) {
+                if (state.monitoringStatus == OverviewViewModel.MonitoringStatus.SEARCHING) {
                     item(key = "monitoring_active") {
                         MonitoringActiveCard()
                     }
@@ -453,6 +465,7 @@ private fun OverviewScreenWithDevicesPreview() = PreviewWrapper {
             ),
             isDebug = false,
             isBluetoothEnabled = true,
+            effectiveMode = MonitorMode.AUTOMATIC,
             profiles = listOf(
                 MockPodDataProvider.profile("My AirPods Pro", PodModel.AIRPODS_PRO2),
                 MockPodDataProvider.profile("AirPods Max", PodModel.AIRPODS_MAX),
@@ -490,6 +503,7 @@ private fun OverviewScreenEmptyPreview() = PreviewWrapper {
             devices = emptyList(),
             isDebug = false,
             isBluetoothEnabled = true,
+            effectiveMode = MonitorMode.AUTOMATIC,
             profiles = listOf(MockPodDataProvider.profile("My AirPods", PodModel.AIRPODS_PRO2)),
             upgradeInfo = MockPodDataProvider.fossInfo(),
             showUnmatchedDevices = false,
@@ -513,6 +527,7 @@ private fun OverviewScreenNoProfilesPreview() = PreviewWrapper {
             devices = emptyList(),
             isDebug = false,
             isBluetoothEnabled = true,
+            effectiveMode = MonitorMode.MANUAL,
             profiles = emptyList(),
             upgradeInfo = MockPodDataProvider.gplayInfo(),
             showUnmatchedDevices = false,
@@ -536,8 +551,35 @@ private fun OverviewScreenBluetoothOffPreview() = PreviewWrapper {
             devices = emptyList(),
             isDebug = false,
             isBluetoothEnabled = false,
+            effectiveMode = MonitorMode.AUTOMATIC,
             profiles = listOf(MockPodDataProvider.profile("My AirPods", PodModel.AIRPODS_PRO2)),
             upgradeInfo = MockPodDataProvider.fossInfo(isPro = true),
+            showUnmatchedDevices = false,
+        ),
+        onRequestPermission = {},
+        onBluetoothSettings = {},
+        onManageDevices = {},
+        onSettings = {},
+        onUpgrade = {},
+        onToggleUnmatched = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun OverviewScreenMonitoringOffPreview() = PreviewWrapper {
+    OverviewScreen(
+        state = OverviewViewModel.State(
+            now = SystemTimeSource.now(),
+            permissions = emptySet(),
+            devices = emptyList(),
+            isDebug = false,
+            isBluetoothEnabled = true,
+            effectiveMode = MonitorMode.MANUAL,
+            profiles = listOf(
+                MockPodDataProvider.profile("My AirPods", PodModel.AIRPODS_PRO2, address = null),
+            ),
+            upgradeInfo = MockPodDataProvider.fossInfo(),
             showUnmatchedDevices = false,
         ),
         onRequestPermission = {},

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -33,6 +33,7 @@ import eu.darken.capod.pods.core.apple.aap.protocol.AapCommand
 import eu.darken.capod.pods.core.apple.aap.protocol.AapSetting
 import eu.darken.capod.profiles.core.DeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfilesRepo
+import eu.darken.capod.profiles.core.ProfileId
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
@@ -90,6 +91,7 @@ class OverviewViewModel @Inject constructor(
         val hideUnmatchedDevices: Boolean,
         val showTroubleshootSuggestion: Boolean,
         val batteryEstimates: Map<String, BatteryEstimate>,
+        val effectiveMode: MonitorMode,
     )
 
     /**
@@ -126,12 +128,14 @@ class OverviewViewModel @Inject constructor(
         generalSettings.hideUnmatchedDevices.flow,
         troubleshootSuggestion,
         batteryEstimator.estimates,
-    ) { reactionsHintDismissed, hideUnmatched, showTroubleshootSuggestion, batteryEstimates ->
+        monitorModeResolver.effectiveMode,
+    ) { reactionsHintDismissed, hideUnmatched, showTroubleshootSuggestion, batteryEstimates, effectiveMode ->
         OverviewUiSettings(
             reactionsHintDismissed = reactionsHintDismissed,
             hideUnmatchedDevices = hideUnmatched,
             showTroubleshootSuggestion = showTroubleshootSuggestion,
             batteryEstimates = batteryEstimates,
+            effectiveMode = effectiveMode,
         )
     }
 
@@ -214,6 +218,7 @@ class OverviewViewModel @Inject constructor(
             devices = devices,
             isDebug = isDebug,
             isBluetoothEnabled = isBluetoothEnabled,
+            effectiveMode = uiSettings.effectiveMode,
             profiles = profiles,
             upgradeInfo = upgradeInfo,
             showUnmatchedDevices = showUnmatched,
@@ -227,12 +232,15 @@ class OverviewViewModel @Inject constructor(
 
     enum class BluetoothIconState { HIDDEN, DISABLED, NEARBY, CONNECTED }
 
+    enum class MonitoringStatus { HIDDEN, SEARCHING, BACKGROUND_OFF }
+
     data class State(
         val now: Instant,
         val permissions: Set<Permission>,
         val devices: List<PodDevice>,
         val isDebug: Boolean,
         val isBluetoothEnabled: Boolean,
+        val effectiveMode: MonitorMode,
         val profiles: List<DeviceProfile>,
         val upgradeInfo: UpgradeRepo.Info,
         val showUnmatchedDevices: Boolean,
@@ -290,6 +298,22 @@ class OverviewViewModel @Inject constructor(
                 else -> BluetoothIconState.HIDDEN
             }
 
+        /**
+         * [MonitoringStatus.BACKGROUND_OFF] is deliberately not conditioned on the absence of device
+         * cards: an address-less wildcard profile can still match an unrecognised Apple payload, and
+         * the resulting card carries neither the missing-paired-device banner nor an edit action.
+         */
+        val monitoringStatus: MonitoringStatus
+            get() = when {
+                isScanBlocked || !isBluetoothEnabled -> MonitoringStatus.HIDDEN
+                profiles.isEmpty() -> MonitoringStatus.HIDDEN
+                effectiveMode == MonitorMode.MANUAL -> MonitoringStatus.BACKGROUND_OFF
+                profiledDevices.isEmpty() && !shouldShowUnmatchedSection -> MonitoringStatus.SEARCHING
+                else -> MonitoringStatus.HIDDEN
+            }
+
+        val soleProfileId: ProfileId? get() = profiles.singleOrNull()?.id
+
         fun isPinned(device: PodDevice, index: Int): Boolean =
             device.isSystemConnected || index == 0
 
@@ -336,6 +360,10 @@ class OverviewViewModel @Inject constructor(
 
     fun goToEditProfile(device: PodDevice) {
         val profileId = device.profileId ?: return
+        goToEditProfile(profileId)
+    }
+
+    fun goToEditProfile(profileId: ProfileId) {
         log(TAG, INFO) { "goToEditProfile(profileId=$profileId)" }
         navTo(Nav.Main.DeviceProfileCreation(profileId = profileId))
     }

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/BackgroundMonitoringOffCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/BackgroundMonitoringOffCard.kt
@@ -1,0 +1,67 @@
+package eu.darken.capod.main.ui.overview.cards
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.DevicesOther
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.Preview2
+import eu.darken.capod.common.compose.PreviewWrapper
+
+@Composable
+fun BackgroundMonitoringOffCard(onSetupPairedDevice: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.overview_monitoring_off_label),
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.overview_monitoring_off_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = onSetupPairedDevice,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.DevicesOther,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+                Text(text = stringResource(R.string.overview_monitoring_off_action))
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun BackgroundMonitoringOffCardPreview() = PreviewWrapper {
+    BackgroundMonitoringOffCard(onSetupPairedDevice = {})
+}

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/components/MissingPairedDeviceBanner.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/components/MissingPairedDeviceBanner.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.main.ui.overview.cards.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -46,12 +47,20 @@ fun MissingPairedDeviceBanner(
                     .padding(end = 10.dp)
                     .size(20.dp),
             )
-            Text(
-                text = stringResource(R.string.overview_card_missing_paired_device),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
+            Column(
                 modifier = Modifier.weight(1f),
-            )
+            ) {
+                Text(
+                    text = stringResource(R.string.overview_card_missing_paired_device),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
+                )
+                Text(
+                    text = stringResource(R.string.overview_card_missing_paired_device_consequence),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth is disabled, enable it ;)</string>
     <string name="overview_monitoring_active_label">Monitoring for devices</string>
     <string name="overview_monitoring_active_description">Make sure your device is nearby and active.</string>
+    <string name="overview_monitoring_off_label">Background monitoring is off</string>
+    <string name="overview_monitoring_off_description">No profile has a paired Bluetooth device, so CAPod only updates while the app is open. Select one to enable background monitoring, the ongoing notification and reactions.</string>
+    <string name="overview_monitoring_off_action">Select paired device</string>
     <string name="overview_troubleshoot_suggestion_label">Connected, but no data</string>
     <string name="overview_troubleshoot_suggestion_description">Your device is connected, but CAPod isn\'t receiving any live data from it. Your phone may need a compatibility option — the troubleshooter can try to find one automatically.</string>
     <string name="overview_troubleshoot_suggestion_action">Run troubleshooter</string>
@@ -527,6 +530,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Double press to end call</string>
     <string name="device_settings_open_cd">Open device settings</string>
     <string name="overview_card_missing_paired_device">This profile has no paired Bluetooth device.</string>
+    <string name="overview_card_missing_paired_device_consequence">Without one, device settings and auto-connect aren\'t available.</string>
     <string name="overview_reactions_hint_title">Reactions are per device</string>
     <string name="overview_reactions_hint_body">Auto-play, auto-pause and pop-ups are now configured per device. Tap the settings icon on a card while your headphones are connected.</string>
 

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/MissingPairedDeviceBannerTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/MissingPairedDeviceBannerTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.capod.main.ui.overview
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.PreviewWrapper
+import eu.darken.capod.main.ui.overview.cards.components.MissingPairedDeviceBanner
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class MissingPairedDeviceBannerTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `states the missing paired device and what it costs`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                MissingPairedDeviceBanner(onClick = {})
+            }
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.overview_card_missing_paired_device))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.overview_card_missing_paired_device_consequence))
+            .assertCountEquals(1)
+    }
+
+    @Test
+    fun `tapping the banner invokes the callback`() {
+        var clicked = false
+
+        composeRule.setContent {
+            PreviewWrapper {
+                MissingPairedDeviceBanner(onClick = { clicked = true })
+            }
+        }
+
+        composeRule.onNodeWithText(context.getString(R.string.overview_card_missing_paired_device))
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            assertTrue(clicked)
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewScreenMonitoringTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewScreenMonitoringTest.kt
@@ -1,0 +1,112 @@
+package eu.darken.capod.main.ui.overview
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.PreviewWrapper
+import eu.darken.capod.common.compose.preview.MOCK_NOW
+import eu.darken.capod.common.compose.preview.MockPodDataProvider
+import eu.darken.capod.main.core.MonitorMode
+import eu.darken.capod.pods.core.apple.PodModel
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class OverviewScreenMonitoringTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun state(
+        effectiveMode: MonitorMode,
+        address: String?,
+    ) = OverviewViewModel.State(
+        now = MOCK_NOW,
+        permissions = emptySet(),
+        devices = emptyList(),
+        isDebug = false,
+        isBluetoothEnabled = true,
+        effectiveMode = effectiveMode,
+        profiles = listOf(
+            MockPodDataProvider.profile("My Headphones", PodModel.AIRPODS_PRO2, address = address),
+        ),
+        upgradeInfo = MockPodDataProvider.fossInfo(),
+        showUnmatchedDevices = false,
+    )
+
+    @Test
+    fun `MANUAL mode states that background monitoring is off`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                OverviewScreen(
+                    state = state(effectiveMode = MonitorMode.MANUAL, address = null),
+                    onRequestPermission = {},
+                    onBluetoothSettings = {},
+                    onManageDevices = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onToggleUnmatched = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.overview_monitoring_off_label))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.overview_monitoring_active_label))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `the setup action invokes the callback`() {
+        var clicked = false
+
+        composeRule.setContent {
+            PreviewWrapper {
+                OverviewScreen(
+                    state = state(effectiveMode = MonitorMode.MANUAL, address = null),
+                    onRequestPermission = {},
+                    onBluetoothSettings = {},
+                    onManageDevices = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onToggleUnmatched = {},
+                    onSetupPairedDevice = { clicked = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(context.getString(R.string.overview_monitoring_off_action))
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            assertTrue(clicked)
+        }
+    }
+
+    @Test
+    fun `AUTOMATIC mode without devices keeps the searching card`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                OverviewScreen(
+                    state = state(effectiveMode = MonitorMode.AUTOMATIC, address = "AA:BB:CC:DD:EE:FF"),
+                    onRequestPermission = {},
+                    onBluetoothSettings = {},
+                    onManageDevices = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onToggleUnmatched = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.overview_monitoring_active_label))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.overview_monitoring_off_label))
+            .assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
@@ -16,6 +16,7 @@ import eu.darken.capod.monitor.core.battery.BatteryEstimate
 import eu.darken.capod.monitor.core.battery.BatteryEstimator
 import eu.darken.capod.monitor.core.worker.MonitorControl
 import eu.darken.capod.pods.core.apple.PodModel
+import eu.darken.capod.pods.core.apple.ble.BlePodSnapshot
 import eu.darken.capod.profiles.core.AppleDeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfile
 import eu.darken.capod.profiles.core.DeviceProfilesRepo
@@ -208,6 +209,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(profiled, unmatched),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = mockk(relaxed = true),
                 showUnmatchedDevices = false,
@@ -235,6 +237,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(profiled, unmatched),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = mockk(relaxed = true),
                 showUnmatchedDevices = false,
@@ -257,6 +260,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = emptyList(),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -281,6 +285,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(profiled),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -307,6 +312,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(device1, device2, device3),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -333,6 +339,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(device1, device2, device3),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -361,6 +368,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(device1, device2, device3),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -387,6 +395,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(device1, device2),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -413,6 +422,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(profiled1, profiled2, unmatched),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = upgradeInfo,
                 showUnmatchedDevices = false,
@@ -450,6 +460,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(unmatched),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = mockk(relaxed = true),
                 showUnmatchedDevices = false,
@@ -475,6 +486,7 @@ class OverviewViewModelTest : BaseTest() {
                 devices = listOf(unmatched),
                 isDebug = false,
                 isBluetoothEnabled = true,
+                effectiveMode = MonitorMode.AUTOMATIC,
                 profiles = emptyList(),
                 upgradeInfo = mockk(relaxed = true),
                 showUnmatchedDevices = false,
@@ -483,6 +495,127 @@ class OverviewViewModelTest : BaseTest() {
 
             state.profiledDevices shouldBe emptyList()
             state.shouldShowUnmatchedSection shouldBe false
+        }
+    }
+
+    @Nested
+    inner class MonitoringStatusTests {
+
+        private fun addressLessProfile(): DeviceProfile = AppleDeviceProfile(
+            label = "My Headphones",
+            model = PodModel.UNKNOWN,
+        )
+
+        private fun addressedProfile(): DeviceProfile = AppleDeviceProfile(
+            label = "My AirPods",
+            model = PodModel.AIRPODS_PRO2,
+            address = "AA:BB:CC:DD:EE:FF",
+        )
+
+        private fun monitoringState(
+            effectiveMode: MonitorMode,
+            profiles: List<DeviceProfile>,
+            devices: List<PodDevice> = emptyList(),
+            permissions: Set<Permission> = emptySet(),
+            isBluetoothEnabled: Boolean = true,
+        ) = OverviewViewModel.State(
+            now = java.time.Instant.now(),
+            permissions = permissions,
+            devices = devices,
+            isDebug = false,
+            isBluetoothEnabled = isBluetoothEnabled,
+            effectiveMode = effectiveMode,
+            profiles = profiles,
+            upgradeInfo = mockk(relaxed = true),
+            showUnmatchedDevices = false,
+        )
+
+        @Test
+        fun `MANUAL with an address-less profile reports background monitoring off`() {
+            val state = monitoringState(
+                effectiveMode = MonitorMode.MANUAL,
+                profiles = listOf(addressLessProfile()),
+            )
+
+            state.monitoringStatus shouldBe OverviewViewModel.MonitoringStatus.BACKGROUND_OFF
+        }
+
+        @Test
+        fun `MANUAL still reports background monitoring off while an unknown device card shows`() {
+            // The auto-created wildcard profile can match an unrecognised Apple payload, and that
+            // card carries neither the missing-paired-device banner nor an edit action.
+            val unknownDevice = PodDevice(
+                profileId = "auto-created",
+                ble = mockk<BlePodSnapshot>(relaxed = true) {
+                    every { model } returns PodModel.UNKNOWN
+                },
+                aap = null,
+            )
+            val state = monitoringState(
+                effectiveMode = MonitorMode.MANUAL,
+                profiles = listOf(addressLessProfile()),
+                devices = listOf(unknownDevice),
+            )
+
+            state.monitoringStatus shouldBe OverviewViewModel.MonitoringStatus.BACKGROUND_OFF
+        }
+
+        @Test
+        fun `AUTOMATIC without devices reports searching`() {
+            val state = monitoringState(
+                effectiveMode = MonitorMode.AUTOMATIC,
+                profiles = listOf(addressedProfile()),
+            )
+
+            state.monitoringStatus shouldBe OverviewViewModel.MonitoringStatus.SEARCHING
+        }
+
+        @Test
+        fun `hidden while a scan-blocking permission is missing`() {
+            val state = monitoringState(
+                effectiveMode = MonitorMode.MANUAL,
+                profiles = listOf(addressLessProfile()),
+                permissions = setOf(Permission.BLUETOOTH_SCAN),
+            )
+
+            state.monitoringStatus shouldBe OverviewViewModel.MonitoringStatus.HIDDEN
+        }
+
+        @Test
+        fun `hidden while bluetooth is disabled`() {
+            val state = monitoringState(
+                effectiveMode = MonitorMode.MANUAL,
+                profiles = listOf(addressLessProfile()),
+                isBluetoothEnabled = false,
+            )
+
+            state.monitoringStatus shouldBe OverviewViewModel.MonitoringStatus.HIDDEN
+        }
+
+        @Test
+        fun `hidden when there are no profiles at all`() {
+            val state = monitoringState(
+                effectiveMode = MonitorMode.MANUAL,
+                profiles = emptyList(),
+            )
+
+            state.monitoringStatus shouldBe OverviewViewModel.MonitoringStatus.HIDDEN
+        }
+
+        @Test
+        fun `effectiveMode tracks the resolver`() = runTest(testDispatcher) {
+            effectiveModeFlow.value = MonitorMode.MANUAL
+            val vm = createViewModel()
+            var latest: OverviewViewModel.State? = null
+            backgroundScope.launch { vm.state.collect { latest = it } }
+
+            advanceTimeBy(1_000)
+            latest!!.effectiveMode shouldBe MonitorMode.MANUAL
+
+            effectiveModeFlow.value = MonitorMode.ALWAYS
+
+            advanceTimeBy(1_000)
+            latest!!.effectiveMode shouldBe MonitorMode.ALWAYS
         }
     }
 
@@ -751,6 +884,7 @@ class OverviewViewModelTest : BaseTest() {
             devices = listOf(device),
             isDebug = false,
             isBluetoothEnabled = true,
+            effectiveMode = MonitorMode.AUTOMATIC,
             profiles = emptyList(),
             upgradeInfo = mockk(relaxed = true),
             showUnmatchedDevices = false,


### PR DESCRIPTION
## What changed

A fresh install could look like it was working while it silently wasn't.

On first launch CAPod creates a profile called "My Headphones" with no paired Bluetooth device
assigned. In that state CAPod can only read battery levels while the app is open on screen —
background monitoring, the ongoing notification and all reactions are off. The dashboard nevertheless
said "Monitoring for devices", and the only hint was a small banner that appeared on a device card,
and only when headphones happened to be in range.

The dashboard now says "Background monitoring is off" whenever no profile has a paired device,
explains that CAPod only updates while the app is open, and offers a "Select paired device" button
that goes straight to the profile where you pick one. The existing "this profile has no paired
Bluetooth device" banner now also spells out what it costs.

Closes #658

## Technical Context

- **Root cause**: `MonitorModeResolver` derives the mode from the first *addressed* profile. The
  auto-created profile has `address = null`, so the mode is `MANUAL` and `MonitorService` cancels its
  scope about a second after every start. `BlePodMonitor` scans only while its flow is collected, so
  the dashboard really does receive live data while it is open — which is why the old "Monitoring for
  devices" card never looked obviously wrong, and why both support cases needed a round-trip to
  diagnose (#619, and the SM-S9370 thread quoted in #658).
- **Why this option**: #658 listed four (don't create the profile, auto-prune it, state the
  consequence, handle it in onboarding). Only "state the consequence" is implemented. It covers fresh
  installs, existing installs, and profiles a user made address-less themselves; auto-pruning would
  have fixed neither observed support case, since both had only the blank profile.
- **The card is deliberately not suppressed when a device card is visible.** The auto-created profile
  matches any Apple payload (`model == UNKNOWN`, no IRK), and an unrecognised payload renders
  `UnknownPodDeviceCard`, which carries neither the missing-paired-device banner nor an edit action.
  Suppressing the card whenever some device card exists would have recreated the silent state.
- **The banner's new line is narrower than the card's on purpose.** Monitoring is app-wide: with a
  second, addressed profile keeping the service alive, an address-less profile still receives BLE
  battery updates and BLE-driven reactions. Only address-dependent features — the AAP session (device
  settings, ANC, press controls) and auto-connect — are genuinely unavailable, so the banner claims
  only those. The card, which appears only when *no* profile is addressed, states the full
  consequence.
- **Behavioural consequence worth knowing**: an install whose headphones are bonded to a different
  phone (BLE-only monitoring, which the profile editor permits) now sees this card permanently, with
  an action it cannot complete. Kept deliberately — the card's condition is exactly "no profile on
  this install can drive background monitoring", so the statement is true whenever it appears, and a
  dismiss affordance would reintroduce the ignore-the-signal failure mode the issue is about.
- `State.effectiveMode` is a required field rather than a defaulted one, so no preview or screenshot
  fixture can silently depict an unconfigured install as configured; `MockPodDataProvider.profile()`
  gained an address for the same reason.
- The visibility decision lives in `State.monitoringStatus`, mirroring the existing
  `bluetoothIconState` pattern, and carries its own scan/Bluetooth gates so it does not depend on the
  caller's outer condition.
- New strings are base-locale only. The existing `overview_card_missing_paired_device` key and its
  translations are untouched — the consequence line is a separate new key, so no locale ends up
  showing a stale meaning.
