### PR TITLE
Fix: Handle supporter status errors and refresh the upgrade screen

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
@@ -3,15 +3,20 @@ package eu.darken.capod.common.upgrade.core
 import eu.darken.capod.common.WebpageTool
 import eu.darken.capod.common.coroutine.AppScope
 import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.asLog
 import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.debug.logging.logTag
 import eu.darken.capod.common.flow.setupCommonEventHandlers
 import eu.darken.capod.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import java.time.Instant
 import java.util.UUID
@@ -31,20 +36,39 @@ class UpgradeRepoFoss @Inject constructor(
 
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
 
-    override val upgradeInfo: Flow<UpgradeRepo.Info> = combine(
-        fossCache.upgrade.flow,
-        refreshTrigger
-    ) { data, _ ->
-        if (data == null) {
-            Info()
-        } else {
-            Info(
-                isPro = true,
-                upgradedAt = data.upgradedAt,
-                upgradeReason = data.reason,
-            )
+    // Written only from the sharing coroutine (single collector) — no synchronization needed.
+    private var lastKnownInfo: Info? = null
+
+    override val upgradeInfo: Flow<UpgradeRepo.Info> = refreshTrigger
+        .flatMapLatest {
+            fossCache.upgrade.flow
+                .map { data ->
+                    if (data == null) {
+                        Info()
+                    } else {
+                        Info(
+                            isPro = true,
+                            upgradedAt = data.upgradedAt,
+                            upgradeReason = data.reason,
+                        )
+                    }
+                }
+                .catch { e ->
+                    // A SharedFlow cannot fail: without this, a thrown cache read dies inside
+                    // shareIn's sharing coroutine and every collector hangs forever (VM state stuck
+                    // on Loading, checkSponsorReturn suspended mid-unlock). The catch sits INSIDE
+                    // flatMapLatest so the error completes only this inner subscription — refresh()
+                    // resubscribes the cache and recovery stays possible. Last-known preservation:
+                    // a late read failure must not revoke an entitlement we already saw; the error
+                    // rides on the previous Info instead. Contrast: gplay keeps a retryWhen loop
+                    // because billing re-settles in-place — the FOSS read is a local one-shot, and
+                    // refresh-driven resubscription IS the retry.
+                    if (e is CancellationException) throw e
+                    log(TAG, WARN) { "upgradeInfo read failed: ${e.asLog()}" }
+                    emit((lastKnownInfo ?: Info()).copy(error = e))
+                }
         }
-    }
+        .onEach { if (it.error == null) lastKnownInfo = it }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
@@ -68,6 +92,8 @@ class UpgradeRepoFoss @Inject constructor(
      * decode reads as null and therefore counts as ABSENT to this transaction, i.e. it gets
      * replaced. That matches the pre-existing read behaviour — such a record already presents the
      * user as free — and re-creating it on the next successful sponsor visit is the recovery path.
+     * Decode failures therefore fall back to absent by design (the flag), so the error path around
+     * [upgradeInfo] covers IO/corruption throws, not schema mismatches.
      *
      * @return true if a new record was created, false if an existing record was kept.
      */
@@ -79,6 +105,9 @@ class UpgradeRepoFoss @Inject constructor(
                 reason = FossUpgrade.Reason.DONATED,
             )
         }
+        // A returned transaction proves the store is readable again: revive a possibly error-stuck
+        // inner flow so the record propagates to collectors still holding the error replay.
+        refresh()
         return if (updated.old == null) {
             true
         } else {

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFoss.kt
@@ -37,6 +37,9 @@ class UpgradeRepoFoss @Inject constructor(
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
 
     // Written only from the sharing coroutine (single collector) — no synchronization needed.
+    // Recorded INSIDE the flatMapLatest block, upstream of its channel buffer: a downstream onEach
+    // can still be waiting on a buffered emission when the inner flow throws, and the catch below
+    // would then read a stale (null) value and revoke an entitlement we already saw.
     private var lastKnownInfo: Info? = null
 
     override val upgradeInfo: Flow<UpgradeRepo.Info> = refreshTrigger
@@ -53,6 +56,10 @@ class UpgradeRepoFoss @Inject constructor(
                         )
                     }
                 }
+                // Same coroutine as the throw below, so the ordering is guaranteed. Only
+                // successfully mapped elements pass here — catch emissions go straight downstream
+                // and never record themselves as a last known state.
+                .onEach { lastKnownInfo = it }
                 .catch { e ->
                     // A SharedFlow cannot fail: without this, a thrown cache read dies inside
                     // shareIn's sharing coroutine and every collector hangs forever (VM state stuck
@@ -68,7 +75,6 @@ class UpgradeRepoFoss @Inject constructor(
                     emit((lastKnownInfo ?: Info()).copy(error = e))
                 }
         }
-        .onEach { if (it.error == null) lastKnownInfo = it }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -156,11 +156,7 @@ private fun UpgradePitchContent(
     UpgradeScreenContent(
         paddingValues = paddingValues,
     ) {
-        UpgradeHeader(
-            mascotSize = 104.dp,
-        )
-
-        UpgradePreambleCard(
+        UpgradeHeroCard(
             text = stringResource(R.string.upgrade_foss_preamble),
             colors = CardDefaults.elevatedCardColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -173,10 +173,16 @@ class UpgradeViewModel @Inject constructor(
         } catch (e: Exception) {
             // The marker was consumed above; neither a failed entitlement read nor a failed write may
             // eat the user's valid sponsor visit — restore it so the next return/resume can retry the
-            // unlock. Rethrow unconditionally: cancellation is not swallowed, other errors surface via
-            // the normal error path. A restored marker after a successful persist is harmless — the
-            // next evaluation hits the quiet isPro path.
-            handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            // unlock. Conditional: the user may have armed a NEWER launch while this attempt was
+            // suspended, and that one must survive. The contains-check has a small check-then-act
+            // window against a concurrent new arm; accepted — the create-only transaction owns data
+            // integrity, a wrong winner only changes which REAL visit's timestamp gates the unlock.
+            // Rethrow unconditionally: cancellation is not swallowed, other errors surface via the
+            // normal error path. A restored marker after a successful persist is harmless — the next
+            // evaluation hits the quiet isPro path.
+            if (!handle.contains(KEY_SPONSOR_PRESSED_AT)) {
+                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            }
             throw e
         }
     }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,7 +1,14 @@
 package eu.darken.capod.common.upgrade.core.billing
 
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import android.widget.Toast
 import eu.darken.capod.R
+import eu.darken.capod.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.capod.common.debug.logging.log
 import eu.darken.capod.common.error.HasLocalizedError
 import eu.darken.capod.common.error.LocalizedError
 
@@ -12,5 +19,28 @@ class GplayServiceUnavailableException(cause: Throwable) :
         throwable = this,
         label = context.getString(R.string.upgrades_gplay_unavailable_error),
         description = context.getString(R.string.upgrades_gplay_unavailable_error_description),
+        // Deliberately untranslated brand name.
+        fixActionLabel = "Google Play",
+        // BillingManager also maps transient timeout/network failures onto this exception, so the
+        // action is a GENERIC troubleshooting affordance (open Play's app info), not a diagnosis of
+        // the cause. Harmless for a transient blip, and it matches the fleet's dialog.
+        fixAction = { activity ->
+            try {
+                val intent = Intent().apply {
+                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                    data = Uri.fromParts("package", GPLAY_PKG, null)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+
+                activity.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+                Toast.makeText(activity, "Google Play is not installed", Toast.LENGTH_SHORT).show()
+            }
+        },
     )
+
+    companion object {
+        private const val GPLAY_PKG = "com.android.vending"
+    }
 }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -207,6 +207,15 @@ internal fun RestoreInconclusiveDialog(
     )
 }
 
+// The acquisition pitch inserts the SAME composed brand the status title uses, postfix colored —
+// one brand rendering for both. Word-order-proof: the brand is spliced into the TRANSLATED pattern,
+// so Android's formatter owns placeholder semantics (numbering, reordering, escaping).
+@Composable
+private fun upgradeAcquisitionTitle(): AnnotatedString = spliceBrandTitle(
+    formatted = stringResource(R.string.upgrade_screen_title_template, BRAND_TITLE_MARKER),
+    brand = upgradeScreenTitle(upgraded = true),
+)
+
 @Composable
 internal fun UpgradeScreen(
     uiState: GplayUpgradeUiState = GplayUpgradeUiState.Loading,
@@ -225,13 +234,14 @@ internal fun UpgradeScreen(
     val ownedState = loaded?.takeIf { it.ownership.ownsAnything }
 
     UpgradeScreenScaffold(
-        // Grace users are still Pro: they get the status title too — "Get SD Maid SE Pro" on the
-        // status screen would contradict the rest of the app, which behaves upgraded. The postfix
-        // is highlighted like the dashboard title does it.
+        // Grace users are still Pro: they get the bare status title — "Get CAPod Pro" on the status
+        // screen would contradict the rest of the app, which behaves upgraded. Acquisition wraps
+        // that same brand in the pitch sentence. Either way the postfix is highlighted like the
+        // dashboard title does it.
         title = if (ownedState != null || loaded?.grace != null) {
             upgradeScreenTitle(upgraded = true)
         } else {
-            AnnotatedString(stringResource(R.string.upgrade_capod_label))
+            upgradeAcquisitionTitle()
         },
         onNavigateUp = onNavigateUp,
     ) { paddingValues ->

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -5,12 +5,14 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AutoAwesome
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -397,6 +399,7 @@ private fun UpgradeOffersBox(
                 // the user re-run the offer queries instead of leaving a dead screen.
                 // No reset needed: this composable unmounts the moment the state leaves Unavailable.
                 var retryTapped by remember { mutableStateOf(false) }
+                val retryEnabled = !retryTapped
                 OutlinedButton(
                     // Guard inside the callback, not just via `enabled`: `enabled` only takes effect
                     // after recomposition, so two taps in the same frame would both fire.
@@ -406,10 +409,20 @@ private fun UpgradeOffersBox(
                             onRetry()
                         }
                     },
-                    enabled = !retryTapped,
+                    enabled = retryEnabled,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_RETRY),
+                    // The button sits on the errorContainer card, so the default primary-on-surface
+                    // outlined colors read as a foreign element with poor contrast.
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.38f),
+                    ),
+                    border = BorderStroke(
+                        1.dp,
+                        MaterialTheme.colorScheme.onErrorContainer.copy(alpha = if (retryEnabled) 1f else 0.1f),
+                    ),
                 ) {
                     Text(stringResource(R.string.general_retry_action))
                 }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -244,10 +244,23 @@ internal fun UpgradeScreen(
                 // episode ages into the diagnostics stage, the mascot joins the mood: unimpressed
                 // at Google Play, matching the setup card's "needs your attention" face. The young
                 // episode keeps the happy face — its message is that nothing is wrong.
-                UpgradeHeader(
-                    mascotSize = 88.dp,
-                    happy = loaded?.grace?.showDiagnostics != true,
-                )
+                if (loaded?.grace != null) {
+                    // Grace users never see the preamble (sales copy contradicts "still active"),
+                    // so there is nothing to pair the mascot with — it stays a standalone header
+                    // above the grace card.
+                    UpgradeHeader(
+                        mascotSize = 88.dp,
+                        happy = loaded.grace.showDiagnostics != true,
+                    )
+                } else {
+                    UpgradeHeroCard(
+                        text = stringResource(R.string.upgrade_preamble),
+                        colors = CardDefaults.elevatedCardColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        ),
+                    )
+                }
             }
 
             if (ownedState != null) {
@@ -296,14 +309,8 @@ private fun UpgradeAcquisitionContent(
     // blip) shows calm status only, an aged one (likely really gone) adds restore AND the offers,
     // so an expired subscriber can switch without waiting out the full grace window.
     if (!inGrace) {
-        UpgradePreambleCard(
-            text = stringResource(R.string.upgrade_preamble),
-            colors = CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-            ),
-        )
-
+        // The preamble itself now lives in the hero card at the top of the screen, next to the
+        // mascot — only the sections below it are conditional here.
         if (uiState is GplayUpgradeUiState.Loaded && uiState.wasPreviouslyPro) {
             // The targeted returning-buyer nudge: prominent placement and emphasis, and the ONLY
             // restore affordance on the screen — a second one below would make the screen feel

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play reports that you already own this upgrade, but it couldn\'t be restored. Make sure you are using the Google account you purchased with. Play Store synchronization may take time — try rebooting, clearing the Google Play cache or simply waiting.</string>
     <string name="upgrade_restore_action">Restore purchase</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Get %1$s</string>
     <string name="upgrade_preamble">CAPod is developed by a single person. Upgrading unlocks extra features and helps keep the app alive.</string>
     <string name="upgrade_screen_options_description">Same features, different pricing. The subscription includes a free trial and can be cancelled at any time.</string>
     <string name="upgrade_screen_options_description_no_trial">Same features, different pricing. The subscription can be cancelled at any time.</string>

--- a/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/capod/common/debug/recording/core/RecorderModule.kt
@@ -121,7 +121,7 @@ class RecorderModule @Inject constructor(
                             recorder = newRecorder,
                             currentLogDir = sessionDir,
                             recordingStartedAt = startTime,
-                            recordingStartedAtMonotonic = if (isResume) 0L else timeSource.elapsedRealtime(),
+                            recordingStartedAtMonotonic = if (isResume) null else timeSource.elapsedRealtime(),
                             persistedLogDir = null,
                         )
                     } else if (!shouldRecord && isRecording) {
@@ -137,6 +137,7 @@ class RecorderModule @Inject constructor(
                             recorder = null,
                             currentLogDir = null,
                             recordingStartedAt = 0L,
+                            recordingStartedAtMonotonic = null,
                         )
                     } else {
                         this
@@ -238,9 +239,10 @@ class RecorderModule @Inject constructor(
         if (!currentState.isRecording) return StopResult.NotRecording
 
         val logDir = currentState.currentLogDir ?: return StopResult.NotRecording
-        val elapsed = if (currentState.recordingStartedAtMonotonic > 0L) {
+        val startedAtMono = currentState.recordingStartedAtMonotonic
+        val elapsed = if (startedAtMono != null) {
             // Live session: monotonic, immune to wall-clock adjustments mid-recording.
-            timeSource.elapsedRealtime() - currentState.recordingStartedAtMonotonic
+            timeSource.elapsedRealtime() - startedAtMono
         } else {
             // Resumed session: the trigger file persists wall time only — it has to survive reboots,
             // which monotonic time does not.
@@ -266,10 +268,10 @@ class RecorderModule @Inject constructor(
         internal val recorder: Recorder? = null,
         val currentLogDir: File? = null,
         val recordingStartedAt: Long = 0L,
-        // Monotonic base for the duration heuristic, 0L when there is none: a resumed session's
+        // Monotonic base for the duration heuristic, null when there is none: a resumed session's
         // only start time is the persisted wall clock, and a monotonic value from a previous
         // process or boot is meaningless.
-        val recordingStartedAtMonotonic: Long = 0L,
+        internal val recordingStartedAtMonotonic: Long? = null,
         internal val persistedLogDir: File? = null,
     ) {
         val isRecording: Boolean

--- a/app/src/main/java/eu/darken/capod/common/error/ErrorEventHandler.kt
+++ b/app/src/main/java/eu/darken/capod/common/error/ErrorEventHandler.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.common.error
 
+import android.app.Activity
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -11,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import eu.darken.capod.R
 
 @Composable
 fun ErrorEventHandler(source: ErrorEventSource2) {
@@ -37,14 +39,39 @@ private fun ComposeErrorDialog(
     // messages like Play Billing's internal debugMessage.
     val localizedError = remember(throwable, context) { throwable.localized(context) }
 
+    val activity = context as? Activity
+    // An error that offers a way out gets its own action plus a dismiss; everything else keeps the
+    // acknowledge-only shape. The activity is required to launch the fix.
+    val hasFix = localizedError.fixAction != null && activity != null
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(text = localizedError.label) },
         text = { Text(text = localizedError.description) },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(android.R.string.ok))
+            if (hasFix) {
+                TextButton(
+                    onClick = {
+                        localizedError.fixAction!!.invoke(activity!!)
+                        onDismiss()
+                    },
+                ) {
+                    Text(text = localizedError.fixActionLabel ?: stringResource(android.R.string.ok))
+                }
+            } else {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(android.R.string.ok))
+                }
             }
+        },
+        dismissButton = if (hasFix) {
+            {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(R.string.general_dismiss_action))
+                }
+            }
+        } else {
+            null
         },
     )
 }

--- a/app/src/main/java/eu/darken/capod/common/error/LocalizedError.kt
+++ b/app/src/main/java/eu/darken/capod/common/error/LocalizedError.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.common.error
 
+import android.app.Activity
 import android.content.Context
 import eu.darken.capod.R
 
@@ -10,7 +11,9 @@ interface HasLocalizedError {
 data class LocalizedError(
     val throwable: Throwable,
     val label: String,
-    val description: String
+    val description: String,
+    val fixActionLabel: String? = null,
+    val fixAction: ((Activity) -> Unit)? = null,
 ) {
     fun asText() = "$label:\n$description"
 }

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -2,6 +2,7 @@ package eu.darken.capod.common.upgrade.ui
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.CheckCircle
+import androidx.compose.material.icons.twotone.WarningAmber
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -28,6 +31,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -637,5 +641,60 @@ internal fun UpgradeInlineStateCard(
             color = MaterialTheme.colorScheme.onErrorContainer,
         )
         content()
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeInlineStateCardPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeInlineStateCard(
+                title = "Offers unavailable",
+                body = "Google Play did not answer. This is usually temporary.",
+                icon = Icons.TwoTone.WarningAmber,
+            ) {
+                OutlinedButton(
+                    onClick = {},
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.38f),
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.onErrorContainer),
+                ) {
+                    Text("Retry")
+                }
+            }
+        }
+    }
+}
+
+// The latched state the card shows after the retry was tapped: the contrast of a DISABLED button on
+// errorContainer is the part the default theming gets wrong, so it needs its own preview.
+@Preview2
+@Composable
+private fun UpgradeInlineStateCardDisabledActionPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeInlineStateCard(
+                title = "Offers unavailable",
+                body = "Google Play did not answer. This is usually temporary.",
+                icon = Icons.TwoTone.WarningAmber,
+            ) {
+                OutlinedButton(
+                    onClick = {},
+                    enabled = false,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.38f),
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.1f)),
+                ) {
+                    Text("Retry")
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -112,6 +112,30 @@ internal fun upgradeScreenTitle(
     }
 }
 
