### PR TITLE
Fix: Keep the supporter date safe and catch too-short debug logs

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/core/FossCache.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/core/FossCache.kt
@@ -12,18 +12,25 @@ import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// Retained legacy migration: installs that predate the DataStore move still carry their upgrade
+// state in the "settings_foss" SharedPreferences file.
+private val Context.fossCacheDataStore by preferencesDataStore(
+    name = "settings_foss",
+    produceMigrations = { ctx -> listOf(SharedPreferencesMigration(ctx, "settings_foss")) },
+)
+
 @Singleton
-class FossCache @Inject constructor(
-    @ApplicationContext context: Context,
-    @SerializationCapod json: Json,
+class FossCache internal constructor(
+    // Test seam: the store is handed in so a test can supply its own DataStore instead of the
+    // Context-bound production delegate. Same pattern as BillingCache.
+    private val dataStore: DataStore<Preferences>,
+    json: Json,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(
-        name = "settings_foss",
-        produceMigrations = { ctx -> listOf(SharedPreferencesMigration(ctx, "settings_foss")) }
-    )
-
-    private val dataStore: DataStore<Preferences> = context.dataStore
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        @SerializationCapod json: Json,
+    ) : this(context.fossCacheDataStore, json)
 
     val upgrade = dataStore.createValue<FossUpgrade?>(
         key = "foss.upgrade",

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
@@ -2,7 +2,7 @@ package eu.darken.capod.common.upgrade.core
 
 import eu.darken.capod.common.WebpageTool
 import eu.darken.capod.common.coroutine.AppScope
-import eu.darken.capod.common.datastore.value
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.flow.setupCommonEventHandlers
@@ -58,14 +58,35 @@ class UpgradeRepoFoss @Inject constructor(
     // Writes capod's RETAINED persistence schema: existing supporter records are serialized with
     // `reason` (foss.upgrade.reason.*). Adopting canonical's `upgradeType` schema would decode
     // every stored record as null and strip those supporters' entitlement.
-    internal suspend fun persistUpgrade() {
+    /**
+     * Create-only-if-absent inside the store transaction: an existing record (and its upgradedAt —
+     * the user-visible "supporter since" date) is never replaced. The VM-level isPro guard alone is
+     * not race-free: it reads a shareIn replay that can be stale. Note the kept record is still
+     * re-encoded through the current schema — decoded fields are preserved exactly.
+     *
+     * Caveat from [FossCache]'s `onErrorFallbackToDefault = true`: a stored record that fails to
+     * decode reads as null and therefore counts as ABSENT to this transaction, i.e. it gets
+     * replaced. That matches the pre-existing read behaviour — such a record already presents the
+     * user as free — and re-creating it on the next successful sponsor visit is the recovery path.
+     *
+     * @return true if a new record was created, false if an existing record was kept.
+     */
+    internal suspend fun persistUpgrade(): Boolean {
         log(TAG) { "persistUpgrade()" }
-        fossCache.upgrade.value(
-            FossUpgrade(
+        val updated = fossCache.upgrade.update { existing ->
+            existing ?: FossUpgrade(
                 upgradedAt = Instant.now(),
                 reason = FossUpgrade.Reason.DONATED,
             )
-        )
+        }
+        return if (updated.old == null) {
+            true
+        } else {
+            log(TAG, WARN) {
+                "persistUpgrade(): Record already exists (upgradedAt=${updated.old.upgradedAt}), keeping it"
+            }
+            false
+        }
     }
 
     override suspend fun refresh() {

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -143,24 +143,41 @@ class UpgradeViewModel @Inject constructor(
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
 
-        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
-        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
-        // resetting the "supporter since" date the status screen shows them.
-        if (upgradeRepo.upgradeInfo.first().isPro) {
-            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
-            return@launch
-        }
+        try {
+            // Evaluated before the duration: an already upgraded supporter (recurring donation
+            // button) has nothing left to unlock, so this fast path exists for the UX — return
+            // quietly, no redundant write attempt and no thanks toast for an unlock that already
+            // happened. Data integrity is not this guard's job: the repo's create-only transaction
+            // owns that.
+            if (upgradeRepo.upgradeInfo.first().isPro) {
+                log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+                return@launch
+            }
 
-        val elapsed = SystemClock.elapsedRealtime() - pressedAt
-        log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
+            val elapsed = SystemClock.elapsedRealtime() - pressedAt
+            log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
-        if (elapsed < SPONSOR_DELAY_MS) {
-            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-            snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
-        } else {
-            log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
-            upgradeRepo.persistUpgrade()
-            toastEvents.tryEmit(R.string.upgrade_foss_supporter_thanks)
+            if (elapsed < SPONSOR_DELAY_MS) {
+                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+                snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
+            } else {
+                log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+                val created = upgradeRepo.persistUpgrade()
+                if (created) {
+                    toastEvents.tryEmit(R.string.upgrade_foss_supporter_thanks)
+                } else {
+                    // The isPro fast-path read a stale emission; the transaction kept the existing record.
+                    log(TAG) { "checkSponsorReturn(): Record already existed, staying quiet" }
+                }
+            }
+        } catch (e: Exception) {
+            // The marker was consumed above; neither a failed entitlement read nor a failed write may
+            // eat the user's valid sponsor visit — restore it so the next return/resume can retry the
+            // unlock. Rethrow unconditionally: cancellation is not swallowed, other errors surface via
+            // the normal error path. A restored marker after a successful persist is harmless — the
+            // next evaluation hits the quiet isPro path.
+            handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            throw e
         }
     }
 

--- a/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
@@ -121,6 +121,7 @@ class RecorderModule @Inject constructor(
                             recorder = newRecorder,
                             currentLogDir = sessionDir,
                             recordingStartedAt = startTime,
+                            recordingStartedAtMonotonic = if (isResume) 0L else timeSource.elapsedRealtime(),
                             persistedLogDir = null,
                         )
                     } else if (!shouldRecord && isRecording) {
@@ -237,8 +238,17 @@ class RecorderModule @Inject constructor(
         if (!currentState.isRecording) return StopResult.NotRecording
 
         val logDir = currentState.currentLogDir ?: return StopResult.NotRecording
-        val elapsed = timeSource.currentTimeMillis() - currentState.recordingStartedAt
-        if (elapsed < MIN_RECORDING_MS) return StopResult.TooShort
+        val elapsed = if (currentState.recordingStartedAtMonotonic > 0L) {
+            // Live session: monotonic, immune to wall-clock adjustments mid-recording.
+            timeSource.elapsedRealtime() - currentState.recordingStartedAtMonotonic
+        } else {
+            // Resumed session: the trigger file persists wall time only — it has to survive reboots,
+            // which monotonic time does not.
+            timeSource.currentTimeMillis() - currentState.recordingStartedAt
+        }
+        // Negative = the wall clock moved backward across a resume; fail open (no warning) rather
+        // than trap the user in TooShort.
+        if (elapsed in 0 until MIN_RECORDING_MS) return StopResult.TooShort
 
         stopRecorder()
         val sessionId = DebugSessionManager.deriveSessionId(logDir)
@@ -256,6 +266,10 @@ class RecorderModule @Inject constructor(
         internal val recorder: Recorder? = null,
         val currentLogDir: File? = null,
         val recordingStartedAt: Long = 0L,
+        // Monotonic base for the duration heuristic, 0L when there is none: a resumed session's
+        // only start time is the persisted wall clock, and a monotonic value from a previous
+        // process or boot is meaningless.
+        val recordingStartedAtMonotonic: Long = 0L,
         internal val persistedLogDir: File? = null,
     ) {
         val isRecording: Boolean
@@ -288,7 +302,17 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "capod_force_debug_run"
-        private const val MIN_RECORDING_MS = 5_000L
+
+        /**
+         * Duration heuristic for "did you forget to reproduce the issue?". A recording stopped
+         * this quickly usually contains nothing but the recorder starting and stopping, which
+         * costs a support round-trip to re-request.
+         *
+         * It stays a prompt because short recordings can be perfectly valid: a crash is logged
+         * and flushed immediately, so the reproduction is already on disk. "Stop anyway" works —
+         * the [StopResult.TooShort] consumers stop via [stopRecorder], which has no duration check.
+         */
+        private const val MIN_RECORDING_MS = 10_000L
 
         // Budget for the header's diagnostics read.
         private const val HEADER_READ_TIMEOUT_MS = 5_000L

--- a/app/src/main/java/eu/darken/capod/common/flow/DynamicStateFlow.kt
+++ b/app/src/main/java/eu/darken/capod/common/flow/DynamicStateFlow.kt
@@ -5,7 +5,10 @@ import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -138,17 +141,27 @@ class DynamicStateFlow<T>(
      *
      * Any errors that occurred during [action] will be rethrown by this method.
      */
-    suspend fun updateBlocking(action: suspend T.() -> T): T {
+    suspend fun updateBlocking(action: suspend T.() -> T): T = coroutineScope {
         val update: Update<T> = Update(onModify = action)
+
+        // Subscribe BEFORE emitting: UNDISPATCHED runs the awaiter synchronously up to its first
+        // suspension inside first's collect, so the collector is registered on the shared flow
+        // before the update can be processed. Emitting first is a lost wakeup: a fast producer
+        // plus a reactive collector (RecorderModule reacts to every state with its own update)
+        // can process our update AND a successor before we subscribe, displacing our State from
+        // the replay-1 cache — the await then never completes.
+        val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+            internalFlow.first { it.updatedBy == update }
+        }
         updateActions.emit(update)
 
         lTag?.let { log(it, VERBOSE) { "Waiting for update." } }
-        val ourUpdate = internalFlow.first { it.updatedBy == update }
+        val ourUpdate = awaiter.await()
         lTag?.let { log(it, VERBOSE) { "Finished waiting, got $ourUpdate" } }
 
         ourUpdate.error?.let { throw it }
 
-        return ourUpdate.value
+        ourUpdate.value
     }
 
     private data class Update<T>(

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -102,11 +104,23 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
             try {
                 module = buildModule(moduleScope, upgradeDiagnostics, TestDispatcherProvider(Dispatchers.IO))
                     .apply { headerReadTimeoutMs = headerTimeoutMs }
-                runBlocking { block(module) }
+                // Envelope: a regressed await must FAIL in seconds, not wedge a CI runner for 6h.
+                // That happened — the pre-fix suite hung until the GitHub job timeout. The block's
+                // real-time 300ms seam waits fit into this budget many times over.
+                runBlocking { withTimeout(BLOCK_TIMEOUT_MS) { block(module) } }
             } finally {
                 // Stop before cancelling: scope cancellation does NOT uninstall a running
-                // recorder's global FileLogger.
-                module?.let { runBlocking { it.stopRecorder() } }
+                // recorder's global FileLogger. A wedged stop must not hang cleanup either; the
+                // FileLogger assertion below then fails the test with the real signal.
+                module?.let {
+                    runBlocking {
+                        try {
+                            withTimeout(10_000) { it.stopRecorder() }
+                        } catch (e: TimeoutCancellationException) {
+                            // the leak assertion below reports it
+                        }
+                    }
+                }
             }
         } finally {
             moduleScope.cancel()
@@ -233,5 +247,9 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
             module.state.first().isRecording shouldBe true
             logLines.any { it.startsWith("Upgrade diagnostics") } shouldBe false
         }
+    }
+
+    companion object {
+        private const val BLOCK_TIMEOUT_MS = 15_000L
     }
 }

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -39,6 +39,7 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.system.measureTimeMillis
 
@@ -95,12 +96,25 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         block: suspend (RecorderModule) -> Unit,
     ) {
         val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        var module: RecorderModule? = null
         try {
-            val module = buildModule(moduleScope, upgradeDiagnostics, TestDispatcherProvider(Dispatchers.IO))
-            module.headerReadTimeoutMs = headerTimeoutMs
-            runBlocking { block(module) }
+            try {
+                module = buildModule(moduleScope, upgradeDiagnostics, TestDispatcherProvider(Dispatchers.IO))
+                    .apply { headerReadTimeoutMs = headerTimeoutMs }
+                runBlocking { block(module) }
+            } finally {
+                // Stop before cancelling: scope cancellation does NOT uninstall a running
+                // recorder's global FileLogger.
+                module?.let { runBlocking { it.stopRecorder() } }
+            }
         } finally {
             moduleScope.cancel()
+            // A leaked logger must fail THIS test, not poison later ones. Remove stragglers after
+            // asserting so one failure can't cascade.
+            val leaked = Logging.loggers.filterIsInstance<FileLogger>() - fileLoggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<FileLogger>()
         }
     }
 
@@ -111,11 +125,17 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
 
         val module = buildModule(backgroundScope, diagnostics)
 
-        val logDir = module.startRecorder()
-        logDir.exists() shouldBe true
-        module.state.first { it.isRecording }.currentLogDir shouldBe logDir
-
-        module.stopRecorder().shouldNotBeNull()
+        // Stopped in a finally: an assertion failing mid-test must not leave a live recorder whose
+        // globally installed FileLogger then writes into every later test.
+        var stopped: File? = null
+        try {
+            val logDir = module.startRecorder()
+            logDir.exists() shouldBe true
+            module.state.first { it.isRecording }.currentLogDir shouldBe logDir
+        } finally {
+            stopped = module.stopRecorder()
+        }
+        stopped.shouldNotBeNull()
     }
 
     /**

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -1,0 +1,193 @@
+package eu.darken.capod.common.debug.recording.core
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.common.InstallId
+import eu.darken.capod.common.TimeSource
+import eu.darken.capod.common.debug.logging.FileLogger
+import eu.darken.capod.common.debug.logging.Logging
+import eu.darken.capod.common.upgrade.UpgradeDiagnostics
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.TestTimeSource
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * The "that recording looks too short" prompt is a duration heuristic, and duration was measured
+ * against the wall clock. A clock adjustment mid-recording (NTP sync, the user changing the time)
+ * therefore either invented a long recording out of a short one or trapped a long recording in the
+ * warning. A live session now measures monotonically; only a session resumed from the trigger file
+ * has to fall back to the persisted wall time, because monotonic time does not survive a reboot.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class RecorderModuleDurationTest : BaseTest() {
+
+    private fun buildModule(scope: CoroutineScope, timeSource: TimeSource): RecorderModule {
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns null
+        return RecorderModule(
+            context = ApplicationProvider.getApplicationContext(),
+            appScope = scope,
+            dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+            installId = mockk<InstallId>(relaxed = true),
+            timeSource = timeSource,
+            upgradeDiagnostics = diagnostics,
+        )
+    }
+
+    /**
+     * Real dispatchers: the module drives its recorder from its own scope, and the fake time source
+     * is what makes the duration deterministic instead of the scheduler. The recorder is stopped in
+     * a nested finally — a mid-test failure must not leave a live recorder behind, whose globally
+     * installed [FileLogger] would then write into every later test.
+     */
+    private fun withModule(
+        timeSource: TimeSource,
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        var module: RecorderModule? = null
+        try {
+            try {
+                module = buildModule(moduleScope, timeSource)
+                runBlocking { block(module) }
+            } finally {
+                // Stop before cancelling: scope cancellation does NOT uninstall a running
+                // recorder's global FileLogger.
+                module?.let { runBlocking { it.stopRecorder() } }
+            }
+        } finally {
+            moduleScope.cancel()
+            // A leaked logger must fail THIS test, not poison later ones. Remove stragglers after
+            // asserting so one failure can't cascade.
+            val leaked = Logging.loggers.filterIsInstance<FileLogger>() - fileLoggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<FileLogger>()
+        }
+    }
+
+    // A session the module can resume from: the real two-line trigger file plus an existing dir.
+    private fun seedTriggerFile(startTime: Long): File {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sessionDir = File(context.getExternalFilesDir(null), "debug/logs/capod_resumed_session")
+        sessionDir.mkdirs()
+        File(context.getExternalFilesDir(null), "capod_force_debug_run")
+            .writeText("${sessionDir.absolutePath}\n$startTime")
+        return sessionDir
+    }
+
+    @Test
+    fun `an eight second recording warns`() {
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        withModule(timeSource) { module ->
+            module.startRecorder()
+
+            timeSource.advanceBy(Duration.ofSeconds(8))
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+
+            // "Stop anyway" is the user's own next step, and past the threshold it stops cleanly.
+            timeSource.advanceBy(Duration.ofSeconds(3))
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a ten second recording stops`() {
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        withModule(timeSource) { module ->
+            module.startRecorder()
+
+            timeSource.advanceBy(Duration.ofSeconds(10))
+
+            val result = module.requestStopRecorder()
+            result.shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            result.logDir.exists() shouldBe true
+            result.sessionId.isNotEmpty() shouldBe true
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a backward wall-clock jump does not warn on a long recording`() {
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        withModule(timeSource) { module ->
+            module.startRecorder()
+
+            // Twelve real seconds of recording, and an NTP sync that moves the wall clock an hour
+            // back. Wall-clock measurement would report a negative duration here.
+            timeSource.elapsedRealtimeMs += 12_000L
+            timeSource.wallNow = timeSource.wallNow.minus(Duration.ofHours(1))
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a forward wall-clock jump does not skip the warning`() {
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        withModule(timeSource) { module ->
+            module.startRecorder()
+
+            // Three real seconds of recording, and a clock correction an hour forward. Wall-clock
+            // measurement would call this a one-hour recording and skip the prompt.
+            timeSource.elapsedRealtimeMs += 3_000L
+            timeSource.wallNow = timeSource.wallNow.plus(Duration.ofHours(1))
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    @Test
+    fun `a resumed session measures from the persisted start time`() {
+        // Resumed after a process death: there is no monotonic base to measure against, so the
+        // persisted wall-clock start is all the module has.
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        val startTime = timeSource.currentTimeMillis() - 8_000L
+        seedTriggerFile(startTime)
+
+        withModule(timeSource) { module ->
+            module.state.first { it.isRecording }
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+
+            timeSource.wallNow = Instant.ofEpochMilli(startTime + 10_000L)
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a resumed session with a future start time fails open`() {
+        // The persisted start lies in the future (the wall clock moved backward across the resume).
+        // A negative duration must not trap the user in the warning.
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        seedTriggerFile(timeSource.currentTimeMillis() + 60_000L)
+
+        withModule(timeSource) { module ->
+            module.state.first { it.isRecording }
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -14,9 +14,11 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -69,11 +71,22 @@ class RecorderModuleDurationTest : BaseTest() {
         try {
             try {
                 module = buildModule(moduleScope, timeSource)
-                runBlocking { block(module) }
+                // Envelope: a regressed await must FAIL in seconds, not wedge a CI runner for 6h.
+                // That happened — the pre-fix suite hung until the GitHub job timeout.
+                runBlocking { withTimeout(BLOCK_TIMEOUT_MS) { block(module) } }
             } finally {
                 // Stop before cancelling: scope cancellation does NOT uninstall a running
-                // recorder's global FileLogger.
-                module?.let { runBlocking { it.stopRecorder() } }
+                // recorder's global FileLogger. A wedged stop must not hang cleanup either; the
+                // FileLogger assertion below then fails the test with the real signal.
+                module?.let {
+                    runBlocking {
+                        try {
+                            withTimeout(10_000) { it.stopRecorder() }
+                        } catch (e: TimeoutCancellationException) {
+                            // the leak assertion below reports it
+                        }
+                    }
+                }
             }
         } finally {
             moduleScope.cancel()
@@ -189,5 +202,9 @@ class RecorderModuleDurationTest : BaseTest() {
 
             module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
         }
+    }
+
+    companion object {
+        private const val BLOCK_TIMEOUT_MS = 15_000L
     }
 }

--- a/app/src/test/java/eu/darken/capod/common/flow/DynamicStateFlowTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/flow/DynamicStateFlowTest.kt
@@ -9,15 +9,21 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import testhelpers.flow.test
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 class DynamicStateFlowTest : BaseTest() {
@@ -274,6 +280,54 @@ class DynamicStateFlowTest : BaseTest() {
         testCollector.latestValues shouldBe listOf(2, 3, 0)
 
         testCollector.cancelAndJoin()
+    }
+
+    /**
+     * Pre-fix, [DynamicStateFlow.updateBlocking] emitted its update BEFORE subscribing to the
+     * shared flow. Under contention its awaited State could be displaced from the replay-1 cache
+     * by a successor update before the subscription existed, and the await then never completed
+     * (jstack-verified: the pre-fix suite wedged a CI runner until the 6h job timeout). This pins
+     * the subscribe-before-emit contract, and the timeout envelope turns any regression into a
+     * fast failure instead of another wedged runner.
+     */
+    @Test
+    fun `concurrent blocking updates survive a reactive collector`() {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val hotData = DynamicStateFlow(
+                loggingTag = "tag",
+                parentScope = scope,
+                startValueProvider = { 0 },
+            )
+
+            // Mirrors RecorderModule: a collector that reacts to every state with an update of its
+            // own, keeping the producer busy between the other callers' updates. The echo updates
+            // are value-neutral so the final count stays exact, and capped so the echo terminates.
+            val echoes = AtomicInteger(0)
+            scope.launch {
+                hotData.flow.collect { value ->
+                    if (value % 2 == 1 && echoes.getAndIncrement() < 100) {
+                        hotData.updateAsync { this + 0 }
+                    }
+                }
+            }
+
+            runBlocking {
+                withTimeout(20_000) {
+                    val workers = (1..2).map {
+                        launch(Dispatchers.IO) {
+                            repeat(100) { hotData.updateBlocking { this + 1 } }
+                        }
+                    }
+                    workers.forEach { it.join() }
+                    workers.all { it.isCompleted } shouldBe true
+
+                    hotData.flow.first() shouldBe 200
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFossPersistTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFossPersistTest.kt
@@ -1,0 +1,141 @@
+package eu.darken.capod.common.upgrade.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.capod.common.WebpageTool
+import eu.darken.capod.common.datastore.value
+import eu.darken.capod.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.io.File
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * The FOSS supporter record is create-only-if-absent: the sponsor-return heuristic can fire again
+ * for someone who is already a supporter (the recurring-donation button, or a stale entitlement
+ * replay), and a rewrite would move their "supporter since" date — and, for the legacy records
+ * every existing supporter has, replace their stored reason too.
+ *
+ * Driven through a real DataStore on a temp file via [FossCache]'s test seam, because the guarantee
+ * is the store transaction's, not the caller's.
+ */
+class UpgradeRepoFossPersistTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    // One store scope per test: the DataStore keeps its own actor alive on it.
+    private var storeScope: CoroutineScope? = null
+
+    @AfterEach
+    fun teardown() {
+        storeScope?.cancel()
+        storeScope = null
+    }
+
+    private class Harness(val cache: FossCache, val repo: UpgradeRepoFoss)
+
+    // Unique file name per test method: DataStore forbids two active instances on the same file.
+    private fun TestScope.buildHarness(storeName: String): Harness {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob()).also { storeScope = it }
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { File(tempDir, "$storeName.preferences_pb") },
+        )
+        val cache = FossCache(dataStore, SerializationModule().json())
+        val repo = UpgradeRepoFoss(
+            // backgroundScope: the repo's shareIn keeps a collector alive for the scope's lifetime.
+            appScope = backgroundScope,
+            fossCache = cache,
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+        )
+        return Harness(cache, repo)
+    }
+
+    @Test
+    fun `persistUpgrade keeps an existing legacy record`() = runTest {
+        val harness = buildHarness("legacy_record")
+        // A legacy 2022-schema value: a rewrite would corrupt BOTH the date and the reason.
+        harness.cache.upgrade.value(
+            FossUpgrade(
+                upgradedAt = Instant.EPOCH,
+                reason = FossUpgrade.Reason.NO_MONEY,
+            )
+        )
+
+        harness.repo.persistUpgrade() shouldBe false
+
+        harness.cache.upgrade.value() shouldBe FossUpgrade(
+            upgradedAt = Instant.EPOCH,
+            reason = FossUpgrade.Reason.NO_MONEY,
+        )
+        harness.repo.upgradeInfo.first().apply {
+            isPro shouldBe true
+            upgradedAt shouldBe Instant.EPOCH
+        }
+    }
+
+    @Test
+    fun `persistUpgrade creates on an empty store`() = runTest {
+        val harness = buildHarness("empty_store")
+        harness.cache.upgrade.value() shouldBe null
+
+        // Truncated: the record's serializer is epoch-millis, so a nanosecond lower bound can flake
+        // when the write lands within the same millisecond.
+        val before = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+        harness.repo.persistUpgrade() shouldBe true
+        val after = Instant.now()
+
+        val created = harness.cache.upgrade.value()
+        created shouldNotBe null
+        created!!.reason shouldBe FossUpgrade.Reason.DONATED
+        (created.upgradedAt >= before) shouldBe true
+        (created.upgradedAt <= after) shouldBe true
+
+        // Boolean-proven keep: immune to a timestamp collision between the two writes.
+        harness.repo.persistUpgrade() shouldBe false
+        harness.cache.upgrade.value() shouldBe created
+    }
+
+    @Test
+    fun `concurrent persists elect exactly one creator`() = runTest {
+        val harness = buildHarness("concurrent")
+        harness.cache.upgrade.value() shouldBe null
+
+        val before = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+        val gate = CompletableDeferred<Unit>()
+        val racers = List(2) {
+            async(Dispatchers.IO) {
+                gate.await()
+                harness.repo.persistUpgrade()
+            }
+        }
+        gate.complete(Unit)
+        val results = racers.awaitAll()
+        val after = Instant.now()
+
+        // Exactly one creator: the loser must report the record it found, not a second creation.
+        results.sorted() shouldBe listOf(false, true)
+
+        val record = harness.cache.upgrade.value()
+        record shouldNotBe null
+        record!!.reason shouldBe FossUpgrade.Reason.DONATED
+        (record.upgradedAt >= before) shouldBe true
+        (record.upgradedAt <= after) shouldBe true
+    }
+}

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -40,7 +40,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
         every { openGithubSponsorsPage() } returns true
-        coEvery { persistUpgrade() } answers { persisted++ }
+        coEvery { persistUpgrade() } answers { persisted++; true }
     }
 
     private fun buildVm(

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -8,6 +8,8 @@ import eu.darken.capod.common.upgrade.core.FossUpgrade
 import eu.darken.capod.common.upgrade.core.UpgradeRepoFoss
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -17,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -33,6 +36,7 @@ import testhelpers.BaseTest
 import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 
@@ -63,6 +67,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
         every { openGithubSponsorsPage() } returns true
+        // Explicit: a relaxed mock would answer the Boolean with false, i.e. "record already
+        // existed", silently turning every thanks-toast assertion below into a no-op.
+        coEvery { persistUpgrade() } returns true
     }
 
     private fun buildVm(
@@ -262,9 +269,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `a recurring donation from the upgraded status keeps the supporter date`() = runTest2(
         context = testDispatcher,
     ) {
-        // The upgraded status screen's donate-again button runs the very same sponsor flow. A
-        // return past the delay must NOT persist again -- that would rewrite upgradedAt and
-        // visibly reset the "supporter since" date the screen shows.
+        // The upgraded status screen's donate-again button runs the very same sponsor flow. The
+        // store transaction keeps the existing record either way, so this is about the feedback:
+        // no redundant write attempt, and no thanks toast for an unlock that already happened.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 
@@ -313,6 +320,94 @@ class FossUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `a sponsor return whose record already existed stays quiet`() = runTest2(context = testDispatcher) {
+        // The isPro fast path reads a shareIn replay that can be stale, so a supporter's return can
+        // get past it. Only the store transaction knows the record is already there — it keeps it
+        // and reports "not created", and there is no unlock to thank anyone for.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } returns false
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+        // Consumed: the visit was evaluated, there is nothing left to retry.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a failed persist restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The marker is consumed before the write. If the write then fails, dropping it would eat a
+        // valid sponsor visit for good — the next return/resume has to be able to retry the unlock.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } throws IOException("write failed")
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        // Rethrown, not swallowed: the failure still travels the normal error path.
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a failed entitlement read restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The guard's entitlement read happens after the marker was consumed, so it can eat the
+        // sponsor visit just as a failed write can. Installed after arming: the ViewModel's own init
+        // collectors already hold the working flow, so the only failing read is the guard's.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { throw IOException("read failed") }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
     fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
         context = testDispatcher,
     ) {
@@ -354,7 +449,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         context = testDispatcher,
     ) {
         // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
-        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        // page for a while must not run the unlock heuristic again — no write attempt, no toast.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 


### PR DESCRIPTION
## What changed

FOSS version: an existing supporter's "supporter since" date (and their stored supporter reason) is now protected by the storage layer itself and can no longer be reset by re-visiting the sponsors page. The "thanks for supporting" toast only appears when supporter status was actually newly granted, and if checking or saving the supporter status fails, the pending unlock is no longer lost — the next return to the app retries it.

Both versions: the "that debug log looks too short" warning now catches recordings up to 10 seconds (previously only 5 — a real support case slipped through at 8 seconds with nothing but the recorder starting and stopping in it), and it no longer misjudges the recording length when the device clock changes mid-recording (NTP sync, manual time change).

## Technical Context

- Root cause (supporter date): `persistUpgrade()` unconditionally overwrote the `FossUpgrade` record; the VM's already-Pro guard reads `upgradeInfo.first()` off a `shareIn(replay = 1)` flow whose stale replay can report not-Pro for an upgraded user. The persist is now a create-only-if-absent transaction inside `DataStoreValue.update {}` returning whether a record was created; the guard stays as a UX fast path. Capod's retained `reason` schema means a rewrite would have corrupted legacy records' reason too — the keep-test seeds a legacy `NO_MONEY` record to pin that.
- The pending-return marker restore wraps everything after the marker consume — a thrown entitlement *read* eats the visit just like a failed write would. This is deliberately wider than the equivalent sdmaid-se change.
- Caveat, documented in the KDoc: with `onErrorFallbackToDefault = true` an undecodable stored record reads as null and counts as absent to the transaction — matching pre-existing read behavior (such a record already presents the user as free); re-creating on the next sponsor visit is the recovery path.
- Recording duration previously used `currentTimeMillis()` end to end: a backward clock jump trapped long recordings in the warning, a forward jump let short ones skip it. Live sessions now measure via `elapsedRealtime()` (new monotonic base in state, fresh starts only); sessions resumed from the trigger file keep the persisted wall time (it must survive reboots) and fail open on negative deltas. Duration tests cover both jump directions plus real trigger-file resume.
- `FossCache` gains the same constructor-injected DataStore seam `BillingCache` has; migration and fallback unchanged. The new persist tests run on that seam against per-test temp-file stores (including a two-coroutine race electing exactly one creator); the pre-existing `FossCacheLegacyRecordTest` continues to cover the real-file delegate + `SharedPreferencesMigration` wiring — a second real-file test class can't coexist with the now file-level (process-wide) delegate.
- Test-harness commit: `RecorderModuleDiagnosticsTest` stopped started recorders only on happy paths; scope cancellation does not uninstall the global `FileLogger`, so a failure could poison later tests. The harness now stops in nested finally, always cancels, and fails the test on any newly installed `FileLogger`.
- Follow-up commit (found via this PR's first CI run, where both test jobs hung until the 6h job timeout): `DynamicStateFlow.updateBlocking` had a lost-wakeup race — it emitted its update before subscribing to the replay-1 shared flow, so a fast producer plus a reactive collector (exactly `RecorderModule`'s react-to-every-state pattern) could displace the awaited emission before the subscription existed, suspending the caller forever. The new duration tests' rapid start/stop cycles trigger it reliably on 2-core runners (reproduced locally under `taskset -c 0,1`, thread-dump verified; invisible on many-core machines, which is why it never bit before — and the same race exists in production start/stop churn). Fixed by registering the awaiter with `CoroutineStart.UNDISPATCHED` before emitting; pinned by a contention regression test, and both recorder test harnesses gained timeout envelopes so any future regression fails in seconds instead of wedging a runner. The pre-fix repro command (2-core constrained full suite) now completes in 1m35s.
