### PR TITLE
General: Ask happy users for a Play Store review

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,6 +198,9 @@ dependencies {
     "gplayImplementation"("com.android.billingclient:billing:8.3.0")
     "gplayImplementation"("com.android.billingclient:billing-ktx:8.3.0")
 
+    "gplayImplementation"("com.google.android.play:review:2.0.2")
+    "gplayImplementation"("com.google.android.play:review-ktx:2.0.2")
+
     // Robolectric-backed Compose UI tests (run as regular unit tests via the vintage engine).
     testImplementation(platform("androidx.compose:compose-bom:${Versions.Compose.bom}"))
     testImplementation("androidx.compose.ui:ui-test-junit4")

--- a/app/src/foss/java/eu/darken/capod/common/review/FossReviewTool.kt
+++ b/app/src/foss/java/eu/darken/capod/common/review/FossReviewTool.kt
@@ -1,0 +1,31 @@
+package eu.darken.capod.common.review
+
+import android.app.Activity
+import eu.darken.capod.common.debug.logging.Logging.Priority.INFO
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FossReviewTool @Inject constructor() : ReviewTool {
+
+
+    override val state: Flow<ReviewTool.State> = flowOf(ReviewTool.State())
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        // NOOP
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+        // NOOP
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "FOSS")
+    }
+}

--- a/app/src/foss/java/eu/darken/capod/common/review/ReviewModule.kt
+++ b/app/src/foss/java/eu/darken/capod/common/review/ReviewModule.kt
@@ -1,0 +1,16 @@
+package eu.darken.capod.common.review
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: FossReviewTool): ReviewTool
+}

--- a/app/src/gplay/java/eu/darken/capod/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/review/GplayReviewTool.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -65,6 +66,13 @@ class GplayReviewTool @Inject constructor(
         hasPaidForPro && !isSnoozed && !hasReviewed
     }
         .distinctUntilChanged()
+        // Upstream of the shares below: an exception there would kill the sharing coroutine on
+        // AppScope (crashing the process) instead of reaching any downstream `catch`.
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Eligibility failed: ${e.asLog()}" }
+            emit(false)
+        }
 
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
@@ -107,6 +115,11 @@ class GplayReviewTool @Inject constructor(
     }
         .throttleLatest(500)
         .onStart { emit(ReviewTool.State()) }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "State failed: ${e.asLog()}" }
+            emit(ReviewTool.State())
+        }
         .replayingShare(appScope)
 
     // Single-flight: a second tap must not queue up behind the first, or Play's flow would be

--- a/app/src/gplay/java/eu/darken/capod/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/review/GplayReviewTool.kt
@@ -1,0 +1,194 @@
+package eu.darken.capod.common.review
+
+import android.app.Activity
+import com.google.android.play.core.ktx.launchReview
+import com.google.android.play.core.ktx.requestReview
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.capod.common.coroutine.AppScope
+import eu.darken.capod.common.datastore.value
+import eu.darken.capod.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.capod.common.debug.logging.Logging.Priority.INFO
+import eu.darken.capod.common.debug.logging.Logging.Priority.WARN
+import eu.darken.capod.common.debug.logging.asLog
+import eu.darken.capod.common.debug.logging.log
+import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.flow.replayingShare
+import eu.darken.capod.common.flow.throttleLatest
+import eu.darken.capod.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.sync.Mutex
+import java.time.Duration
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
+
+@Singleton
+class GplayReviewTool @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    private val settings: ReviewSettings,
+    private val manager: ReviewManager,
+    upgradeRepo: UpgradeRepo,
+) : ReviewTool {
+
+    // Test seam: the probe backoff runs on AppScope (a real dispatcher), so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
+
+    // Local bookkeeping only: decided without talking to Play, so an ineligible user never
+    // triggers a Play round-trip.
+    private val isLocallyEligible: Flow<Boolean> = combine(
+        settings.lastDismissed.flow,
+        settings.reviewedAt.flow,
+        upgradeRepo.upgradeInfo,
+    ) { lastDismissed, reviewedAt, upgradeInfo ->
+        val now = Instant.now()
+
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
+        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+        .distinctUntilChanged()
+
+    // Only probed once the user is eligible: Play counts requests against the app's quota, and an
+    // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
+    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+        .flatMapLatest { eligible ->
+            if (!eligible) return@flatMapLatest flowOf(false)
+
+            flow {
+                for (attempt in 1..PROBE_ATTEMPTS) {
+                    val info = try {
+                        manager.requestReview()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
+                        continue
+                    }
+                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+                    emit(info.canShow)
+                    return@flow
+                }
+                // Re-probed when eligibility changes or on the next process start
+                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
+                emit(false)
+            }
+        }
+        .replayingShare(appScope)
+
+    override val state: Flow<ReviewTool.State> = combine(
+        isLocallyEligible,
+        isReviewAvailable,
+        settings.reviewedAt.flow,
+    ) { eligible, available, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+        ReviewTool.State(
+            shouldAskForReview = eligible && available,
+            hasReviewed = reviewedAt != null,
+        )
+    }
+        .throttleLatest(500)
+        .onStart { emit(ReviewTool.State()) }
+        .replayingShare(appScope)
+
+    // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
+    // launched again the moment the user returns from it.
+    private val reviewLock = Mutex()
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        settings.lastDismissed.value(Instant.now())
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+
+        if (!reviewLock.tryLock()) {
+            log(TAG, WARN) { "reviewNow(...) is already in progress, skipping" }
+            return
+        }
+
+        try {
+            // ReviewInfo is short lived, Google wants it requested shortly before the launch,
+            // a token cached at process start is likely stale by the time the user taps.
+            val reviewInfo = try {
+                manager.requestReview()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient failure is not user intent: don't snooze the card, the next tap retries
+                log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
+                return
+            }
+            log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (!reviewInfo.canShow) {
+                // Play's quota verdict, asking again right away would be pointless
+                log(TAG, WARN) { "Play says we can't show the prompt, snoozing" }
+                settings.lastDismissed.value(Instant.now())
+                return
+            }
+
+            if (activity.isFinishing || activity.isDestroyed) {
+                log(TAG, WARN) { "Activity is gone, aborting: $activity" }
+                return
+            }
+
+            val reviewTime = measureTimeMillis {
+                try {
+                    manager.launchReview(activity, reviewInfo)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
+                    return
+                }
+            }
+            log(TAG) { "Review completed after ${reviewTime}ms" }
+
+            if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
+                log(TAG, INFO) { "Marking review as completed" }
+                settings.reviewedAt.value(Instant.now())
+            } else {
+                log(TAG, INFO) { "Review was too quick, counting as dismiss" }
+                settings.lastDismissed.value(Instant.now())
+            }
+        } finally {
+            reviewLock.unlock()
+        }
+    }
+
+    private val ReviewInfo.canShow: Boolean
+        get() = when {
+            toString().contains("isNoOp=true") -> false
+            else -> true
+        }
+
+    private fun ReviewInfo.desc(): String {
+        return "ReviewInfo(canShow=$canShow, ${toString()})"
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "Gplay")
+        private const val PROBE_ATTEMPTS = 3
+        private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
+    }
+}