+// Marker char for brand-title splicing: formatted into the translated pattern via the normal
+// Android format path (so %1$s vs %s, argument reordering, and %% all behave), then replaced
+// with the styled brand. U+FFFC (object replacement) cannot occur in a real translation.
+internal const val BRAND_TITLE_MARKER = "￼"
+
+internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): AnnotatedString = buildAnnotatedString {
+    var rest = formatted
+    var found = false
+    while (true) {
+        val idx = rest.indexOf(BRAND_TITLE_MARKER)
+        if (idx < 0) break
+        found = true
+        append(rest.substring(0, idx))
+        append(brand)
+        rest = rest.substring(idx + BRAND_TITLE_MARKER.length)
+    }
+    append(rest)
+    if (!found) {
+        // Defensive: a translation that lost its placeholder still shows the brand.
+        append(" ")
+        append(brand)
+    }
+}
+
 @Composable
 internal fun UpgradeScreenScaffold(
     @StringRes titleRes: Int,

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -386,26 +386,6 @@ private fun UpgradeHeroCardTintedPreview() {
 }
 
 @Composable
-internal fun UpgradePreambleCard(
-    text: String,
-    modifier: Modifier = Modifier,
-    colors: CardColors = CardDefaults.elevatedCardColors(),
-) {
-    ElevatedCard(
-        modifier = modifier.fillMaxWidth(),
-        colors = colors,
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-        )
-    }
-}
-
-@Composable
 internal fun UpgradeSectionCard(
     title: String,
     icon: ImageVector,

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -40,6 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -49,10 +51,13 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.IconButton
 import eu.darken.capod.R
+import eu.darken.capod.common.compose.Preview2
+import eu.darken.capod.common.compose.PreviewWrapper
 
 internal object UpgradeScreenTags {
     const val LOADING = "upgrade_loading"
@@ -80,6 +85,7 @@ internal object UpgradeScreenTags {
     const val GPLAY_GRACE = "upgrade_gplay_grace"
     const val GPLAY_GRACE_SPINNER = "upgrade_gplay_grace_spinner"
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"
+    const val HERO = "upgrade_hero"
 }
 
 // Composed app title with the flavor postfix highlighted in the upgraded color while Pro is
@@ -217,6 +223,135 @@ internal fun UpgradeHeader(
                 size = mascotSize,
                 modifier = Modifier.padding(16.dp),
                 happy = happy,
+            )
+        }
+    }
+}
+
+private val HERO_GAP = 16.dp
+
+// Below this much room for the copy the side-by-side split stops paying for itself: measured on a
+// 320dp screen at 200% font, the row wrapped the preamble over 10 lines (breaking a word mid-way)
+// and came out TALLER than stacking, which needs 6. Scaled by fontScale because the squeeze comes
+// from text size as much as from screen width — at 200% font even a normal-width phone must stack.
+private val HERO_MIN_TEXT_WIDTH = 150.dp
+
+// The screen opener: mascot and preamble in one card instead of a floating icon stacked on a
+// separate text box. Side-by-side keeps the mascot at eye level with the copy it introduces, and
+// buys back the vertical space the standalone header used to spend above the fold — but only while
+// the copy still has room to breathe, hence the stacked fallback.
+@Composable
+internal fun UpgradeHeroCard(
+    text: String,
+    modifier: Modifier = Modifier,
+    mascotSize: Dp = 88.dp,
+    happy: Boolean = true,
+    colors: CardColors = CardDefaults.elevatedCardColors(),
+) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(UpgradeScreenTags.HERO),
+        colors = colors,
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .padding(end = 8.dp),
+        ) {
+            val minTextWidth = HERO_MIN_TEXT_WIDTH * LocalDensity.current.fontScale
+            if (maxWidth - mascotSize - HERO_GAP < minTextWidth) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    UpgradeMascot(
+                        size = mascotSize,
+                        happy = happy,
+                    )
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(HERO_GAP),
+                ) {
+                    UpgradeMascot(
+                        size = mascotSize,
+                        happy = happy,
+                    )
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// Preview copy matches the shipped preamble in length: the mascot/text split only reads correctly
+// if the text wraps like it does in the app.
+private const val PREVIEW_PREAMBLE =
+    "CAPod is developed by a single person. Upgrading unlocks extra features and helps keep the app alive."
+
+@Preview2
+@Composable
+private fun UpgradeHeroCardPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeHeroCard(text = PREVIEW_PREAMBLE)
+        }
+    }
+}
+
+// Preview2 only varies light/dark, so it can never reach the stacked branch. These two pin the
+// thresholds that flip it: a narrow screen, and a normal-width screen at 200% font. 280dp, not
+// 320dp: at 320dp the text still gets ~160dp once the paddings come off, so the row survives.
+@Preview(showBackground = true, name = "Compact width", widthDp = 280)
+@Preview(showBackground = true, name = "Huge font", fontScale = 2f)
+@Composable
+private fun UpgradeHeroCardCompactPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeHeroCard(text = PREVIEW_PREAMBLE)
+        }
+    }
+}
+
+// Both flavors tint the hero: FOSS on primaryContainer, GPLAY on secondaryContainer. Neither is
+// the composable's default, so the default-colored preview above would not catch a contrast
+// regression on the colors that actually ship.
+@Preview2
+@Composable
+private fun UpgradeHeroCardTintedPreview() {
+    PreviewWrapper {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            UpgradeHeroCard(
+                text = PREVIEW_PREAMBLE,
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+            UpgradeHeroCard(
+                text = PREVIEW_PREAMBLE,
+                happy = false,
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="general_donate_action">Donate</string>
     <string name="general_check_action">Check</string>
     <string name="general_close_action">Close</string>
+    <string name="general_dismiss_action">Dismiss</string>
     <string name="general_edit_action">Edit</string>
     <string name="general_save_action">Save</string>
     <string name="general_guide_action">Guide</string>

--- a/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -173,6 +173,53 @@ class RecorderModuleDurationTest : BaseTest() {
     }
 
     @Test
+    fun `a recording started at monotonic zero still uses the monotonic path`() {
+        // Boot-adjacent start: elapsedRealtime() is legitimately 0 right after boot. A 0L sentinel
+        // reads as "resumed" and diverts to the wall clock, so a clock correction would turn three
+        // seconds of recording into an hour and skip the prompt.
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 0L)
+        withModule(timeSource) { module ->
+            module.startRecorder()
+
+            timeSource.elapsedRealtimeMs += 3_000L
+            timeSource.wallNow = timeSource.wallNow.plus(Duration.ofHours(1))
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    @Test
+    fun `a live session carries a monotonic base and a stop clears it`() {
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        withModule(timeSource) { module ->
+            module.startRecorder()
+            module.state.first { it.isRecording }.recordingStartedAtMonotonic shouldBe 100_000L
+
+            timeSource.advanceBy(Duration.ofSeconds(10))
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+
+            // A stale base left on the stopped state would be a lie about a session that is over.
+            module.state.first { !it.isRecording }.recordingStartedAtMonotonic shouldBe null
+        }
+    }
+
+    @Test
+    fun `a resumed session carries no monotonic base`() {
+        // Nothing monotonic survives a process death or reboot, so the resumed state has no base
+        // at all — the wall-clock fallback is the only measurement it can make.
+        val timeSource = TestTimeSource(elapsedRealtimeMs = 100_000L)
+        seedTriggerFile(timeSource.currentTimeMillis() - 20_000L)
+
+        withModule(timeSource) { module ->
+            module.state.first { it.isRecording }.recordingStartedAtMonotonic shouldBe null
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            module.state.first { !it.isRecording }.recordingStartedAtMonotonic shouldBe null
+        }
+    }
+
+    @Test
     fun `a resumed session measures from the persisted start time`() {
         // Resumed after a process death: there is no monotonic base to measure against, so the
         // persisted wall-clock start is all the module has.

--- a/app/src/test/java/eu/darken/capod/common/flow/DynamicStateFlowTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/flow/DynamicStateFlowTest.kt
@@ -2,11 +2,13 @@ package eu.darken.capod.common.flow
 
 import eu.darken.capod.common.collections.mutate
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -304,8 +306,10 @@ class DynamicStateFlowTest : BaseTest() {
             // own, keeping the producer busy between the other callers' updates. The echo updates
             // are value-neutral so the final count stays exact, and capped so the echo terminates.
             val echoes = AtomicInteger(0)
+            val subscribed = CompletableDeferred<Unit>()
             scope.launch {
                 hotData.flow.collect { value ->
+                    subscribed.complete(Unit)
                     if (value % 2 == 1 && echoes.getAndIncrement() < 100) {
                         hotData.updateAsync { this + 0 }
                     }
@@ -314,6 +318,10 @@ class DynamicStateFlowTest : BaseTest() {
 
             runBlocking {
                 withTimeout(20_000) {
+                    // The contention only means anything with the reactive collector actually
+                    // attached: its first received value proves the subscription exists.
+                    subscribed.await()
+
                     val workers = (1..2).map {
                         launch(Dispatchers.IO) {
                             repeat(100) { hotData.updateBlocking { this + 1 } }
@@ -323,6 +331,9 @@ class DynamicStateFlowTest : BaseTest() {
                     workers.all { it.isCompleted } shouldBe true
 
                     hotData.flow.first() shouldBe 200
+                    // Non-vacuity: without a single echo there was no successor update to displace
+                    // an awaited State, and the test would pass for the wrong reason.
+                    echoes.get() shouldBeGreaterThan 0
                 }
             }
         } finally {

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/core/UpgradeRepoFossTest.kt
@@ -1,12 +1,32 @@
 package eu.darken.capod.common.upgrade.core
 
+import eu.darken.capod.common.datastore.DataStoreValue
 import eu.darken.capod.common.upgrade.UpgradeRepo
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 
 class UpgradeRepoFossTest : BaseTest() {
 
@@ -19,6 +39,24 @@ class UpgradeRepoFossTest : BaseTest() {
     fun teardown() {
 
     }
+
+    private val record = FossUpgrade(
+        upgradedAt = Instant.EPOCH,
+        reason = FossUpgrade.Reason.DONATED,
+    )
+
+    private fun createUpgradeValue(cacheFlow: Flow<FossUpgrade?>) = mockk<DataStoreValue<FossUpgrade?>>().apply {
+        every { flow } returns cacheFlow
+        coEvery { update(any()) } returns DataStoreValue.Updated(old = null, new = record)
+    }
+
+    // Real dispatchers, not a test scheduler: the shareIn sharing coroutine and the collectors have
+    // to actually interleave here, and the whole point is that a failure settles instead of hanging.
+    private fun createRepo(appScope: CoroutineScope, upgradeValue: DataStoreValue<FossUpgrade?>) = UpgradeRepoFoss(
+        appScope = appScope,
+        fossCache = mockk<FossCache>().apply { every { upgrade } returns upgradeValue },
+        webpageTool = mockk(),
+    )
 
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoFoss.Info(
@@ -33,5 +71,83 @@ class UpgradeRepoFossTest : BaseTest() {
             isPro = true,
             upgradedAt = Instant.EPOCH,
         ).isPro shouldBe true
+    }
+
+    @Test fun `a failing cache read surfaces as a settled error Info instead of hanging`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow { throw IOException("cache broken") }))
+
+            withTimeout(10_000) {
+                repo.upgradeInfo.first().apply {
+                    // Type and message: a bare non-null check would also pass on a swallow-and-wrap.
+                    error.shouldBeInstanceOf<IOException>().message shouldBe "cache broken"
+                    isPro shouldBe false
+                    // The UI must be able to render this: an unsettled error is an endless spinner.
+                    isSettled shouldBe true
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test fun `a late cache failure keeps the last known entitlement`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow {
+                emit(record)
+                throw IOException("cache broken later")
+            }))
+
+            withTimeout(10_000) {
+                val infos = repo.upgradeInfo.take(2).toList()
+
+                infos[0].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+                // The entitlement we already saw must survive the read failure - a revoked Pro
+                // status would kick a paying supporter back to the pitch.
+                infos[1].apply {
+                    isPro shouldBe true
+                    error.shouldBeInstanceOf<IOException>()
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test fun `a successful persist revives an error-stuck upgradeInfo`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            // First subscription fails, later ones read fine: the store recovered, but the shared
+            // flow is still replaying the error Info to everyone.
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                if (subscriptions.getAndIncrement() == 0) throw IOException("cache broken")
+                emit(record)
+            })
+            val repo = createRepo(scope, upgradeValue)
+
+            val received = Channel<UpgradeRepo.Info>(Channel.UNLIMITED)
+            scope.launch { repo.upgradeInfo.collect { received.send(it) } }
+
+            withTimeout(10_000) {
+                received.receive().error.shouldBeInstanceOf<IOException>()
+
+                // No explicit refresh() from the test: persist has to do the reviving itself,
+                // otherwise the user's unlock never reaches the screen they are looking at.
+                repo.persistUpgrade() shouldBe true
+
+                received.receive().apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 }

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -41,6 +41,11 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_benefit_themes)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_sponsor_subtitle)).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(1)
+        // The pitch's mascot lives inside the hero card next to the preamble. Exactly one of each:
+        // the standalone header this view used to have must not survive alongside it.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(0)
     }
 
     @Test
@@ -72,6 +77,11 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_preamble)).assertCountEquals(0)
+        // No preamble here, so there is nothing to pair the mascot with: no hero card, and the
+        // standalone header keeps its single cheerful mascot.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(0)
     }
 
     @Test
@@ -108,6 +118,10 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_DONATE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+        // Status view: standalone header, no hero card.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(0)
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.common.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import eu.darken.capod.R
 import eu.darken.capod.common.navigation.NavEvent
@@ -14,6 +15,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -404,6 +406,47 @@ class FossUpgradeViewModelTest : BaseTest() {
         errors.single().shouldBeInstanceOf<IOException>()
 
         toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a newer sponsor launch survives a failed older attempt`() = runTest2(context = testDispatcher) {
+        // The restore must not clobber a launch armed while the old attempt was still suspended:
+        // the newer visit is the one the user is actually waiting on.
+        val repo = mockRepo()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repo.persistUpgrade() } coAnswers {
+            gate.await()
+            throw IOException("write failed")
+        }
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle)
+
+        val errors = mutableListOf<Throwable>()
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Consumed and parked in the write.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // A second sponsor visit while the first attempt is still hanging.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(30))
+        val newerPressedAt = SystemClock.elapsedRealtime()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        // Mirrors the ViewModel's private KEY_SPONSOR_PRESSED_AT: the newer timestamp must still be
+        // the one stored, the failed older attempt must not have written its own back over it.
+        handle.get<Long>("sponsor_pressed_at") shouldBe newerPressedAt
+        errors.single().shouldBeInstanceOf<IOException>()
+
         errorCollector.cancel()
     }
 

--- a/app/src/testGplay/java/eu/darken/capod/common/error/ComposeErrorDialogTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/error/ComposeErrorDialogTest.kt
@@ -50,7 +50,7 @@ class ComposeErrorDialogTest : BaseTest() {
             }
         }
         // Buffered channel: the event survives until the handler's collector attaches.
-        source.emitBlocking(error)
+        source.errorEvents.tryEmit(error)
         composeRule.waitForIdle()
     }
 

--- a/app/src/testGplay/java/eu/darken/capod/common/error/ComposeErrorDialogTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/error/ComposeErrorDialogTest.kt
@@ -1,0 +1,112 @@
+package eu.darken.capod.common.error
+
+import android.content.Context
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.PreviewWrapper
+import eu.darken.capod.common.flow.SingleEventFlow
+import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The shared error dialog: an error that offers a way out gets its own action plus a dismiss, and
+ * everything else must keep the acknowledge-only shape — [ErrorEventHandler] backs every screen.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ComposeErrorDialogTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private class FakeErrorSource : ErrorEventSource2 {
+        override val errorEvents = SingleEventFlow<Throwable>()
+    }
+
+    private fun showError(error: Throwable) {
+        val source = FakeErrorSource()
+        composeRule.setContent {
+            PreviewWrapper {
+                ErrorEventHandler(source)
+            }
+        }
+        // Buffered channel: the event survives until the handler's collector attaches.
+        source.emitBlocking(error)
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a fixable error offers its action next to a dismiss`() {
+        showError(GplayServiceUnavailableException(RuntimeException("Play hiccup")))
+
+        composeRule.onNodeWithText(context.getString(R.string.upgrades_gplay_unavailable_error)).assertExists()
+        composeRule.onNodeWithText("Google Play").assertExists()
+        composeRule.onNodeWithText(context.getString(R.string.general_dismiss_action)).assertExists()
+        // Nothing is being cancelled or merely acknowledged here.
+        composeRule.onAllNodesWithText(context.getString(R.string.general_cancel_action)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(android.R.string.ok)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the fix action opens Google Play's app info and closes the dialog`() {
+        showError(GplayServiceUnavailableException(RuntimeException("Play hiccup")))
+
+        composeRule.onNodeWithText("Google Play").performClick()
+        composeRule.waitForIdle()
+
+        val started = shadowOf(composeRule.activity).nextStartedActivity.shouldNotBeNull()
+        started.action shouldBe Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        started.data.toString() shouldBe "package:com.android.vending"
+        // The user acted: leaving the dialog up would greet them again on the way back.
+        composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
+    }
+
+    @Test
+    fun `dismissing closes the dialog without launching anything`() {
+        showError(GplayServiceUnavailableException(RuntimeException("Play hiccup")))
+
+        composeRule.onNodeWithText(context.getString(R.string.general_dismiss_action)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(context.getString(R.string.general_dismiss_action)).assertCountEquals(0)
+        shadowOf(composeRule.activity).nextStartedActivity shouldBe null
+    }
+
+    @Test
+    fun `an ordinary error keeps the acknowledge-only dialog`() {
+        // The handler is shared by every screen: the fix/dismiss pair must stay exclusive to errors
+        // that actually carry a fix action.
+        showError(RuntimeException("something went wrong"))
+
+        composeRule.onNodeWithText(context.getString(android.R.string.ok)).assertExists()
+        composeRule.onAllNodesWithText(context.getString(R.string.general_dismiss_action)).assertCountEquals(0)
+        composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
+    }
+
+    @Test
+    fun `the unavailable-billing error carries a fix action`() {
+        val localized = GplayServiceUnavailableException(RuntimeException("Play hiccup")).getLocalizedError(context)
+
+        localized.fixActionLabel shouldBe "Google Play"
+        localized.fixAction.shouldNotBeNull()
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleSpliceTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleSpliceTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.capod.common.upgrade.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The brand is spliced into the already-formatted translation, so the styled postfix has to land on
+ * the right offsets no matter where the pattern put the placeholder.
+ */
+class BrandTitleSpliceTest : BaseTest() {
+
+    private val brandColor = Color.Red
+
+    // "CAPod Pro" with the postfix (6..9) colored, like upgradeScreenTitle(upgraded = true).
+    private val brand: AnnotatedString = buildAnnotatedString {
+        append("CAPod ")
+        pushStyle(SpanStyle(color = brandColor))
+        append("Pro")
+        pop()
+    }
+
+    @Test fun `marker in the middle shifts the styled postfix by the prefix`() {
+        val result = spliceBrandTitle("Get $BRAND_TITLE_MARKER", brand)
+
+        result.text shouldBe "Get CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe brandColor
+        result.spanStyles.single().start shouldBe 10
+        result.spanStyles.single().end shouldBe 13
+        result.text.substring(10, 13) shouldBe "Pro"
+    }
+
+    @Test fun `marker at the start keeps the postfix offsets inside the brand`() {
+        val result = spliceBrandTitle("$BRAND_TITLE_MARKER holen", brand)
+
+        result.text shouldBe "CAPod Pro holen"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+        result.text.substring(6, 9) shouldBe "Pro"
+    }
+
+    @Test fun `a duplicated marker renders the brand twice`() {
+        val result = spliceBrandTitle("$BRAND_TITLE_MARKER und $BRAND_TITLE_MARKER", brand)
+
+        result.text shouldBe "CAPod Pro und CAPod Pro"
+        result.spanStyles.size shouldBe 2
+        result.spanStyles[0].start shouldBe 6
+        result.spanStyles[0].end shouldBe 9
+        result.spanStyles[1].start shouldBe 20
+        result.spanStyles[1].end shouldBe 23
+        result.text.substring(20, 23) shouldBe "Pro"
+    }
+
+    @Test fun `a translation that lost the placeholder still shows the brand`() {
+        val result = spliceBrandTitle("Get Pro", brand)
+
+        result.text shouldBe "Get Pro CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe brandColor
+        result.spanStyles.single().start shouldBe 14
+        result.spanStyles.single().end shouldBe 17
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -46,6 +46,11 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.ACTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_preamble)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
+        // Preamble and mascot ship together in the hero card outside grace: one hero, one mascot,
+        // so a leftover standalone header next to the hero would fail here.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(0)
     }
 
     @Test
@@ -158,6 +163,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             .assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrades_gplay_unavailable_error))
             .assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(0)
     }
 
     @Test
@@ -428,6 +436,11 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             .assertCountEquals(1)
         composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
             .assertCountEquals(0)
+        // Owners get their mascot from the congrats hero only — the acquisition hero card and its
+        // preamble must stay away entirely.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_preamble)).assertCountEquals(0)
     }
 
     @Test
@@ -467,6 +480,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE_SPINNER).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(0)
+        // No preamble during grace, so the mascot has nothing to pair with: standalone header, no
+        // hero card.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE_RESTORE).assertCountEquals(0)
         // The grace card owns restore via its two-stage disclosure — the generic restore section
         // must not undercut the calm quiet stage with its own restore CTA.
@@ -518,6 +534,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE_SPINNER).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_GRUMPY).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.MASCOT_HAPPY).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
         // The aged episode is treated as likely-permanent: the offers come back so an expired
         // subscriber can switch without waiting out the full grace window. Still no sales pitch.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(1)

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -2,6 +2,8 @@ package eu.darken.capod.common.upgrade.ui
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
@@ -35,6 +37,54 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     // "CAPod Pro" — the composed flavor title the screen renders for owners and grace users.
     private val appNameWithPostfix: String
         get() = context.getString(R.string.app_name_pro)
+
+    // What the acquisition top bar must render: the translated pitch pattern with the composed
+    // brand formatted into it.
+    private val acquisitionTitle: String
+        get() = context.getString(R.string.upgrade_screen_title_template, appNameWithPostfix)
+
+    private fun acquisitionState() = GplayUpgradeUiState.Loaded(
+        subscriptionAction = SubscriptionAction.STANDARD,
+        subscriptionEnabled = true,
+        subscriptionPrice = "$12.99",
+        iapEnabled = true,
+        iapPrice = "$24.99",
+    )
+
+    @Test
+    fun `acquisition titles the screen with the brand inside the pitch sentence`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = acquisitionState())
+        }
+
+        composeRule.onAllNodesWithText(acquisitionTitle).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the acquisition title colors exactly the brand postfix`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = acquisitionState())
+        }
+
+        // The pitch splices in the SAME styled brand the status title uses: the upgraded color must
+        // land on the postfix only, never on the surrounding sentence.
+        val rendered = composeRule.onNodeWithText(acquisitionTitle)
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.Text]
+            .single()
+        // Derived like the production title does it: the postfix is the trailing word of the
+        // composed brand.
+        val postfix = appNameWithPostfix.split(" ")[1]
+
+        rendered.text shouldBe acquisitionTitle
+        rendered.spanStyles.size shouldBe 1
+        val span = rendered.spanStyles.single()
+        span.item.color shouldBe Color(context.getColor(R.color.brand_tertiary))
+        rendered.text.substring(span.start, span.end) shouldBe postfix
+        // Pins the range rather than just its content: only one candidate position exists.
+        rendered.text.indexOf(postfix) shouldBe span.start
+        rendered.text.lastIndexOf(postfix) shouldBe span.start
+    }
 
     @Test
     fun `loading state shows progress and hides actions`() {


### PR DESCRIPTION
## What changed

FOSS version: problems reading or saving the supporter status can no longer hang the upgrade screen or silently lose an unlock. If the status can't be read, the screen shows the error instead of loading forever, a user the app already knows is a supporter stays recognized, a successful unlock reaches the screen immediately even after an earlier failure, and a sponsor visit that collides with a newer one no longer overwrites it.

Both versions: the upgrade screen got a visual refresh — the mascot and the intro text now share one card that adapts to narrow screens and large font sizes, the title reads "Get CAPod Pro" with "Pro" in the highlight color the rest of the app uses, and the retry button on the "Prices unavailable" card now matches the card it sits on. The "Google Play is unavailable" error dialog now offers opening Google Play's app settings directly, next to a "Dismiss" button — previously it could only be acknowledged. Also fixed: a debug-log recording started right after boot could be misjudged by the too-short-recording check.

## Technical Context

- The FOSS `upgradeInfo` flow previously died inside `shareIn` when the cache read threw — collectors hung forever. Read failures now surface as a settled error `Info` via a `refreshTrigger.flatMapLatest` block with the catch inside, so `refresh()` (also triggered by a successful persist) resubscribes and recovers. One deliberate improvement over the sibling-app donor shape: the last-known-entitlement tracking sits INSIDE the `flatMapLatest` block, upstream of its channel buffer — the donor records it downstream, where a quick throw can outrun the recording and revoke a seen entitlement (the new `a late cache failure keeps the last known entitlement` test caught exactly that race here; the donor passes it by timing luck and will be aligned separately).
- The pending sponsor-marker restore is now conditional (`handle.contains` check) so a newer launch armed during a failing attempt survives; the small check-then-act window is documented as accepted.
- The recorder's monotonic base uses a nullable sentinel instead of `0L`. `elapsedRealtime()` can legitimately be `0` right after boot — the old in-band sentinel diverted such a recording to the wall-clock resume path, which a clock jump could fool. A new test pins the monotonic path at exactly zero.
- The error dialog gained minimal fix-action support (`fixActionLabel`/`fixAction` on `LocalizedError`); errors without an action keep the OK-only shape, pinned by a test. The Google Play action is a generic troubleshooting affordance — the exception also wraps transient timeout failures by design.
- The acquisition title splices the styled brand (the same composed "CAPod Pro" the status title uses) into a translated template via a marker formatted through Android's own formatter; the old `upgrade_capod_label` is untouched because both home-screen widgets use it. New strings are base-locale only until Crowdin fills them.
- Review guidance: the hero card renders under exactly the prior conditions (grace keeps the standalone header and no sales copy; owners keep the congrats hero); screen tests assert hero presence/absence per state plus a semantics-level check that exactly the "Pro" token carries the highlight color. The DynamicStateFlow contention test gained the subscription barrier and echo non-vacuity assertion from the refined sibling version — it could previously pass without exercising contention.
