### PR TITLE
General: Keep the review prompt working when Google Play hangs

### DIFF
--- a/app/src/gplay/java/eu/darken/capod/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/review/GplayReviewTool.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -27,7 +28,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -46,6 +49,23 @@ class GplayReviewTool @Inject constructor(
     // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
     internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
 
+    // Test seam: same reason, the cooldown between failed probe rounds is a production sized wait.
+    internal var probeFailureCooldown: Duration = PROBE_FAILURE_COOLDOWN
+
+    // Test seam: the launch duration is wall-clock measured, so a virtual-time test cannot reach
+    // the production bound either.
+    internal var reviewMinDuration: Duration = REVIEW_MIN_DURATION
+
+    // Test seam: a hung Play call would otherwise have to be waited out for the production bound.
+    internal var requestTimeout: Duration = REQUEST_TIMEOUT
+
+    // Test seam: same reason, the review sheet bound is minutes long.
+    internal var launchTimeout: Duration = LAUNCH_TIMEOUT
+
+    // Test seam: eligibility is a function of wall-clock time, a virtual-time test needs to be able
+    // to move "now" itself. Only used for eligibility, the persisted timestamps stay real.
+    internal var nowProvider: () -> Instant = Instant::now
+
     // Local bookkeeping only: decided without talking to Play, so an ineligible user never
     // triggers a Play round-trip.
     private val isLocallyEligible: Flow<Boolean> = combine(
@@ -53,18 +73,33 @@ class GplayReviewTool @Inject constructor(
         settings.reviewedAt.flow,
         upgradeRepo.upgradeInfo,
     ) { lastDismissed, reviewedAt, upgradeInfo ->
-        val now = Instant.now()
-
-        // Free trial is 14 days, only ask for review after the user has paid something
-        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
-        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
-        val hasReviewed = reviewedAt != null
-
-        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
-        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
-
-        hasPaidForPro && !isSnoozed && !hasReviewed
+        EligibilityInputs(
+            lastDismissed = lastDismissed,
+            reviewedAt = reviewedAt,
+            upgradedAt = upgradeInfo.upgradedAt,
+        )
     }
+        // Eligibility depends on time, not just on the inputs: a snooze that runs out while the
+        // process is alive has to flip the verdict, otherwise the card only reappears after a
+        // restart. Re-evaluated at the upcoming boundaries, an input change restarts the whole
+        // schedule via flatMapLatest.
+        .flatMapLatest { inputs ->
+            flow {
+                var wakes = 0
+                while (true) {
+                    val now = nowProvider()
+                    emit(inputs.isEligibleAt(now))
+
+                    val nextBoundary = inputs.boundariesAfter(now).minOrNull()
+                    if (nextBoundary == null || wakes == MAX_BOUNDARY_WAKES) break
+
+                    wakes++
+                    val wakeIn = Duration.between(now, nextBoundary) + BOUNDARY_WAKE_MARGIN
+                    log(TAG) { "Eligibility: Re-evaluating in $wakeIn (boundary $nextBoundary)" }
+                    delay(wakeIn.toMillis())
+                }
+            }
+        }
         .distinctUntilChanged()
         // Upstream of the shares below: an exception there would kill the sharing coroutine on
         // AppScope (crashing the process) instead of reaching any downstream `catch`.
@@ -74,42 +109,93 @@ class GplayReviewTool @Inject constructor(
             emit(false)
         }
 
+    // Play's definitive answers are worth exactly one round-trip per process: quota is limited and
+    // the verdict doesn't change while the app runs. Survives eligibility flips, unlike the share.
+    @Volatile private var cachedVerdict: Verdict? = null
+
+    // Process-wide on purpose: the eligibility flatMapLatest below restarts this branch on every
+    // input change (a billing flicker flipping upgradedAt is enough), and a restart must not hand
+    // out a fresh round budget.
+    @Volatile private var probeRoundsStarted: Int = 0
+
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
-    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+    // `null` means no probe ran (not eligible), which is not a Play answer and is never cached.
+    private val reviewAvailability: Flow<Verdict?> = isLocallyEligible
         .flatMapLatest { eligible ->
-            if (!eligible) return@flatMapLatest flowOf(false)
+            if (!eligible) return@flatMapLatest flowOf<Verdict?>(null)
 
             flow {
-                for (attempt in 1..PROBE_ATTEMPTS) {
-                    val info = try {
-                        manager.requestReview()
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
-                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
-                        continue
-                    }
-                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
-                    emit(info.canShow)
+                cachedVerdict?.let {
+                    log(TAG) { "Reusing cached probe verdict: $it" }
+                    emit(it)
                     return@flow
                 }
-                // Re-probed when eligibility changes or on the next process start
-                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
-                emit(false)
+
+                while (true) {
+                    if (probeRoundsStarted == FAILURE_RETRY_ROUNDS + 1) {
+                        log(TAG, WARN) { "Probe failed in all ${FAILURE_RETRY_ROUNDS + 1} rounds, giving up" }
+                        emit(Verdict.TRANSIENT_FAILURE)
+                        return@flow
+                    }
+                    if (probeRoundsStarted > 0) delay(probeFailureCooldown.toMillis())
+
+                    val round = probeRoundsStarted
+                    probeRoundsStarted++
+
+                    val verdict = probeRound(round)
+                    emit(verdict)
+
+                    if (verdict != Verdict.TRANSIENT_FAILURE) {
+                        // Play answered, that answer holds for the rest of the process
+                        cachedVerdict = verdict
+                        return@flow
+                    }
+                }
             }
         }
-        .replayingShare(appScope)
+        // Lazily, not WhileSubscribed: a re-subscription must not spend another Play request on a
+        // question that was already answered (or given up on) in this process.
+        .shareIn(appScope, SharingStarted.Lazily, replay = 1)
+
+    private suspend fun probeRound(round: Int): Verdict {
+        for (attempt in 1..PROBE_ATTEMPTS) {
+            val info = try {
+                // withTimeoutOrNull, never withTimeout: TimeoutCancellationException IS-A
+                // CancellationException and would escape through the rethrow below.
+                withTimeoutOrNull(requestTimeout.toMillis()) { manager.requestReview() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Probe $round:$attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
+                continue
+            }
+
+            if (info == null) {
+                // Our timeout does not cancel the underlying Play Task: an immediate retry would
+                // stack concurrent quota-consuming requests against an already hung service, so the
+                // whole round is abandoned. The orphaned Task is tolerated, its completion resumes
+                // a cancelled continuation and is discarded.
+                log(TAG, WARN) { "Probe $round:$attempt/$PROBE_ATTEMPTS timed out, abandoning the round" }
+                return Verdict.TRANSIENT_FAILURE
+            }
+
+            log(TAG) { "Probe $round:$attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+            return if (info.canShow) Verdict.AVAILABLE else Verdict.UNAVAILABLE_BY_PLAY
+        }
+        log(TAG, WARN) { "Probe round $round gave up after $PROBE_ATTEMPTS attempts" }
+        return Verdict.TRANSIENT_FAILURE
+    }
 
     override val state: Flow<ReviewTool.State> = combine(
         isLocallyEligible,
-        isReviewAvailable,
+        reviewAvailability,
         settings.reviewedAt.flow,
-    ) { eligible, available, reviewedAt ->
-        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+    ) { eligible, verdict, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, verdict=$verdict, reviewedAt=$reviewedAt" }
         ReviewTool.State(
-            shouldAskForReview = eligible && available,
+            shouldAskForReview = eligible && verdict == Verdict.AVAILABLE,
             hasReviewed = reviewedAt != null,
         )
     }
@@ -126,8 +212,15 @@ class GplayReviewTool @Inject constructor(
     // launched again the moment the user returns from it.
     private val reviewLock = Mutex()
 
+    // Tap race backstop: a dismiss can land while a reviewNow is waiting on Play. In-memory on
+    // purpose, re-reading the persisted timestamp would race the write it is supposed to observe.
+    @Volatile private var dismissGeneration: Int = 0
+
     override suspend fun dismiss() {
         log(TAG, INFO) { "dismiss()" }
+        // Bumped before the write: an in-flight reviewNow has to see the dismiss immediately,
+        // not once DataStore has persisted it.
+        dismissGeneration++
         settings.lastDismissed.value(Instant.now())
     }
 
@@ -140,10 +233,12 @@ class GplayReviewTool @Inject constructor(
         }
 
         try {
+            val generation = dismissGeneration
+
             // ReviewInfo is short lived, Google wants it requested shortly before the launch,
             // a token cached at process start is likely stale by the time the user taps.
             val reviewInfo = try {
-                manager.requestReview()
+                withTimeoutOrNull(requestTimeout.toMillis()) { manager.requestReview() }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -151,7 +246,18 @@ class GplayReviewTool @Inject constructor(
                 log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
                 return
             }
+
+            if (reviewInfo == null) {
+                // A hang is not user intent either: persist nothing, the next tap retries
+                log(TAG, ERROR) { "Timed out requesting a fresh ReviewInfo" }
+                return
+            }
             log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (dismissGeneration != generation) {
+                log(TAG, WARN) { "Dismissed while we were requesting a fresh ReviewInfo, aborting" }
+                return
+            }
 
             if (!reviewInfo.canShow) {
                 // Play's quota verdict, asking again right away would be pointless
@@ -165,19 +271,34 @@ class GplayReviewTool @Inject constructor(
                 return
             }
 
+            if (dismissGeneration != generation) {
+                log(TAG, WARN) { "Dismissed before we could launch, aborting" }
+                return
+            }
+
             val reviewTime = measureTimeMillis {
-                try {
-                    manager.launchReview(activity, reviewInfo)
+                val launched = try {
+                    // withTimeoutOrNull for the same reason as the probe: a withTimeout would be
+                    // rethrown as cancellation by the branch below.
+                    withTimeoutOrNull(launchTimeout.toMillis()) { manager.launchReview(activity, reviewInfo) }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
                     return
                 }
+
+                if (launched == null) {
+                    // Far beyond any real review session: the sheet's Task is hung and must not hold
+                    // the single-flight lock forever. The outcome is unknown, so nothing is persisted
+                    // and the duration heuristic below is skipped.
+                    log(TAG, WARN) { "Timed out waiting for the review flow to finish" }
+                    return
+                }
             }
             log(TAG) { "Review completed after ${reviewTime}ms" }
 
-            if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
+            if (Duration.ofMillis(reviewTime) >= reviewMinDuration) {
                 log(TAG, INFO) { "Marking review as completed" }
                 settings.reviewedAt.value(Instant.now())
             } else {
@@ -189,6 +310,29 @@ class GplayReviewTool @Inject constructor(
         }
     }
 
+    private data class EligibilityInputs(
+        val lastDismissed: Instant?,
+        val reviewedAt: Instant?,
+        val upgradedAt: Instant?,
+    )
+
+    private fun EligibilityInputs.isEligibleAt(now: Instant): Boolean {
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = Duration.between(upgradedAt ?: now, now) > PRO_GRACE_PERIOD
+        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < SNOOZE_PERIOD
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro ($upgradedAt)" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        return hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+
+    private fun EligibilityInputs.boundariesAfter(now: Instant): List<Instant> = listOfNotNull(
+        lastDismissed?.plus(SNOOZE_PERIOD),
+        upgradedAt?.plus(PRO_GRACE_PERIOD),
+    ).filter { it > now }
+
     private val ReviewInfo.canShow: Boolean
         get() = when {
             toString().contains("isNoOp=true") -> false
@@ -199,9 +343,29 @@ class GplayReviewTool @Inject constructor(
         return "ReviewInfo(canShow=$canShow, ${toString()})"
     }
 
+    private enum class Verdict {
+        // Play answered with a usable ReviewInfo
+        AVAILABLE,
+
+        // Play answered with an isNoOp ReviewInfo, i.e. a deliberate "no"
+        UNAVAILABLE_BY_PLAY,
+
+        // No answer: attempts exhausted by exceptions, or the round was abandoned on a timeout
+        TRANSIENT_FAILURE,
+    }
+
     companion object {
         private val TAG = logTag("Review", "Tool", "Gplay")
         private const val PROBE_ATTEMPTS = 3
+        private const val FAILURE_RETRY_ROUNDS = 3
         private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
+        private val PROBE_FAILURE_COOLDOWN = Duration.ofMinutes(15)
+        private val REVIEW_MIN_DURATION = Duration.ofSeconds(2)
+        private val REQUEST_TIMEOUT = Duration.ofSeconds(10)
+        private val LAUNCH_TIMEOUT = Duration.ofMinutes(10)
+        private val SNOOZE_PERIOD = Duration.ofDays(14)
+        private val PRO_GRACE_PERIOD = Duration.ofDays(21)
+        private const val MAX_BOUNDARY_WAKES = 4
+        private val BOUNDARY_WAKE_MARGIN = Duration.ofSeconds(1)
     }
 }

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/ReviewCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/ReviewCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,8 +43,13 @@ fun ReviewCard(
     // the review bookkeeping with a snooze) and a review after a dismiss. A repeated review tap is
     // harmless, the tool's single-flight lock absorbs it, and blocking it here would leave a dead
     // card whenever a Play request fails and nothing gets persisted.
-    var dismissLocked by rememberSaveable { mutableStateOf(false) }
-    var fullyLatched by rememberSaveable { mutableStateOf(false) }
+    //
+    // Plain remember, not rememberSaveable: the card is a keyed item in a lazy list, which hands
+    // saveable state back when the item returns, so a card that was removed by a higher priority
+    // card would come back still latched. Disposal is the intended reset, the latch only has to
+    // survive the sub-second window until the next state emission takes the card away.
+    var dismissLocked by remember { mutableStateOf(false) }
+    var fullyLatched by remember { mutableStateOf(false) }
     Card(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/ReviewCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/ReviewCard.kt
@@ -17,6 +17,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -34,6 +38,13 @@ fun ReviewCard(
     onReview: (() -> Unit)?,
     onDismiss: () -> Unit,
 ) {
+    // The card only disappears with the next state emission, so the tap targets need a latch. It is
+    // asymmetric on purpose: the harmful orderings are a dismiss after a review (which overwrites
+    // the review bookkeeping with a snooze) and a review after a dismiss. A repeated review tap is
+    // harmless, the tool's single-flight lock absorbs it, and blocking it here would leave a dead
+    // card whenever a Play request fails and nothing gets persisted.
+    var dismissLocked by rememberSaveable { mutableStateOf(false) }
+    var fullyLatched by rememberSaveable { mutableStateOf(false) }
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -71,13 +82,27 @@ fun ReviewCard(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onDismiss) {
+                TextButton(
+                    onClick = {
+                        if (!fullyLatched && !dismissLocked) {
+                            dismissLocked = true
+                            fullyLatched = true
+                            onDismiss()
+                        }
+                    },
+                    enabled = !fullyLatched && !dismissLocked,
+                ) {
                     Text(text = stringResource(R.string.review_app_dismiss_action))
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
-                    onClick = { onReview?.invoke() },
-                    enabled = onReview != null,
+                    onClick = {
+                        if (!fullyLatched && onReview != null) {
+                            dismissLocked = true
+                            onReview.invoke()
+                        }
+                    },
+                    enabled = onReview != null && !fullyLatched,
                 ) {
                     Text(text = stringResource(R.string.review_app_review_action))
                 }

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/cards/ReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/cards/ReviewCardTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.capod.main.ui.overview.cards
 
 import android.content.Context
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -124,6 +126,41 @@ class ReviewCardTest : BaseComposeRobolectricTest() {
             reviews shouldBe 2
             dismisses shouldBe 0
         }
+    }
+
+    @Test
+    fun `a card that left the list comes back unlatched`() {
+        val visible = mutableStateOf(true)
+        composeRule.setContent {
+            PreviewWrapper {
+                // Mirrors OverviewScreen: the card is a keyed item in a lazy list, which keeps the
+                // saveable state of removed items around and hands it back when they return.
+                LazyColumn {
+                    if (visible.value) {
+                        item(key = "review") {
+                            ReviewCard(
+                                onReview = { reviews++ },
+                                onDismiss = { dismisses++ },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 1 }
+        composeRule.onNodeWithText(dismissLabel).assertIsNotEnabled()
+
+        // A higher priority card takes the slot and gives it back, e.g. Bluetooth flipping off
+        composeRule.runOnIdle { visible.value = false }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { visible.value = true }
+        composeRule.waitForIdle()
+
+        // The latch only guards the taps on one showing of the card, it must not outlive it
+        composeRule.onNode(reviewButton).assertIsEnabled()
+        composeRule.onNodeWithText(dismissLabel).assertIsEnabled()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/capod/main/ui/overview/cards/ReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/capod/main/ui/overview/cards/ReviewCardTest.kt
@@ -11,10 +11,17 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.capod.R
 import eu.darken.capod.common.compose.PreviewWrapper
-import org.junit.Assert.assertTrue
+import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
 
+/**
+ * The card only disappears once the next state emission arrives, so its two tap targets need a
+ * latch: a dismiss after a review would overwrite the completed-review bookkeeping with a snooze,
+ * a review after a dismiss would re-open what the user just closed. The latch is asymmetric —
+ * repeated review taps stay allowed, because a Play request can fail without persisting anything,
+ * which leaves the card on screen and in need of a retry.
+ */
 class ReviewCardTest : BaseComposeRobolectricTest() {
 
     private val context: Context
@@ -26,6 +33,21 @@ class ReviewCardTest : BaseComposeRobolectricTest() {
 
     // The card's title reuses the review label, so the action is matched by its click semantics.
     private val reviewButton get() = hasText(reviewLabel) and hasClickAction()
+
+    private var reviews = 0
+    private var dismisses = 0
+
+    private fun setContent(withActivity: Boolean = true) {
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(
+                    // Null callback = no Activity to launch Play's review flow with.
+                    onReview = if (withActivity) ({ reviews++ }) else null,
+                    onDismiss = { dismisses++ },
+                )
+            }
+        }
+    }
 
     @Test
     fun `renders the body and both actions`() {
@@ -41,29 +63,6 @@ class ReviewCardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `both actions invoke their callback`() {
-        var reviewed = false
-        var dismissed = false
-
-        composeRule.setContent {
-            PreviewWrapper {
-                ReviewCard(
-                    onReview = { reviewed = true },
-                    onDismiss = { dismissed = true },
-                )
-            }
-        }
-
-        composeRule.onNodeWithText(dismissLabel).performSemanticsAction(SemanticsActions.OnClick)
-        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
-
-        composeRule.runOnIdle {
-            assertTrue(dismissed)
-            assertTrue(reviewed)
-        }
-    }
-
-    @Test
     fun `the review action is disabled without a hosting activity`() {
         composeRule.setContent {
             PreviewWrapper {
@@ -75,5 +74,70 @@ class ReviewCardTest : BaseComposeRobolectricTest() {
         composeRule.onNode(reviewButton).assertIsNotEnabled()
         // Dismissing has to stay possible, it doesn't need an Activity.
         composeRule.onNodeWithText(dismissLabel).assertIsEnabled()
+    }
+
+    @Test
+    fun `a dismissed card ignores a later review tap`() {
+        setContent()
+
+        composeRule.onNodeWithText(dismissLabel).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { dismisses shouldBe 1 }
+
+        composeRule.onNode(reviewButton).assertIsNotEnabled()
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            reviews shouldBe 0
+            dismisses shouldBe 1
+        }
+    }
+
+    @Test
+    fun `a reviewed card ignores a later dismiss tap`() {
+        setContent()
+
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 1 }
+
+        composeRule.onNodeWithText(dismissLabel).assertIsNotEnabled()
+        composeRule.onNodeWithText(dismissLabel).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            reviews shouldBe 1
+            dismisses shouldBe 0
+        }
+    }
+
+    @Test
+    fun `repeated review taps are not absorbed by the card`() {
+        setContent()
+
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 1 }
+
+        // A failed Play request persists nothing and leaves the card up, so the retry has to work.
+        // Duplicates are the tool's problem, it holds a single-flight lock for exactly this.
+        composeRule.onNode(reviewButton).assertIsEnabled()
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            reviews shouldBe 2
+            dismisses shouldBe 0
+        }
+    }
+
+    @Test
+    fun `a review tap without an activity consumes neither latch`() {
+        setContent(withActivity = false)
+
+        composeRule.onNode(reviewButton).assertIsNotEnabled()
+        composeRule.onNode(reviewButton).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { reviews shouldBe 0 }
+
+        // Nothing was handed to the caller, so the card must still be dismissable
+        composeRule.onNodeWithText(dismissLabel).assertIsEnabled()
+        composeRule.onNodeWithText(dismissLabel).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle { dismisses shouldBe 1 }
     }
 }

--- a/app/src/testGplay/java/eu/darken/capod/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/review/GplayReviewToolTest.kt
@@ -17,13 +17,18 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
@@ -39,10 +44,17 @@ class GplayReviewToolTest : BaseTest() {
     private val upgradeRepo = mockk<UpgradeRepo>()
     private lateinit var lastDismissedMock: DataStoreValue<Instant?>
     private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+    private lateinit var lastDismissedFlow: MutableStateFlow<Instant?>
 
     // Relaxed so the `.value(new)` writes (which go through `update`) succeed and can be verified.
     private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
         every { flow } returns flowOf(initial)
+    }
+
+    // Hot variant: a value written after the tool started collecting has to reach the pipeline,
+    // which a one-shot `flowOf` can't do.
+    private fun <T> hotSetting(source: Flow<T>): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns source
     }
 
     // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
@@ -51,8 +63,14 @@ class GplayReviewToolTest : BaseTest() {
         upgradedAt: Instant? = Instant.now().minus(Duration.ofDays(30)),
         lastDismissed: Instant? = null,
         reviewedAt: Instant? = null,
+        minDuration: Duration? = null,
+        hotSettings: Boolean = false,
     ): GplayReviewTool {
-        lastDismissedMock = rwSetting(lastDismissed)
+        lastDismissedFlow = MutableStateFlow(lastDismissed)
+        lastDismissedMock = when {
+            hotSettings -> hotSetting(lastDismissedFlow)
+            else -> rwSetting(lastDismissed)
+        }
         reviewedAtMock = rwSetting(reviewedAt)
         every { settings.lastDismissed } returns lastDismissedMock
         every { settings.reviewedAt } returns reviewedAtMock
@@ -66,7 +84,13 @@ class GplayReviewToolTest : BaseTest() {
             settings = settings,
             manager = manager,
             upgradeRepo = upgradeRepo,
-        ).apply { probeRetryDelay = Duration.ofSeconds(1) }
+        ).apply {
+            probeRetryDelay = PROBE_RETRY_DELAY
+            probeFailureCooldown = PROBE_FAILURE_COOLDOWN
+            requestTimeout = REQUEST_TIMEOUT
+            launchTimeout = LAUNCH_TIMEOUT
+            minDuration?.let { reviewMinDuration = it }
+        }
     }
 
     private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
@@ -86,8 +110,29 @@ class GplayReviewToolTest : BaseTest() {
 
     private fun launchOk(): Task<Void?> = Tasks.forResult(null)
 
+    // A Play call that never comes back: the ktx wrapper suspends on the listeners it registers
+    // with the Task, and a relaxed mock never invokes them.
+    private fun <T> hangingTask(): Task<T> = mockk<Task<T>>(relaxed = true).apply {
+        every { isComplete } returns false
+    }
+
     // The `onStart` seed is not a computed state, every assertion has to await the first real one.
     private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    // Live view of everything the tool emitted so far, for assertions that have to move the clock
+    // between emissions instead of awaiting a single one.
+    private fun TestScope.collectStates(tool: GplayReviewTool): List<ReviewTool.State> {
+        val states = mutableListOf<ReviewTool.State>()
+        backgroundScope.launch { tool.state.collect { states += it } }
+        return states
+    }
+
+    // The tool's flows all run on the background scope, and `advanceUntilIdle` only advances while
+    // there is foreground work, so every wait has to name the span it is waiting for.
+    private fun TestScope.advanceBy(duration: Duration) {
+        advanceTimeBy(duration.toMillis())
+        runCurrent()
+    }
 
     @Test fun `an eligible user is asked for a review`() = runTest2 {
         every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
@@ -113,6 +158,18 @@ class GplayReviewToolTest : BaseTest() {
 
         tool(lastDismissed = Instant.now().minus(Duration.ofDays(3)))
             .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a user who already reviewed is never asked or probed again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(reviewedAt = Instant.now().minus(Duration.ofDays(200))).computedState().apply {
+            shouldAskForReview shouldBe false
+            // The card is gone for good, but the fact stays readable for anything else that asks.
+            hasReviewed shouldBe true
+        }
 
         verify(exactly = 0) { manager.requestReviewFlow() }
     }
@@ -173,6 +230,33 @@ class GplayReviewToolTest : BaseTest() {
         coVerify(exactly = 0) { reviewedAtMock.update(any()) }
     }
 
+    @Test fun `a launch the user dismissed instantly counts as a snooze`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        // Play returns immediately when it decides not to show anything, that is not a review.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a launch the user stayed in counts as a completed review`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        // Real sleep on purpose: the heuristic measures wall clock, virtual time cannot reach it.
+        every { manager.launchReviewFlow(any(), any()) } answers {
+            Thread.sleep(150)
+            launchOk()
+        }
+        val tool = tool(minDuration = Duration.ofMillis(50))
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 1) { reviewedAtMock.update(any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+    }
+
     @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
         every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
         every { manager.launchReviewFlow(any(), any()) } returns launchOk()
@@ -203,8 +287,10 @@ class GplayReviewToolTest : BaseTest() {
         val tool = tool()
         val activity = activity()
 
+        // runCurrent, not advanceUntilIdle: the first call has to be parked on the request when the
+        // second tap arrives, an unbounded time advance would trip the request timeout first.
         val first = launch { tool.reviewNow(activity) }
-        advanceUntilIdle()
+        runCurrent()
 
         tool.reviewNow(activity)
 
@@ -234,6 +320,15 @@ class GplayReviewToolTest : BaseTest() {
         tool().computedState().shouldAskForReview shouldBe false
 
         verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `an isNoOp probe answer is accepted instead of retried`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        // isNoOp is an answer, not a failure: burning the retry budget on it would just cost quota.
+        verify(exactly = 1) { manager.requestReviewFlow() }
     }
 
     @Test fun `corrupt review settings fall back to the default state`() = runTest2 {
@@ -285,5 +380,293 @@ class GplayReviewToolTest : BaseTest() {
         computed shouldBe null
         // The general failure path would have burned all 3 attempts and settled on "unavailable".
         verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that times out abandons the whole round`() = runTest2 {
+        var hanging = true
+        every { manager.requestReviewFlow() } answers {
+            if (hanging) hangingTask() else Tasks.forResult(reviewInfo())
+        }
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(REQUEST_TIMEOUT.multipliedBy(2))
+
+        // Our timeout does not cancel the Play Task: an in-round retry would stack concurrent
+        // quota-consuming requests against a service that is already hung.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        hanging = false
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(2))
+
+        // Recovery comes from the next cooldown round, not from the abandoned one.
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a probe exception is still retried inside the round`() = runTest2 {
+        // Only a timeout abandons the round, the exception path keeps its 3 attempt budget.
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_RETRY_DELAY.multipliedBy(4))
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a hanging fresh request releases the lock without persisting`() = runTest2 {
+        var hanging = true
+        every { manager.requestReviewFlow() } answers {
+            if (hanging) hangingTask() else Tasks.forResult(reviewInfo())
+        }
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.reviewNow(activity)
+
+        // A hang is not user intent: no launch, no bookkeeping, the next tap has to be able to retry.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+
+        hanging = false
+        tool.reviewNow(activity)
+
+        // Without the timeout the single-flight lock would still be held by the first tap.
+        verify(exactly = 1) { manager.launchReviewFlow(activity, any()) }
+    }
+
+    @Test fun `a hanging launch releases the lock without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var hanging = true
+        every { manager.launchReviewFlow(any(), any()) } answers {
+            if (hanging) hangingTask() else launchOk()
+        }
+        val tool = tool()
+        val activity = activity()
+
+        tool.reviewNow(activity)
+
+        // The outcome is unknown, so neither the review nor the snooze may be recorded, and the
+        // duration heuristic must not treat the timeout as a completed review.
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+
+        hanging = false
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.launchReviewFlow(activity, any()) }
+    }
+
+    @Test fun `a dismiss racing the fresh request aborts the launch`() = runTest2 {
+        val tool = tool()
+        every { manager.requestReviewFlow() } answers {
+            // The user hits "maybe later" while Play is still answering the review tap.
+            runBlocking { tool.dismiss() }
+            Tasks.forResult(reviewInfo())
+        }
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // Only the dismiss' own write, reviewNow must not add bookkeeping on top of it.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a definitive probe answer is not requested twice`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        val tool = tool()
+
+        val first = mutableListOf<ReviewTool.State>()
+        val firstJob = backgroundScope.launch { tool.state.collect { first += it } }
+        advanceBy(Duration.ofSeconds(1))
+        first.last().shouldAskForReview shouldBe true
+        firstJob.cancelAndJoin()
+
+        val second = mutableListOf<ReviewTool.State>()
+        val secondJob = backgroundScope.launch { tool.state.collect { second += it } }
+        advanceBy(Duration.ofSeconds(1))
+        second.last().shouldAskForReview shouldBe true
+        secondJob.cancelAndJoin()
+
+        // Play's answer holds for the rest of the process, a re-subscription must not cost quota.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `an isNoOp answer is not requested twice either`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        val first = mutableListOf<ReviewTool.State>()
+        val firstJob = backgroundScope.launch { tool.state.collect { first += it } }
+        advanceBy(Duration.ofSeconds(1))
+        first.last().shouldAskForReview shouldBe false
+        firstJob.cancelAndJoin()
+
+        val second = mutableListOf<ReviewTool.State>()
+        val secondJob = backgroundScope.launch { tool.state.collect { second += it } }
+        advanceBy(Duration.ofSeconds(1))
+        second.last().shouldAskForReview shouldBe false
+        secondJob.cancelAndJoin()
+
+        // isNoOp is a verdict, not a failure: it is cached like any other answer.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a transient probe failure is retried after the cooldown`() = runTest2 {
+        var healthy = false
+        every { manager.requestReviewFlow() } answers {
+            if (healthy) Tasks.forResult(reviewInfo()) else Tasks.forException(RuntimeException("Play unavailable"))
+        }
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_FAILURE_COOLDOWN.dividedBy(2))
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        healthy = true
+        advanceBy(PROBE_FAILURE_COOLDOWN)
+
+        // A failure is not an answer, so Play gets asked again once the cooldown is over.
+        verify(exactly = 4) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `the probe retry rounds are bounded`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool(hotSettings = true)
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(4))
+
+        // The initial round plus 3 cooldown rounds, 3 attempts each, then the process gives up.
+        verify(exactly = 12) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(20))
+
+        verify(exactly = 12) { manager.requestReviewFlow() }
+
+        // The budget is spent for the process: an eligibility flicker restarts the probe branch,
+        // but it must not hand out a fresh set of rounds.
+        lastDismissedFlow.value = Instant.now()
+        advanceBy(Duration.ofSeconds(1))
+        lastDismissedFlow.value = null
+        advanceBy(PROBE_FAILURE_COOLDOWN.multipliedBy(10))
+
+        verify(exactly = 12) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a snooze running out flips the card on without a restart`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW.minus(Duration.ofDays(60)),
+            lastDismissed = BASE_NOW.minus(Duration.ofDays(13)),
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(Duration.ofSeconds(1))
+        states.last().shouldAskForReview shouldBe false
+
+        // The snooze ends a day later: the scheduled re-evaluation has to re-read the clock.
+        fakeNow = BASE_NOW.plus(Duration.ofDays(2))
+        advanceBy(Duration.ofDays(2))
+
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `the pro grace period boundary is strict`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val upgradedAt = BASE_NOW.minus(Duration.ofDays(21))
+
+        val atBoundary = tool(upgradedAt = upgradedAt).apply { nowProvider = { fakeNow } }
+        val atBoundaryStates = collectStates(atBoundary)
+        advanceBy(Duration.ofSeconds(1))
+        // 21 days have to have passed, not just been reached
+        atBoundaryStates.last().shouldAskForReview shouldBe false
+
+        // A second instance because nothing is pending on the first one: the wake schedule only
+        // keeps boundaries strictly after "now", and this one is exactly "now".
+        fakeNow = BASE_NOW.plus(Duration.ofSeconds(1))
+        val pastBoundary = tool(upgradedAt = upgradedAt).apply { nowProvider = { fakeNow } }
+        val pastBoundaryStates = collectStates(pastBoundary)
+        advanceBy(Duration.ofSeconds(1))
+
+        pastBoundaryStates.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a new dismiss reschedules the boundary re-evaluation`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW.minus(Duration.ofDays(60)),
+            lastDismissed = BASE_NOW.minus(Duration.ofDays(13)),
+            hotSettings = true,
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(Duration.ofSeconds(1))
+        states.last().shouldAskForReview shouldBe false
+
+        // Dismissed again while the old snooze end was still scheduled
+        lastDismissedFlow.value = BASE_NOW
+        advanceBy(Duration.ofSeconds(1))
+
+        fakeNow = BASE_NOW.plus(Duration.ofDays(2))
+        advanceBy(Duration.ofDays(3))
+        // The stale boundary must not flip the card back on, the new snooze governs now
+        states.last().shouldAskForReview shouldBe false
+
+        fakeNow = BASE_NOW.plus(Duration.ofDays(15))
+        advanceBy(Duration.ofDays(15))
+
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a clock that moved backwards re-evaluates instead of flipping`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW.minus(Duration.ofDays(60)),
+            lastDismissed = BASE_NOW.minus(Duration.ofDays(13)),
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(Duration.ofSeconds(1))
+        states.last().shouldAskForReview shouldBe false
+
+        // The device clock moved back: the wake fires on schedule, but the snooze is still running
+        fakeNow = BASE_NOW.minus(Duration.ofDays(5))
+        advanceBy(Duration.ofDays(30))
+
+        states.last().shouldAskForReview shouldBe false
+        verify(exactly = 0) { manager.requestReviewFlow() }
+
+        // Rescheduling is capped, so a backwards clock cannot keep the process waking forever
+        fakeNow = BASE_NOW.plus(Duration.ofDays(2))
+        advanceBy(Duration.ofDays(30))
+
+        states.last().shouldAskForReview shouldBe false
+    }
+
+    companion object {
+        private val BASE_NOW: Instant = Instant.parse("2024-06-01T12:00:00Z")
+        private val PROBE_RETRY_DELAY: Duration = Duration.ofSeconds(1)
+        private val PROBE_FAILURE_COOLDOWN: Duration = Duration.ofMinutes(5)
+        private val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(5)
+        private val LAUNCH_TIMEOUT: Duration = Duration.ofMinutes(1)
     }
 }


### PR DESCRIPTION
## What changed

Hardens the Google Play review prompt, ported from the same hardening that just landed in SD Maid SE. If Play hung while the app was checking review availability or launching the review sheet, the review feature could silently stop working until the next app restart — those calls now time out and the next tap simply retries. Fast conflicting taps on the review card can no longer trigger contradictory actions, and a card that briefly leaves the overview (displaced by a higher-priority card) no longer comes back with dead buttons. The app also asks Play about review availability only once per app start instead of on every overview visit, and the card appears on time when the snooze or the post-purchase waiting period runs out while the app is open.

## Technical Context

- Port of the reviewed donor change in SD Maid SE (d4rken-org/sdmaid-se#2619); the review tool is byte-identical to the donor after package normalization.
- Root cause of the headline fix: the `ReviewManager` suspend calls are unbounded over Play IPC — a hang stalls the availability probe or leaves `reviewNow` holding its single-flight mutex, dropping every later tap until process death. All three call sites now use `withTimeoutOrNull` (10s requests, generous 10min sheet); a probe timeout abandons the whole round since our timeout cannot cancel the underlying Play Task.
- Definitive availability verdicts are cached for the process lifetime with a process-wide retry budget; transient failures retry on a 15-minute cooldown and are never cached.
- The card latch is asymmetric (review taps stay retryable so a transient Play failure doesn't strand the card; a dismissal locks everything) and uses plain `remember` — review found that `rememberSaveable` inside the overview's `item(key = "review")` is retained across item removal, so a latched card that left the list came back with disabled buttons. The regression test was written first and reproduced exactly that before the fix.
- The pre-existing `both actions invoke their callback` card test asserted a sequence the latch deliberately blocks; it is superseded by the latch matrix tests.
- Tool test suite brought to parity with the donor's 31 tests (adds the launch-duration seam and its timing coverage); eligibility boundaries are driven by a `nowProvider` seam under virtual time. The existing `TimeSource` abstraction was deliberately not used, to keep the review tool file fleet-canonical.