--- a/app/src/gplay/java/eu/darken/capod/common/review/ReviewModule.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/review/ReviewModule.kt
@@ -1,0 +1,27 @@
+package eu.darken.capod.common.review
+
+import android.content.Context
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: GplayReviewTool): ReviewTool
+
+    companion object {
+        @Provides
+        @Singleton
+        fun reviewManager(@ApplicationContext context: Context): ReviewManager = ReviewManagerFactory.create(context)
+    }
+}

--- a/app/src/gplay/java/eu/darken/capod/common/review/ReviewSettings.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/review/ReviewSettings.kt
@@ -1,0 +1,47 @@
+package eu.darken.capod.common.review
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.capod.common.datastore.createValue
+import eu.darken.capod.common.debug.logging.logTag
+import eu.darken.capod.common.serialization.InstantEpochMillisSerializer
+import eu.darken.capod.common.serialization.SerializationCapod
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.json.Json
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReviewSettings @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @SerializationCapod json: Json,
+) {
+
+    private val Context.dataStore by preferencesDataStore(name = "settings_review_gplay")
+
+    val dataStore: DataStore<Preferences>
+        get() = context.dataStore
+
+    // Explicit serializer: `java.time.Instant` has no `@Serializable` companion, so the reified
+    // `serializer<T>()` the inline overload uses cannot resolve one for it.
+    val lastDismissed = dataStore.createValue(
+        key = "review.dismissedAt",
+        defaultValue = null as Instant?,
+        json = json,
+        serializer = InstantEpochMillisSerializer.nullable,
+    )
+    val reviewedAt = dataStore.createValue(
+        key = "review.reviewedAt",
+        defaultValue = null as Instant?,
+        json = json,
+        serializer = InstantEpochMillisSerializer.nullable,
+    )
+
+    companion object {
+        internal val TAG = logTag("Review", "Settings", "Gplay")
+    }
+}

--- a/app/src/main/java/eu/darken/capod/common/review/ReviewTool.kt
+++ b/app/src/main/java/eu/darken/capod/common/review/ReviewTool.kt
@@ -1,0 +1,18 @@
+package eu.darken.capod.common.review
+
+import android.app.Activity
+import kotlinx.coroutines.flow.Flow
+
+interface ReviewTool {
+
+    val state: Flow<State>
+
+    data class State(
+        val shouldAskForReview: Boolean = false,
+        val hasReviewed: Boolean = false,
+    )
+
+    suspend fun dismiss()
+
+    suspend fun reviewNow(activity: Activity)
+}

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.main.ui.overview
 
+import android.app.Activity
 import android.content.Intent
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -62,6 +63,7 @@ import eu.darken.capod.main.ui.overview.cards.MonitoringActiveCard
 import eu.darken.capod.main.ui.overview.cards.NoProfilesCard
 import eu.darken.capod.main.ui.overview.cards.PermissionCard
 import eu.darken.capod.main.ui.overview.cards.ReactionsMovedHintCard
+import eu.darken.capod.main.ui.overview.cards.ReviewCard
 import eu.darken.capod.main.ui.overview.cards.SinglePodsCard
 import eu.darken.capod.main.ui.overview.cards.TroubleshootSuggestionCard
 import eu.darken.capod.main.ui.overview.cards.UnknownPodDeviceCard
@@ -163,6 +165,10 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
     val state by vm.state.collectAsStateWithLifecycle(initialValue = null)
     val currentState = state ?: return
 
+    // Play's in-app review flow needs a hosting Activity. Without one the card still renders, but
+    // with its review action disabled instead of silently doing nothing.
+    val activity = context as? Activity
+
     OverviewScreen(
         state = currentState,
         snackbarHostState = snackbarHostState,
@@ -191,6 +197,8 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
         onSetupPairedDevice = {
             currentState.soleProfileId?.let { vm.goToEditProfile(it) } ?: vm.goToDeviceManager()
         },
+        onReviewNow = activity?.let { host -> { vm.reviewNow(host) } },
+        onReviewDismiss = { vm.reviewDismiss() },
     )
 }
 
@@ -210,6 +218,8 @@ fun OverviewScreen(
     onEditProfile: (PodDevice) -> Unit = {},
     onToggleDeviceExpansion: (PodDevice) -> Unit = {},
     onSetupPairedDevice: () -> Unit = {},
+    onReviewNow: (() -> Unit)? = null,
+    onReviewDismiss: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -309,6 +319,16 @@ fun OverviewScreen(
             if (state.profiles.isEmpty() && !state.isScanBlocked && state.isBluetoothEnabled) {
                 item(key = "no_profiles") {
                     NoProfilesCard(onManageDevices = onManageDevices)
+                }
+            }
+
+            // 3b. Review prompt, only shown while no higher priority card is on screen
+            if (state.showReviewCard) {
+                item(key = "review") {
+                    ReviewCard(
+                        onReview = onReviewNow,
+                        onDismiss = onReviewDismiss,
+                    )
                 }
             }
 

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.main.ui.overview
 
+import android.app.Activity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.capod.common.TimeSource
 import eu.darken.capod.common.bluetooth.BluetoothManager2
@@ -15,6 +16,7 @@ import eu.darken.capod.common.flow.combine
 import eu.darken.capod.common.flow.throttleLatest
 import eu.darken.capod.common.navigation.Nav
 import eu.darken.capod.common.permissions.Permission
+import eu.darken.capod.common.review.ReviewTool
 import eu.darken.capod.common.uix.ViewModel4
 import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.core.GeneralSettings
@@ -65,6 +67,7 @@ class OverviewViewModel @Inject constructor(
     private val monitorModeResolver: MonitorModeResolver,
     private val batteryEstimator: BatteryEstimator,
     private val timeSource: TimeSource,
+    private val reviewTool: ReviewTool,
 ) : ViewModel4(dispatcherProvider) {
 
     val requestPermissionEvent = SingleEventFlow<Permission>()
@@ -92,6 +95,7 @@ class OverviewViewModel @Inject constructor(
         val showTroubleshootSuggestion: Boolean,
         val batteryEstimates: Map<String, BatteryEstimate>,
         val effectiveMode: MonitorMode,
+        val reviewState: ReviewTool.State,
     )
 
     /**
@@ -123,19 +127,23 @@ class OverviewViewModel @Inject constructor(
         .onStart { emit(false) }
         .distinctUntilChanged()
 
-    private val overviewUiSettings = combineFlows(
+    private val overviewUiSettings = combine(
         generalSettings.reactionsHintDismissed.flow,
         generalSettings.hideUnmatchedDevices.flow,
         troubleshootSuggestion,
         batteryEstimator.estimates,
         monitorModeResolver.effectiveMode,
-    ) { reactionsHintDismissed, hideUnmatched, showTroubleshootSuggestion, batteryEstimates, effectiveMode ->
+        // The review prompt is a nice-to-have: a failing review backend must never take the whole
+        // overview down with it, so it falls back to "don't ask".
+        reviewTool.state.catch { emit(ReviewTool.State()) },
+    ) { reactionsHintDismissed, hideUnmatched, showTroubleshootSuggestion, batteryEstimates, effectiveMode, reviewState ->
         OverviewUiSettings(
             reactionsHintDismissed = reactionsHintDismissed,
             hideUnmatchedDevices = hideUnmatched,
             showTroubleshootSuggestion = showTroubleshootSuggestion,
             batteryEstimates = batteryEstimates,
             effectiveMode = effectiveMode,
+            reviewState = reviewState,
         )
     }
 
@@ -212,7 +220,7 @@ class OverviewViewModel @Inject constructor(
         val currentProfileIds = profiles.map { it.id }.toSet()
         val prunedExpandedIds = expandedIds.filter { it in currentProfileIds }.toSet()
 
-        State(
+        val state = State(
             now = timeSource.now(),
             permissions = permissions,
             devices = devices,
@@ -228,6 +236,15 @@ class OverviewViewModel @Inject constructor(
             showTroubleshootSuggestion = uiSettings.showTroubleshootSuggestion,
             batteryEstimates = uiSettings.batteryEstimates,
         )
+
+        // Asking for a review is the lowest priority thing the overview can say: it only appears on
+        // an otherwise quiet screen, never stacked on top of something the user has to act on.
+        val showReviewCard = uiSettings.reviewState.shouldAskForReview && !state.hasHigherPriorityCard
+        if (uiSettings.reviewState.shouldAskForReview && !showReviewCard) {
+            log(TAG) { "Could show review card but higher priority cards are currently being shown" }
+        }
+
+        state.copy(showReviewCard = showReviewCard)
     }.asLiveState()
 
     enum class BluetoothIconState { HIDDEN, DISABLED, NEARBY, CONNECTED }
@@ -249,6 +266,7 @@ class OverviewViewModel @Inject constructor(
         val hideUnmatchedDevices: Boolean = false,
         val showTroubleshootSuggestion: Boolean = false,
         val batteryEstimates: Map<String, BatteryEstimate> = emptyMap(),
+        val showReviewCard: Boolean = false,
     ) {
         val isScanBlocked: Boolean get() = permissions.any { it.isScanBlocking }
 
@@ -311,6 +329,18 @@ class OverviewViewModel @Inject constructor(
                 profiledDevices.isEmpty() && !shouldShowUnmatchedSection -> MonitoringStatus.SEARCHING
                 else -> MonitoringStatus.HIDDEN
             }
+
+        /**
+         * Whether the overview is currently showing a card that outranks the review prompt: a
+         * missing permission, the troubleshooter hint, the background-monitoring-off notice or the
+         * no-profiles setup card. All of those ask the user to do something, so the review prompt
+         * stays hidden while any of them is on screen.
+         */
+        val hasHigherPriorityCard: Boolean
+            get() = permissions.isNotEmpty() ||
+                    showTroubleshootSuggestion ||
+                    monitoringStatus == MonitoringStatus.BACKGROUND_OFF ||
+                    (profiles.isEmpty() && !isScanBlocked && isBluetoothEnabled)
 
         val soleProfileId: ProfileId? get() = profiles.singleOrNull()?.id
 
@@ -390,6 +420,16 @@ class OverviewViewModel @Inject constructor(
         launch {
             generalSettings.reactionsHintDismissed.value(true)
         }
+    }
+
+    fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+        launch { reviewTool.reviewNow(activity) }
+    }
+
+    fun reviewDismiss() {
+        log(TAG, INFO) { "reviewDismiss()" }
+        launch { reviewTool.dismiss() }
     }
 
     fun requestPermission(permission: Permission) {

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewViewModel.kt
@@ -332,14 +332,15 @@ class OverviewViewModel @Inject constructor(
 
         /**
          * Whether the overview is currently showing a card that outranks the review prompt: a
-         * missing permission, the troubleshooter hint, the background-monitoring-off notice or the
-         * no-profiles setup card. All of those ask the user to do something, so the review prompt
-         * stays hidden while any of them is on screen.
+         * missing permission, the troubleshooter hint, the background-monitoring-off notice, the
+         * no-profiles setup card or the enable-Bluetooth prompt. All of those ask the user to do
+         * something, so the review prompt stays hidden while any of them is on screen.
          */
         val hasHigherPriorityCard: Boolean
             get() = permissions.isNotEmpty() ||
                     showTroubleshootSuggestion ||
                     monitoringStatus == MonitoringStatus.BACKGROUND_OFF ||
+                    !isBluetoothEnabled ||
                     (profiles.isEmpty() && !isScanBlocked && isBluetoothEnabled)
 
         val soleProfileId: ProfileId? get() = profiles.singleOrNull()?.id

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/ReviewCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/ReviewCard.kt
@@ -1,0 +1,96 @@
+package eu.darken.capod.main.ui.overview.cards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.Preview2
+import eu.darken.capod.common.compose.PreviewWrapper
+
+/**
+ * Asks the user to leave a review. [onReview] is null when no hosting Activity is available, Play's
+ * in-app review flow can't be launched without one, so the action is shown disabled instead.
+ */
+@Composable
+fun ReviewCard(
+    onReview: (() -> Unit)?,
+    onDismiss: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.TwoTone.Stars,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 12.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = stringResource(R.string.review_app_review_action),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.review_app_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(R.string.review_app_dismiss_action))
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = { onReview?.invoke() },
+                    enabled = onReview != null,
+                ) {
+                    Text(text = stringResource(R.string.review_app_review_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun ReviewCardPreview() = PreviewWrapper {
+    ReviewCard(
+        onReview = {},
+        onDismiss = {},
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,6 +534,9 @@
     <string name="overview_card_missing_paired_device_consequence">Without one, device settings and auto-connect aren\'t available.</string>
     <string name="overview_reactions_hint_title">Reactions are per device</string>
     <string name="overview_reactions_hint_body">Auto-play, auto-pause and pop-ups are now configured per device. Tap the settings icon on a card while your headphones are connected.</string>
+    <string name="review_app_review_action">Review</string>
+    <string name="review_app_dismiss_action">Maybe later</string>
+    <string name="review_app_body">Would you like to leave CAPod a review? ❤️</string>
 
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
@@ -5,6 +5,7 @@ import eu.darken.capod.common.bluetooth.BluetoothDevice2
 import eu.darken.capod.common.bluetooth.BluetoothManager2
 import eu.darken.capod.common.debug.Bugs
 import eu.darken.capod.common.permissions.Permission
+import eu.darken.capod.common.review.ReviewTool
 import eu.darken.capod.common.upgrade.UpgradeRepo
 import eu.darken.capod.main.core.GeneralSettings
 import eu.darken.capod.main.core.MonitorMode
@@ -60,6 +61,7 @@ class OverviewViewModelTest : BaseTest() {
     private lateinit var profilesRepo: DeviceProfilesRepo
     private lateinit var monitorModeResolver: MonitorModeResolver
     private lateinit var batteryEstimator: BatteryEstimator
+    private lateinit var reviewTool: ReviewTool
     private val timeSource: TimeSource = TestTimeSource()
 
     private lateinit var missingPermissionsFlow: MutableStateFlow<Set<Permission>>
@@ -70,6 +72,7 @@ class OverviewViewModelTest : BaseTest() {
     private lateinit var hadLegacyReactionDataFlow: MutableStateFlow<Boolean>
     private lateinit var upgradeInfoFlow: MutableStateFlow<UpgradeRepo.Info>
     private lateinit var effectiveModeFlow: MutableStateFlow<MonitorMode>
+    private lateinit var reviewStateFlow: MutableStateFlow<ReviewTool.State>
     private lateinit var fakeReactionsHintDismissed: FakeDataStoreValue<Boolean>
     private lateinit var fakeHideUnmatchedDevices: FakeDataStoreValue<Boolean>
 
@@ -88,6 +91,7 @@ class OverviewViewModelTest : BaseTest() {
             every { it.error } returns null
         })
         effectiveModeFlow = MutableStateFlow(MonitorMode.AUTOMATIC)
+        reviewStateFlow = MutableStateFlow(ReviewTool.State())
         fakeReactionsHintDismissed = FakeDataStoreValue(false)
         fakeHideUnmatchedDevices = FakeDataStoreValue(false)
         Bugs.isDebug.value = false
@@ -131,6 +135,12 @@ class OverviewViewModelTest : BaseTest() {
             every { it.profiles } returns profilesFlow
             every { it.hadLegacyReactionData } returns hadLegacyReactionDataFlow
         }
+
+        // Explicitly stubbed, never relaxed: a relaxed mock hands back a flow that never emits,
+        // which would starve the combine backing `state` and hang every test in this class.
+        reviewTool = mockk<ReviewTool>().also {
+            every { it.state } returns reviewStateFlow
+        }
     }
 
     @AfterEach
@@ -152,6 +162,7 @@ class OverviewViewModelTest : BaseTest() {
         monitorModeResolver = monitorModeResolver,
         batteryEstimator = batteryEstimator,
         timeSource = timeSource,
+        reviewTool = reviewTool,
     )
 
     @Nested
@@ -845,6 +856,94 @@ class OverviewViewModelTest : BaseTest() {
             devicesFlow.value = listOf(PodDevice(profileId = null, ble = mockk(relaxed = true), aap = null))
             advanceTimeBy(10_000)
             latest!!.showTroubleshootSuggestion shouldBe false
+        }
+    }
+
+    @Nested
+    inner class ReviewCardTests {
+
+        private val connectedAddress = "AA:BB:CC:DD:EE:FF"
+
+        private fun profile(): DeviceProfile = AppleDeviceProfile(
+            label = "Test",
+            model = PodModel.AIRPODS_PRO2,
+            address = connectedAddress,
+        )
+
+        /** Quiet overview: a set up profile, no missing permissions, nothing else to act on. */
+        private fun quietOverview() {
+            profilesFlow.value = listOf(profile())
+            missingPermissionsFlow.value = emptySet()
+            effectiveModeFlow.value = MonitorMode.AUTOMATIC
+            reviewStateFlow.value = ReviewTool.State(shouldAskForReview = true)
+        }
+
+        @Test
+        fun `shown on a quiet overview when the tool asks for it`() = runTest(testDispatcher) {
+            quietOverview()
+
+            val vm = createViewModel()
+
+            vm.state.first().showReviewCard shouldBe true
+        }
+
+        @Test
+        fun `not shown while the tool does not ask for it`() = runTest(testDispatcher) {
+            quietOverview()
+            reviewStateFlow.value = ReviewTool.State(shouldAskForReview = false)
+
+            val vm = createViewModel()
+
+            vm.state.first().showReviewCard shouldBe false
+        }
+
+        @Test
+        fun `suppressed by a missing permission`() = runTest(testDispatcher) {
+            quietOverview()
+            missingPermissionsFlow.value = setOf(Permission.BLUETOOTH_SCAN)
+
+            val vm = createViewModel()
+
+            vm.state.first().showReviewCard shouldBe false
+        }
+
+        @Test
+        fun `suppressed by the no-profiles setup card`() = runTest(testDispatcher) {
+            quietOverview()
+            profilesFlow.value = emptyList()
+
+            val vm = createViewModel()
+
+            vm.state.first().showReviewCard shouldBe false
+        }
+
+        @Test
+        fun `suppressed by the background-monitoring-off card`() = runTest(testDispatcher) {
+            quietOverview()
+            effectiveModeFlow.value = MonitorMode.MANUAL
+
+            val vm = createViewModel()
+
+            vm.state.first().showReviewCard shouldBe false
+        }
+
+        @Test
+        fun `suppressed by the troubleshooter suggestion`() = runTest(testDispatcher) {
+            quietOverview()
+            // Connected via audio but no live data: the hint appears after its debounce window.
+            connectedDevicesFlow.value = listOf(
+                mockk<BluetoothDevice2>(relaxed = true) { every { address } returns connectedAddress }
+            )
+            devicesFlow.value = emptyList()
+
+            val vm = createViewModel()
+            var latest: OverviewViewModel.State? = null
+            backgroundScope.launch { vm.state.collect { latest = it } }
+
+            advanceTimeBy(20_000)
+
+            latest!!.showTroubleshootSuggestion shouldBe true
+            latest!!.showReviewCard shouldBe false
         }
     }
 

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/OverviewViewModelTest.kt
@@ -928,6 +928,16 @@ class OverviewViewModelTest : BaseTest() {
         }
 
         @Test
+        fun `suppressed by the enable-Bluetooth prompt`() = runTest(testDispatcher) {
+            quietOverview()
+            isBluetoothEnabledFlow.value = false
+
+            val vm = createViewModel()
+
+            vm.state.first().showReviewCard shouldBe false
+        }
+
+        @Test
         fun `suppressed by the troubleshooter suggestion`() = runTest(testDispatcher) {
             quietOverview()
             // Connected via audio but no live data: the hint appears after its debounce window.

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/cards/ReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/cards/ReviewCardTest.kt
@@ -1,0 +1,79 @@
+package eu.darken.capod.main.ui.overview.cards
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.PreviewWrapper
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class ReviewCardTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val bodyText get() = context.getString(R.string.review_app_body)
+    private val reviewLabel get() = context.getString(R.string.review_app_review_action)
+    private val dismissLabel get() = context.getString(R.string.review_app_dismiss_action)
+
+    // The card's title reuses the review label, so the action is matched by its click semantics.
+    private val reviewButton get() = hasText(reviewLabel) and hasClickAction()
+
+    @Test
+    fun `renders the body and both actions`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(onReview = {}, onDismiss = {})
+            }
+        }
+
+        composeRule.onNodeWithText(bodyText).assertExists()
+        composeRule.onNodeWithText(dismissLabel).assertExists()
+        composeRule.onNode(reviewButton).assertIsEnabled()
+    }
+
+    @Test
+    fun `both actions invoke their callback`() {
+        var reviewed = false
+        var dismissed = false
+
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(
+                    onReview = { reviewed = true },
+                    onDismiss = { dismissed = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(dismissLabel).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            assertTrue(dismissed)
+            assertTrue(reviewed)
+        }
+    }
+
+    @Test
+    fun `the review action is disabled without a hosting activity`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                // Null callback = no Activity to launch Play's review flow with.
+                ReviewCard(onReview = null, onDismiss = {})
+            }
+        }
+
+        composeRule.onNode(reviewButton).assertIsNotEnabled()
+        // Dismissing has to stay possible, it doesn't need an Activity.
+        composeRule.onNodeWithText(dismissLabel).assertIsEnabled()
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/review/GplayReviewToolTest.kt
@@ -19,11 +19,13 @@ import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -232,6 +234,32 @@ class GplayReviewToolTest : BaseTest() {
         tool().computedState().shouldAskForReview shouldBe false
 
         verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `corrupt review settings fall back to the default state`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        lastDismissedMock = rwSetting(null)
+        // A malformed stored timestamp throws when the DataStore flow is read.
+        reviewedAtMock = mockk<DataStoreValue<Instant?>>(relaxed = true).apply {
+            every { flow } returns flow { throw SerializationException("corrupt") }
+        }
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns Instant.now().minus(Duration.ofDays(30))
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        val tool = GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        )
+
+        // The failure has to be absorbed upstream of the share: on the shared coroutine it would go
+        // to AppScope (no handler, i.e. a process crash) and never reach a downstream collector.
+        tool.computedState() shouldBe ReviewTool.State()
     }
 
     @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/capod/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/review/GplayReviewToolTest.kt
@@ -1,0 +1,261 @@
+package eu.darken.capod.common.review
+
+import android.app.Activity
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.capod.common.datastore.DataStoreValue
+import eu.darken.capod.common.upgrade.UpgradeRepo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import java.time.Instant
+
+class GplayReviewToolTest : BaseTest() {
+
+    private val manager = mockk<ReviewManager>()
+    private val settings = mockk<ReviewSettings>()
+    private val upgradeRepo = mockk<UpgradeRepo>()
+    private lateinit var lastDismissedMock: DataStoreValue<Instant?>
+    private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+
+    // Relaxed so the `.value(new)` writes (which go through `update`) succeed and can be verified.
+    private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns flowOf(initial)
+    }
+
+    // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
+    // state throttle would burn real time.
+    private fun TestScope.tool(
+        upgradedAt: Instant? = Instant.now().minus(Duration.ofDays(30)),
+        lastDismissed: Instant? = null,
+        reviewedAt: Instant? = null,
+    ): GplayReviewTool {
+        lastDismissedMock = rwSetting(lastDismissed)
+        reviewedAtMock = rwSetting(reviewedAt)
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns upgradedAt
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        return GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        ).apply { probeRetryDelay = Duration.ofSeconds(1) }
+    }
+
+    private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
+        val info = mockk<ReviewInfo>()
+        // There is no public accessor for the isNoOp flag, the tool sniffs the toString().
+        every { info.toString() } returns when {
+            canShow -> "ReviewInfo{pendingIntent=PendingIntent{1}, isNoOp=false}"
+            else -> "ReviewInfo{pendingIntent=null, isNoOp=true}"
+        }
+        return info
+    }
+
+    private fun activity(finishing: Boolean = false, destroyed: Boolean = false) = mockk<Activity>().apply {
+        every { isFinishing } returns finishing
+        every { isDestroyed } returns destroyed
+    }
+
+    private fun launchOk(): Task<Void?> = Tasks.forResult(null)
+
+    // The `onStart` seed is not a computed state, every assertion has to await the first real one.
+    private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    @Test fun `an eligible user is asked for a review`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool().computedState().apply {
+            shouldAskForReview shouldBe true
+            hasReviewed shouldBe false
+        }
+    }
+
+    @Test fun `a user who has not paid for pro long enough is never probed`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(upgradedAt = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        // Eligibility is decided locally first: Play's request quota is only spent on candidates.
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a recently dismissed card is not shown again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(lastDismissed = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `reviewNow launches with a freshly requested ReviewInfo`() = runTest2 {
+        // ReviewInfo is short lived, the token used for the launch must not be the one the
+        // availability probe obtained (potentially hours) earlier.
+        val probeInfo = reviewInfo()
+        val freshInfo = reviewInfo()
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forResult(probeInfo),
+            Tasks.forResult(freshInfo),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.computedState().shouldAskForReview shouldBe true
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(activity, freshInfo) }
+        verify(exactly = 0) { manager.launchReviewFlow(activity, probeInfo) }
+    }
+
+    @Test fun `a failed fresh request keeps the card and persists nothing`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // A transient failure is not user intent, the next tap has to be able to retry.
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a fresh isNoOp answer snoozes the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // isNoOp is Play's quota verdict, asking again right away would be pointless.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a failed launch persists nothing and does not escape`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns Tasks.forException(RuntimeException("launch failed"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        // The fresh request is a Play round-trip, the activity can be gone by the time it returns.
+        tool.reviewNow(activity(finishing = true))
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `overlapping reviewNow calls launch the flow only once`() = runTest2 {
+        // Park the first call on an unresolved Play request, so the second genuinely overlaps it.
+        val successListener = slot<OnSuccessListener<in ReviewInfo>>()
+        val pendingRequest = mockk<Task<ReviewInfo>>().apply {
+            every { isComplete } returns false
+            every { addOnSuccessListener(capture(successListener)) } returns this
+            every { addOnFailureListener(any<OnFailureListener>()) } returns this
+        }
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            pendingRequest,
+            // A second request would resolve instantly, so a broken guard shows up as a launch.
+            Tasks.forResult(reviewInfo()),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        val first = launch { tool.reviewNow(activity) }
+        advanceUntilIdle()
+
+        tool.reviewNow(activity)
+
+        successListener.captured.onSuccess(reviewInfo())
+        first.join()
+
+        // Without the single-flight guard the second tap would run its own request+launch, and
+        // Play's flow would pop up again the moment the user returned from the first one.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(any(), any()) }
+    }
+
+    @Test fun `a probe that fails once still resolves within the retry budget`() = runTest2 {
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+
+        tool().computedState().shouldAskForReview shouldBe true
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that keeps failing hides the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        shouldThrow<CancellationException> { tool.reviewNow(activity()) }
+
+        // A cancelled coroutine is not a Play failure: no launch, no bookkeeping.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `cancellation during the probe is not swallowed into the retry path`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        // Cancellation takes the probe down with its scope, no verdict is ever computed (virtual
+        // time, so the timeout costs nothing).
+        val computed = withTimeoutOrNull(Duration.ofMinutes(1).toMillis()) { tool.computedState() }
+
+        computed shouldBe null
+        // The general failure path would have burned all 3 attempts and settled on "unavailable".
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/review/ReviewSettingsTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/review/ReviewSettingsTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.capod.common.review
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.common.datastore.value
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ReviewSettingsTest : BaseTest() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // One test method on purpose: ReviewSettings is a @Singleton whose DataStore is bound to the
+    // Context property delegate, and DataStore forbids two active instances on the same file.
+    @Test
+    fun `the review timestamps round-trip through the real DataStore`() = runTest {
+        // Real time and real I/O: the DataStore does its work off the test scheduler.
+        withContext(Dispatchers.IO) {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+
+            // Real DataStore, no mocks: this catches a mismatch between what the explicit
+            // Instant serializer writes and what the reader expects to find.
+            val settings = ReviewSettings(context, json)
+
+            settings.lastDismissed.value() shouldBe null
+            settings.reviewedAt.value() shouldBe null
+
+            // Millisecond granularity, that is all InstantEpochMillisSerializer preserves.
+            val dismissedAt = Instant.ofEpochMilli(1_700_000_000_000L)
+            val reviewedAt = Instant.ofEpochMilli(1_700_000_123_456L)
+
+            settings.lastDismissed.value(dismissedAt)
+            settings.reviewedAt.value(reviewedAt)
+
+            settings.lastDismissed.value() shouldBe dismissedAt
+            settings.reviewedAt.value() shouldBe reviewedAt
+
+            // Writing null clears the key instead of storing a literal "null" that would then be
+            // decoded on the next read.
+            settings.lastDismissed.value(null)
+            settings.lastDismissed.value() shouldBe null
+            settings.dataStore.data.first().contains(DISMISSED_KEY) shouldBe false
+
+            // onErrorFallbackToDefault is off, so corrupt data surfaces instead of silently
+            // resetting the snooze/reviewed bookkeeping to "never".
+            settings.dataStore.edit { it[REVIEWED_KEY] = "not-a-timestamp" }
+            shouldThrow<SerializationException> { settings.reviewedAt.value() }
+        }
+    }
+
+    companion object {
+        private val DISMISSED_KEY = stringPreferencesKey("review.dismissedAt")
+        private val REVIEWED_KEY = stringPreferencesKey("review.reviewedAt")
+    }
+}


### PR DESCRIPTION
## What changed

CAPod can now ask satisfied Pro users for a Play Store review. Users who have been Pro for more than 3 weeks may see a small card on the overview asking for a review — only when the screen is otherwise quiet (no permission prompts, no Bluetooth/setup/troubleshooting cards). Tapping "Review" opens Google Play's own in-app review sheet, "Maybe later" hides the card for two weeks, and once a review was left the card never returns.

## Technical Context

- Port of SD Maid SE's review-prompt design (the fleet's canonical implementation): `ReviewTool` interface with a FOSS no-op and a gplay implementation — FOSS builds are completely unaffected.
- Eligibility (Pro age, snooze, already-reviewed) is computed locally first; Google Play is only probed for eligible users, so review quota isn't spent on users who can't be asked. The launch always requests a fresh `ReviewInfo` (Play documents them as short-lived).
- Review state persists in its own DataStore; timestamps use the epoch-millis Instant serializer via the explicit `createValue` overload (the reified overload can't resolve `java.time.Instant`).
- Hardened beyond the donor: exceptions from corrupt review preferences used to terminate the shared state flow inside the app scope (a process crash a downstream `catch` can't intercept — reproduced in a regression test); the tool now fails closed upstream of `replayingShare` and the card simply stays hidden. This fix is scheduled for backport to the donor.
- Review guidance: the ViewModel folds review state into the existing `OverviewUiSettings` combine; the card suppression rule lives in `State.hasHigherPriorityCard`.
- Strings are English-only for now and join the next translation pass. On the release carrying this, every Pro user past the 21-day mark becomes eligible at once — a one-time wave of review cards is expected.
