### PR TITLE
General: Update app translations from Crowdin

### DIFF
--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_upgrade_status_description">Votre statut de supporter.</string>
     <string name="upgrade_screen_why_title">Avantages de la mise à niveau</string>
     <string name="upgrade_screen_how_title">Comment aider</string>
+    <string name="upgrade_screen_how_body">Devenez mécène et soutenez le développement. Touchez le bouton ci-dessous pour activer toutes les fonctions supplémentaires et ouvrir mon profil GitHub Sponsors.</string>
     <string name="upgrade_screen_status_free_title">Version gratuite</string>
     <string name="upgrade_screen_status_free_body">Vous utilisez la version gratuite de CAPod. Des fonctionnalités supplémentaires peuvent être déverrouillées en soutenant le développement.</string>
     <string name="upgrade_screen_status_free_action">Voir les options de mise à niveau</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -16,7 +16,9 @@
     <string name="upgrade_screen_how_title">របៀបជួយ</string>
     <string name="upgrade_screen_how_body">ក្លាយជាអ្នកឧបត្ថម្ភ និងឧបត្ថម្ភការអភិវឌ្ឍន៍! ចុចប៊ូតុងខាងក្រោមដើម្បីធ្វើឱ្យមុខងារបន្ថែមទាំងអស់សកម្ម និងបើកប្រវត្តិរូប GitHub Sponsors របស់ខ្ញុំ។</string>
     <string name="upgrade_screen_status_free_title">កំណែឥតគិតថ្លៃ</string>
+    <string name="upgrade_screen_status_free_body">អ្នកកំពុងប្រើប្រាស់កំណែឥតគិតថ្លៃរបស់ CAPod។ មុខងារលម្អិតបន្ថែមលេចឡើងដោយការគាំទ័របង្កើនលេខ។</string>
     <string name="upgrade_screen_status_free_action">មើលជម្រើសលើកកម្ពស់</string>
     <string name="upgrade_screen_status_upgraded_title">លើកកម្ពស់សកម្ម</string>
     <string name="upgrade_screen_recurring_title">បន្តដង្ហើម</string>
+    <string name="upgrade_screen_recurring_body">CAPod បន្តលូតលាស់តាមរយៈការធ្វើឱ្យថ្មីនិងការកែប្រែ។ ប្រសិនបើអ្នកចង់រក្សាវាឱ្យរស់រាន, ពិចារណាការរួមចំណែកម្តងម្កាលរបស់អ្នកតាមរយៈ GitHub Sponsors។</string>
 </resources>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -20,4 +20,5 @@
     <string name="upgrade_screen_status_free_action">ನವೀಕರಣ ಆಯ್ಕೆಗಳನ್ನು ನೋಡಿ</string>
     <string name="upgrade_screen_status_upgraded_title">ನವೀಕರಣ ಕ್ರಿಯಾಶೀಲ</string>
     <string name="upgrade_screen_recurring_title">ಅದನ್ನು ಮುಂದುವರಿಸಿ</string>
+    <string name="upgrade_screen_recurring_body">CAPod ನವೀಕರಣ ಮತ್ತು ಸುಧಾರೆಗಳ ಮೂಲಕ ನಿರಂತರವಾಗಿ ಅಭಿವೃದ್ಧಿ ಆಗುತ್ತಿದೆ. ನೀವು ಇದನ್ನು ಮುಂದುವರಿಸಲು ಬಯಸಿದರೆ, GitHub Sponsors ಮೂಲಕ ನಿಯಮಿತ ದಾನವನ್ನು ಪರಿಗಣಿಸಿ.</string>
 </resources>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Buka halaman penaja</string>
     <string name="settings_upgrade_status_label">Menajakan CAPod</string>
     <string name="settings_upgrade_status_description">Status penyokong anda.</string>
+    <string name="upgrade_screen_why_title">Manfaat peningkatan</string>
+    <string name="upgrade_screen_how_title">Bagaimana untuk membantu</string>
+    <string name="upgrade_screen_how_body">Menjadi penaung dan penaja pembangunan! Ketik butang di bawah untuk mengaktifkan semua ciri tambahan dan buka profil Penaja GitHub saya.</string>
+    <string name="upgrade_screen_status_free_title">Versi percuma</string>
+    <string name="upgrade_screen_status_free_body">Anda menggunakan versi percuma CAPod. Ciri-ciri tambahan boleh dibuka kunci dengan menyokong pembangunan.</string>
+    <string name="upgrade_screen_status_free_action">Lihat pilihan peningkatan</string>
+    <string name="upgrade_screen_status_upgraded_title">Peningkatan aktif</string>
+    <string name="upgrade_screen_recurring_title">Teruskan</string>
+    <string name="upgrade_screen_recurring_body">CAPod terus berkembang melalui kemas kini dan pembetulan. Jika anda ingin menopang itu, pertimbangkan sumbangan berulang melalui GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">ပံ့ပိုးသူစာမျက်နှာကို ဖွင့်ပါ</string>
     <string name="settings_upgrade_status_label">CAPod ကို ပံ့ပိုးပါ</string>
     <string name="settings_upgrade_status_description">သင်၏ ပံ့ပိုးသူ အခြေအနေ။</string>
+    <string name="upgrade_screen_why_title">အဆင့်မြှင့်တင်မှု အကျိုးအကျေးမများ</string>
+    <string name="upgrade_screen_how_title">ကူညီနည်းလမ်း</string>
+    <string name="upgrade_screen_how_body">ကူညီသူဖြစ်ပြီး ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးပါ! အပိုဝန်ဆောင်မှုများအားလုံးကို ဖွင့်ပြီး ကျွန်ုပ်၏ GitHub Sponsors ပရိုဖိုင်းကို ဖွင့်ရန် အောက်ပါခလုတ်ကို နှိပ်ပါ။</string>
+    <string name="upgrade_screen_status_free_title">အခမဲ့ ဗားရှင်း</string>
+    <string name="upgrade_screen_status_free_body">သင် CAPod ၏ အခမဲ့ ဗားရှင်း ကို အသုံးပြုနေသည်။ ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးခြင်းအားဖြင့် ထပ်ဆောင်း လုပ်ဆောင်ချက်များ အသုံးပြုခွင့်ရှိနိုင်သည်။</string>
+    <string name="upgrade_screen_status_free_action">အဆင့်မြှင့်တင်မှု ရွေးချယ်စရာများ ကြည့်ပါ</string>
+    <string name="upgrade_screen_status_upgraded_title">အဆင့်မြှင့်တင်မှု ကျင်လည်နေသည်</string>
+    <string name="upgrade_screen_recurring_title">ဆက်လက်စွာ ပံ့ပိုးပါ</string>
+    <string name="upgrade_screen_recurring_body">CAPod သည် အဆင့်မြှင့်တင်မှု နှင့် ပြုပြင်ဖြေရှင်းမှုများ မှတစ်ဆင့် ဆက်လက်စွာ ကောင်းမွန်လာသည်။ ထိုကဲ့သို့ ကျေးဇူးတင်သည့်အတွက် GitHub Sponsors မှ ပုံမှန် လှူဒါန်းမှုကို စဉ်းစားကြည့်ပါ။</string>
 </resources>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Åpne sponsorside</string>
     <string name="settings_upgrade_status_label">Støtt CAPod</string>
     <string name="settings_upgrade_status_description">Din status som støtter.</string>
+    <string name="upgrade_screen_why_title">Oppgraderingsfordeler</string>
+    <string name="upgrade_screen_how_title">Hvordan hjelpe</string>
+    <string name="upgrade_screen_how_body">Bli en patron og støtt utviklingen! Trykk på knappen under for å aktivere alle ekstra funksjoner og åpne sponsorprofilen min på GitHub.</string>
+    <string name="upgrade_screen_status_free_title">Gratis versjon</string>
+    <string name="upgrade_screen_status_free_body">Du bruker den gratis versjonen av CAPod. Ekstra funksjoner kan låses opp ved å støtte utviklingen.</string>
+    <string name="upgrade_screen_status_free_action">Se oppgraderingsalternativene</string>
+    <string name="upgrade_screen_status_upgraded_title">Oppgradering aktiv</string>
+    <string name="upgrade_screen_recurring_title">Hold det gående</string>
+    <string name="upgrade_screen_recurring_body">CAPod fortsetter å utvikle seg gjennom oppdateringer og rettinger. Hvis du vil opprettholde det, kan du vurdere en gjentakende donasjon via GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">प्रायोजक पृष्ठ खोल्नुहोस्</string>
     <string name="settings_upgrade_status_label">CAPod को प्रायोजन गर्नुहोस्</string>
     <string name="settings_upgrade_status_description">आफ्नो समर्थक स्थिति।</string>
+    <string name="upgrade_screen_why_title">अपग्रेड लाभहरु</string>
+    <string name="upgrade_screen_how_title">कसरी मद्दत गर्ने</string>
+    <string name="upgrade_screen_how_body">संरक्षक बन्नुहोस् र विकासलाई प्रायोजन गर्नुहोस्! सबै अतिरिक्त सुविधाहरू सक्रिय पार्न र मेरो GitHub Sponsors प्रोफाइल खोल्न तलको बटन ट्याप गर्नुहोस्।</string>
+    <string name="upgrade_screen_status_free_title">निःशुल्क संस्करण</string>
+    <string name="upgrade_screen_status_free_body">तपाईं CAPod को निःशुल्क संस्करण प्रयोग गरिरहनुभएको छ। विकास समर्थन गरेर अतिरिक्त सुविधा अनलक गर्न सकिन्छ।</string>
+    <string name="upgrade_screen_status_free_action">अपग्रेड विकल्पहरु हेर्नुहोस्</string>
+    <string name="upgrade_screen_status_upgraded_title">अपग्रेड सक्रिय छ</string>
+    <string name="upgrade_screen_recurring_title">यो जारी राख्नुहोस्</string>
+    <string name="upgrade_screen_recurring_body">CAPod अद्यावधिक र सुधार मार्फत विकसित भइरहेको छ। यदि तपाई यो जारी राख्न चाहनुहुन्छ भने, GitHub Sponsors मार्फत आवर्ती दान विचार गर्नुहोस्।</string>
 </resources>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Open de sponsorpagina</string>
     <string name="settings_upgrade_status_label">Sponsor CAPod</string>
     <string name="settings_upgrade_status_description">Je ondersteunersstatus.</string>
+    <string name="upgrade_screen_why_title">Voordelen van de upgrade</string>
+    <string name="upgrade_screen_how_title">Hoe kun je helpen</string>
+    <string name="upgrade_screen_how_body">Word mecenas en sponsor ontwikkelaar! Tik op de onderstaande knop om alle extra functies te activeren en mijn GitHub Sponsors-profiel te openen.</string>
+    <string name="upgrade_screen_status_free_title">Gratis versie</string>
+    <string name="upgrade_screen_status_free_body">Je gebruikt de gratis versie van CAPod. Extra functies kunnen worden ontgrendeld door de ontwikkeling te ondersteunen.</string>
+    <string name="upgrade_screen_status_free_action">Bekijk upgrade-opties</string>
+    <string name="upgrade_screen_status_upgraded_title">Upgrade actief</string>
+    <string name="upgrade_screen_recurring_title">Ga zo door</string>
+    <string name="upgrade_screen_recurring_body">CAPod blijft zich ontwikkelen door middel van updates en bugfixes. Als je dit wilt blijven ondersteunen, kun je overwegen om een ​​terugkerende donatie te doen via GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Otwórz stronę wspierającego</string>
     <string name="settings_upgrade_status_label">Sponsoruj CAPod</string>
     <string name="settings_upgrade_status_description">Status twojego wsparcia.</string>
+    <string name="upgrade_screen_why_title">Korzyści z uaktualnienia</string>
+    <string name="upgrade_screen_how_title">Jak pomóc</string>
+    <string name="upgrade_screen_how_body">Zostań patronem i wspieraj rozwój! Dotknij przycisku poniżej, aby aktywować wszystkie dodatkowe funkcje i otworzyć mój profil GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Wersja darmowa</string>
+    <string name="upgrade_screen_status_free_body">Korzystasz z bezpłatnej wersji CAPod. Dodatkowe funkcje można odblokować poprzez wsparcie programisty.</string>
+    <string name="upgrade_screen_status_free_action">Zobacz opcje aktualizacji</string>
+    <string name="upgrade_screen_status_upgraded_title">Aktualizacja aktywna</string>
+    <string name="upgrade_screen_recurring_title">Wspieraj dalej</string>
+    <string name="upgrade_screen_recurring_body">CAPod stale się rozwija dzięki aktualizacjom i poprawkom. Jeśli chcesz go wspierać, rozważ cykliczną darowiznę za pośrednictwem GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocínio</string>
     <string name="settings_upgrade_status_label">Patrocine o CAPod</string>
     <string name="settings_upgrade_status_description">Seu status de apoiador.</string>
+    <string name="upgrade_screen_why_title">Benefícios da atualização</string>
+    <string name="upgrade_screen_how_title">Como ajudar</string>
+    <string name="upgrade_screen_how_body">Torne-se um patrocinador e financie o desenvolvimento! Clique no botão abaixo para ativar todos os recursos extras e abrir meu perfil Github Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Versão gratuita</string>
+    <string name="upgrade_screen_status_free_body">Você está usando a versão gratuita do CAPod. Recursos extras podem ser desbloqueados apoiando o desenvolvimento.</string>
+    <string name="upgrade_screen_status_free_action">Ver opções de atualização</string>
+    <string name="upgrade_screen_status_upgraded_title">Atualização ativa</string>
+    <string name="upgrade_screen_recurring_title">Mantenha assim</string>
+    <string name="upgrade_screen_recurring_body">CAPod continua evoluindo com atualizações e correções. Se você quiser sustentá-lo, considere fazer uma doação recorrente via GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocínio</string>
     <string name="settings_upgrade_status_label">Apoie o CAPod</string>
     <string name="settings_upgrade_status_description">O seu estado de apoiante.</string>
+    <string name="upgrade_screen_why_title">Benefícios da atualização</string>
+    <string name="upgrade_screen_how_title">Como ajudar</string>
+    <string name="upgrade_screen_how_body">Torne-se patrono e apoie o desenvolvimento! Toque no botão abaixo para ativar todas as funcionalidades adicionais e abrir o meu perfil no GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Versão gratuita</string>
+    <string name="upgrade_screen_status_free_body">Você está usando a versão gratuita do CAPod. Recursos extras podem ser desbloqueados ao apoiar o desenvolvimento.</string>
+    <string name="upgrade_screen_status_free_action">Ver opções de atualização</string>
+    <string name="upgrade_screen_status_upgraded_title">Atualização ativa</string>
+    <string name="upgrade_screen_recurring_title">Continue a apoiar</string>
+    <string name="upgrade_screen_recurring_body">O CAPod continua evoluindo por meio de atualizações e correções. Se você quiser ajudar a manter isso, considere fazer uma doação recorrente pelo GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Avrir la pagina da sponsurisaziun</string>
     <string name="settings_upgrade_status_label">Sponsurar CAPod</string>
     <string name="settings_upgrade_status_description">Tes status da supporter.</string>
+    <string name="upgrade_screen_why_title">Bials da l\'upgrade</string>
+    <string name="upgrade_screen_how_title">Sco gidar</string>
+    <string name="upgrade_screen_how_body">Vign patrun e sustegna l\'svilup! Tucha il buttun sut per activar tut las funcziuns extrasas e per avrir miu profil da GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Versiun gratuitusa</string>
+    <string name="upgrade_screen_status_free_body">Tu utilizzas la versiun gratuitusa da CAPod. Funcziuns extrasas pon vegnir deblochadas cun sustegnair l\'svilup.</string>
+    <string name="upgrade_screen_status_free_action">Vesair las opcziuns da upgrade</string>
+    <string name="upgrade_screen_status_upgraded_title">Upgrade activà</string>
+    <string name="upgrade_screen_recurring_title">Mantegnair d\'en viva</string>
+    <string name="upgrade_screen_recurring_body">CAPod continua a sa sviluppar tras actualizaziuns e reparas. Sche ti vuls sustegnair quai, cunsiglia ina donazziun ricorrent via GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -12,4 +12,12 @@
     <string name="upgrade_foss_sponsor_again_action">Deschide pagina de sponsorizare</string>
     <string name="settings_upgrade_status_label">Sponsorizează CAPod</string>
     <string name="settings_upgrade_status_description">Statusul tău de susținător.</string>
+    <string name="upgrade_screen_why_title">Beneficiile upgrade-ului</string>
+    <string name="upgrade_screen_how_title">Cum să ajuți</string>
+    <string name="upgrade_screen_status_free_title">Versiune gratuită</string>
+    <string name="upgrade_screen_status_free_body">Folosești versiunea gratuită a CAPod. Poți debloca funcții suplimentare susținând dezvoltarea.</string>
+    <string name="upgrade_screen_status_free_action">Vezi opțiunile de upgrade</string>
+    <string name="upgrade_screen_status_upgraded_title">Upgrade activ</string>
+    <string name="upgrade_screen_recurring_title">Ține-o în viață</string>
+    <string name="upgrade_screen_recurring_body">CAPod continuă să evolueze prin actualizări și corecturi. Dacă ai dori să susții asta, ia în considerare o donație recurentă prin GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -14,6 +14,7 @@
     <string name="settings_upgrade_status_description">Statusul tău de susținător.</string>
     <string name="upgrade_screen_why_title">Beneficiile upgrade-ului</string>
     <string name="upgrade_screen_how_title">Cum să ajuți</string>
+    <string name="upgrade_screen_how_body">Devino susținător și sponsorizează dezvoltarea! Apasă butonul de mai jos pentru a activa toate funcțiile suplimentare și a deschide profilul meu GitHub Sponsors.</string>
     <string name="upgrade_screen_status_free_title">Versiune gratuită</string>
     <string name="upgrade_screen_status_free_body">Folosești versiunea gratuită a CAPod. Poți debloca funcții suplimentare susținând dezvoltarea.</string>
     <string name="upgrade_screen_status_free_action">Vezi opțiunile de upgrade</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Открыть страницу спонсорства</string>
     <string name="settings_upgrade_status_label">Поддержать CAPod</string>
     <string name="settings_upgrade_status_description">Статус Вашей поддержки.</string>
+    <string name="upgrade_screen_why_title">Преимущества обновления</string>
+    <string name="upgrade_screen_how_title">Как помочь</string>
+    <string name="upgrade_screen_how_body">Станьте спонсором и поддержите разработку! Нажмите кнопку ниже, чтобы активировать все дополнительные функции и открыть мой профиль GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Бесплатная версия</string>
+    <string name="upgrade_screen_status_free_body">Вы используете бесплатную версию CAPod. Дополнительные функции можно разблокировать, поддерживая разработку.</string>
+    <string name="upgrade_screen_status_free_action">Посмотреть варианты обновления</string>
+    <string name="upgrade_screen_status_upgraded_title">Обновление активно</string>
+    <string name="upgrade_screen_recurring_title">Поддержите развитие</string>
+    <string name="upgrade_screen_recurring_body">CAPod продолжает развиваться через обновления и исправления. Если Вы хотите осуществить поддержку, рассмотрите возможность периодического пожертвования через спонсоров GitHub.</string>
 </resources>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Aberi sa pàgina de sponsorizatzione</string>
     <string name="settings_upgrade_status_label">Sostene CAPod</string>
     <string name="settings_upgrade_status_description">S\'istadu tuo de sustentadore.</string>
+    <string name="upgrade_screen_why_title">Benefitzios de s\'agiornamentu</string>
+    <string name="upgrade_screen_how_title">Comente agiudare</string>
+    <string name="upgrade_screen_how_body">Diventa patronu e sponsoriza s\'isvilupu! Tocca su butone in bassu pro ativare totu sas funtzionalidades addizionales e abèrrere su profilu meu de GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Versione lìbera</string>
+    <string name="upgrade_screen_status_free_body">Tù ses usende sa versione lìbera de CAPod. Benefitzios extras podent esse desblocados si supportas su sviluppu.</string>
+    <string name="upgrade_screen_status_free_action">Bide sas optziones de agiornamentu</string>
+    <string name="upgrade_screen_status_upgraded_title">Agiornamentu attivu</string>
+    <string name="upgrade_screen_recurring_title">Fide an\'abantis</string>
+    <string name="upgrade_screen_recurring_body">CAPod cuntìnua a evolutionare cun agiornamentos e corretziones. Si tù bolis mantenere custu, pentziona a una donatzione reciclica pro via GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">අනුග්‍රාහක පිටුව විවෘත කරන්න</string>
     <string name="settings_upgrade_status_label">CAPod සඳහා අනුග්‍රහක්</string>
     <string name="settings_upgrade_status_description">ඔබේ සහයෝගිතා තත්‍වය.</string>
+    <string name="upgrade_screen_why_title">උඩ්ග්‍රේඩ් ප්‍රතිලාභ</string>
+    <string name="upgrade_screen_how_title">උදව් කරන්නේ කෙසේද</string>
+    <string name="upgrade_screen_how_body">අනුග්‍රාහකයෙකු වී සංවර්ධනයට අනුග්‍රහ කරන්න! සියලු අමතර විශේෂාංග සක්‍රිය කර මගේ GitHub Sponsors පැතිකඩ විවෘත කිරීමට පහත බොත්තම ස්පර්ශ කරන්න.</string>
+    <string name="upgrade_screen_status_free_title">නිදහස් සංස්කරණය</string>
+    <string name="upgrade_screen_status_free_body">ඔබ CAPod හි නිදහස් සංස්කරණය භාවිතා කරමින් පවතී. අතිරේක විශේෂාංග සංවර්ධනයට සහයෝගය දීමෙන් අඩුවිය හැක.</string>
+    <string name="upgrade_screen_status_free_action">උඩ්ග්‍රේඩ් විකල්ප බලන්න</string>
+    <string name="upgrade_screen_status_upgraded_title">උඩ්ග්‍රේඩ් සක්‍රිය</string>
+    <string name="upgrade_screen_recurring_title">එයින් දිගටම</string>
+    <string name="upgrade_screen_recurring_body">CAPod දිගටම සංවර්ධනය වෙමින් පවතී යාවත්කාලීනයන් සහ නිවැරදි කිරීම් මගින්. ඔබ එය පවතින්නට කිරීමට අවශ්‍ය නම්, GitHub Sponsors හරහා පුනරාවර්තක පරිත්‍යාගයක් සලකා බලන්න.</string>
 </resources>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Otvoriť stránku sponzorstva</string>
     <string name="settings_upgrade_status_label">Podporiť CAPod</string>
     <string name="settings_upgrade_status_description">Váš status podporovateľa.</string>
+    <string name="upgrade_screen_why_title">Výhody upgradu</string>
+    <string name="upgrade_screen_how_title">Ako pomôcť</string>
+    <string name="upgrade_screen_how_body">Staňte sa patrónom a sponzorujte rozvoj! Klepnutím na tlačidlo nižšie aktivujete všetky ďalšie funkcie a otvoríte môj profil sponzorov GitHub.</string>
+    <string name="upgrade_screen_status_free_title">Bezplatná verzia</string>
+    <string name="upgrade_screen_status_free_body">Používate bezplatnú verziu aplikácie CAPod. Dodatočné funkcie je možné odomknúť podporou vývoja.</string>
+    <string name="upgrade_screen_status_free_action">Zobraziť možnosti upgradu</string>
+    <string name="upgrade_screen_status_upgraded_title">Upgrade aktívny</string>
+    <string name="upgrade_screen_recurring_title">Pokračuj ďalej</string>
+    <string name="upgrade_screen_recurring_body">CAPod sa neustále vyvíja prostredníctvom aktualizácií a oprav. Ak chcete to podporiť, zvážte si opakujúcu sa donáciu prostredníctvom GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Odpri stran za sponzorstvo</string>
     <string name="settings_upgrade_status_label">Podpri CAPod</string>
     <string name="settings_upgrade_status_description">Tvoj status podpornika.</string>
+    <string name="upgrade_screen_why_title">Prednosti nadgradnje</string>
+    <string name="upgrade_screen_how_title">Kako pomagati.</string>
+    <string name="upgrade_screen_how_body">Postanite pokrovitelj in prispevajte k razvoju!  Dotaknite se spodnjega gumba, da omogočite dodatne funkcije in odprete moj pokroviteljski profil na GitHubu.</string>
+    <string name="upgrade_screen_status_free_title">Brezplačna različica</string>
+    <string name="upgrade_screen_status_free_body">Uporabljate brezplačno različico CAPoda. Dodatne funkcionalnosti se odklenejo s podporo razvoju.</string>
+    <string name="upgrade_screen_status_free_action">Prikaži možnosti nadgradnje</string>
+    <string name="upgrade_screen_status_upgraded_title">Nadgradnja je aktivna</string>
+    <string name="upgrade_screen_recurring_title">Nadaljuj s tem</string>
+    <string name="upgrade_screen_recurring_body">CAPod se stalno razvija z posodobitvami in popravki. Če želite to podpreti, razmislite o ponavljajočem se prispevku prek GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Hap faqen e sponsorizimit</string>
     <string name="settings_upgrade_status_label">Mbështesni CAPod</string>
     <string name="settings_upgrade_status_description">Statusi juaj si mbështetës.</string>
+    <string name="upgrade_screen_why_title">Përfitime të përmirësimit</string>
+    <string name="upgrade_screen_how_title">Si të ndihmoj</string>
+    <string name="upgrade_screen_how_body">Bëhuni një mbrojtës dhe sponsor i zhvillimit! Prekni butonin më poshtë për të aktivizuar të gjitha veçoritë shtesë dhe për të hapur profilin tim të sponsorëve të GitHub.</string>
+    <string name="upgrade_screen_status_free_title">Versioni falas</string>
+    <string name="upgrade_screen_status_free_body">Jeni duke përdorur versionin falas të CAPod. Veçoritë shtesë mund të aktivizohen duke mbështetur zhvillimin.</string>
+    <string name="upgrade_screen_status_free_action">Shikoni opsionet e përmirësimit</string>
+    <string name="upgrade_screen_status_upgraded_title">Përmirësimi aktiv</string>
+    <string name="upgrade_screen_recurring_title">Mbajeni të vazhdueshme</string>
+    <string name="upgrade_screen_recurring_body">CAPod vazhdon të zhvillohet përmes përditësimeve dhe përmirësimesh. Nëse dëshironi ta mbështetin atë, shqyrtoni një donacion të përsëritur përmes GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Отворите страницу за спонзорство</string>
     <string name="settings_upgrade_status_label">Подржите CAPod</string>
     <string name="settings_upgrade_status_description">Статус вашег подржавања.</string>
+    <string name="upgrade_screen_why_title">Предности надградње</string>
+    <string name="upgrade_screen_how_title">Како помоћи</string>
+    <string name="upgrade_screen_how_body">Постаните покровитељ и спонзоришите развој! Додирните дугме испод да активирате све додатне функције и отворите мој GitHub Sponsors профил.</string>
+    <string name="upgrade_screen_status_free_title">Бесплатна верзија</string>
+    <string name="upgrade_screen_status_free_body">Користите бесплатну верзију CAPod. Додатне функције можете откључати подржавањем развоја.</string>
+    <string name="upgrade_screen_status_free_action">Погледајте опције надградње</string>
+    <string name="upgrade_screen_status_upgraded_title">Надградња је активна</string>
+    <string name="upgrade_screen_recurring_title">Подржите развој</string>
+    <string name="upgrade_screen_recurring_body">CAPod се наставља развијати кроз ажурирања и исправке. Ако желите да то подржите, размотрите редовну донацију преко GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Öppna sponsorsidan</string>
     <string name="settings_upgrade_status_label">Sponsra CAPod</string>
     <string name="settings_upgrade_status_description">Din supporterstatus.</string>
+    <string name="upgrade_screen_why_title">Uppgraderingsfördelar</string>
+    <string name="upgrade_screen_how_title">Hur du kan hjälpa</string>
+    <string name="upgrade_screen_how_body">Bli en beskyddare och sponsra utvecklingen! Tryck på knappen nedan för att aktivera alla extra funktioner och öppna min GitHub Sponsors-profil.</string>
+    <string name="upgrade_screen_status_free_title">Gratis version</string>
+    <string name="upgrade_screen_status_free_body">Du använder den kostnadsfria versionen av CAPod. Extrafunktioner kan låsas upp genom att stödja utvecklingen.</string>
+    <string name="upgrade_screen_status_free_action">Se uppgraderingsalternativ</string>
+    <string name="upgrade_screen_status_upgraded_title">Uppgradering aktiv</string>
+    <string name="upgrade_screen_recurring_title">Håll det igång</string>
+    <string name="upgrade_screen_recurring_body">CAPod utvecklas ständigt genom uppdateringar och felkorrigeringar. Om du vill stödja det, överväg en återkommande donation via GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Fungua ukurasa wa udhamini</string>
     <string name="settings_upgrade_status_label">Kuunga mkono CAPod</string>
     <string name="settings_upgrade_status_description">Hali yako ya kuunga mkono.</string>
+    <string name="upgrade_screen_why_title">Faida za kuboreshwa</string>
+    <string name="upgrade_screen_how_title">Jinsi ya kusaidia</string>
+    <string name="upgrade_screen_how_body">Kuwa mfumo na mfadhili wa maendeleo! Gusa kitufe kilicho hapa chini ili kuwezesha vipengele vyote vya ziada na kufungua wasifu wangu wa GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Toleo la bure</string>
+    <string name="upgrade_screen_status_free_body">Unatumia toleo la bure la CAPod. Huduma za ziada zinaweza kufunguliwa kwa kusaidia maendeleo.</string>
+    <string name="upgrade_screen_status_free_action">Tazama chaguo za kuboreshwa</string>
+    <string name="upgrade_screen_status_upgraded_title">Kuboreshwa kimefanya kazi</string>
+    <string name="upgrade_screen_recurring_title">Endelea na hilo</string>
+    <string name="upgrade_screen_recurring_body">CAPod inaendelea kupitia sasisho na marekebisho. Ikiwa ungependa kusaidia, fikiria kumfanya mchango wa mara kwa mara kupitia GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">ஸ்பான்சர் பக்கத்தைத் திற</string>
     <string name="settings_upgrade_status_label">CAPod ஐ ஆதரிக்கவும்</string>
     <string name="settings_upgrade_status_description">உங்கள் ஆதரவாளர் நிலை.</string>
+    <string name="upgrade_screen_why_title">மேம்படுத்தல் நன்மைகள்</string>
+    <string name="upgrade_screen_how_title">எப்படி உதவுவது</string>
+    <string name="upgrade_screen_how_body">புரவலராக மாறி மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்! அனைத்து கூடுதல் அம்சங்களையும் செயல்படுத்த மற்றும் எனது GitHub Sponsors சுயவிவரத்தைத் திறக்க கீழே உள்ள பொத்தானைத் தட்டவும்.</string>
+    <string name="upgrade_screen_status_free_title">இலவச பதிப்பு</string>
+    <string name="upgrade_screen_status_free_body">நீங்கள் CAPod இன் இலவச பதிப்பைப் பயன்படுத்துகிறீர்கள். வளர்ச்சியை ஆதரிப்பதன் மூலம் கூடுதல் அம்சங்களைத் திறக்க முடியும்.</string>
+    <string name="upgrade_screen_status_free_action">மேம்படுத்தல் விருப்பங்களைப் பார்க்கவும்</string>
+    <string name="upgrade_screen_status_upgraded_title">மேம்படுத்தல் செயல்பட்டுள்ளது</string>
+    <string name="upgrade_screen_recurring_title">இதைத் தொடரவும்</string>
+    <string name="upgrade_screen_recurring_body">CAPod புதுப்பிப்புகள் மற்றும் திருத்தங்களின் மூலம் தொடர்ந்து உருவாகிறது. நீங்கள் அதை நிலைத்து வைக்க விரும்பினால், GitHub Sponsors மூலம் தொடர்ச்சியான தான வழங்கலை பரிசீலியுங்கள்.</string>
 </resources>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">స్పాన్సర్ పేజీని తెరవండి</string>
     <string name="settings_upgrade_status_label">CAPodకు స్పాన్సర్ చేయండి</string>
     <string name="settings_upgrade_status_description">మీ సపోర్టర్ స్థితి.</string>
+    <string name="upgrade_screen_why_title">అప్‌గ్రేడ్ ప్రయోజనాలు</string>
+    <string name="upgrade_screen_how_title">ఎలా సహాయం చేయాలి</string>
+    <string name="upgrade_screen_how_body">పేట్రన్ అవ్వండి మరియు అభివృద్ధిని స్పాన్సర్ చేయండి! అన్ని అదనపు ఫీచర్లను యాక్టివేట్ చేయడానికి మరియు నా GitHub Sponsors ప్రొఫైల్‌ను తెరవడానికి దిగువ బటన్‌ను నొక్కండి.</string>
+    <string name="upgrade_screen_status_free_title">ఉచిత సంస్కరణ</string>
+    <string name="upgrade_screen_status_free_body">మీరు CAPod యొక్క ఉచిత సంస్కరణని ఉపయోగిస్తున్నారు. అభివృద్ధిని సపోర్ట్ చేయడం ద్వారా అతిరిక్త ఫీచర్‌లను అన్‌లాక్ చేయవచ్చు.</string>
+    <string name="upgrade_screen_status_free_action">అప్‌గ్రేడ్ ఎంపికలను చూడండి</string>
+    <string name="upgrade_screen_status_upgraded_title">అప్‌గ్రేడ్ క్రియాశీలమైనది</string>
+    <string name="upgrade_screen_recurring_title">దీన్నిని కొనసాగించండి</string>
+    <string name="upgrade_screen_recurring_body">CAPod నవీకరణలు మరియు సరిదిద్దుకుల ద్వారా వికసిస్తూ ఉంది. మీరు దీన్నిని కొనసాగించాలనుకుంటే, GitHub Sponsors ద్వారా పునరావృత దానం గురించి ఆలోచించండి.</string>
 </resources>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">เปิดหน้าสนับสนุน</string>
     <string name="settings_upgrade_status_label">สนับสนุน CAPod</string>
     <string name="settings_upgrade_status_description">สถานะผู้สนับสนุนของคุณ</string>
+    <string name="upgrade_screen_why_title">ประโยชน์ของการอัปเกรด</string>
+    <string name="upgrade_screen_how_title">วิธีการช่วยเหลือ</string>
+    <string name="upgrade_screen_how_body">เป็นผู้อุปถัมภ์และสปอนเซอร์การพัฒนา! แตะปุ่มด้านล่างเพื่อเปิดใช้ฟีเจอร์เพิ่มเติมทั้งหมดและเปิดโปรไฟล์ GitHub Sponsors ของฉัน</string>
+    <string name="upgrade_screen_status_free_title">เวอร์ชันฟรี</string>
+    <string name="upgrade_screen_status_free_body">คุณกำลังใช้เวอร์ชันฟรีของ CAPod คุณลักษณะเพิ่มเติมสามารถปลดล็อกได้โดยการสนับสนุนการพัฒนา</string>
+    <string name="upgrade_screen_status_free_action">ดูตัวเลือกการอัปเกรด</string>
+    <string name="upgrade_screen_status_upgraded_title">เปิดใช้งานการอัปเกรด</string>
+    <string name="upgrade_screen_recurring_title">ทำให้มันดำเนินต่อไป</string>
+    <string name="upgrade_screen_recurring_body">CAPod ยังคงพัฒนาต่อไปผ่านการอัปเดตและการแก้ไข หากคุณต้องการสนับสนุนสิ่งนั้นต่อไป โปรดพิจารณาการบริจาคที่เกิดขึ้นซ้ำผ่าน GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Sponsor sayfasını aç</string>
     <string name="settings_upgrade_status_label">CAPod\'u destekle</string>
     <string name="settings_upgrade_status_description">Destekçi durumun.</string>
+    <string name="upgrade_screen_why_title">Yükseltme Avantajları</string>
+    <string name="upgrade_screen_how_title">Nasıl yardım edilir</string>
+    <string name="upgrade_screen_how_body">Haminiz olun ve gelişime sponsor olun! Tüm ekstra özellikleri etkinleştirmek ve GitHub Sponsorları profilimi açmak için aşağıdaki düğmeye dokunun.</string>
+    <string name="upgrade_screen_status_free_title">Ücretsiz Sürüm</string>
+    <string name="upgrade_screen_status_free_body">CAPod\'un ücretsiz sürümünü kullanıyorsunuz. Ek özellikler, geliştirmeyi destekleyerek kilidini açabilir.</string>
+    <string name="upgrade_screen_status_free_action">Yükseltme Seçeneklerini Gör</string>
+    <string name="upgrade_screen_status_upgraded_title">Yükseltme Etkin</string>
+    <string name="upgrade_screen_recurring_title">Devam Ettirin</string>
+    <string name="upgrade_screen_recurring_body">CAPod güncellemeler ve düzeltmeler aracılığıyla gelişmeye devam ediyor. Bunu sürdürmek istiyorsanız, GitHub Sponsors aracılığıyla yinelenen bir bağış yapmayı düşünün.</string>
 </resources>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Відкрити сторінку спонсорства</string>
     <string name="settings_upgrade_status_label">Спонсорувати CAPod</string>
     <string name="settings_upgrade_status_description">Ваш статус прихильника.</string>
+    <string name="upgrade_screen_why_title">Переваги оновлення</string>
+    <string name="upgrade_screen_how_title">Як допомогти</string>
+    <string name="upgrade_screen_how_body">Стань меценатом і спонсором розробки! Торкніться кнопки нижче, щоб активувати всі додаткові функції та відкрити мій профіль спонсорів GitHub.</string>
+    <string name="upgrade_screen_status_free_title">Безплатна версія</string>
+    <string name="upgrade_screen_status_free_body">Ви використовуєте безплатну версію CAPod. Додаткові функції можна розблокувати, підтримавши розробку.</string>
+    <string name="upgrade_screen_status_free_action">Переглянути варіанти оновлення</string>
+    <string name="upgrade_screen_status_upgraded_title">Оновлення активне</string>
+    <string name="upgrade_screen_recurring_title">Підтримайте розвиток</string>
+    <string name="upgrade_screen_recurring_body">CAPod постійно розвивається завдяки оновленням та виправленням. Якщо ви хочете підтримати це, розгляньте можливість регулярного пожертвування через GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">سپانسر پیج کھولیں</string>
     <string name="settings_upgrade_status_label">CAPod کی سرپرستی کریں</string>
     <string name="settings_upgrade_status_description">آپ کی حامی حالت۔</string>
+    <string name="upgrade_screen_why_title">اپ گریڈ کے فوائد</string>
+    <string name="upgrade_screen_how_title">کیسے مدد کریں</string>
+    <string name="upgrade_screen_how_body">سرپرست بنیں اور ترقی کو اسپانسر کریں! تمام اضافی خصوصیات کو فعال کرنے اور میری GitHub Sponsors پروفائل کھولنے کے لیے نیچے دیا گیا بٹن دبائیں۔</string>
+    <string name="upgrade_screen_status_free_title">مفت ورژن</string>
+    <string name="upgrade_screen_status_free_body">آپ CAPod کے مفت ورژن کا استعمال کر رہے ہیں۔ ترقی کی حمایت کر کے اضافی خصوصیات کو کھولا جا سکتا ہے۔</string>
+    <string name="upgrade_screen_status_free_action">اپ گریڈ کے آپشنز دیکھیں</string>
+    <string name="upgrade_screen_status_upgraded_title">اپ گریڈ فعال ہے</string>
+    <string name="upgrade_screen_recurring_title">اسے جاری رکھیں</string>
+    <string name="upgrade_screen_recurring_body">CAPod اپ ڈیٹس اور اصلاحات کے ذریعے ترقی کرتا رہتا ہے۔ اگر آپ اسے برقرار رکھنا چاہتے ہیں، تو GitHub Sponsors کے ذریعے بار بار عطیہ کرنے پر غور کریں۔</string>
 </resources>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Homiylik sahifasini ochish</string>
     <string name="settings_upgrade_status_label">CAPod ni homiylik qiling</string>
     <string name="settings_upgrade_status_description">Sizning homiy holati.</string>
+    <string name="upgrade_screen_why_title">Yangilashning afzalliklari</string>
+    <string name="upgrade_screen_how_title">Qanday yordam berish</string>
+    <string name="upgrade_screen_how_body">Homiy bo\'ling va rivojlanishni sponsorlik qiling! Barcha qo\'shimcha xususiyatlarni faollashtirish va GitHub Sponsors profilimni ochish uchun quyidagi tugmani bosing.</string>
+    <string name="upgrade_screen_status_free_title">Bepul versiya</string>
+    <string name="upgrade_screen_status_free_body">Siz CAPod-ning bepul versiyasidan foydalanyapsiz. Qo\'shimcha xususiyatlarni rivojlantirishni qo\'llab-quvvatlash orqali bo\'shatib olish mumkin.</string>
+    <string name="upgrade_screen_status_free_action">Yangilash variantlarini ko\'rish</string>
+    <string name="upgrade_screen_status_upgraded_title">Yangilash faol</string>
+    <string name="upgrade_screen_recurring_title">Davom eting</string>
+    <string name="upgrade_screen_recurring_body">CAPod yangilashlar va tuzatishlar orqali rivojlanishda davom etmoqda. Agar siz buni qo\'llab-quvvatlamoqchi bo\'lsangiz, GitHub Sponsors orqali takroriy hamdorlashni ko\'rib chiqing.</string>
 </resources>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Mở trang tài trợ</string>
     <string name="settings_upgrade_status_label">Tài trợ cho CAPod</string>
     <string name="settings_upgrade_status_description">Trạng thái nhà tài trợ của bạn.</string>
+    <string name="upgrade_screen_why_title">Lợi ích nâng cấp</string>
+    <string name="upgrade_screen_how_title">Làm thế nào để giúp đỡ</string>
+    <string name="upgrade_screen_how_body">Trở thành người bảo trợ và tài trợ phát triển! Nhấp vào nút bên dưới để kích hoạt tất cả các tính năng bổ sung và mở hồ sơ Nhà tài trợ GitHub của tôi.</string>
+    <string name="upgrade_screen_status_free_title">Phiên bản miễn phí</string>
+    <string name="upgrade_screen_status_free_body">Bạn đang sử dụng phiên bản miễn phí của CAPod. Các tính năng bổ sung có thể được mở khóa bằng cách hỗ trợ phát triển.</string>
+    <string name="upgrade_screen_status_free_action">Xem các tùy chọn nâng cấp</string>
+    <string name="upgrade_screen_status_upgraded_title">Nâng cấp đang hoạt động</string>
+    <string name="upgrade_screen_recurring_title">Tiếp tục hỗ trợ</string>
+    <string name="upgrade_screen_recurring_body">CAPod không ngừng phát triển thông qua các bản cập nhật và sửa chữa. Nếu bạn muốn duy trì điều đó, hãy xem xét quyên góp định kỳ thông qua GitHub Sponsors.</string>
 </resources>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">打开赞助页面</string>
     <string name="settings_upgrade_status_label">赞助 CAPod</string>
     <string name="settings_upgrade_status_description">您的赞助者身份。</string>
+    <string name="upgrade_screen_why_title">升级优势</string>
+    <string name="upgrade_screen_how_title">如何帮助我们</string>
+    <string name="upgrade_screen_how_body">成为赞助者并支持我们的开发！点击下面的按钮激活所有额外功能并打开我的 GitHub 赞助者资料。</string>
+    <string name="upgrade_screen_status_free_title">免费版本</string>
+    <string name="upgrade_screen_status_free_body">您正在使用免费版本的 CAPod。支持开发可以解锁额外功能。</string>
+    <string name="upgrade_screen_status_free_action">查看升级选项</string>
+    <string name="upgrade_screen_status_upgraded_title">升级已激活</string>
+    <string name="upgrade_screen_recurring_title">让它继续</string>
+    <string name="upgrade_screen_recurring_body">CAPod 通过更新和修复不断发展。如果您想维持这一点，请考虑通过 GitHub Sponsors 进行定期捐赠。</string>
 </resources>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">開啟贊助頁面</string>
     <string name="settings_upgrade_status_label">贊助 CAPod</string>
     <string name="settings_upgrade_status_description">您的贊助者身份。</string>
+    <string name="upgrade_screen_why_title">升級優勢</string>
+    <string name="upgrade_screen_how_title">如何協助</string>
+    <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
+    <string name="upgrade_screen_status_free_title">免費版本</string>
+    <string name="upgrade_screen_status_free_body">您正在使用 CAPod 的免費版本。透過支持開發可以解鎖更多功能。</string>
+    <string name="upgrade_screen_status_free_action">查看升級選項</string>
+    <string name="upgrade_screen_status_upgraded_title">升級已啟用</string>
+    <string name="upgrade_screen_recurring_title">繼續支持</string>
+    <string name="upgrade_screen_recurring_body">CAPod 透過更新和修復不斷演進。如果您想支持我們，請考慮透過 GitHub Sponsors 進行定期捐款。</string>
 </resources>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">開啟贊助頁面</string>
     <string name="settings_upgrade_status_label">贊助 CAPod</string>
     <string name="settings_upgrade_status_description">您的贊助狀態。</string>
+    <string name="upgrade_screen_why_title">升級優勢</string>
+    <string name="upgrade_screen_how_title">如何協助</string>
+    <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
+    <string name="upgrade_screen_status_free_title">免費版本</string>
+    <string name="upgrade_screen_status_free_body">您正在使用 CAPod 的免費版本。透過支持開發可解鎖額外功能。</string>
+    <string name="upgrade_screen_status_free_action">查看升級選項</string>
+    <string name="upgrade_screen_status_upgraded_title">升級已啟用</string>
+    <string name="upgrade_screen_recurring_title">繼續支持</string>
+    <string name="upgrade_screen_recurring_body">CAPod 透過不斷更新與修復不斷進步。如果您希望支持這項發展，請考慮透過 GitHub Sponsors 進行定期捐款。</string>
 </resources>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -12,4 +12,13 @@
     <string name="upgrade_foss_sponsor_again_action">Vula ikhasi lomxhasi</string>
     <string name="settings_upgrade_status_label">Uxhasa i-CAPod</string>
     <string name="settings_upgrade_status_description">Isimo sakho sokusekela.</string>
+    <string name="upgrade_screen_why_title">Imikhulu yokuphucula</string>
+    <string name="upgrade_screen_how_title">Indlela yokusiza</string>
+    <string name="upgrade_screen_how_body">Yiba ngumnikazi futhi uxhase ukuthuthukiswa! Thepha inkinobho engezansi ukuze unike amandla zonke izici ezengeziwe futhi uvule iphrofayili yami ye-GitHub Sponsors.</string>
+    <string name="upgrade_screen_status_free_title">Inguqulo yamahhala</string>
+    <string name="upgrade_screen_status_free_body">Usebenzisa inguqulo yamahhala ye-CAPod. Izinto ezongeziwe zingavulwa ngokusekela ukuthuthukiswa kwe-app.</string>
+    <string name="upgrade_screen_status_free_action">Bheka opsyon yokuphucula</string>
+    <string name="upgrade_screen_status_upgraded_title">I-upgrade iyagcinwa</string>
+    <string name="upgrade_screen_recurring_title">Qhubeka ngokwenza kunjalo</string>
+    <string name="upgrade_screen_recurring_body">I-CAPod iqhubeka nokuthuthuka ne-update kanye ne-fix. Uma uthanda ukugcina lokho, cabangela ukunikeza ngamashora okuthutha ngokuchubo nge-GitHub Sponsors.</string>
 </resources>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -70,7 +70,7 @@
     <string name="settings_upgrade_status_description">Estat de la vostra actualització i compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat sessió amb el vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
-    <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Pot ser que no estigui instal·lat, desactivat o restringit en aquest dispositiu.</string>
+    <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Pot ser que no estigui disponible, estigui desactivat o restringit en aquest dispositiu.</string>
     <string name="upgrades_gplay_internal_error_title">Error del Google Play</string>
     <string name="upgrades_gplay_internal_error_description">S\'ha produït un error intern del Google Play. Proveu el següent:\n\n• Reinicieu el dispositiu\n• Esborreu la memòria cau del Google Play Store\n• Torneu-ho a provar més tard</string>
     <string name="upgrades_gplay_network_error_title">Error de connexió</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -70,7 +70,7 @@
     <string name="settings_upgrade_status_description">Dein Upgrade- und Kaufstatus.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und auf dem neuesten Stand? Ist dein Google-Konto angemeldet? Versuche, den Cache der Google-Play-App zu leeren und dein Gerät neu zu starten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
-    <string name="upgrades_gplay_not_installed_message">Konnte Google Play nicht öffnen. Die App fehlt möglicherweise, ist deaktiviert oder eingeschränkt auf diesem Gerät.</string>
+    <string name="upgrades_gplay_not_installed_message">Google Play konnte nicht geöffnet werden. Möglicherweise ist die App auf diesem Gerät nicht installiert, deaktiviert oder der Zugriff darauf wurde eingeschränkt.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play Fehler</string>
     <string name="upgrades_gplay_internal_error_description">Ein interner Fehler bei Google Play ist aufgetreten. Bitte versuche Folgendes:\n\n• Starte dein Gerät neu\n• Leere den Cache des Google Play Stores\n• Versuche es später erneut</string>
     <string name="upgrades_gplay_network_error_title">Verbindungsfehler</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -57,9 +57,15 @@
     <string name="upgrade_screen_offers_body">លក្ខណៈដូចគ្នា តែម៉ូដែលតម្លៃខុសៗគ្នា។</string>
     <string name="upgrade_screen_offers_unavailable_title">តម្លៃមិនលេច</string>
     <string name="upgrade_screen_offers_unavailable_message">Google Play មិនបានផ្ដល់តម្លៃឥឡូវនេះទេ។ ពិនិត្យការតភ្ជាប់របស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
+    <string name="upgrade_screen_subscription_offer_title">ការផ្នូល​ប្រចាំឆ្នាំ</string>
+    <string name="upgrade_screen_subscription_offer_body">រលាប់ឡើងវិញរៀងរាល់ឆ្នាំបន្ទាប់ពីការសាកល្បងឥតគិតថ្លៃ។ អាចលុបចោលនៅពេលណាក៏បាននៅក្នុង Google Play។</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">រលាប់ឡើងវិញរៀងរាល់ឆ្នាំ។ អាចលុបចោលនៅពេលណាក៏បាននៅក្នុង Google Play។</string>
+    <string name="upgrade_screen_iap_offer_body">ការបង់ប្រាក់តែម្តងប៉ុណ្ណោះ គ្មានការរលាប់ឡើងវិញ។</string>
     <string name="upgrade_screen_benefits_title">អត្ថប្រយោជន៍នៃការឡើងកម្រិត</string>
     <string name="upgrade_screen_restore_body">ការស្ដារឡើងវិញនឹងស្នើឱ្យ Google Play ពិនិត្យឡើងវិញលើការទិញនៃកម្មវិធីនេះសម្រាប់គណនីបច្ចុប្បន្ន។ វាមិនបង្កើតការទិញថ្មីទេ។</string>
     <string name="upgrade_screen_restore_checked_message">CAPod ទើបតែពិនិត្យ Google Play ប៉ុណ្ណោះ ប៉ុន្ដែ មិនមានការទិញ Pro ដែលអាចបញ្ជាក់បានសម្រាប់គណនីដែល Google Play ប្រើប្រាស់សម្រាប់កម្មវិធីនេះទេ។</string>
+    <string name="upgrade_screen_restore_contact_hint">នៅតែមាន​បញ្ហា? ទាក់ទងក្រុមគាំទ័របន្ថែមដោយប្រើលិខិតអ៊ីមែលដែលបានប្រើក្នុងការទិញ ហើយរួមបញ្ចូលលេខលំដាប់របស់អ្នក Google Play។</string>
+    <string name="upgrade_screen_contact_support_action">ទាក់ទងក្រុមគាំទ័របន្ថែម</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">ស្ថានភាពនៃការឡើងកម្រិត និងការទិញរបស់អ្នក។</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ តើ Google Play បានដំឡើង និងធ្វើបច្ចុប្បន្នភាពឬទេ? តើគណនី Google របស់អ្នកបានចូលហើយឬនៅ? សាកល្បងសម្អាតឃ្លាំងសម្ងាត់កម្មវិធី Google Play និងចាប់ផ្តើមឧបករណ៍របស់អ្នកឡើងវិញ។</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -70,7 +70,7 @@
     <string name="settings_upgrade_status_description">Jūsu jaunināšanas un pirkuma statuss.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai jūsu Google konts ir pieteicies? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un restartēt ierīci.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
-    <string name="upgrades_gplay_not_installed_message">Neizdevās atvērt Google Play. Tas var būt pazudis, atspējots vai ierobežots šajā ierīcē.</string>
+    <string name="upgrades_gplay_not_installed_message">Nevarēja atvērt Google Play. Tā šajā ierīcē var nebūt, tas var būt atspējots vai ierobežots.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play kļūda</string>
     <string name="upgrades_gplay_internal_error_description">Notika iekšēja Google Play kļūda. Lūdzu, mēģiniet tālāk norādīto:\n\n• Restartējiet ierīci\n• Notīriet Google Play Store kešatmiņu\n• Vēlāk mēģiniet vēlreiz</string>
     <string name="upgrades_gplay_network_error_title">Savienojuma kļūda</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play melaporkan bahawa anda sudah memiliki peningkatan ini, tetapi ia tidak dapat dipulihkan. Pastikan anda menggunakan akaun Google yang digunakan semasa pembelian. Penyegerakan Play Store mungkin mengambil masa — cuba mulakan semula peranti, kosongkan cache Google Play atau tunggu sebentar.</string>
     <string name="upgrade_restore_action">Pulihkan pembelian</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Dapatkan %1$s</string>
     <string name="upgrade_preamble">CAPod dibangunkan oleh seorang individu. Peningkatan membuka kunci ciri tambahan dan membantu mengekalkan aplikasi ini.</string>
     <string name="upgrade_screen_options_description">Ciri yang sama, harga yang berbeza. Langganan termasuk percubaan percuma dan boleh dibatalkan pada bila-bila masa.</string>
     <string name="upgrade_screen_options_description_no_trial">Ciri yang sama, harga yang berbeza. Langganan boleh dibatalkan pada bila-bila masa.</string>
@@ -66,4 +68,12 @@
     <string name="upgrade_screen_contact_support_action">Hubungi Sokongan</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Status peningkatan dan pembelian anda.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod tidak dapat menyambung ke Google Play. Adakah Google Play dipasang dan dikemaskini? Adakah Akaun Google anda log masuk? Cuba kosongkan cache aplikasi Google Play dan but semula peranti anda.</string>
+    <string name="upgrades_gplay_internal_error_title">Ralat Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ralat dalaman Google Play telah berlaku. Sila cuba perkara berikut:\n\n• But semula peranti anda\n• Kosongkan cache Google Play Store\n• Cuba lagi nanti</string>
+    <string name="upgrades_gplay_network_error_title">Ralat sambungan</string>
+    <string name="upgrades_gplay_network_error_description">Tidak dapat menyambung ke Google Play. Sila periksa sambungan internet anda dan cuba lagi.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Penawaran tidak tersedia</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tidak menawarkan pilihan peningkatan ini pada masa ini. Sila cuba lagi nanti atau periksa Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Pemeriksaan dengan Google Play tidak selesai dalam masa, jadi status pembelian anda masih tidak diketahui. Tiada apa-apa yang telah berubah pada akaun anda.</string>
 </resources>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -69,6 +69,8 @@
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Status peningkatan dan pembelian anda.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod tidak dapat menyambung ke Google Play. Adakah Google Play dipasang dan dikemaskini? Adakah Akaun Google anda log masuk? Cuba kosongkan cache aplikasi Google Play dan but semula peranti anda.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Tidak dapat membuka Google Play. Ia mungkin tiada, dilumpuhkan atau disekat pada peranti ini.</string>
     <string name="upgrades_gplay_internal_error_title">Ralat Google Play</string>
     <string name="upgrades_gplay_internal_error_description">Ralat dalaman Google Play telah berlaku. Sila cuba perkara berikut:\n\n• But semula peranti anda\n• Kosongkan cache Google Play Store\n• Cuba lagi nanti</string>
     <string name="upgrades_gplay_network_error_title">Ralat sambungan</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play က ဤအဆင့်မြှင့်တင်မှုကို သင်ပိုင်ဆိုင်ပြီးသားဖြစ်ကြောင်း သတင်းပို့ခဲ့သော်လည်း ၎င်းကို ပြန်လည်ရယူ၍မရနိုင်ခဲ့ပါ။ သင်ဝယ်ယူခဲ့သည့် Google အကောင့်ကို အသုံးပြုနေကြောင်း သေချာပါစေ။ Play Store ထပ်တူပြုမှုသည် အချိန်အနည်းငယ်ကြာနိုင်ပါသည် — ပြန်လည်စတင်ကြည့်ပါ၊ Google Play ကက်ရှ်ကို ရှင်းလင်းကြည့်ပါ (သို့) စောင့်ဆိုင်းကြည့်ပါ။</string>
     <string name="upgrade_restore_action">ဝယ်ယူမှုကို ပြန်လည်ရယူမည်</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s ကို ရယူပါ</string>
     <string name="upgrade_preamble">CAPod ကို လူတစ်ဦးတည်းက ဖန်တီးထားခြင်းဖြစ်သည်။ အဆင့်မြှင့်တင်ခြင်းက ထပ်ဆောင်းအင်္ဂါရပ်များကို ဖွင့်ပေးပြီး အက်ပ်ကို ဆက်လက်တည်ရှိစေရန် ကူညီပေးပါသည်။</string>
     <string name="upgrade_screen_options_description">အင်္ဂါရပ်များ တူညီပြီး စျေးနှုန်းသာ ကွာခြားပါသည်။ စာရင်းသွင်းမှုတွင် အခမဲ့စမ်းသပ်ကာလ ပါဝင်ပြီး အချိန်မရွေး ပယ်ဖျက်နိုင်ပါသည်။</string>
     <string name="upgrade_screen_options_description_no_trial">အင်္ဂါရပ်များ တူညီပြီး စျေးနှုန်းသာ ကွာခြားပါသည်။ စာရင်းသွင်းမှုကို အချိန်မရွေး ပယ်ဖျက်နိုင်ပါသည်။</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">အကူအညီ ဆက်သွယ်ပါ</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">သင်၏ အဆင့်မြင့်တင်ခြင်း နှင့် ဝယ်ယူမှု အခြေအနေ။</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod သည် Google Play နှင့် ချိတ်ဆက်၍မရပါ။ Google Play ကို ထည့်သွင်းပြီး အပ်ဒိတ်လုပ်ထားပါသလား။ သင့် Google အကောင့် ဝင်ရောက်ထားပါသလား။ Google Play အက်ပ်၏ cache ကို ရှင်းလင်းပြီး သင့်စက်ကို ပြန်လည်စတင်ကြည့်ပါ။</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ကိုဖွင့်လို့မရခဲ့ပါ။ ၎င်းသည်ပျောက်နိုင်သည်၊ ပိတ်ထားနိုင်သည် သို့မဟုတ် ဤစက်ပစ္စည်းတွင် ကန့်သတ်ထားနိုင်သည်။</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play အမှားအယွင်း</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play အတွင်းပိုင်း အမှားအယွင်း ကျေးဇူးပြု၍ အောက်ပါတို့ကို ကြိုးစားကြည့်ပါ:\n\n• သင့်စက်ကို ပြန်လည်စတင်ပါ\n• Google Play Store cache ကို ရှင်းလင်းပါ\n• နောက်မှ ထပ်မံ ကြိုးစားကြည့်ပါ</string>
+    <string name="upgrades_gplay_network_error_title">ချိတ်ဆက်မှု အမှားအယွင်း</string>
+    <string name="upgrades_gplay_network_error_description">Google Play နှင့် ချိတ်ဆက်၍ မရပါ။ သင့် အင်တာနက် ချိတ်ဆက်မှု စစ်ဆေးပြီး ထပ်မံ ကြိုးစားကြည့်ပါ။</string>
+    <string name="upgrades_gplay_offer_unavailable_title">အဆိုအဖြေ မရှိပါ</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play သည် လက်ရှိ ဤအဆင့်မြှင့်တင်မှု ရွေးချယ်စရာ ကို အဆိုအဖြေ မပေးနေပါ။ နောက်မှ ထပ်မံ ကြိုးစားကြည့်ပါ သို့မဟုတ် Google Play Store ကို စစ်ဆေးကြည့်ပါ။</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ကို စစ်ဆေးမှု အချိန်မီ အပြီးမျှသွားမရသဖြင့် သင့် ဝယ်ယူမှု အခြေအနေ သည် မသိရှိရသေးပါ။ သင့် အကောင့်တွင် မည်သည့်အရာမျှ မပြောင်းလဲသွားပါ။</string>
 </resources>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterer at du allerede eier denne oppgraderingen, men den kunne ikke gjenopprettes. Sørg for at du bruker Google-kontoen du kjøpte med. Synkronisering med Play Store kan ta tid — prøv å starte på nytt, tømme Google Play-hurtigbufferen eller bare vente.</string>
     <string name="upgrade_restore_action">Gjenopprett kjøp</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Få %1$s</string>
     <string name="upgrade_preamble">CAPod er utviklet av én person. Oppgradering låser opp ekstra funksjoner og hjelper med å holde appen i live.</string>
     <string name="upgrade_screen_options_description">Samme funksjoner, ulik prising. Abonnementet inkluderer en gratis prøveperiode og kan kanselleres når som helst.</string>
     <string name="upgrade_screen_options_description_no_trial">Samme funksjoner, ulik prising. Abonnementet kan kanselleres når som helst.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Kontakt support</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Status for din oppgradering og kjøp.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din pålogget? Prøv å tømme hurtigbufferen for Google Play-appen og start enheten på nytt.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Klarte ikke å åpne Google Play. Den kan være manglende, deaktivert eller begrenset på denne enheten.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-feil</string>
+    <string name="upgrades_gplay_internal_error_description">En intern Google Play-feil oppstod. Prøv følgende:\n\n• Start enheten på nytt\n• Tøm Google Play Store-hurtigbufferen\n• Prøv igjen senere</string>
+    <string name="upgrades_gplay_network_error_title">Tilkoblingsfeil</string>
+    <string name="upgrades_gplay_network_error_description">Kan ikke koble til Google Play. Kontroller internettforbindelsen din og prøv igjen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tilbud utilgjengelig</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbyr ikke dette oppgraderingsalternativet for øyeblikket. Prøv igjen senere eller sjekk Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play ble ikke fullført i tide, så kjøpstatusen din er fortsatt ukjent. Ingenting har endret seg på kontoen din.</string>
 </resources>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ले तपाईंसँग यो अपग्रेड पहिले नै छ भनी रिपोर्ट गर्छ, तर यसलाई पुनर्स्थापना गर्न सकिएन। तपाईंले खरिद गर्दा प्रयोग गरेको Google खाता नै प्रयोग गरिरहनुभएको सुनिश्चित गर्नुहोस्। Play Store समिकरणमा समय लाग्न सक्छ — रिबुट गर्ने, Google Play क्यास खाली गर्ने वा केही समय पर्खने प्रयास गर्नुहोस्।</string>
     <string name="upgrade_restore_action">खरिद पुनर्स्थापना गर्नुहोस्</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s प्राप्त गर्नुहोस्</string>
     <string name="upgrade_preamble">CAPod एक जना व्यक्तिद्वारा विकास गरिएको हो। अपग्रेड गर्दा थप सुविधाहरू अनलक हुन्छन् र एपलाई जीवित राख्न मद्दत पुग्छ।</string>
     <string name="upgrade_screen_options_description">उस्तै सुविधाहरू, फरक मूल्य निर्धारण। सदस्यतामा नि:शुल्क परीक्षण समावेश छ र यसलाई जुनसुकै बेला रद्द गर्न सकिन्छ।</string>
     <string name="upgrade_screen_options_description_no_trial">उस्तै सुविधाहरू, फरक मूल्य निर्धारण। सदस्यतालाई जुनसुकै बेला रद्द गर्न सकिन्छ।</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">समर्थन सम्पर्क गर्नुहोस्</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">आफ्नो अपग्रेड र खरिद स्थिति।</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play सँग जडान गर्न सक्दैन। के Google Play स्थापना र अद्यावधिक गरिएको छ? के तपाईंको Google खाता लग इन गरिएको छ? Google Play एपको क्यास खाली गरेर र तपाईंको उपकरण रिबुट गर्ने प्रयास गर्नुहोस्।</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play खोल्न सकिएन। यो उपकरणमा हराएको, असक्षम वा प्रतिबंधित हुन सक्छ।</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play मा आन्तरिक त्रुटि भएको छ। कृपया निम्न प्रयास गर्नुहोस्:\n\n• आफ्नो उपकरण पुनः सुरु गर्नुहोस्\n• Google Play Store क्यास खाली गर्नुहोस्\n• पछि फेरि प्रयास गर्नुहोस्</string>
+    <string name="upgrades_gplay_network_error_title">जडान त्रुटि</string>
+    <string name="upgrades_gplay_network_error_description">Google Play सँग जडान गर्न सक्नु भएन। कृपया आफ्नो इन्टरनेट जडान जाँच गरेर फेरि प्रयास गर्नुहोस्।</string>
+    <string name="upgrades_gplay_offer_unavailable_title">अफर उपलब्ध छैन</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play हाल यो अपग्रेड विकल्प प्रदान गरिरहेको छैन। कृपया पछि फेरि प्रयास गर्नुहोस् वा Google Play Store जाँच गर्नुहोस्।</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play सँगको जाँच समयमा पूरा भएन, त्यसैले तपाईंको खरीद स्थिति अझै अज्ञात छ। तपाईंको खातामा कुनै परिवर्तन भएको छैन।</string>
 </resources>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play meldt dat je deze upgrade al bezit, maar deze kon niet worden hersteld. Zorg ervoor dat je het Google-account gebruikt waarmee je hebt gekocht. Synchronisatie van de Play Store kan tijd kosten — probeer opnieuw op te starten, de cache van Google Play te wissen of gewoon te wachten.</string>
     <string name="upgrade_restore_action">Herstel aankoop</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Haal %1$s</string>
     <string name="upgrade_preamble">CAPod wordt ontwikkeld door één persoon. Upgraden ontgrendelt extra functies en helpt de app in leven te houden.</string>
     <string name="upgrade_screen_options_description">Dezelfde functies, verschillende prijzen. Het abonnement bevat een gratis proefperiode en kan op elk moment worden opgezegd.</string>
     <string name="upgrade_screen_options_description_no_trial">Dezelfde functies, andere prijzen. Het abonnement kan op elk moment worden opgezegd.</string>
@@ -45,7 +47,7 @@
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog steeds actief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Je abonnement wordt automatisch verlengd. Annuleer het eerst in Google Play en schakel daarna over naar de eenmalige aankoop. Net geannuleerd? Geef Google Play even de tijd en probeer het opnieuw.</string>
     <string name="upgrade_screen_sub_check_failed_title">Controle van abonnement mislukt</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kon je abonnementsstatus niet controleren bij Google Play. Probeer het straks opnieuw om een dubbele aankoop te voorkomen.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Je abonnementsstatus kon niet worden gecontroleerd bij Google Play. Om een ​​dubbele aankoop te voorkomen, probeer het over een moment opnieuw.</string>
     <string name="upgrade_screen_grace_title">Je aankoop wordt bevestigd</string>
     <string name="upgrade_screen_grace_body_short">Google Play heeft je aankoop nog niet bevestigd. Pro is nog steeds actief — geen actie nodig.</string>
     <string name="upgrade_screen_grace_body">Google Play heeft je aankoop al een tijdje niet bevestigd. Pro is nog steeds actief. Zorg ervoor dat je online bent en bent ingelogd met het Google-account dat je voor de aankoop hebt gebruikt, en probeer het dan opnieuw te herstellen.</string>
@@ -60,10 +62,20 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Wordt jaarlijks vernieuwd. Annuleer op elk moment in Google Play.</string>
     <string name="upgrade_screen_iap_offer_body">Eenmalige betaling, geen vernieuwingen.</string>
     <string name="upgrade_screen_benefits_title">Voordelen van de upgrade</string>
-    <string name="upgrade_screen_restore_body">Bij het herstellen van een app vraagt Google Play om de aankopen van deze app voor het huidige account opnieuw te controleren. Er wordt geen nieuwe aankoop gestart.</string>
+    <string name="upgrade_screen_restore_body">Bij het herstellen van een app vraagt ​​Google Play om de aankopen van deze app voor het huidige account opnieuw te controleren. Er wordt geen nieuwe aankoop gestart.</string>
     <string name="upgrade_screen_restore_checked_message">CAPod heeft zojuist Google Play gecontroleerd, maar er kon geen Pro-aankoop worden bevestigd voor het Google Play-account dat voor deze app wordt gebruikt.</string>
     <string name="upgrade_screen_restore_contact_hint">Zit je nog steeds vast? Neem dan contact op met de klantenservice via het e-mailadres waarmee je de aankoop hebt gedaan en vermeld je Google Play-bestelnummer.</string>
     <string name="upgrade_screen_contact_support_action">Neem contact op met ondersteuning</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Je upgrade- en aankoopstatus.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Ben je ingelogd met je Google-account? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kon Google Play niet openen. Het kan ontbreken, uitgeschakeld of beperkt zijn op dit apparaat.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>
+    <string name="upgrades_gplay_internal_error_description">Er is een interne Google Play-fout opgetreden. Probeer het volgende:\n\n• Herstart je apparaat\n• Wis de cache van de Google Play Store\n• Probeer het later opnieuw</string>
+    <string name="upgrades_gplay_network_error_title">Verbindingsfout</string>
+    <string name="upgrades_gplay_network_error_description">Kan geen verbinding maken met Google Play. Controleer je internetverbinding en probeer het opnieuw.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Aanbieding niet beschikbaar</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play biedt deze upgrade-optie momenteel niet aan. Probeer het later opnieuw of raadpleeg de Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">De controle bij Google Play is niet op tijd voltooid, waardoor de status van je aankoop nog steeds onbekend is. Er is niets gewijzigd in je account.</string>
 </resources>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Sklep Google Play zgłasza, że już posiadasz tę aktualizację, ale nie udało się jej przywrócić. Upewnij się, że używasz konta Google, na które dokonano zakupu. Synchronizacja Sklepu Google Play może chwilę potrwać — spróbuj zrestartować urządzenie, wyczyścić pamięć podręczną Sklepu Google Play lub po prostu poczekaj.</string>
     <string name="upgrade_restore_action">Przywróć zakup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Uzyskaj %1$s</string>
     <string name="upgrade_preamble">CAPod jest rozwijany przez jedną osobę. Aktualizacja odblokowuje dodatkowe funkcje i pomaga utrzymać aplikację przy życiu.</string>
     <string name="upgrade_screen_options_description">Te same funkcje, różne ceny. Subskrypcja obejmuje bezpłatny okres próbny i może zostać anulowana w dowolnym momencie.</string>
     <string name="upgrade_screen_options_description_no_trial">Te same funkcje, inna cena. Subskrypcję możesz anulować w dowolnym momencie.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Skontaktuj się z pomocą techniczną</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Stan twojego zakupu i aktualizacji.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod nie może połączyć się z Sklepem Google Play. Czy Sklep Google Play jest zainstalowany i aktualny? Czy jesteś zalogowany na koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Sklepu Google Play i zrestartuj urządzenie.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nie można otworzyć Sklepu Google Play. Usługa może być niedostępna, wyłączona lub ograniczona na tym urządzeniu.</string>
+    <string name="upgrades_gplay_internal_error_title">Błąd Sklepu Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Wystąpił wewnętrzny błąd Google Play. Spróbuj najpierw:\n\n• Uruchomić ponownie urządzenie\n• Wyczyść pamięć podręczną sklepu Google Play\n• Spróbuj ponownie później</string>
+    <string name="upgrades_gplay_network_error_title">Błąd połączenia</string>
+    <string name="upgrades_gplay_network_error_description">Nie udało się połączyć się z Google Play. Sprawdź swoje połączenie internetowe i spróbuj ponownie.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta niedostępna</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Sklep Google Play obecnie nie oferuje tej opcji aktualizacji. Spróbuj ponownie później lub sprawdź w Sklepie Google Play.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Weryfikacja w Sklepie Google Play nie zakończyła się na czas, więc status twojego zakupu jest nadal nieznany. Na twoim koncie nic się nie zmieniło.</string>
 </resources>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">O Google Play informa que você já possui este upgrade, mas ele não pôde ser restaurado. Verifique se você está usando a conta Google com a qual fez a compra. A sincronização da Play Store pode levar algum tempo — tente reiniciar, limpar o cache do Google Play ou simplesmente aguardar.</string>
     <string name="upgrade_restore_action">Restaurar a compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">O CAPod é desenvolvido por uma única pessoa. Fazer o upgrade desbloqueia recursos extras e ajuda a manter o aplicativo vivo.</string>
     <string name="upgrade_screen_options_description">Os mesmos recursos, preços diferentes. A assinatura inclui um teste gratuito e pode ser cancelada a qualquer momento.</string>
     <string name="upgrade_screen_options_description_no_trial">Os mesmos recursos, preços diferentes. A assinatura pode ser cancelada a qualquer momento.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Contatar suporte</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Seu status de atualização e compra.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod não pode conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar ausente, desabilitado ou restrito neste dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Erro do Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocorreu um erro interno do Google Play. Tente o seguinte:\n\n• Reinicie o dispositivo\n• Limpe o cache do Google Play Store\n• Tente novamente mais tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de conexão</string>
+    <string name="upgrades_gplay_network_error_description">Não foi possível conectar ao Google Play. Verifique sua conexão com a internet e tente novamente.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta indisponível</string>
+    <string name="upgrades_gplay_offer_unavailable_description">O Google Play não está oferecendo esta opção de atualização no momento. Tente novamente mais tarde ou verifique a Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não foi concluída a tempo, portanto seu status de compra ainda é desconhecido. Nada mudou em sua conta.</string>
 </resources>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">O Google Play indica que já possuis esta atualização, mas não foi possível restaurá-la. Certifica-te de que estás a usar a conta Google com que efetuaste a compra. A sincronização da Play Store pode demorar algum tempo — tenta reiniciar, limpar a cache do Google Play ou simplesmente aguardar.</string>
     <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">O CAPod é desenvolvido por uma única pessoa. A atualização desbloqueia funcionalidades extra e ajuda a manter a aplicação viva.</string>
     <string name="upgrade_screen_options_description">As mesmas funcionalidades, preços diferentes. A subscrição inclui um período de avaliação gratuito e pode ser cancelada a qualquer momento.</string>
     <string name="upgrade_screen_options_description_no_trial">As mesmas funcionalidades, preços diferentes. A subscrição pode ser cancelada a qualquer momento.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Contactar o apoio</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">O seu estado de atualização e compra.</string>
+    <string name="upgrades_gplay_unavailable_error_description">O CAPod não consegue se conectar ao Google Play. O Google Play está instalado e atualizado? Você está conectado à sua Conta do Google? Tente limpar o cache do aplicativo Google Play e reiniciar o seu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar em falta, desativado ou restrito neste dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Erro no Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocorreu um erro interno do Google Play. Tente o seguinte:\n\n• Reinicie o dispositivo\n• Limpe a cache da Google Play Store\n• Tente novamente mais tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de ligação</string>
+    <string name="upgrades_gplay_network_error_description">Não foi possível estabelecer ligação ao Google Play. Verifique a ligação à Internet e tente novamente.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta indisponível</string>
+    <string name="upgrades_gplay_offer_unavailable_description">O Google Play não está oferecendo esta opção de upgrade no momento. Por favor, tente novamente mais tarde ou verifique a Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não foi concluída a tempo, por isso o status da sua compra ainda é desconhecido. Nenhuma alteração foi feita na sua conta.</string>
 </resources>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporta che ti possedas gia quest upgrade, ma el n\'ha betg pudì vegnir restaurà. Controllescha che ti utiliseschias il conto Google cun il qual ti has cumprà. La sincronisaziun da Play Store po durar in pau temp — emprova da reaviar il apparat, svidar la cache da Google Play u simplamain spetgar.</string>
     <string name="upgrade_restore_action">Restaurar la cumpra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obtegnair %1$s</string>
     <string name="upgrade_preamble">CAPod vegn sviluppà da ina persuna suletta. In upgrade sblochescha funcziuns supplementaras ed ajuda a mantegnair l\'app en vita.</string>
     <string name="upgrade_screen_options_description">Medemas funcziuns, autra tarifa. L\'abunament includa in emprova gratuita e po vegnir annullà da tut temp.</string>
     <string name="upgrade_screen_options_description_no_trial">Medemas funcziuns, autra tarifa. L\'abunament po vegnir annullà da tut temp.</string>
@@ -65,4 +67,14 @@
     <string name="upgrade_screen_contact_support_action">Contactar il support</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tes status dal upgrade e da l\'acquista.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod n\'uschia connectar a Google Play. Es Google Play installà e actualizà? Es tia conta Google connectada? Emprova a svida il cache da l\'app Google Play e a restartar tes apparat.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Na pud avrir Google Play. El po esser gliensch, deactivad ubain retrett sin quest apparat.</string>
+    <string name="upgrades_gplay_internal_error_title">Errur Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">In errur intern da Google Play è succidìda. Emprova sco suondas:\n\n• Restartar tes apparat\n• Svida il cache dal Google Play Store\n• Prova pli tard</string>
+    <string name="upgrades_gplay_network_error_title">Errur da connexiun</string>
+    <string name="upgrades_gplay_network_error_description">N\'uschia connectar a Google Play. Controlla tia connexiun da internet e prova anc ina giada.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offerta n\'è betg disponibla</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play n\'offra actualmain betg questa opziun da upgrade. Prova pli tard u controlla il Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Il control cun Google Play n\'ha betg finì a temp, perquai che tes status d\'aquista è anc ignot. Nagin che ha sa midà en tia conta.</string>
 </resources>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -56,6 +56,7 @@
     <string name="upgrade_screen_offers_or">u</string>
     <string name="upgrade_screen_offers_body">Medemas caracteristicas, suleta en models da preziun differentas.</string>
     <string name="upgrade_screen_offers_unavailable_title">Preziuns betg disponiblas</string>
+    <string name="upgrade_screen_offers_unavailable_message">Google Play n\'ha betg inditgà ils pretschs actualmain. Controllescha tia connexiun ed emprova anc\'ina giada in mument pli tard.</string>
     <string name="upgrade_screen_subscription_offer_title">Abbunament annual</string>
     <string name="upgrade_screen_subscription_offer_body">Renova mintgamai tut l\'onn suenter la prova gratuita. Annullescha mintga temp en Google Play.</string>
     <string name="upgrade_screen_subscription_offer_body_no_trial">Renova mintgamai tut l\'onn. Annullescha mintga temp en Google Play.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play raportează că deții deja acest upgrade, dar nu a putut fi restaurat. Asigură-te că folosești contul Google cu care ai făcut achiziția. Sincronizarea Play Store poate dura ceva timp — încearcă să repornești telefonul, să ștergi memoria cache a Google Play sau pur și simplu așteaptă.</string>
     <string name="upgrade_restore_action">Restabiliți achiziția</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obține %1$s</string>
     <string name="upgrade_preamble">CAPod este dezvoltat de o singură persoană. Upgrade-ul deblochează funcții suplimentare și ajută la menținerea aplicației în viață.</string>
     <string name="upgrade_screen_options_description">Aceleași funcții, prețuri diferite. Abonamentul include o perioadă de probă gratuită și poate fi anulat oricând.</string>
     <string name="upgrade_screen_options_description_no_trial">Aceleași funcții, prețuri diferite. Abonamentul poate fi anulat oricând.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Contactează suportul</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Statusul tău de actualizare și achiziție.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod nu se poate conecta la Google Play. Este Google Play instalat și actualizat? Contul tău Google este conectat? Încearcă să ștergi memoria cache a aplicației Google Play și să repornești dispozitivul.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nu s-a putut deschide Google Play. Este posibil să lipsească, să fie dezactivat sau restricționat pe acest dispozitiv.</string>
+    <string name="upgrades_gplay_internal_error_title">Eroare Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">A apărut o eroare internă din Google Play. Te rugăm să încerci următoarele:\n\n• Repornește dispozitivul\n• Șterge memoria cache Google Play Store\n• Încearcă din nou mai târziu</string>
+    <string name="upgrades_gplay_network_error_title">Eroare de conectare</string>
+    <string name="upgrades_gplay_network_error_description">Nu se poate conecta la Google Play. Te rugăm să verifici conexiunea ta la internet și să încerci din nou.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ofertă indisponibilă</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nu oferă în prezent această opțiune de upgrade. Te rugăm să încerci din nou mai târziu sau să verifici Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Verificarea cu Google Play nu s-a încheiat la timp, deci statutul achiziției tale rămâne necunoscut. Nimic nu s-a schimbat pe contul tău.</string>
 </resources>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play сообщает, что Вы купили это обновление, но его не удалось восстановить. Убедитесь, что Вы используете тот же аккаунт Google, с которого была совершена покупка. Синхронизация Play Store может занять некоторое время — попробуйте перезагрузить устройство, очистить кэш Google Play или просто подождать.</string>
     <string name="upgrade_restore_action">Восстановить покупку</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Получить %1$s</string>
     <string name="upgrade_preamble">CAPod разработан одним человеком. Обновление открывает дополнительные функции и помогает поддерживать приложение.</string>
     <string name="upgrade_screen_options_description">Одинаковые функции, разные цены. Подписка включает бесплатный пробный период и может быть отменена в любое время.</string>
     <string name="upgrade_screen_options_description_no_trial">Одинаковые функции, разные цены. Подписку можно отменить в любое время.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Связаться с поддержкой</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ваш статус обновления и покупки.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod не может подключиться к Google Play. Проверьте, установлен ли Google Play и обновлен ли до последней версии? Выполнен ли вход с Вашей учетной записью Google? Попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не удалось открыть Google Play. Возможно, он отсутствует, отключен или недоступен на этом устройстве.</string>
+    <string name="upgrades_gplay_internal_error_title">Ошибка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Произошла внутренняя ошибка Google Play. Пожалуйста, попробуйте следующее:\n\n• Перезапустите устройство\n• Очистите кэш Google Play Store\n• Повторите попытку позже</string>
+    <string name="upgrades_gplay_network_error_title">Ошибка соединения</string>
+    <string name="upgrades_gplay_network_error_description">Не удалось подключиться к Google Play. Пожалуйста, проверьте подключение к интернету и повторите попытку.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Предложение недоступно</string>
+    <string name="upgrades_gplay_offer_unavailable_description">В настоящее время Google Play не предлагает эту опцию обновления. Пожалуйста, повторите попытку позже или проверьте Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Проверка с Google Play не закончилась вовремя, поэтому статус покупки до сих пор неизвестен. В Вашей учетной записи ничего не изменилось.</string>
 </resources>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -56,11 +56,14 @@
     <string name="upgrade_screen_offers_or">o</string>
     <string name="upgrade_screen_offers_body">Istessas features, ma modelos de prezu differentis.</string>
     <string name="upgrade_screen_offers_unavailable_title">Prezu non disponìbile</string>
+    <string name="upgrade_screen_offers_unavailable_message">Google Play no at torradu is prètzios como. Controlla sa connessione tua e torra a proare intre pagu tempus.</string>
+    <string name="upgrade_screen_subscription_offer_title">Abbonamentu annuale</string>
     <string name="upgrade_screen_subscription_offer_body">Si renovet anu po anu dopo sa proba libera. Podes cantzellare in cuale mumentu in Google Play.</string>
     <string name="upgrade_screen_subscription_offer_body_no_trial">Si renovet anu po anu. Podes cantzellare in cuale mumentu in Google Play.</string>
     <string name="upgrade_screen_iap_offer_body">Unu pagamentu, sena renovatziones.</string>
     <string name="upgrade_screen_benefits_title">Beneficios de s\'agiornamentu</string>
     <string name="upgrade_screen_restore_body">Su ristoru domanda a Google Play de verificà de noe sos compronius de sa aplicatzione pro s\'acontu in usu. No iniciat ungha noa compra.</string>
+    <string name="upgrade_screen_restore_checked_message">CAPod at pena controlladu Google Play, ma perunu comporu Pro at pòtzidu èssere cunfirmadu pro su contu chi Google Play est impreende pro custa aplicatzione.</string>
     <string name="upgrade_screen_restore_contact_hint">Ancora blocau? Cunta sos suportu dae s\'email chi at fetu sa compra e inclui su numeru de s\'ordine Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Cunta sos suportu</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play informat chi tenes giai custu megioramentu, ma no est istadu possìbile lu ripristinare. Assegura·ti de impreare su contu Google chi as impreadu pro comporare. Sa sincronizatzione de su Play Store podet leare tempus — proa a torrare a allutu su dispositivu, a bogare sa memoria cache de Google Play o solu a aspetare.</string>
     <string name="upgrade_restore_action">Recùpera su cùmperu</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Otine %1$s</string>
     <string name="upgrade_preamble">CAPod est isvilupada de una persona sola. Su megioramentu isblocat funtziones in prus e agiudat a mantènnere s\'aplicatzione bia.</string>
     <string name="upgrade_screen_options_description">Matessi funtziones, prètzios diferentes. S\'abbonamentu includet una proa gratùita e podet èssere cantzelladu in cale si siat momentu.</string>
     <string name="upgrade_screen_options_description_no_trial">Matessi funtziones, prètzios diferentes. S\'abbonamentu podet èssere cantzelladu in cale si siat momentu.</string>
@@ -58,8 +60,19 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Si renovet anu po anu. Podes cantzellare in cuale mumentu in Google Play.</string>
     <string name="upgrade_screen_iap_offer_body">Unu pagamentu, sena renovatziones.</string>
     <string name="upgrade_screen_benefits_title">Beneficios de s\'agiornamentu</string>
+    <string name="upgrade_screen_restore_body">Su ristoru domanda a Google Play de verificà de noe sos compronius de sa aplicatzione pro s\'acontu in usu. No iniciat ungha noa compra.</string>
     <string name="upgrade_screen_restore_contact_hint">Ancora blocau? Cunta sos suportu dae s\'email chi at fetu sa compra e inclui su numeru de s\'ordine Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Cunta sos suportu</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">S\'istadu de su megioramentu e de sa comporadura tua.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod non podet si connètere a Google Play. Google Play est installadu e agiornadu? Su contu Google tuo est intradu? Proa a limpiare sa cache de s\'aplicatzione Google Play e a torrare a allùghere su dispositivu tuo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No s\'at pòdidhu abèrere Google Play. Podet esse mancante, disabilitadu o ristrettu in custu dispositibu.</string>
+    <string name="upgrades_gplay_internal_error_title">Errore de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Unu errore intèrnu de Google Play est acabuddu. Proa sa seguiente:\n\n• Torrare a allùghere su dispositivu tuo\n• Limpiare sa cache de Google Play Store\n• Proare prus tardu</string>
+    <string name="upgrades_gplay_network_error_title">Errore de sa connessione</string>
+    <string name="upgrades_gplay_network_error_description">Non potzo mi connectere a Google Play. Cuntrolla sa connessione a internet tua e proare de nòu.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offerta non disponìbile</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no est presentende est\'optzione de agiornamentu in custu momentu. Proare de nòu prus tardu o cuntrolla Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Sa controlli cun Google Play non est acabbudda in tempus, ita ca su stadu de sa compra tua est aìnda non notu. Nulla est cambiadu in su contu tuo.</string>
 </resources>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">ඔබ දැනටමත් මෙම උසස් කිරීම හිමිකරගෙන ඇති බව Google Play වාර්තා කරයි, නමුත් එය ප්‍රතිසාධනය කළ නොහැකි විය. ඔබ මිලදී ගැනීමට භාවිත කළ Google ගිණුමම භාවිත කරන බව තහවුරු කරගන්න. Play Store සමමුහුර්තකරණයට කාලය ගත විය හැක — නැවත ආරම්භ කිරීම, Google Play කෑෂය හිස් කිරීම, හෝ මදක් රැඳී සිටීම උත්සාහ කරන්න.</string>
     <string name="upgrade_restore_action">මිලදී ගැනීම ප්‍රතිසාධනය කරන්න</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s ලබා ගන්න</string>
     <string name="upgrade_preamble">CAPod සංවර්ධනය කරනු ලබන්නේ එක් පුද්ගලයෙකු විසිනි. උසස් කිරීම අමතර විශේෂාංග අගුළු හරින අතර යෙදුම ක්‍රියාත්මකව තබා ගැනීමට උපකාරී වේ.</string>
     <string name="upgrade_screen_options_description">විශේෂාංග එකම ය, මිල ගණන් වෙනස් ය. දායකත්වයට නොමිලේ අත්හදා බැලීමක් ඇතුළත් වන අතර ඕනෑම වේලාවක එය අවලංගු කළ හැක.</string>
     <string name="upgrade_screen_options_description_no_trial">විශේෂාංග එකම ය, මිල ගණන් වෙනස් ය. දායකත්වය ඕනෑම වේලාවක අවලංගු කළ හැක.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">සහාය සම්බන්ධ කරන්න</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">ඔබේ වැඩිදුම් සහ ගිණුම් තත්‍වය.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod හට Google Play වෙත සම්බන්ධ විය නොහැක. Google Play ස්ථාපනය කර යාවත්කාලීන කර තිබේද? ඔබගේ Google ගිණුම පුරනය වී තිබේද? Google Play යෙදුමේ හැඹිලිය මකා ඔබගේ උපාංගය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play විවෘත කළ නොහැකි විය. එය මෙම උපකරණයේ නැතිවිය, අක්‍රිය කර ඇත හෝ සීමාබද්ධ විය හැකිය.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play දෝෂය</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play හි අභ්‍යන්තර දෝෂයක් ඇතිවිය. කරුණාකර පහත සැලසුම් උත්සාහ කරන්න:\n\n• ඔබගේ උපාංගය නැවත ආරම්භ කරන්න\n• Google Play Store හැඹිලිය මකන්න\n• පසුව නැවත උත්සාහ කරන්න</string>
+    <string name="upgrades_gplay_network_error_title">සම්බන්ධතා දෝෂය</string>
+    <string name="upgrades_gplay_network_error_description">Google Play වෙත සම්බන්ධ විය නොහැක. කරුණාකර ඔබගේ අන්තර්ජාල සම්බන්ධතාවය පරීක්ෂා කර නැවත උත්සාහ කරන්න.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ඉදිරිපත් කිරීම නොමැත</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play දැනට මෙම උඩ්ග්‍රේඩ් විකල්ප ඉදිරිපත් නොකරයි. කරුණාකර පසුව නැවත උත්සාහ කරන්න හෝ Google Play Store පරීක්ෂා කරන්න.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play සමඟ පරීක්ෂාව කාලීනව සම්පූර්ණ වුණේ නැත, එබැවින් ඔබගේ ගැනුම් තත්ත්‍වය තවමත් නොදන්නා සේ ඉතුරු ඇත. ඔබගේ ගිණුමට කිසිවක් වෙනස් වී නැත.</string>
 </resources>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play hlási, že tento upgrade už vlastníte, no nepodarilo sa ho obnoviť. Uistite sa, že používate rovnaký účet Google, s ktorým ste nákup uskutočnili. Synchronizácia Play Store môže chvíľu trvať — skúste reštartovať zariadenie, vymazať vyrovnávaciu pamäť Google Play alebo jednoducho počkať.</string>
     <string name="upgrade_restore_action">Obnoviť nákup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Získať %1$s</string>
     <string name="upgrade_preamble">CAPod vyvíja jedna osoba. Upgradom odomknete ďalšie funkcie a pomôžete udržať aplikáciu nažive.</string>
     <string name="upgrade_screen_options_description">Rovnaké funkcie, odlišná cena. Predplatné zahŕňa bezplatnú skúšobnú verziu a možno ho kedykoľvek zrušiť.</string>
     <string name="upgrade_screen_options_description_no_trial">Rovnaké funkcie, odlišná cena. Predplatné možno kedykoľvek zrušiť.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Kontaktovať podporu</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Váš stav upgradu a nákupu.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod sa nemôže pripojiť k službe Google Play. Je Google Play nainštalovaný a aktuálny? Je váš účet Google prihlásený? Skúste vymazať vyrovnávaciu pamäť aplikácie Google Play a reštartujte zariadenie.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nepodarilo sa otvoriť Google Play. Môže byť chýbajúci, zakázaný alebo obmedzený na tomto zariadení.</string>
+    <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Vyskytla sa interná chyba Google Play. Skúste nasledovné:\n\n• Reštartujte zariadenie\n• Vymažte vyrovnávaciu pamäť Google Play Store\n• Skúste neskôr</string>
+    <string name="upgrades_gplay_network_error_title">Chyba pripojenia</string>
+    <string name="upgrades_gplay_network_error_description">Nie je možné pripojiť sa k službe Google Play. Skontrolujte internetové pripojenie a skúste znova.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponuka nie je dostupná</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Služba Google Play v súčasnosti neposkytuje túto možnosť upgradu. Skúste neskôr alebo skontrolujte Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrola so službou Google Play sa nestihla dokončiť v čase, takže váš stav nákupu je stále neznámy. Na vašom účte sa nič nezmenilo.</string>
 </resources>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play sporoča, da to nadgradnjo že imate, vendar je ni bilo mogoče obnoviti. Prepričajte se, da uporabljate Google račun, s katerim ste opravili nakup. Sinhronizacija Trgovine Play lahko traja nekaj časa — poskusite znova zagnati napravo, počistiti predpomnilnik Google Play ali preprosto počakajte.</string>
     <string name="upgrade_restore_action">Obnovi nakup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Pridobite %1$s</string>
     <string name="upgrade_preamble">CAPod razvija ena sama oseba. Nadgradnja odklene dodatne funkcije in pomaga ohranjati aplikacijo pri življenju.</string>
     <string name="upgrade_screen_options_description">Enake funkcije, različno oblikovanje cen. Naročnina vključuje brezplačno preizkusno obdobje in jo je mogoče kadarkoli preklicati.</string>
     <string name="upgrade_screen_options_description_no_trial">Enake funkcije, različno oblikovanje cen. Naročnino je mogoče kadarkoli preklicati.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Kontaktiraj podporo</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tvoj status nadgradnje in nakupa.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod se ne more povezati z Googlom Play. Ali je nameščen in posodobljen? Ali ste prijavljeni v Googlov račun? Poizkusite počistiti predpomnilnik programa Google Play in napravo ponovno zagnati.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Ni bilo mogoče odpreti Google Play. Morda je aplikacija manjkajoča, onemogočena ali omejena na tej napravi.</string>
+    <string name="upgrades_gplay_internal_error_title">Težava z Googlom Play</string>
+    <string name="upgrades_gplay_internal_error_description">Prišlo je do notranje napake v Googlu Play. Prosimo, poskusite naslednje:\n\n• Ponovno zaženite napravo\n• Počistite predpomnilnik trgovine Google Play\n• Poskusite ponovno pozneje</string>
+    <string name="upgrades_gplay_network_error_title">Napaka pri povezavi</string>
+    <string name="upgrades_gplay_network_error_description">Ne morem se povezati z Googlom Play. Preverite internetno povezavo in poskusite ponovno.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponudba ni na voljo</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play trenutno ne nudi te možnosti nadgradnje. Poskusite ponovno pozneje ali preverite trgovino Google Play.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Preverjanje z Googlom Play se ni zaključilo pravočasno, zato je vaš status nakupa še vedno neznan. Nič se ni spremenilo na vašem računu.</string>
 </resources>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play raporton se ju e zotëroni tashmë këtë përmirësim, por nuk mund të rikthehet. Sigurohuni që po përdorni llogarinë Google me të cilën keni bërë blerjen. Sinkronizimi i Play Store mund të marrë kohë — provoni ta rinisni pajisjen, të pastroni memorien e fshehtë (cache) të Google Play, ose thjesht të prisni.</string>
     <string name="upgrade_restore_action">Rivendos blerjen</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Merrni %1$s</string>
     <string name="upgrade_preamble">CAPod zhvillohet nga një person i vetëm. Përmirësimi zhbllokon veçori shtesë dhe ndihmon të mbahet aplikacioni gjallë.</string>
     <string name="upgrade_screen_options_description">Të njëjtat veçori, çmime të ndryshme. Abonimi përfshin një periudhë provë falas dhe mund të anulohet në çdo kohë.</string>
     <string name="upgrade_screen_options_description_no_trial">Të njëjtat veçori, çmime të ndryshme. Abonimi mund të anulohet në çdo kohë.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Kontaktoni mbështetjen</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Statusi juaj i përmirësimit dhe blerjes.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod nuk mund të lidhet me Google Play dyqanin. A është Google Play dyqani i instaluar dhe i përditësuar? A është identifikuar llogaria juaj e Google? Provoni të pastroni cache-in e aplikacionit Google Play dhe të rindizni pajisjen tuaj.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nuk mund ta hapa Google Play. Mund të mungojë, të jetë i çaktivizuar ose i kufizuar në këtë pajisje.</string>
+    <string name="upgrades_gplay_internal_error_title">Gabim në Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ndodhi një gabim i brendshëm në Google Play. Ju lutemi provoni sa vijon:\n\n• Rinisni pajisjen tuaj\n• Pastroni cache-in e Google Play Store\n• Provoni më vonë</string>
+    <string name="upgrades_gplay_network_error_title">Gabim i lidhjes</string>
+    <string name="upgrades_gplay_network_error_description">Nuk mund të lidhet me Google Play. Ju lutemi kontrolloni lidhjen tuaj në internet dhe provoni përsëri.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta nuk disponohet</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nuk ofron aktualisht këtë opsion përmirësimi. Ju lutemi provoni më vonë ose kontrolloni Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrollimi me Google Play nuk përfundoi në kohë, kështu që statusi i blerjes tuaj është ende i panjohur. Asgjë nuk ka ndryshuar në llogarinë tuaj.</string>
 </resources>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play пријављује да већ поседујете ову надоградњу, али није могла да се обнови. Проверите да ли користите Google налог са којим сте извршили куповину. Синхронизација Play продавнице може потрајати — покушајте да рестартујете уређај, обришете кеш Google Play-а или једноставно сачекате.</string>
     <string name="upgrade_restore_action">Врати куповину</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Узмите %1$s</string>
     <string name="upgrade_preamble">CAPod развија једна особа. Надоградња откључава додатне функције и помаже да апликација опстане.</string>
     <string name="upgrade_screen_options_description">Исте функције, различите цене. Претплата укључује бесплатан пробни период и може се отказати у сваком тренутку.</string>
     <string name="upgrade_screen_options_description_no_trial">Исте функције, различите цене. Претплата се може отказати у сваком тренутку.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Контактирајте подршку</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Статус ваше надоградње и куповине.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod не може да се повеже са Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли сте пријављени на свој Google налог? Покушајте да очистите кеш Google Play апликације и поново покрените уређај.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Није могуће отворити Google Play. Можда је онемогућено, недостаје или је ограничено на овом уређају.</string>
+    <string name="upgrades_gplay_internal_error_title">Грешка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Дошло је до интерне грешке Google Play. Покушајте следеће:\n\n• Поново покрените уређај\n• Очистите кеш Google Play Store\n• Покушајте касније</string>
+    <string name="upgrades_gplay_network_error_title">Грешка повезивања</string>
+    <string name="upgrades_gplay_network_error_description">Не могу да се повежем са Google Play. Проверите своју интернет везу и покушајте поново.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Понуда недоступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play не нуди ову опцију надградње у овом тренутку. Покушајте касније или проверите Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Провера са Google Play није завршена на време, тако да статус куповине остаје непознат. Ништа се није променило на вашем налогу.</string>
 </resources>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterar att du redan äger den här uppgraderingen, men den kunde inte återställas. Kontrollera att du använder samma Google-konto som du köpte med. Synkroniseringen med Play Butik kan ta tid — prova att starta om, rensa cacheminnet för Google Play eller helt enkelt vänta.</string>
     <string name="upgrade_restore_action">Återställ köp</string>
     <string name="upgrade_badge_label">Expert</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Skaffa %1$s</string>
     <string name="upgrade_preamble">CAPod utvecklas av en enda person. En uppgradering låser upp extra funktioner och hjälper till att hålla appen vid liv.</string>
     <string name="upgrade_screen_options_description">Samma funktioner, olika priser. Prenumerationen inkluderar en kostnadsfri provperiod och kan avslutas när som helst.</string>
     <string name="upgrade_screen_options_description_no_trial">Samma funktioner, olika priser. Prenumerationen kan avslutas när som helst.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Kontakta support</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Din uppgraderings- och köpstatus.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunde inte öppna Google Play. Det kan saknas, vara inaktiverat eller begränsat på denna enhet.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fel</string>
+    <string name="upgrades_gplay_internal_error_description">Ett internt Google Play-fel uppstod. Försök med följande:\n\n• Starta om enheten\n• Rensa Google Play Store-cache\n• Försök igen senare</string>
+    <string name="upgrades_gplay_network_error_title">Anslutningsfel</string>
+    <string name="upgrades_gplay_network_error_description">Det gick inte att ansluta till Google Play. Kontrollera din internetanslutning och försök igen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Erbjudandet är inte tillgängligt</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play erbjuder för närvarande inte detta uppgraderingsalternativ. Försök igen senare eller kontrollera Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play slutfördes inte i tid, så din köpstatus är fortfarande okänd. Ingenting har ändrats på ditt konto.</string>
 </resources>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play inaripoti kuwa tayari unamiliki uboreshaji huu, lakini haukuweza kurejeshwa. Hakikisha unatumia akaunti ya Google uliyotumia kununua. Usawazishaji wa Play Store unaweza kuchukua muda — jaribu kuwasha upya kifaa, kufuta hifadhi ya Google Play au kusubiri tu.</string>
     <string name="upgrade_restore_action">Rejesha ununuzi</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Pata %1$s</string>
     <string name="upgrade_preamble">CAPod inatengenezwa na mtu mmoja tu. Kuboresha kunafungua vipengele vya ziada na kusaidia kuendeleza programu hii.</string>
     <string name="upgrade_screen_options_description">Vipengele sawa, bei tofauti. Usajili unajumuisha jaribio la bure na unaweza kughairiwa wakati wowote.</string>
     <string name="upgrade_screen_options_description_no_trial">Vipengele sawa, bei tofauti. Usajili unaweza kughairiwa wakati wowote.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Wasiliana na msaada</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Hali yako ya Upgrade na Ununuzi.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod haiwezi kuunganisha na Google Play. Je, Google Play imesakinishwa na imesasishwa? Je, akaunti yako ya Google imeingia? Jaribu kusafisha akiba ya programu ya Google Play na uanzishe upya kifaa chako.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Hakuweza kufungua Google Play. Huenda haipo, imelemazwa au imezuiliwa kwenye kifaa hiki.</string>
+    <string name="upgrades_gplay_internal_error_title">Hitilafu ya Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Hitilafu ya ndani ya Google Play ilitokea. Tafadhali jaribu zifuatazo:\n\n• Anzisha upya kifaa chako\n• Safisha hifadhi ya Google Play Store\n• Jaribu tena baadaye</string>
+    <string name="upgrades_gplay_network_error_title">Hitilafu ya kuunganisha</string>
+    <string name="upgrades_gplay_network_error_description">Haiwezi kuunganisha na Google Play. Tafadhali angalia muunganisho wako wa mtandao na jaribu tena.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ofa haipatikani</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Chaguo hili la kuboreshwa haipatikani kwenye Google Play sasa hivi. Tafadhali jaribu tena baadaye au angalia Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Angalia kwa Google Play haikumalizia kwa wakati, kwa hivyo hali ya ununuzi wako bado haijulikani. Hakuna jambo lililobadilika kwenye akaunti yako.</string>
 </resources>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">இந்த மேம்படுத்தலை நீங்கள் ஏற்கனவே வைத்திருப்பதாக Google Play தெரிவிக்கிறது, ஆனால் அதை மீட்டெடுக்க முடியவில்லை. நீங்கள் வாங்கிய Google கணக்கைப் பயன்படுத்துகிறீர்களா எனச் சரிபார்க்கவும். Play Store ஒத்திசைவு சிறிது நேரம் எடுக்கலாம் — மறுதொடக்கம் செய்யவும், Google Play தேக்ககத்தை அழிக்கவும் அல்லது சிறிது காத்திருக்கவும்.</string>
     <string name="upgrade_restore_action">வாங்குதலை மீட்டமை</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s ஐப் பெறுக</string>
     <string name="upgrade_preamble">CAPod ஒரே ஒரு நபரால் உருவாக்கப்படுகிறது. மேம்படுத்துவது கூடுதல் அம்சங்களைத் திறக்கும் மற்றும் ஆப்பை உயிருடன் வைத்திருக்க உதவும்.</string>
     <string name="upgrade_screen_options_description">அதே அம்சங்கள், வேறு விலை. சந்தா இலவச சோதனைக் காலத்தை உள்ளடக்கியது மற்றும் எப்போது வேண்டுமானாலும் ரத்து செய்யலாம்.</string>
     <string name="upgrade_screen_options_description_no_trial">அதே அம்சங்கள், வேறு விலை. சந்தாவை எப்போது வேண்டுமானாலும் ரத்து செய்யலாம்.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">ஆதரவைத் தொடர்பு கொள்ளவும்</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">உங்கள் மேம்பாடு மற்றும் வாங்குதல் நிலை.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play உடன் இணைக்க முடியவில்லை. Google Play நிறுவப்பட்டு புதுப்பிக்கப்பட்டுள்ளதா? உங்கள் Google கணக்கு உள்நுழைந்துள்ளதா? Google Play ஆப்பின் தற்காலிக சேமிப்பை அழித்து உங்கள் சாதனத்தை மறுதொடக்கம் செய்ய முயற்சிக்கவும்.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ஐ திறக்க முடியவில்லை. இது சாதனத்தில் கிடைக்கவில்லை, முடக்கப்பட்டிருக்கலாம் அல்லது வரையறுக்கப்பட்டிருக்கலாம்.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play பிழை</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play இல் உள் பிழை ஏற்பட்டுள்ளது. தயவுசெய்து பின்வருவனவற்றை முயற்சிக்கவும்:\n\n• உங்கள் சாதனத்தை மறுதொடக்கம் செய்க\n• Google Play Store தற்காலிக சேமிப்பை அழிக்கவும்\n• பின்னர் மீண்டும் முயற்சிக்கவும்</string>
+    <string name="upgrades_gplay_network_error_title">இணைப்பு பிழை</string>
+    <string name="upgrades_gplay_network_error_description">Google Play உடன் இணைக்க முடியவில்லை. உங்கள் இணைய இணைப்பைச் சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சிக்கவும்.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">வழங்கல் கிடைக்கவில்லை</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play தற்போது இந்த மேம்படுத்தல் விருப்பத்தை வழங்கவில்லை. பின்னர் மீண்டும் முயற்சிக்கவும் அல்லது Google Play Store ஐச் சரிபார்க்கவும்.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play உடனான சரிபார்ப்பு சரியான நேரத்தில் முடியவில்லை, எனவே உங்கள் வாங்குதல் நிலை இன்னும் தெரியவில்லை. உங்கள் கணக்கில் எதுவும் மாறவில்லை.</string>
 </resources>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">మీరు ఇప్పటికే ఈ అప్‌గ్రేడ్‌ను కలిగి ఉన్నారని Google Play నివేదిస్తోంది, కానీ దాన్ని పునరుద్ధరించడం సాధ్యం కాలేదు. మీరు కొనుగోలు చేసిన అదే Google ఖాతాను ఉపయోగిస్తున్నారని నిర్ధారించుకోండి. Play Store సమకాలీకరణకు సమయం పట్టవచ్చు — పునఃప్రారంభించడం, Google Play కాష్‌ను క్లియర్ చేయడం లేదా కొంత సమయం వేచి ఉండటం ప్రయత్నించండి.</string>
     <string name="upgrade_restore_action">కొనుగోలును పునరుద్ధరించండి</string>
     <string name="upgrade_badge_label">ప్రొ</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">పొందండి %1$s</string>
     <string name="upgrade_preamble">CAPodని ఒకే వ్యక్తి అభివృద్ధి చేస్తున్నారు. అప్‌గ్రేడ్ చేయడం అదనపు ఫీచర్లను అన్‌లాక్ చేస్తుంది మరియు యాప్‌ను సజీవంగా ఉంచడంలో సహాయపడుతుంది.</string>
     <string name="upgrade_screen_options_description">అదే ఫీచర్లు, వేర్వేరు ధరలు. సబ్‌స్క్రిప్షన్‌లో ఉచిత ట్రయల్ ఉంటుంది మరియు దీన్ని ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
     <string name="upgrade_screen_options_description_no_trial">అదే ఫీచర్లు, వేర్వేరు ధరలు. సబ్‌స్క్రిప్షన్‌ను ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">సపోర్టుకు సంప్రదించండి</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">మీ అప్‌గ్రేడ్ మరియు కొనుగోలు స్థితి.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod Google Playకి కనెక్ట్ చేయలేదు. Google Play ఇన్‌స్టాల్ చేయబడి నవీకరించబడిందా? మీ Google ఖాతా లాగిన్ చేయబడిందా? Google Play యాప్ యొక్క కాష్‌ని క్లియర్ చేసి మీ పరికరాన్ని రీబూట్ చేయడానికి ప్రయత్నించండి.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play తెరవలేకపోయాను. ఇది ఉండకపోవచ్చు, నిలిపివేయబడ్డ ఉండవచ్చు లేదా ఈ పరికరంలో పరిమితం చేయబడ్డ ఉండవచ్చు.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play లోపం</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play లో అంతర్గత లోపం సంభవించింది. దయచేసి ఈ క్రింది వాటిని ప్రయత్నించండి:\n\n• మీ పరికరాన్ని రీస్టార్ట్ చేయండి\n• Google Play Store కాష్‌ను క్లియర్ చేయండి\n• తర్వాత ప్రయత్నించండి</string>
+    <string name="upgrades_gplay_network_error_title">కనెక్షన్ లోపం</string>
+    <string name="upgrades_gplay_network_error_description">Google Playకు కనెక్ట్ చేయడం సాధ్యం కాలేదు. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను చెక్ చేసి ఆపై ప్రయత్నించండి.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ఆఫర్ అందుబాటులో లేనిది</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ప్రస్తుతం ఈ అప్‌గ్రేడ్ ఆఫర్‌ను అందిస్తుండటం లేదు. దయచేసి తర్వాత ప్రయత్నించండి లేదా Google Play Store ను చెక్ చేయండి.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Playతో చెక్ సమయానికి పూర్తి కాలేదు, కాబట్టి మీ కొనుగోలు స్థితి ఇప్పటికీ తెలియదు. మీ ఖాతాలో ఏమీ మార్పులేదు.</string>
 </resources>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play รายงานว่าคุณเป็นเจ้าของการอัปเกรดนี้อยู่แล้ว แต่ไม่สามารถกู้คืนได้ ตรวจสอบให้แน่ใจว่าคุณใช้บัญชี Google เดียวกับที่ใช้ซื้อ การซิงค์ข้อมูลของ Play Store อาจใช้เวลาสักครู่ — ลองรีสตาร์ทเครื่อง ล้างแคชของ Google Play หรือรอสักครู่</string>
     <string name="upgrade_restore_action">กู้คืนการซื้อ</string>
     <string name="upgrade_badge_label">โปร</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">รับ %1$s</string>
     <string name="upgrade_preamble">CAPod พัฒนาโดยคนคนเดียว การอัปเกรดจะปลดล็อกฟีเจอร์เพิ่มเติมและช่วยให้แอปนี้ยังคงอยู่ต่อไป</string>
     <string name="upgrade_screen_options_description">ฟีเจอร์เหมือนกัน แต่ราคาต่างกัน การสมัครสมาชิกมีช่วงทดลองใช้ฟรีและสามารถยกเลิกได้ทุกเมื่อ</string>
     <string name="upgrade_screen_options_description_no_trial">ฟีเจอร์เหมือนกัน แต่ราคาต่างกัน การสมัครสมาชิกสามารถยกเลิกได้ทุกเมื่อ</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">ติดต่อฝ่ายสนับสนุน</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">สถานะการอัปเกรดและการซื้อของคุณ</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">ไม่สามารถเปิด Google Play ได้ แอปอาจไม่มี ถูกปิดใช้งาน หรือถูกจำกัดบนอุปกรณ์นี้</string>
+    <string name="upgrades_gplay_internal_error_title">ข้อผิดพลาด Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">เกิดข้อผิดพลาด Google Play ภายในระบบ โปรดลองดำเนินการต่อไปนี้:\n\n• รีสตาร์ตอุปกรณ์ของคุณ\n• ล้างแคชของ Google Play Store\n• ลองอีกครั้งในภายหลัง</string>
+    <string name="upgrades_gplay_network_error_title">ข้อผิดพลาดการเชื่อมต่อ</string>
+    <string name="upgrades_gplay_network_error_description">ไม่สามารถเชื่อมต่อกับ Google Play ได้ โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ข้อเสนอไม่พร้อมใช้งาน</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ไม่ได้นำเสนอตัวเลือกการอัปเกรดนี้ในขณะนี้ โปรดลองอีกครั้งในภายหลังหรือตรวจสอบ Google Play Store</string>
+    <string name="upgrade_screen_restore_inconclusive_message">การตรวจสอบกับ Google Play ไม่เสร็จสิ้นทันเวลา ดังนั้นสถานะการซื้อของคุณยังคงไม่ชัดเจน ไม่มีการเปลี่ยนแปลงใดๆ บนบัญชีของคุณ</string>
 </resources>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play, bu yükseltmeye zaten sahip olduğunu bildiriyor ancak geri yüklenemedi. Satın alırken kullandığın Google hesabını kullandığından emin ol. Play Store senkronizasyonu zaman alabilir — yeniden başlatmayı, Google Play önbelleğini temizlemeyi veya biraz beklemeyi dene.</string>
     <string name="upgrade_restore_action">Satın almayı geri yükle</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s\'i Al</string>
     <string name="upgrade_preamble">CAPod bir kişi tarafından geliştirilmiştir. Yükseltme ekstra özelliklerin kilidini açar ve uygulamanın canlı kalabilmesine yardımcı olur.</string>
     <string name="upgrade_screen_options_description">Aynı özellikler, farklı fiyatlandırma. Abonelik ücretsiz deneme içerir ve istediğin zaman iptal edilebilirsin.</string>
     <string name="upgrade_screen_options_description_no_trial">Aynı özellikler, farklı fiyatlandırma. Aboneliği istediğin zaman iptal edebilirsin.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Desteğe başvur</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Yükseltme ve satın alma durumunuz.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play açılamadı. Cihazda eksik, devre dışı veya kısıtlı olabilir.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play Hatası</string>
+    <string name="upgrades_gplay_internal_error_description">Bir iç Google Play hatası oluştu. Lütfen aşağıdakini deneyin:\n\n• Cihazınızı yeniden başlatın\n• Google Play Store önbelleğini temizleyin\n• Daha sonra tekrar deneyin</string>
+    <string name="upgrades_gplay_network_error_title">Bağlantı Hatası</string>
+    <string name="upgrades_gplay_network_error_description">Google Play\'e bağlanılamıyor. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Teklif Kullanılamıyor</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play şu anda bu yükseltme seçeneğini sunmuyor. Lütfen daha sonra tekrar deneyin veya Google Play Store\'u kontrol edin.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play kontrolü zamanında tamamlanmadı, bu nedenle satın alma durumunuz hala bilinmiyor. Hesabınızda bir değişiklik olmadı.</string>
 </resources>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play повідомляє, що ви вже маєте це оновлення, але його не вдалося відновити. Переконайтеся, що ви використовуєте обліковий запис Google, з яким здійснили покупку. Синхронізація Play Store може тривати деякий час — спробуйте перезавантажити пристрій, очистити кеш Google Play або просто зачекати.</string>
     <string name="upgrade_restore_action">Відновити покупку</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Отримати %1$s</string>
     <string name="upgrade_preamble">CAPod розробляє одна людина. Оновлення розблоковує додаткові функції та допомагає підтримувати розвиток застосунку.</string>
     <string name="upgrade_screen_options_description">Ті самі функції, різні варіанти оплати. Підписка включає безкоштовний пробний період і може бути скасована в будь-який час.</string>
     <string name="upgrade_screen_options_description_no_trial">Ті самі функції, різні варіанти оплати. Підписку можна скасувати в будь-який час.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Зв\'язок з підтримкою</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ваш статус оновлення та покупки.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod не може підключитися до Google Play. Чи встановлено та оновлено Google Play? Ви ввійшли до свого облікового запису Google? Спробуйте очистити кеш застосунку Google Play і перезавантажити пристрій.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не вдалося відкрити Google Play. Можливо, він відсутній, вимкнений або обмежений на цьому пристрої.</string>
+    <string name="upgrades_gplay_internal_error_title">Помилка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Сталася внутрішня помилка Google Play. Спробуйте виконати наступні дії:\n\n• Перезапустіть пристрій\n• Очистіть кеш Google Play Store\n• Спробуйте пізніше</string>
+    <string name="upgrades_gplay_network_error_title">Помилка підключення</string>
+    <string name="upgrades_gplay_network_error_description">Неможливо підключитися до Google Play. Перевірте підключення до Інтернету та спробуйте ще раз.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Пропозиція недоступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play наразі не пропонує цей варіант оновлення. Спробуйте пізніше або перевірте Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Перевірка з Google Play не завершилась вчасно, тому статус вашої покупки залишається невідомим. На вашому обліковому записі нічого не змінилось.</string>
 </resources>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">گوگل پلے کے مطابق آپ پہلے ہی یہ اپ گریڈ خرید چکے ہیں، لیکن اسے بحال نہیں کیا جا سکا۔ یقینی بنائیں کہ آپ وہی گوگل اکاؤنٹ استعمال کر رہے ہیں جس سے آپ نے خریداری کی تھی۔ پلے سٹور کی ہم آہنگی میں وقت لگ سکتا ہے — دوبارہ شروع کرنے، گوگل پلے کیشے صاف کرنے یا محض انتظار کرنے کی کوشش کریں۔</string>
     <string name="upgrade_restore_action">خریداری بحال کریں</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s حاصل کریں</string>
     <string name="upgrade_preamble">CAPod ایک ہی شخص کی طرف سے تیار کیا گیا ہے۔ اپ گریڈ کرنے سے اضافی خصوصیات کھلتی ہیں اور ایپ کو زندہ رکھنے میں مدد ملتی ہے۔</string>
     <string name="upgrade_screen_options_description">وہی خصوصیات، مختلف قیمتیں۔ سبسکرپشن میں مفت ٹرائل شامل ہے اور اسے کسی بھی وقت منسوخ کیا جا سکتا ہے۔</string>
     <string name="upgrade_screen_options_description_no_trial">وہی خصوصیات، مختلف قیمتیں۔ سبسکرپشن کو کسی بھی وقت منسوخ کیا جا سکتا ہے۔</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">معاونت سے رابطہ کریں</string>
     <string name="settings_upgrade_status_label">سی اے پوڈ پرو</string>
     <string name="settings_upgrade_status_description">آپ کی اپ گریڈ اور خریداری کی حالت۔</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play سے رابطہ نہیں کر سکتا۔ کیا Google Play انسٹال اور اپ ڈیٹ ہے؟ کیا آپ کا Google اکاؤنٹ لاگ ان ہے؟ Google Play ایپ کی کیش صاف کرنے اور اپنا ڈیوائس دوبارہ شروع کرنے کی کوشش کریں۔</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play کھل نہیں سکا۔ ہو سکتا ہے کہ یہ اس ڈیوائس پر موجود نہ ہو، غیر فعال ہو یا محدود ہو۔</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play میں خرابی</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play میں ایک داخلی خرابی پیش آئی۔ براہ کرم درج ذیل کو آزمائیں:\n\n• اپنے ڈیوائس کو دوبارہ شروع کریں\n• Google Play Store کی کیش صاف کریں\n• بعد میں دوبارہ کوشش کریں</string>
+    <string name="upgrades_gplay_network_error_title">رابطے میں خرابی</string>
+    <string name="upgrades_gplay_network_error_description">Google Play سے رابطہ کرنے میں ناکام۔ براہ کرم اپنے انٹرنیٹ کنکشن کو چیک کریں اور دوبارہ کوشش کریں۔</string>
+    <string name="upgrades_gplay_offer_unavailable_title">آفر دستیاب نہیں</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play فی الوقت یہ اپ گریڈ آپشن پیش نہیں کر رہا۔ براہ کرم بعد میں دوبارہ کوشش کریں یا Google Play Store کو چیک کریں۔</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play کے ساتھ چیک وقت سے پہلے ختم نہیں ہو سکی، اس لیے آپ کی خریداری کی حالت ابھی نامعلوم ہے۔ آپ کے اکاؤنٹ میں کوئی تبدیلی نہیں ہوئی۔</string>
 </resources>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ushbu yangilanishga allaqachon ega ekanligingizni bildiradi, ammo uni tiklab bo\'lmadi. Xarid qilgan Google hisobingizdan foydalanayotganingizga ishonch hosil qiling. Play Store sinxronizatsiyasi vaqt olishi mumkin — qurilmani qayta ishga tushirib ko\'ring, Google Play keshini tozalang yoki shunchaki kuting.</string>
     <string name="upgrade_restore_action">Xaridni tiklash</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s-ni oling</string>
     <string name="upgrade_preamble">CAPod yagona shaxs tomonidan ishlab chiqilmoqda. Yangilash qo\'shimcha funksiyalarni ochadi va ilovani tirik saqlashga yordam beradi.</string>
     <string name="upgrade_screen_options_description">Xususiyatlar bir xil, narxlar boshqacha. Obuna bepul sinov muddatini o\'z ichiga oladi va istalgan vaqtda bekor qilinishi mumkin.</string>
     <string name="upgrade_screen_options_description_no_trial">Xususiyatlar bir xil, narxlar boshqacha. Obunani istalgan vaqtda bekor qilish mumkin.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Qo\'llab-quvvatlash</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Sizning yangilash va sotib olish holati.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play-ga ulanib bo\'lmaydi. Google Play o\'rnatilgan va yangilanganmi? Google hisobingiz tizimga kirilganmi? Google Play ilovasining keshini tozalashni va qurilmangizni qayta ishga tushirishni sinab ko\'ring.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ochilmadi. U bu qurilmada boʻlmasligi, nofaol boʻlishi yoki cheklangan boʻlishi mumkin.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play xatosi</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-da ichki xato yuz berdi. Iltimos, quyidagilarni sinab ko\'ring:\n\n• Qurilmangizni qayta ishga tushiring\n• Google Play Store keshini tozalang\n• Keyinroq qayta sinab ko\'ring</string>
+    <string name="upgrades_gplay_network_error_title">Ulanish xatosi</string>
+    <string name="upgrades_gplay_network_error_description">Google Play-ga ulanib bo\'lmadi. Iltimos, internet ulanishingizni tekshiring va qayta sinab ko\'ring.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Taklif mavjud emas</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play hozir bu yangilash variantini taklif qilmayapti. Iltimos, keyinroq qayta sinab ko\'ring yoki Google Play Store-ni tekshiring.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play bilan tekshirish vaqtida tugamadi, shuning uchun sizning sotib olish holati hali ham noma\'lum. Hisobingizda hech narsa o\'zgarmagani yo\'q.</string>
 </resources>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play cho biết bạn đã sở hữu bản nâng cấp này, nhưng không thể khôi phục. Hãy đảm bảo bạn đang sử dụng đúng tài khoản Google mà bạn đã dùng để mua. Việc đồng bộ hóa Play Store có thể mất chút thời gian — hãy thử khởi động lại thiết bị, xóa bộ nhớ đệm của Google Play hoặc đơn giản là chờ đợi.</string>
     <string name="upgrade_restore_action">Khôi phục thanh toán</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Nhận %1$s</string>
     <string name="upgrade_preamble">CAPod được phát triển bởi một người duy nhất. Việc nâng cấp sẽ mở khóa thêm các tính năng và giúp duy trì ứng dụng.</string>
     <string name="upgrade_screen_options_description">Cùng tính năng, giá khác nhau. Gói đăng ký có bản dùng thử miễn phí và có thể hủy bất cứ lúc nào.</string>
     <string name="upgrade_screen_options_description_no_trial">Cùng tính năng, giá khác nhau. Gói đăng ký có thể hủy bất cứ lúc nào.</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">Liên hệ hỗ trợ</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Trạng thái nâng cấp và mua hàng của bạn.</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Tài khoản Google của bạn đã đăng nhập chưa? Hãy thử xóa bộ nhớ đệm của ứng dụng Google Play và khởi động lại thiết bị của bạn.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Không thể mở Google Play. Ứng dụng có thể không tồn tại, bị tắt hoặc bị hạn chế trên thiết bị này.</string>
+    <string name="upgrades_gplay_internal_error_title">Lỗi Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Đã xảy ra lỗi nội bộ của Google Play. Vui lòng thử những điều sau:\n\n• Khởi động lại thiết bị của bạn\n• Xóa bộ nhớ cache của Google Play Store\n• Thử lại sau</string>
+    <string name="upgrades_gplay_network_error_title">Lỗi kết nối</string>
+    <string name="upgrades_gplay_network_error_description">Không thể kết nối với Google Play. Vui lòng kiểm tra kết nối internet của bạn và thử lại.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ưu đãi không có sẵn</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play hiện tại không cung cấp tùy chọn nâng cấp này. Vui lòng thử lại sau hoặc kiểm tra Cửa hàng Google Play.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kiểm tra với Google Play không hoàn tất kịp thời, vì vậy trạng thái mua hàng của bạn vẫn chưa xác định. Không có gì thay đổi trên tài khoản của bạn.</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play 显示您已拥有此升级,但无法恢复。请确保您使用的是购买时所用的 Google 账号。Play 商店同步可能需要一些时间——请尝试重启设备、清除 Google Play 缓存,或耐心等待。</string>
     <string name="upgrade_restore_action">恢复购买</string>
     <string name="upgrade_badge_label">专业版</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">获取 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一个人独立开发。升级可解锁更多功能,并帮助这款应用持续维护下去。</string>
     <string name="upgrade_screen_options_description">功能相同,价格不同。订阅包含免费试用,并可随时取消。</string>
     <string name="upgrade_screen_options_description_no_trial">功能相同,价格不同。订阅可随时取消。</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">联系支持</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">您的升级和购买状态。</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod 无法连接到 Google Play。Google Play 是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 应用的缓存，然后重启您的设备。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">无法打开 Google Play。它可能未安装、已禁用或在此设备上受限。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 错误</string>
+    <string name="upgrades_gplay_internal_error_description">发生了 Google Play 内部错误。请尝试以下操作：\n\n• 重启您的设备\n• 清除 Google Play 商店缓存\n• 稍后再试</string>
+    <string name="upgrades_gplay_network_error_title">连接错误</string>
+    <string name="upgrades_gplay_network_error_description">无法连接到 Google Play。请检查您的互联网连接，然后重试。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">优惠不可用</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前不提供此升级选项。请稍后重试或检查 Google Play 商店。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play 检查未能按时完成，因此您的购买状态仍然未知。您的账户没有任何更改。</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play 顯示你已經擁有此升級項目，但無法還原。請確保你使用購買時所用的 Google 帳戶。Play 商店同步可能需要一些時間——你可以嘗試重新啟動裝置、清除 Google Play 快取，或耐心等候。</string>
     <string name="upgrade_restore_action">恢復購買</string>
     <string name="upgrade_badge_label">專業版</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">取得 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一個人開發。升級可解鎖額外功能，並有助維持應用程式繼續運作。</string>
     <string name="upgrade_screen_options_description">功能相同，定價不同。訂閱方案包含免費試用，並可隨時取消。</string>
     <string name="upgrade_screen_options_description_no_trial">功能相同，定價不同。訂閱方案可隨時取消。</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">聯絡支援</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">您的升級和購買狀態。</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod 無法連線至 Google Play。請確認 Google Play 已安裝且為最新版本，同時確保已經登入 Google 帳戶。您可以嘗試清除 Google Play 應用程式的快取或重新啟動您的裝置以修正此問題。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。此應用程式可能在此裝置上遺失、已停用或受限制。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>
+    <string name="upgrades_gplay_internal_error_description">發生 Google Play 內部錯誤。請嘗試以下步驟：\n\n• 重新啟動您的裝置\n• 清除 Google Play 商店快取\n• 稍後再試</string>
+    <string name="upgrades_gplay_network_error_title">連線錯誤</string>
+    <string name="upgrades_gplay_network_error_description">無法連線至 Google Play。請檢查您的網際網路連線並重試。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">優惠無法使用</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前未提供此升級選項。請稍後再試或檢查 Google Play 商店。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">與 Google Play 的驗證未能及時完成，因此您的購買狀態仍未確定。您帳戶上沒有任何變更。</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">Google Play 回報您已擁有此升級項目，但無法還原。請確認您使用的是購買時所用的 Google 帳戶。Play 商店同步可能需要一些時間 — 請嘗試重新啟動裝置、清除 Google Play 快取或稍候片刻。</string>
     <string name="upgrade_restore_action">還原購買</string>
     <string name="upgrade_badge_label">專業版</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">取得 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一人獨立開發。升級可解鎖額外功能，並協助維持應用程式的運作。</string>
     <string name="upgrade_screen_options_description">功能相同，價格不同。訂閱方案包含免費試用，且可隨時取消。</string>
     <string name="upgrade_screen_options_description_no_trial">功能相同，價格不同。訂閱方案可隨時取消。</string>
@@ -66,4 +68,14 @@
     <string name="upgrade_screen_contact_support_action">聯絡支援</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">您的升級和購買狀態。</string>
+    <string name="upgrades_gplay_unavailable_error_description">CAPod 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。它可能在此裝置上遺失、已停用或受限。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>
+    <string name="upgrades_gplay_internal_error_description">發生 Google Play 內部錯誤。請嘗試以下方法：\n\n• 重新啟動您的裝置\n• 清除 Google Play Store 快取\n• 稍後再試</string>
+    <string name="upgrades_gplay_network_error_title">連接錯誤</string>
+    <string name="upgrades_gplay_network_error_description">無法連接到 Google Play。請檢查您的網際網路連線並再試一次。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">無法使用此優惠</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前未提供此升級選項。請稍後再試或檢查 Google Play Store。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">與 Google Play 的檢查未能及時完成，因此您的購買狀態仍不確定。您的帳戶未發生任何更改。</string>
 </resources>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -54,10 +54,17 @@
     <!-- Offercard layout -->
     <string name="upgrade_screen_offers_title">Izinketho zokuthuthukiso</string>
     <string name="upgrade_screen_offers_or">noma</string>
+    <string name="upgrade_screen_offers_body">Izici ezifanayo, kuphela amanani ahlukene.</string>
     <string name="upgrade_screen_offers_unavailable_title">Izintengo azitholakali</string>
     <string name="upgrade_screen_offers_unavailable_message">I-Google Play ayibuyiseli izintengo ngalesi sikhathi. Hlola ikhonneksheni yakho ubuyele zama futhi kamuva nje.</string>
+    <string name="upgrade_screen_subscription_offer_title">Ukubhalisa kwaminyaka yonke</string>
+    <string name="upgrade_screen_subscription_offer_body">Kuvuselelwa minyaka yonke ngemva kokuzama kwamahhala. Khansela noma nini ku-Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Kuvuselelwa minyaka yonke. Khansela noma nini ku-Google Play.</string>
     <string name="upgrade_screen_iap_offer_body">Inkokhelo eyodwa, akukho okuphinda.</string>
     <string name="upgrade_screen_benefits_title">Izinzuzo zokuthuthukisa</string>
+    <string name="upgrade_screen_restore_body">Ukubuyisela kucela i-Google Play ukuthi iphinde ihlole ukuthenga kwalolu hlelo lokusebenza kule akhawunti okuyiyo manje. Akuqalisi ukuthenga okusha.</string>
+    <string name="upgrade_screen_restore_checked_message">I-CAPod isanda kuhlola i-Google Play, kodwa akukho kuthenga kwe-Pro okuqinisekiswe kule akhawunti i-Google Play eyisebenzisayo kulolu hlelo lokusebenza.</string>
+    <string name="upgrade_screen_restore_contact_hint">Usabambeke? Xhumana nosizo usuka ku-imeyili eyenza ukuthenga futhi ufake inombolo ye-oda ye-Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Xhumana nolungiselelo</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Isimo sokuthuthukiswa nokuthenga kwakho.</string>
@@ -68,6 +75,7 @@
     <string name="upgrades_gplay_internal_error_description">Kwenzeke iphutha elingaphakathi lika-Google Play. Ngiyakucela uzame lokhu okulandelayo:\n\n• Qalise kabusha idivayisi yakho\n• Sula i-cache ye-Google Play Store\n• Zama kamuva</string>
     <string name="upgrades_gplay_network_error_title">Iphutha lokuxhuma</string>
     <string name="upgrades_gplay_network_error_description">Ayikwazi ukuxhuma ku-Google Play. Ngiyakucela uhlole uxhumano lwakho i-inthanethi futhi uzame kabusha.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Opsyoni ayitholakali</string>
     <string name="upgrades_gplay_offer_unavailable_description">I-Google Play ayikaseli le-opsyon yokuphucula. Ngiyakucela uzame kamuva noma uhlole i-Google Play Store.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Ukuhloliswa okwakuthi ne-Google Play akuqedele ngesikhathi, ngakho isimo sokuthengi sakho sihlulekile ukwaziwa. Akukho okuthile okuthuthele ku-akhawunti yakho.</string>
 </resources>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -10,6 +10,8 @@
     <string name="upgrades_gplay_already_owned_description">I-Google Play ibika ukuthi usuvele unalolu shintsho olusheshisiwe, kodwa alukwazanga ukubuyiselwa. Qinisekisa ukuthi usebenzisa i-akhawunti ye-Google owathenga ngayo. Ukuvumelanisa kwe-Play Store kungase kuthathe isikhathi — zama ukuqala kabusha idivayisi, ukususa i-cache ye-Google Play noma ulinde nje.</string>
     <string name="upgrade_restore_action">Buyisela ukuthenga</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Thola %1$s</string>
     <string name="upgrade_preamble">I-CAPod yenziwe umuntu oyedwa. Ukuthuthukisa kuvula izici ezengeziwe futhi kusize ukugcina uhlelo lokusebenza luphila.</string>
     <string name="upgrade_screen_options_description">Izici ezifanayo, amanani ahlukene. Ukubhalisa kufaka ukuzama kwamahhala futhi kungakhanselwa noma nini.</string>
     <string name="upgrade_screen_options_description_no_trial">Izici ezifanayo, amanani ahlukene. Ukubhalisa kungakhanselwa noma nini.</string>
@@ -59,4 +61,13 @@
     <string name="upgrade_screen_contact_support_action">Xhumana nolungiselelo</string>
     <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Isimo sokuthuthukiswa nokuthenga kwakho.</string>
+    <string name="upgrades_gplay_unavailable_error_description">I-CAPod ayikwazi ukuxhuma ku-Google Play. Ingabe Google Play ifakiwe futhi isesikhathini? Ingabe i-akhawunti yakho ye-Google ingene? Zama ukusula i-cache yohlelo lokusebenza lwe-Google Play futhi uphinde uqalise idivayisi yakho.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Ayikho ukuvula Google Play. Ingabe ayikho, ikungena noma kuthintwa ku-divayisi yakho.</string>
+    <string name="upgrades_gplay_internal_error_title">Iphutha lika-Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Kwenzeke iphutha elingaphakathi lika-Google Play. Ngiyakucela uzame lokhu okulandelayo:\n\n• Qalise kabusha idivayisi yakho\n• Sula i-cache ye-Google Play Store\n• Zama kamuva</string>
+    <string name="upgrades_gplay_network_error_title">Iphutha lokuxhuma</string>
+    <string name="upgrades_gplay_network_error_description">Ayikwazi ukuxhuma ku-Google Play. Ngiyakucela uhlole uxhumano lwakho i-inthanethi futhi uzame kabusha.</string>
+    <string name="upgrades_gplay_offer_unavailable_description">I-Google Play ayikaseli le-opsyon yokuphucula. Ngiyakucela uzame kamuva noma uhlole i-Google Play Store.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Ukuhloliswa okwakuthi ne-Google Play akuqedele ngesikhathi, ngakho isimo sokuthengi sakho sihlulekile ukwaziwa. Akukho okuthile okuthuthele ku-akhawunti yakho.</string>
 </resources>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sonder een is toestelinstellings en outo-verbinding nie beskikbaar nie.</string>
     <string name="overview_reactions_hint_title">Reaksies is per toestel</string>
     <string name="overview_reactions_hint_body">Outo-speel, outo-pouse en opspringers word nou per toestel gekonfigureer. Tik op die instellings-ikoon op \'n kaart terwyl jou kopfone verbind is.</string>
+    <string name="review_app_review_action">Hersien</string>
+    <string name="review_app_dismiss_action">Miskien later</string>
+    <string name="review_app_body">Wil jy graag vir CAPod \'n hersiening los? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Mikrofoon</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -488,6 +488,9 @@
     <string name="overview_card_missing_paired_device">ይህ መገለጫ የጋራ ብሉቱዝ መሳሪያ የለውም።</string>
     <string name="overview_reactions_hint_title">ምላሾች በእያንዳንዱ መሳሪያ ናቸው</string>
     <string name="overview_reactions_hint_body">የራስ-ማጫወት፣ የራስ-ማቆም እና ብቅ-ባይ መስኮቶች አሁን በእያንዳንዱ መሳሪያ ይዋቀራሉ። ጆሮ ማዳመጫዎ ሲገናኙ ካርዱ ላይ ያለውን የቅንብሮች አዶ መታ ያድርጉ።</string>
+    <string name="review_app_review_action">ግምገማ</string>
+    <string name="review_app_dismiss_action">ምናልባት በኋላ</string>
+    <string name="review_app_body">ለCAPod ግምገማ ማስቀመጥ ይፈልጋሉ?️ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">አጠቃላይ</string>
     <string name="device_settings_microphone_mode_label">ማይክሮፎን</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -486,6 +486,7 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ጥሪን ለመጨረስ ሁለት ጊዜ ጀን</string>
     <string name="device_settings_open_cd">የመሣሪያ ቅንብሮችን ክፈት</string>
     <string name="overview_card_missing_paired_device">ይህ መገለጫ የጋራ ብሉቱዝ መሳሪያ የለውም።</string>
+    <string name="overview_card_missing_paired_device_consequence">ያለዚያ፣ የመሣሪያ ቅንብሮች እና ራስ-ሰር ግንኙነት አይገኙም።</string>
     <string name="overview_reactions_hint_title">ምላሾች በእያንዳንዱ መሳሪያ ናቸው</string>
     <string name="overview_reactions_hint_body">የራስ-ማጫወት፣ የራስ-ማቆም እና ብቅ-ባይ መስኮቶች አሁን በእያንዳንዱ መሳሪያ ይዋቀራሉ። ጆሮ ማዳመጫዎ ሲገናኙ ካርዱ ላይ ያለውን የቅንብሮች አዶ መታ ያድርጉ።</string>
     <string name="review_app_review_action">ግምገማ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -513,6 +513,9 @@
     <string name="overview_card_missing_paired_device_consequence">دونها، لن تتوفر إعدادات الجهاز والاتصال التلقائي.</string>
     <string name="overview_reactions_hint_title">ردود الفعل خاصة بكل جهاز</string>
     <string name="overview_reactions_hint_body">يتم الآن تهيئة التشغيل التلقائي والإيقاف التلقائي والنوافذ المنبثقة لكل جهاز على حدة. انقر على أيقونة الإعدادات على البطاقة أثناء توصيل سماعاتك.</string>
+    <string name="review_app_review_action">مراجعة</string>
+    <string name="review_app_dismiss_action">ربما لاحقًا</string>
+    <string name="review_app_body">هل ترغب في ترك تعليق لـ CAPod؟ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عام</string>
     <string name="device_settings_microphone_mode_label">ميكروفون</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Ona olmadan, cihaz ayarları və avtomatik bağlanma əlçatan deyil.</string>
     <string name="overview_reactions_hint_title">Reaksiyalar hər cihaz üçün ayrıdır</string>
     <string name="overview_reactions_hint_body">Avtomatik oxutma, avtomatik dayandırma və açılan pəncərələr artıq hər cihaz üçün ayrıca konfiqurasiya edilir. Qulaqlıqlarınız qoşulu olarkən kartdakı parametrlər ikonasına toxunun.</string>
+    <string name="review_app_review_action">Baxış</string>
+    <string name="review_app_dismiss_action">Bəlkə sonra</string>
+    <string name="review_app_body">CAPod üçün rəy yazmaq istərdinizmi? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ümumi</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -501,6 +501,9 @@
     <string name="overview_card_missing_paired_device_consequence">Без яе налады прылады і аўтападключэнне недаступныя.</string>
     <string name="overview_reactions_hint_title">Рэакцыі ўстаноўлены для кожнай прылады</string>
     <string name="overview_reactions_hint_body">Аўтаўзнаўленне, аўтапаўза і ўсплывальныя вокны цяпер наладжваюцца для кожнай прылады. Націсніце значок налад на картцы, пакуль вашы навушнікі падключаны.</string>
+    <string name="review_app_review_action">Водгук</string>
+    <string name="review_app_dismiss_action">Магчыма пазней</string>
+    <string name="review_app_body">Ці ты хочаш пакінуць водгук на CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Агульныя</string>
     <string name="device_settings_microphone_mode_label">Мікрафон</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Без такова, настройките на устройството и автоматичното свързване не са налични.</string>
     <string name="overview_reactions_hint_title">Реакциите са за всяко устройство поотделно</string>
     <string name="overview_reactions_hint_body">Автоматичното възпроизвеждане, паузирането и изскачащите прозорци вече се конфигурират за всяко устройство поотделно. Натиснете иконата с настройки на картата, докато слушалките ви са свързани.</string>
+    <string name="review_app_review_action">Преглед</string>
+    <string name="review_app_dismiss_action">Може би по-късно</string>
+    <string name="review_app_body">Бихте ли искали да оставите на CAPod оценка? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Общи</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">একটি ছাড়া, ডিভাইস সেটিংস এবং স্বয়ংক্রিয় সংযোগ উপলল্ধ নয়।</string>
     <string name="overview_reactions_hint_title">প্রতিক্রিয়াগুলি প্রতিটি ডিভাইসের জন্য আলাদা</string>
     <string name="overview_reactions_hint_body">অটো-প্লে, অটো-পজ এবং পপ-আপগুলি এখন প্রতিটি ডিভাইসের জন্য আলাদাভাবে কনফিগার করা হয়েছে। আপনার হেডফোন সংযুক্ত থাকাকালীন একটি কার্ডে সেটিংস আইকনে ট্যাপ করুন।</string>
+    <string name="review_app_review_action">পর্যালোচনা করুন</string>
+    <string name="review_app_dismiss_action">হয়তো পরে</string>
+    <string name="review_app_body">আপনি কি CAPodকে একটি পর্যালোচনা দিতে চান? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">সাধারণ</string>
     <string name="device_settings_microphone_mode_label">মাইক্রোফোন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -27,7 +27,8 @@
     <string name="upgrade_benefit_popups">Finestra emergent en obrir la funda i en connectar</string>
     <string name="upgrade_benefit_widgets">Ginys de la pantalla d\'inici</string>
     <string name="upgrade_benefit_device_settings">Configuració avançada del dispositiu</string>
-    <string name="upgrade_benefit_device_controls">Controls del dispositiu: soroll, pliques i més</string>
+    <string name="upgrade_benefit_device_controls">Controls del dispositiu: soroll, pliques i més
+</string>
     <string name="upgrade_benefit_support">Doneu suport al desenvolupador</string>
     <string name="upgrade_benefit_disclaimer">La disponibilitat de les funcions depèn dels auriculars i del dispositiu.</string>
     <string name="settings_monitor_connected_notification_label">Notificació addicional</string>
@@ -489,6 +490,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sense un, la configuració del dispositiu i la connexió automàtica no estan disponibles.</string>
     <string name="overview_reactions_hint_title">Les reaccions són per dispositiu</string>
     <string name="overview_reactions_hint_body">La reproducció automàtica, la pausa automàtica i les finestres emergents ara es configuren per dispositiu. Toqueu la icona de configuració d\'una targeta mentre els vostres auriculars estan connectats.</string>
+    <string name="review_app_review_action">Revisió</string>
+    <string name="review_app_dismiss_action">Potser més tard</string>
+    <string name="review_app_body">Vols deixar una ressenya del CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micròfon</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -501,6 +501,9 @@
     <string name="overview_card_missing_paired_device_consequence">Bez něj nejsou dostupná nastavení zařízení a automatické připojení.</string>
     <string name="overview_reactions_hint_title">Reakce jsou nastaveny pro každé zařízení</string>
     <string name="overview_reactions_hint_body">Automatické přehrávání, automatické pozastavení a vyskakovací okna se nyní nastavují pro každé zařízení zvlášť. Klepněte na ikonu nastavení na kartě, když máte připojená sluchátka.</string>
+    <string name="review_app_review_action">Posoudit</string>
+    <string name="review_app_dismiss_action">Možná později</string>
+    <string name="review_app_body">Chceš ohodnotit CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Obecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Uden en kan enhedsindstillinger og automatisk forbindelse ikke være tilgængelige.</string>
     <string name="overview_reactions_hint_title">Reaktioner er per enhed</string>
     <string name="overview_reactions_hint_body">Automatisk afspilning, automatisk pause og pop-ups er nu konfigureret per enhed. Tryk på indstillingsikonet på et kort, mens dine hovedtelefoner er tilsluttet.</string>
+    <string name="review_app_review_action">Bedøm</string>
+    <string name="review_app_dismiss_action">Måske senere</string>
+    <string name="review_app_body">Har du lyst til at give CAPod en anmeldelse? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Ohne ein solches sind die Geräteeinstellungen und das automatische Verbinden nicht verfügbar.</string>
     <string name="overview_reactions_hint_title">Reaktionen sind gerätespezifisch</string>
     <string name="overview_reactions_hint_body">Auto-Play, Auto-Pause und Pop-ups werden jetzt pro Gerät konfiguriert. Tippe auf das Einstellungssymbol einer Karte, während deine Kopfhörer verbunden sind.</string>
+    <string name="review_app_review_action">Bewerten</string>
+    <string name="review_app_dismiss_action">Vielleicht später</string>
+    <string name="review_app_body">Möchtest du CAPod bewerten? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Allgemein</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -529,7 +532,7 @@
     <string name="device_settings_anc_off_rejected_message">Der Aus-Modus ist auf diesem Gerät nicht aktiviert. Aktiviere „Aus-Modus erlauben“ unter Geräuschsteuerung.</string>
     <string name="device_settings_category_battery_label">Akku</string>
     <string name="device_settings_charge_cap_label">Optimiertes Ladelimit</string>
-    <string name="device_settings_charge_cap_description">Lernt deine Routine und pausiert das Laden bei ca. 80%%, um die Akkulebensdauer zu verlängern, und lädt die Pods vor der wahrscheinlichen Nutzung voll auf.</string>
+    <string name="device_settings_charge_cap_description">Lerne dein Nutzungsverhalten kennen und pausiere das Laden bei etwa 80 %%, um die Akkulaufzeit zu verlängern. Die Earbuds werden erst kurz vor der voraussichtlichen Nutzung vollständig geladen.</string>
     <string name="device_settings_charge_cap_rejected_message">Das optimierte Ladelimit konnte nicht geändert werden. Dies ist eine experimentelle Funktion – bitte melde es, wenn es weiterhin fehlschlägt.</string>
     <string name="device_settings_category_connections_label">Verbundene Geräte</string>
     <string name="device_settings_connected_devices_description">Andere Geräte, die derzeit mit diesen AirPods verbunden sind</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -199,6 +199,8 @@
     <string name="overview_monitoring_active_label">Παρακολούθηση συσκευών</string>
     <string name="overview_monitoring_active_description">Βεβαιωθείτε ότι η συσκευή σας είναι κοντά και ενεργή.</string>
     <string name="overview_monitoring_off_label">Η παρακολούθηση υποβάθρου είναι απενεργοποιημένη</string>
+    <string name="overview_monitoring_off_description">Κανένα προφίλ δεν διαθέτει μια συνδεδεμένη συσκευή Bluetooth, οπότε το CAPod ενημερώνεται μόνο όταν η εφαρμογή είναι ανοιχτή. Επιλέξτε ένα για να ενεργοποιήσετε την παρακολούθηση υποβάθρου, τη συνεχή ειδοποίηση και τις αντιδράσεις.</string>
+    <string name="overview_monitoring_off_action">Επιλέξτε συνδεμένη συσκευή</string>
     <string name="overview_troubleshoot_suggestion_label">Συνδέθηκε, αλλά χωρίς δεδομένα</string>
     <string name="overview_troubleshoot_suggestion_description">Η συσκευή σου είναι συνδεδεμένη, αλλά το CAPod δεν λαμβάνει ζωντανά δεδομένα από αυτήν. Το τηλέφωνό σου μπορεί να χρειαστεί μια επιλογή συμβατότητας — ο εντοπισμός προβλημάτων μπορεί να προσπαθήσει να βρει μία αυτόματα.</string>
     <string name="overview_troubleshoot_suggestion_action">Εκτέλεση εντοπισμού προβλημάτων</string>
@@ -487,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Χωρίς αυτό, οι ρυθμίσεις συσκευής και η αυτόματη σύνδεση δεν είναι διαθέσιμες.</string>
     <string name="overview_reactions_hint_title">Οι αντιδράσεις είναι ανά συσκευή</string>
     <string name="overview_reactions_hint_body">Η αυτόματη αναπαραγωγή, η αυτόματη παύση και τα αναδυόμενα παράθυρα διαμορφώνονται πλέον ανά συσκευή. Πατήστε το εικονίδιο ρυθμίσεων σε μια κάρτα ενώ τα ακουστικά σας είναι συνδεδεμένα.</string>
+    <string name="review_app_review_action">Αξιολόγηση</string>
+    <string name="review_app_dismiss_action">Ίσως αργότερα</string>
+    <string name="review_app_body">Θα θέλατε να αφήσετε μια αξιολόγηση για το CAPod; ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Γενικά</string>
     <string name="device_settings_microphone_mode_label">Μικρόφωνο</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sin uno, la configuración del dispositivo y la conexión automática no están disponibles.</string>
     <string name="overview_reactions_hint_title">Las reacciones son por dispositivo</string>
     <string name="overview_reactions_hint_body">La reproducción automática, la pausa automática y las ventanas emergentes ahora se configuran por dispositivo. Tocá el ícono de configuración en una tarjeta mientras tus auriculares estén conectados.</string>
+    <string name="review_app_review_action">Reseña</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sin uno, la configuración del dispositivo y la conexión automática no están disponibles.</string>
     <string name="overview_reactions_hint_title">Las reacciones son por dispositivo</string>
     <string name="overview_reactions_hint_body">La reproducción automática, la pausa automática y las ventanas emergentes ahora se configuran por dispositivo. Toca el ícono de configuración en una tarjeta mientras tus auriculares estén conectados.</string>
+    <string name="review_app_review_action">Reseñar</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sin uno, la configuración del dispositivo y la conexión automática no están disponibles.</string>
     <string name="overview_reactions_hint_title">Las reacciones son por dispositivo</string>
     <string name="overview_reactions_hint_body">La reproducción automática, la pausa automática y las ventanas emergentes ahora se configuran por dispositivo. Toca el icono de configuración en una tarjeta mientras tus auriculares están conectados.</string>
+    <string name="review_app_review_action">Revisar</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Vastase juhul on seadme seaded ja iseühendumine keelatud.</string>
     <string name="overview_reactions_hint_title">Reaktsioonid on seadmepõhised</string>
     <string name="overview_reactions_hint_body">Automaatne esitus, automaatne paus ja hüpikaknad on nüüd seadmepõhiselt seadistatud. Puudutage kaardi seadete ikooni, kui kõrvaklapid on ühendatud.</string>
+    <string name="review_app_review_action">Arvustus</string>
+    <string name="review_app_dismiss_action">Võib-olla hiljem</string>
+    <string name="review_app_body">Kas soovid kommenteerida CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Üldine</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Bat gabe, gailuaren ezarpenak eta auto-konexioa ez daude eskuragarri.</string>
     <string name="overview_reactions_hint_title">Erreakzioak gailuka konfiguratuta daude</string>
     <string name="overview_reactions_hint_body">Erreprodukzio automatikoa, geldialdia automatikoa eta laster-leihoak orain gailuka konfiguratzen dira. Sakatu txarteleko ezarpenak ikonoa aurikularrak konektatuta dituzun bitartean.</string>
+    <string name="review_app_review_action">Berrikuspen</string>
+    <string name="review_app_dismiss_action">Agian geroago</string>
+    <string name="review_app_body">CAPod-i berrikuspen bat utzi nahi diozu? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Orokorra</string>
     <string name="device_settings_microphone_mode_label">Mikrofonoa</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">بدون آن، تنظیمات دستگاه و اتصال خودکار در دسترس نیستند.</string>
     <string name="overview_reactions_hint_title">واکنش‌ها برای هر دستگاه جداگانه هستند</string>
     <string name="overview_reactions_hint_body">پخش خودکار، توقف خودکار و پنجره‌های بازشو اکنون برای هر دستگاه پیکربندی می‌شوند. در حالی که هدفون‌های شما متصل هستند، روی آیکون تنظیمات روی یک کارت ضربه بزنید.</string>
+    <string name="review_app_review_action">مرور</string>
+    <string name="review_app_dismiss_action">شاید بعداً</string>
+    <string name="review_app_body">آیا می خواهید نظری برای CAPod بگذارید؟ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">میکروفون</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Ilman sitä laitteen asetukset ja automaattinen yhteys eivät ole käytettävissä.</string>
     <string name="overview_reactions_hint_title">Reaktiot ovat laitekohtaisia</string>
     <string name="overview_reactions_hint_body">Automaattinen toisto, automaattinen tauko ja ponnahdusikkunat on nyt määritetty laitekohtaisesti. Napauta kortissa olevaa asetuskuvaketta, kun kuulokkeet ovat yhdistettynä.</string>
+    <string name="review_app_review_action">Arvostele</string>
+    <string name="review_app_dismiss_action">Ehkä myöhemmin</string>
+    <string name="review_app_body">Haluaisitko jättää CAPodille arvostelun? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Yleiset</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Kung walang isa, ang device settings at auto-connect ay hindi available.</string>
     <string name="overview_reactions_hint_title">Ang mga reaksyon ay bawat device</string>
     <string name="overview_reactions_hint_body">Ang auto-play, auto-pause at mga pop-up ay naka-configure na ngayon bawat device. I-tap ang icon ng mga setting sa isang card habang nakakonekta ang iyong mga headphone.</string>
+    <string name="review_app_review_action">Pagsusuri</string>
+    <string name="review_app_dismiss_action">Siguro mamaya</string>
+    <string name="review_app_body">Gusto ba ninyong mag-iwan ng pagsusuri para sa CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Pangkalahatan</string>
     <string name="device_settings_microphone_mode_label">Mikropono</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sans cela, les paramètres de l\'appareil et la connexion automatique ne sont pas disponibles.</string>
     <string name="overview_reactions_hint_title">Les réactions sont par appareil</string>
     <string name="overview_reactions_hint_body">La lecture automatique, la pause automatique et les fenêtres contextuelles sont désormais configurées par appareil. Appuyez sur l’icône des paramètres d’une carte lorsque vos écouteurs sont connectés.</string>
+    <string name="review_app_review_action">Évaluation</string>
+    <string name="review_app_dismiss_action">Plus tard, peut-être</string>
+    <string name="review_app_body">Veux-tu évaluer CAPod ? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Général</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Sen un, a configuración do dispositivo e a conexión automática non están dispoñibles.</string>
     <string name="overview_reactions_hint_title">As reaccións son por dispositivo</string>
     <string name="overview_reactions_hint_body">A reprodución automática, a pausa automática e as ventás emerxentes agora configúranse por dispositivo. Toca a icona de axustes nunha tarxeta mentres os teus auriculares estean conectados.</string>
+    <string name="review_app_review_action">Valorar</string>
+    <string name="review_app_dismiss_action">Quizais máis tarde</string>
+    <string name="review_app_body">Gustaríalle deixar unha valoración para CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Xeral</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">इसके बिना, डिवाइस सेटिंग और स्वचालित कनेक्ट उपलब्ध नहीं हैं।</string>
     <string name="overview_reactions_hint_title">रिएक्शन प्रति डिवाइस हैं</string>
     <string name="overview_reactions_hint_body">ऑटो-प्ले, ऑटो-पॉज़ और पॉप-अप अब प्रति डिवाइस कॉन्फ़िगर किए गए हैं। जब आपके हेडफ़ोन कनेक्ट हों, तो कार्ड पर सेटिंग आइकन टैप करें।</string>
+    <string name="review_app_review_action">समीक्षा करें</string>
+    <string name="review_app_dismiss_action">शायद बाद में</string>
+    <string name="review_app_body">क्या आप CAPod को एक समीक्षा देना चाहेंगे? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफ़ोन</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -495,6 +495,9 @@
     <string name="overview_card_missing_paired_device_consequence">Bez toga, postavke uređaja i automatsko povezivanje nisu dostupne.</string>
     <string name="overview_reactions_hint_title">Reakcije su po uređaju</string>
     <string name="overview_reactions_hint_body">Automatska reprodukcija, automatska pauza i skočni prozori sada se konfiguriraju po uređaju. Dodirnite ikonu postavki na kartici dok su vaše slušalice spojene.</string>
+    <string name="review_app_review_action">Ocijeni</string>
+    <string name="review_app_dismiss_action">Možda kasnije</string>
+    <string name="review_app_body">Želiš li ostaviti recenziju za CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Općenito</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">E nélkül az eszközbeállítások és az automatikus csatlakozás nem érhetők el.</string>
     <string name="overview_reactions_hint_title">A reakciók eszközönként vannak beállítva</string>
     <string name="overview_reactions_hint_body">Az automatikus lejátszás, automatikus szünet és felugró ablakok mostantól eszközönként konfigurálhatók. Koppints a beállítások ikonra egy kártyán, miközben a fejhallgatód csatlakoztatva van.</string>
+    <string name="review_app_review_action">Áttekintés</string>
+    <string name="review_app_dismiss_action">Talán később</string>
+    <string name="review_app_body">Szeretnél véleményt hagyni a CAPodról? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Általános</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Առանց դրա սարքի կարգավորումները և ինքնավար միացումը հասանելի չեն:</string>
     <string name="overview_reactions_hint_title">Ռեակցիաները կարգավորվում են ըստ սարքի</string>
     <string name="overview_reactions_hint_body">Ավտոնվագարկումը, ավտոդադարը և բացվող պատուհանները այժմ կարգավորվում են ըստ սարքի: Կտտացրեք կարգավորումների պատկերակին քարտի վրա, մինչ ձեր ականջակալները միացված են:</string>
+    <string name="review_app_review_action">Կարծիք</string>
+    <string name="review_app_dismiss_action">Գուցե ավելի ուշ</string>
+    <string name="review_app_body">Ցանկանո՞ւմ եք կարծիք թողնել CAPod-ի համար? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ընդհանուր</string>
     <string name="device_settings_microphone_mode_label">Խոսափող</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -483,6 +483,7 @@
     <string name="overview_card_missing_paired_device_consequence">Tanpa satu, pengaturan perangkat dan koneksi otomatis tidak tersedia.</string>
     <string name="overview_reactions_hint_title">Reaksi berlaku per perangkat</string>
     <string name="overview_reactions_hint_body">Putar otomatis, jeda otomatis, dan pop-up kini dikonfigurasi per perangkat. Ketuk ikon pengaturan pada kartu saat headphone Anda terhubung.</string>
+    <string name="review_app_review_action">Ulasan</string>
     <string name="review_app_dismiss_action">Lain kali</string>
     <string name="review_app_body">Mau menulis ulasan untuk CAPod? ❤️</string>
     <!-- New device settings -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -483,6 +483,8 @@
     <string name="overview_card_missing_paired_device_consequence">Tanpa satu, pengaturan perangkat dan koneksi otomatis tidak tersedia.</string>
     <string name="overview_reactions_hint_title">Reaksi berlaku per perangkat</string>
     <string name="overview_reactions_hint_body">Putar otomatis, jeda otomatis, dan pop-up kini dikonfigurasi per perangkat. Ketuk ikon pengaturan pada kartu saat headphone Anda terhubung.</string>
+    <string name="review_app_dismiss_action">Lain kali</string>
+    <string name="review_app_body">Mau menulis ulasan untuk CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Án þess eru tækistillingar og sjálfvirk tenging ekki tiltækar.</string>
     <string name="overview_reactions_hint_title">Viðbrögð eru per tæki</string>
     <string name="overview_reactions_hint_body">Sjálfvirk spilun, sjálfvirk pása og sprettigluggar eru nú stilltir per tæki. Ýttu á stillingatáknið á spjaldi á meðan heyrnartólið þitt er tengt.</string>
+    <string name="review_app_review_action">Umsögn</string>
+    <string name="review_app_dismiss_action">Kannski síðar</string>
+    <string name="review_app_body">Viltu skilja eftir umsögn um CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Álmennt</string>
     <string name="device_settings_microphone_mode_label">Hljóðnemi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Senza uno, le impostazioni del dispositivo e la connessione automatica non sono disponibili.</string>
     <string name="overview_reactions_hint_title">Le reazioni sono per dispositivo</string>
     <string name="overview_reactions_hint_body">Riproduzione automatica, pausa automatica e pop-up sono ora configurati per dispositivo. Tocca l\'icona delle impostazioni su una scheda mentre le cuffie sono collegate.</string>
+    <string name="review_app_review_action">Recensione</string>
+    <string name="review_app_dismiss_action">Forse più tardi</string>
+    <string name="review_app_body">Vuoi lasciare una recensione su CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfono</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -501,6 +501,9 @@
     <string name="overview_card_missing_paired_device_consequence">ללא זה, הגדרות ההתקן והחיבור האוטומטי אינם זמינים.</string>
     <string name="overview_reactions_hint_title">התגובות הן לפי מכשיר</string>
     <string name="overview_reactions_hint_body">הפעלה אוטומטית, השהייה אוטומטית וחלונות קופצים מוגדרים כעת לפי מכשיר. הקש על סמל ההגדרות בכרטיס כאשר האוזניות שלך מחוברות.</string>
+    <string name="review_app_review_action">סקירה</string>
+    <string name="review_app_dismiss_action">אולי מאוחר יותר</string>
+    <string name="review_app_body">להשאיר ביקורת ל-CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">כללי</string>
     <string name="device_settings_microphone_mode_label">מיקרופון</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">寄付</string>
     <string name="general_check_action">確認</string>
     <string name="general_close_action">閉じる</string>
+    <string name="general_dismiss_action">閉じる</string>
     <string name="general_edit_action">編集</string>
     <string name="general_save_action">保存</string>
     <string name="general_guide_action">ガイド</string>
@@ -482,6 +483,9 @@
     <string name="overview_card_missing_paired_device_consequence">デバイスの設定と自動接続は利用できません。</string>
     <string name="overview_reactions_hint_title">リアクションはデバイスごとに設定されます</string>
     <string name="overview_reactions_hint_body">自動再生、自動一時停止、ポップアップはデバイスごとに設定できるようになりました。ヘッドフォンを接続した状態でカードの設定アイコンをタップしてください。</string>
+    <string name="review_app_review_action">レビュー</string>
+    <string name="review_app_dismiss_action">また後で</string>
+    <string name="review_app_body">CAPodをレビューしませんか？ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">マイク</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">მის გარეშე, მოწყობილობის პარამეტრები და ავტომატური კავშირი არ არის ხელმისაწვდომი.</string>
     <string name="overview_reactions_hint_title">რეაქციები განსაზღვრულია თითოეული მოწყობილობისთვის</string>
     <string name="overview_reactions_hint_body">ავტომატური დაკვრა, ავტომატური პაუზა და ამომხტარი ფანჯრები ახლა კონფიგურირებულია თითოეული მოწყობილობისთვის. შეეხეთ პარამეტრების ხატულას ბარათზე, სანამ თქვენი ყურსასმენები დაკავშირებულია.</string>
+    <string name="review_app_review_action">მიმოხილვა</string>
+    <string name="review_app_dismiss_action">შესაძლოა მოგვიანებით</string>
+    <string name="review_app_body">გნებავთ დატოვოთ CAPod-ს მიმოხილვა? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ზოგადი</string>
     <string name="device_settings_microphone_mode_label">მიკროფონი</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -483,6 +483,9 @@
     <string name="overview_card_missing_paired_device_consequence">ដោយគ្មាននោះ ការកំណត់ឧបករណ៍ និងការភ្ជាប់ដោយស្វ័យប្រវត្តិមិនលេច។</string>
     <string name="overview_reactions_hint_title">ប្រតិកម្មគឺខុសគ្នាតាមឧបករណ៍</string>
     <string name="overview_reactions_hint_body">ការចាក់ស្វ័យប្រវត្តិ ការផ្អាកស្វ័យប្រវត្តិ និងបង្អួចលេចឡើង ឥឡូវនេះត្រូវបានកំណត់រៀងរាល់ឧបករណ៍។ ចុចលើរូបតំណាងការកំណត់នៅលើកាតខណៈពេលដែលកាស​귀​យន្ត​ស្ដាប់​របស់​អ្នក​ភ្ជាប់​។</string>
+    <string name="review_app_review_action">ពិនិត្យឡើងវិញ</string>
+    <string name="review_app_dismiss_action">ប្រហែលពេលក្រោយ</string>
+    <string name="review_app_body">តើអ្នកចង់ដាក់ពិនិត្យលើ CAPod ដែរឬទេ? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ជាទូទៅ</string>
     <string name="device_settings_microphone_mode_label">មីក្រូហ្វូន</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -198,6 +198,7 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth neçalak e, wê çalak bikin ;)</string>
     <string name="overview_monitoring_active_label">Amûr tên şopandin</string>
     <string name="overview_monitoring_active_description">Bawer bin ku amûra we nêzîk û çalak e.</string>
+    <string name="overview_monitoring_off_label">Nîgartin di paşplanê de neçalak e</string>
     <string name="overview_monitoring_off_description">Profîl neke xwe girêdanî amûra Bluetooth heye, ji ber vê yekê CAPod tenê gava sepana vebûk e nûkari dike. Ya yekê hilbijêrin da ku cûvandina paşplan, nîşayana berdewam û bersivên xwendinê çalak bikin.</string>
     <string name="overview_monitoring_off_action">Amûra Girêdanî Hilbijêrin</string>
     <string name="overview_troubleshoot_suggestion_label">Girêdayî, lê daneya tune</string>
@@ -488,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Bê yekê, sazkirî û girêdanê xwehûnandî heyî naçûk in.</string>
     <string name="overview_reactions_hint_title">Reaksyon ji bo her amûrê ne</string>
     <string name="overview_reactions_hint_body">Otomatîk-lêdan, otomatîk-rawestandin û pencereyên derkevtinê niha ji bo her amûrê hatine mîheng kirin. Li ser îkonê mîhengan li ser qertek bikirtînin dema guhdarvanên we ve girêdayî ne.</string>
+    <string name="review_app_review_action">Nirx</string>
+    <string name="review_app_dismiss_action">Belkî paşê</string>
+    <string name="review_app_body">Dixwazî tu CAPod nirx bikî? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Giştî</string>
     <string name="device_settings_microphone_mode_label">Mîkrofon</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">ಅದು ಇಲ್ಲದೆ, ಸಾಧನ ಸೆಟ್ಟಿಂಗುಗಳು ಮತ್ತು ಸ್ವಯಂ-ಸಂಪರ್ಕ ಲಭ್ಯವಿಲ್ಲ.</string>
     <string name="overview_reactions_hint_title">ಪ್ರತಿಕ್ರಿಯೆಗಳು ಪ್ರತಿ ಸಾಧನಕ್ಕೆ ಅನ್ವಯಿಸುತ್ತವೆ</string>
     <string name="overview_reactions_hint_body">ಆಟೋ-ಪ್ಲೇ, ಆಟೋ-ಪಾಸ್ ಮತ್ತು ಪಾಪ್-ಅಪ್‌ಗಳನ್ನು ಈಗ ಪ್ರತಿ ಸಾಧನಕ್ಕೆ ಪ್ರತ್ಯೇಕವಾಗಿ ಕಾನ್ಫಿಗರ್ ಮಾಡಲಾಗಿದೆ. ನಿಮ್ಮ ಹೆಡ್‌ಫೋನ್‌ಗಳು ಸಂಪರ್ಕಗೊಂಡಿರುವಾಗ ಕಾರ್ಡ್‌ನಲ್ಲಿ ಸೆಟ್ಟಿಂಗ್‌ಗಳ ಐಕಾನ್ ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡಿ.</string>
+    <string name="review_app_review_action">ವಿಮರ್ಶೆ</string>
+    <string name="review_app_dismiss_action">ಬಹುಶಃ ನಂತರ</string>
+    <string name="review_app_body">CAPod ಗೆ ವಿಮರ್ಶೆ ನೀಡಲು ನೀವು ಬಯಸುವಿರಾ? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ಸಾಮಾನ್ಯ</string>
     <string name="device_settings_microphone_mode_label">ಮೈಕ್ರೊಫೋನ್</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -485,6 +485,9 @@
     <string name="overview_card_missing_paired_device_consequence">없으면 기기 설정과 자동 연결을 사용할 수 없습니다.</string>
     <string name="overview_reactions_hint_title">반응은 기기별로 설정됩니다</string>
     <string name="overview_reactions_hint_body">자동 재생, 자동 일시정지 및 팝업이 이제 기기별로 설정됩니다. 헤드폰이 연결된 상태에서 카드의 설정 아이콘을 탭하세요.</string>
+    <string name="review_app_review_action">리뷰</string>
+    <string name="review_app_dismiss_action">다음에 해요</string>
+    <string name="review_app_body">CAPod 리뷰를 남겨주시겠어요? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">일반</string>
     <string name="device_settings_microphone_mode_label">마이크</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Бирөөнү тандабасаңыз, түзмөк орнотуулары жана автоматтык туташтыруу жеткиликсиз.</string>
     <string name="overview_reactions_hint_title">Реакциялар ар бир түзмөк үчүн жеке</string>
     <string name="overview_reactions_hint_body">Авто-ойноо, авто-тындыруу жана калкып чыгуучу терезелер азыр ар бир түзмөк үчүн жеке конфигурацияланган. Каргоочуларыңыз туташып турганда картадагы жөндөөлөр сүрөтчөсүнө тийиңиз.</string>
+    <string name="review_app_review_action">Баалоо</string>
+    <string name="review_app_dismiss_action">Кийин</string>
+    <string name="review_app_body">CAPod үчүн баалоо берүүнү каалайсызбы? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Жалпы</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -483,6 +483,9 @@
     <string name="overview_card_missing_paired_device_consequence">ໂດຍບໍ່ມີນັ້ນ, ການຕັ້ງຄ່າອຸປະກອນ ແລະການເຊື່ອມຕໍ່ອັດຕະໂນມັດບໍ່ມີ.</string>
     <string name="overview_reactions_hint_title">ການຕອບສະໜອງແມ່ນຕໍ່ອຸປະກອນ</string>
     <string name="overview_reactions_hint_body">ການຫຼິ້ນອັດຕະໂນມັດ, ການຢຸດອັດຕະໂນມັດ ແລະປ໊ອບອັບໄດ້ຖືກຕັ້ງຄ່າຕໍ່ອຸປະກອນແລ້ວ. ແຕະໄອຄອນການຕັ້ງຄ່າໃນບັດຂະນະທີ່ຫູຟັງຂອງທ່ານເຊື່ອມຕໍ່ຢູ່.</string>
+    <string name="review_app_review_action">ຣີວິວ</string>
+    <string name="review_app_dismiss_action">ບາງທີພາຍຫຼັງ</string>
+    <string name="review_app_body">ທ່ານຢາກໃຫ້ CAPod ຣີວິວບໍ? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ທົ່ວໄປ</string>
     <string name="device_settings_microphone_mode_label">ໄມໂຄຣໂຟນ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -501,6 +501,9 @@
     <string name="overview_card_missing_paired_device_consequence">Be jo, įrenginio nustatymai ir automatinis prisijungimas nėra pasiekiami.</string>
     <string name="overview_reactions_hint_title">Reakcijos nustatomos kiekvienam įrenginiui</string>
     <string name="overview_reactions_hint_body">Automatinis paleidimas, automatinis pristabdymas ir iššokantys langai dabar konfigūruojami kiekvienam įrenginiui. Bakstelėkite nustatymų piktogramą kortelėje, kol jūsų ausinės yra prijungtos.</string>
+    <string name="review_app_review_action">Recenzija</string>
+    <string name="review_app_dismiss_action">Galbūt vėliau</string>
+    <string name="review_app_body">Ar norėtumėte palikti CAPod recenziją? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Bendrieji</string>
     <string name="device_settings_microphone_mode_label">Mikrofonas</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -495,6 +495,9 @@
     <string name="overview_card_missing_paired_device_consequence">Bez vienas, ierīces iestatījumi un automātiskais savienojums nav pieejami.</string>
     <string name="overview_reactions_hint_title">Reakcijas ir katrai ierīcei</string>
     <string name="overview_reactions_hint_body">Automātiskā atskaņošana, automātiskā pauzēšana un uznirstošie logi tagad tiek konfigurēti katrai ierīcei. Pieskarieties iestatījumu ikonai kartē, kamēr austiņas ir pievienotas.</string>
+    <string name="review_app_review_action">Atsauksme</string>
+    <string name="review_app_dismiss_action">Varbūt vēlāk</string>
+    <string name="review_app_body">Vai vēlies atstāt CAPod atsauksmi? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Vispārīgi</string>
     <string name="device_settings_microphone_mode_label">Mikrofons</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Без него, поставките на уредот и автоматското поврзување не се достапни.</string>
     <string name="overview_reactions_hint_title">Реакциите се по уред</string>
     <string name="overview_reactions_hint_body">Автоматското пуштање, паузирање и скокачките прозорци сега се конфигурирани по уред. Допрете ја иконата за поставки на картичката додека слушалките се поврзани.</string>
+    <string name="review_app_review_action">Рецензија</string>
+    <string name="review_app_dismiss_action">Можеби подоцна</string>
+    <string name="review_app_body">Дали сакаш да оставиш рецензија за CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Генерално</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">അതില്ലാതെ, ഉപകരണ ക്രമീകരണങ്ങളും സ്വയം-കണക്ട് ലഭ്യമല്ല.</string>
     <string name="overview_reactions_hint_title">റിയാക്ഷനുകൾ ഓരോ ഉപകരണത്തിനും വ്യക്തിഗതമാണ്</string>
     <string name="overview_reactions_hint_body">ഓട്ടോ-പ്ലേ, ഓട്ടോ-പോസ്, പോപ്പ്-അപ്പുകൾ ഇപ്പോൾ ഓരോ ഉപകരണത്തിനും പ്രത്യേകം ക്രമീകരിക്കാം. നിങ്ങളുടെ ഹെഡ്ഫോൺ ബന്ധിപ്പിച്ചിരിക്കുമ്പോൾ കാർഡിലെ സെറ്റിംഗ്സ് ഐക്കൺ ടാപ്പ് ചെയ്യുക.</string>
+    <string name="review_app_review_action">റിവ്യൂ</string>
+    <string name="review_app_dismiss_action">പിന്നീട്</string>
+    <string name="review_app_body">CAPod-നെക്കുറിച്ച് നിങ്ങൾ ഒരു റിവ്യൂ നൽകാൻ ആഗ്രഹിക്കുന്നുണ്ടോ? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">പൊതുവായ</string>
     <string name="device_settings_microphone_mode_label">മൈക്രോഫോൺ</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">Үүнгүйгээр төхөөрөмжийн тохиргоо болон автомат холболт ашиглах боломжгүй.</string>
     <string name="overview_reactions_hint_title">Урвал нь төхөөрөмж бүрт тохируулагддаг</string>
     <string name="overview_reactions_hint_body">Автоматаар тоглуулах, автоматаар зогсоох болон цонхнууд одоо төхөөрөмж бүрт тохируулагддаг. Чихэвч холбогдсон үед картан дээрх тохиргооны дүрс тэмдэг дээр дарна уу.</string>
+    <string name="review_app_review_action">Үнэлгээ</string>
+    <string name="review_app_dismiss_action">Дараа нь магадгүй</string>
+    <string name="review_app_body">CAPod-д үнэлгээ үлдэхийг хүсч байна уу? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ерөнхий</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -489,6 +489,9 @@
     <string name="overview_card_missing_paired_device_consequence">त्याशिवाय डिव्हाइस सेटिंग्ज आणि ऑटो-कनेक्ट उपलब्ध नाहीत.</string>
     <string name="overview_reactions_hint_title">प्रतिक्रिया प्रत्येक डिव्हाइससाठी आहेत</string>
     <string name="overview_reactions_hint_body">ऑटो-प्ले, ऑटो-पॉज आणि पॉप-अप आता प्रत्येक डिव्हाइससाठी कॉन्फिगर केले आहेत. तुमचे हेडफोन कनेक्ट असताना कार्डवरील सेटिंग्ज आयकॉनवर टॅप करा.</string>
+    <string name="review_app_review_action">समीक्षा</string>
+    <string name="review_app_dismiss_action">कदाचित नंतर</string>
+    <string name="review_app_body">CAPod ला समीक्षा द्यायचे आहे का? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">मायक्रोफोन</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Menderma</string>
     <string name="general_check_action">Semak</string>
     <string name="general_close_action">Tutup</string>
+    <string name="general_dismiss_action">Tolak</string>
     <string name="general_edit_action">Edit</string>
     <string name="general_save_action">Simpan</string>
     <string name="general_guide_action">Panduan</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Status peranti</string>
     <string name="notification_channel_device_status_connected_label">Peranti disambungkan</string>
     <string name="monitor_notification_extra_enabled_hint">Anda boleh mematikan pemberitahuan ini dalam tetapan sistem.</string>
+    <string name="monitor_notification_starting">Memulakan…</string>
     <string name="support_debuglog_label">Log nyahpepijat</string>
     <string name="support_debuglog_desc">Rekod semua yang dilakukan oleh apl dalam fail teks yang boleh anda kongsi.</string>
     <string name="debug_debuglog_size_label">Saiz</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth dilumpuhkan, dayakannya ;)</string>
     <string name="overview_monitoring_active_label">Memantau peranti</string>
     <string name="overview_monitoring_active_description">Pastikan peranti anda berdekatan dan aktif.</string>
+    <string name="overview_monitoring_off_label">Pemantauan latar belakang dimatikan</string>
+    <string name="overview_monitoring_off_description">Tiada profil mempunyai peranti Bluetooth yang berpasangan, jadi CAPod hanya berkemas kini apabila aplikasi terbuka. Pilih satu untuk membolehkan pemantauan latar belakang, pemberitahuan berterusan dan reaksi.</string>
+    <string name="overview_monitoring_off_action">Pilih peranti berpasangan</string>
     <string name="overview_troubleshoot_suggestion_label">Disambungkan, tetapi tiada data</string>
     <string name="overview_troubleshoot_suggestion_description">Peranti anda disambungkan, tetapi CAPod tidak menerima sebarang data langsung daripadanya. Telefon anda mungkin memerlukan pilihan keserasian — penyelesai masalah boleh cuba mencari satu secara automatik.</string>
     <string name="overview_troubleshoot_suggestion_action">Jalankan penyelesai masalah</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Tekan dua kali untuk tamatkan panggilan</string>
     <string name="device_settings_open_cd">Buka tetapan peranti</string>
     <string name="overview_card_missing_paired_device">Profil ini tiada peranti Bluetooth yang dipasangkan.</string>
+    <string name="overview_card_missing_paired_device_consequence">Tanpanya, tetapan peranti dan sambungan automatik tidak tersedia.</string>
     <string name="overview_reactions_hint_title">Reaksi adalah setiap peranti</string>
     <string name="overview_reactions_hint_body">Main-auto, jeda-auto dan pop-timbul kini dikonfigurasi setiap peranti. Ketik ikon tetapan pada kad semasa fon kepala anda disambungkan.</string>
+    <string name="review_app_review_action">Ulas aplikasi</string>
+    <string name="review_app_dismiss_action">Tidak, terima kasih</string>
+    <string name="review_app_body">Adakah anda ingin meninggalkan ulasan untuk CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">Tetapkan semula kepada lalai</string>
     <string name="press_controls_reset_confirm_message">Tetapkan semula semua pemetaan tekan kepada lalai?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Buka Kawalan Tekan</string>
+    <string name="general_navigate_up_action">Navigasi ke atas</string>
+    <string name="general_progress_loading">Memuatkan</string>
 </resources>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">လှူဒါန်းပါ</string>
     <string name="general_check_action">စစ်ဆေးရန်</string>
     <string name="general_close_action">ပိတ်ရန်</string>
+    <string name="general_dismiss_action">ပယ်ဖျက်ပါ</string>
     <string name="general_edit_action">တည်းဖြတ်ပါ</string>
     <string name="general_save_action">သိမ်းဆည်းရန်</string>
     <string name="general_guide_action">လမ်းညွှန်</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">စက်ပစ္စည်းအခြေအနေ</string>
     <string name="notification_channel_device_status_connected_label">ချိတ်ဆက်ထားသောစက်ပစ္စည်း</string>
     <string name="monitor_notification_extra_enabled_hint">ဤသတိပေးချက်ကို စနစ်ဆက်တင်များတွင် ပိတ်ထားနိုင်သည်။</string>
+    <string name="monitor_notification_starting">စတင်နေသည်…</string>
     <string name="support_debuglog_label">ချွတ်ယွင်းချက်ပြင်ဆင်ခြင်းမှတ်တမ်း</string>
     <string name="support_debuglog_desc">အက်ပ်လုပ်ဆောင်သမျှကို သင်မျှဝေနိုင်သော စာသားဖိုင်တစ်ခုတွင် မှတ်တမ်းတင်ပါ။</string>
     <string name="debug_debuglog_size_label">အရွယ်အစား</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth ပိတ်ထားသည်၊ ဖွင့်ပါ ;)</string>
     <string name="overview_monitoring_active_label">စက်ပစ္စည်းများကို စောင့်ကြည့်နေသည်</string>
     <string name="overview_monitoring_active_description">သင့်စက်ပစ္စည်းသည် အနီးအနားတွင်ရှိပြီး အသုံးပြုနေကြောင်း သေချာပါစေ။</string>
+    <string name="overview_monitoring_off_label">နောက်ခံ စောင့်ကြည့်မှု ပိတ်ထားသည်</string>
+    <string name="overview_monitoring_off_description">Bluetooth စက်ပစ္စည်း ချည်းဆက်ထားသော အကျောင်းအထည်း မရှိသောကြောင့် CAPod သည် အက်ပ်ကျင်လည်စဉ်သာ အဆင့်မြှင့်တင်သည်။ နောက်ခံစောင့်ကြည့်မှု၊ ဆက်လက်သည့်အကြော်စာ နှင့် တုံ့ပြန်မှုများ ကျင်လည်စေရန် တစ်ခုကို ရွေးချယ်ပါ။</string>
+    <string name="overview_monitoring_off_action">ချည်းဆက်ထားသော စက်ပစ္စည်း ရွေးချယ်ပါ</string>
     <string name="overview_troubleshoot_suggestion_label">ချိတ်ဆက်ထားသည်၊ သို့သော် ဒေတာမရှိ</string>
     <string name="overview_troubleshoot_suggestion_description">သင့်ကိရိယာ ချိတ်ဆက်ထားသော်လည်း CAPod မှ ၎င်းထံမှ တိုက်ရိုက်ဒေတာ မရရှိပါ။ သင့်ဖုန်းသည် တွဲဖက်သုံးနိုင်မှု ရွေးချယ်မှုတစ်ခု လိုအပ်နိုင်သည် — ပြဿနာဖြေရှင်းသူက အလိုအလျောက် ရှာဖွေကြည့်နိုင်သည်။</string>
     <string name="overview_troubleshoot_suggestion_action">ပြဿနာဖြေရှင်းသူ စတင်ရန်</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ဖုန်းပြတ်ရန် နှစ်ကြိမ်နှိပ်ပါ</string>
     <string name="device_settings_open_cd">ကိရိယာ ဆက်တင်များ ဖွင့်ထားပါ</string>
     <string name="overview_card_missing_paired_device">ဤပရိုဖိုင်တွင် တွဲချိတ်ထားသော Bluetooth စက်ပစ္စည်း မရှိပါ။</string>
+    <string name="overview_card_missing_paired_device_consequence">ထိုအတူ မရှိလျှင် စက်ပစ္စည်း ချိန်ညှိချက်များ နှင့် အလိုအလျောက်-ချိတ်ဆက်မှု မရှိနိုင်ပါ။</string>
     <string name="overview_reactions_hint_title">Reactions များသည် စက်ပစ္စည်းတစ်ခုချင်းစီအတွက် ဖြစ်သည်</string>
     <string name="overview_reactions_hint_body">အလိုအလျောက် ဖွင့်ခြင်း၊ အလိုအလျောက် ရပ်ခြင်းနှင့် pop-up များကို ယခု စက်ပစ္စည်းတစ်ခုချင်းစီအတွက် သတ်မှတ်ထားသည်။ သင့် headphones ချိတ်ဆက်နေစဉ် ကတ်တစ်ခုပေါ်ရှိ settings အိုင်ကွန်ကို နှိပ်ပါ။</string>
+    <string name="review_app_review_action">သုံးသပ်ချက် ပေးရန်</string>
+    <string name="review_app_dismiss_action">နောက်ပိုင်းမှ</string>
+    <string name="review_app_body">CAPod အတွက် သုံးသပ်ချက် ချန်ထားလိုပါသလား။ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ယေဘူယျ</string>
     <string name="device_settings_microphone_mode_label">မိုက်ခရိုဖုန်း</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">မူလပ်ထားသာသိုက် ပြန်းသတ်</string>
     <string name="press_controls_reset_confirm_message">နှိပ် မပ်ယားများအလုံးကို မူလပ်ထားသာသိုက်သိုက် ပြန်းသတ်လိုအပ်သည်မှုအကြားသည်အစ်အတား ပြန်းပါမယ်၏</string>
     <string name="device_settings_noise_control_open_press_controls_action">နှိပ် ထိန်းချုပ်များကို ဖွင့်ပါ</string>
+    <string name="general_navigate_up_action">အထက်သို့ သွားရန်</string>
+    <string name="general_progress_loading">တင်နေပါသည်</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Doner</string>
     <string name="general_check_action">Sjekk</string>
     <string name="general_close_action">Lukk</string>
+    <string name="general_dismiss_action">Lukk</string>
     <string name="general_edit_action">Rediger</string>
     <string name="general_save_action">Lagre</string>
     <string name="general_guide_action">Veiledning</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Enhetsstatus</string>
     <string name="notification_channel_device_status_connected_label">Tilkoblet enhet</string>
     <string name="monitor_notification_extra_enabled_hint">Du kan deaktivere dette varselet i systeminnstillingene.</string>
+    <string name="monitor_notification_starting">Starter opp…</string>
     <string name="support_debuglog_label">Feilsøkingslogg</string>
     <string name="support_debuglog_desc">Registrer alt appen gjør i en tekstfil som du kan dele.</string>
     <string name="debug_debuglog_size_label">Størrelse</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth er deaktivert, aktiver det ;)</string>
     <string name="overview_monitoring_active_label">Overvåker etter enheter</string>
     <string name="overview_monitoring_active_description">Sørg for at enheten din er i nærheten og aktiv.</string>
+    <string name="overview_monitoring_off_label">Bakgrunnsovervåking er av</string>
+    <string name="overview_monitoring_off_description">Ingen profil har en paret Bluetooth-enhet, så CAPod oppdateres bare mens appen er åpen. Velg en for å aktivere bakgrunnsovervåking, den pågående varslingen og reaksjoner.</string>
+    <string name="overview_monitoring_off_action">Velg paret enhet</string>
     <string name="overview_troubleshoot_suggestion_label">Tilkoblet, men ingen data</string>
     <string name="overview_troubleshoot_suggestion_description">Enheten din er tilkoblet, men CAPod mottar ikke live-data fra den. Telefonen din kan trenge et kompatibilitetsalternativ — feilsøkeren kan prøve å finne ett automatisk.</string>
     <string name="overview_troubleshoot_suggestion_action">Kjør feilsøker</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dobbelttrykk for å avslutte samtale</string>
     <string name="device_settings_open_cd">Åpne enhetsinnstillinger</string>
     <string name="overview_card_missing_paired_device">Denne profilen har ingen sammenkoblet Bluetooth-enhet.</string>
+    <string name="overview_card_missing_paired_device_consequence">Uten en er enhetsinnstillinger og automatisk tilkobling ikke tilgjengelige.</string>
     <string name="overview_reactions_hint_title">Reaksjoner er per enhet</string>
     <string name="overview_reactions_hint_body">Automatisk avspilling, automatisk pause og hurtigvisninger konfigureres nå per enhet. Trykk på innstillingsikonet på et kort mens hodetelefonene er tilkoblet.</string>
+    <string name="review_app_review_action">Anmeldelse</string>
+    <string name="review_app_dismiss_action">Kanskje senere</string>
+    <string name="review_app_body">Vil du gi CAPod en anmeldelse? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generelt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Tilbakestill til standard</string>
     <string name="press_controls_reset_confirm_message">Tilbakestille alle trykkoblinger til standard?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Åpne trykkkontroller</string>
+    <string name="general_navigate_up_action">Gå opp</string>
+    <string name="general_progress_loading">Laster</string>
 </resources>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">दान दिनुहोस्</string>
     <string name="general_check_action">जाँच गर्नुहोस्</string>
     <string name="general_close_action">बन्द गर्नुहोस्</string>
+    <string name="general_dismiss_action">बन्द गर्नुहोस्</string>
     <string name="general_edit_action">सम्पादन गर्नुहोस्</string>
     <string name="general_save_action"> सुरक्षित गर्नुहोस्</string>
     <string name="general_guide_action">मार्गनिर्देशन</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">उपकरण स्थिति</string>
     <string name="notification_channel_device_status_connected_label">जडान भएको उपकरण</string>
     <string name="monitor_notification_extra_enabled_hint">तपाईं यो सूचना प्रणाली सेटिङमा अक्षम गर्न सक्नुहुन्छ।</string>
+    <string name="monitor_notification_starting">सुरु भइरहेको छ…</string>
     <string name="support_debuglog_label">डिबग लग</string>
     <string name="support_debuglog_desc">एपले गर्ने सबै कुरालाई तपाईंले साझेदारी गर्न सक्ने टेक्स्ट फाइलमा रेकर्ड गर्नुहोस्।</string>
     <string name="debug_debuglog_size_label">आकार</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth असक्षम छ, यसलाई सक्षम गर्नुहोस् ;)</string>
     <string name="overview_monitoring_active_label">उपकरणहरू खोज्दै</string>
     <string name="overview_monitoring_active_description">तपाईंको उपकरण नजिकै र सक्रिय छ भनी सुनिश्चित गर्नुहोस्।</string>
+    <string name="overview_monitoring_off_label">पृष्ठभूमि निगरानी बन्द छ</string>
+    <string name="overview_monitoring_off_description">कुनै प्रोफाइलमा जोडीबद्ध Bluetooth उपकरण छैन, त्यसैले CAPod केवल एप खुला हुँदा अपडेट गर्छ। पृष्ठभूमि निगरानी, चलिरहेको सूचना र प्रतिक्रियाहरु सक्षम गर्न एक छनोट गर्नुहोस्।</string>
+    <string name="overview_monitoring_off_action">जोडीबद्ध उपकरण छनोट गर्नुहोस्</string>
     <string name="overview_troubleshoot_suggestion_label">जोडिएको छ, तर डेटा छैन</string>
     <string name="overview_troubleshoot_suggestion_description">तपाईंको यन्त्र जोडिएको छ, तर CAPod ले यसबाट कुनै लाइभ डेटा प्राप्त गरिरहेको छैन। तपाईंको फोनलाई अनुकूलता विकल्पको आवश्यकता पर्न सक्छ — समस्या निवारकले स्वतः एउटा खोज्ने प्रयास गर्न सक्छ।</string>
     <string name="overview_troubleshoot_suggestion_action">समस्या निवारक चलाउनुस्</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">कल समाप्त गर्न दुईपटक थिच्नुहोस्</string>
     <string name="device_settings_open_cd">उपकरण सेटिङहरू खोल्नुहोस्</string>
     <string name="overview_card_missing_paired_device">यस प्रोफाइलमा कुनै जोडिएको Bluetooth उपकरण छैन।</string>
+    <string name="overview_card_missing_paired_device_consequence">बिना यो, उपकरण सेटिङ्ग र स्वचालित जडान उपलब्ध छैन।</string>
     <string name="overview_reactions_hint_title">प्रतिक्रियाहरू प्रति यन्त्र छन्</string>
     <string name="overview_reactions_hint_body">अटो-प्ले, अटो-पज र पप-अपहरू अब प्रति यन्त्र कन्फिगर गरिएका छन्। आफ्नो हेडफोन जडान भएको बेला कार्डमा सेटिङ आइकनमा ट्याप गर्नुहोस्।</string>
+    <string name="review_app_review_action">समीक्षा</string>
+    <string name="review_app_dismiss_action">पछि गर्ने</string>
+    <string name="review_app_body">के तपाई CAPod को लागि एक समीक्षा दिन चाहनुहुन्छ? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफोन</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">पूर्वनिर्धारितमा रिसेट गर्नुहोस्</string>
     <string name="press_controls_reset_confirm_message">सबै थिचाइ म्यापिङहरू पूर्वनिर्धारितमा रिसेट गर्ने?</string>
     <string name="device_settings_noise_control_open_press_controls_action">थिचाइ नियन्त्रण खोल्नुहोस्</string>
+    <string name="general_navigate_up_action">माथि जानुहोस्</string>
+    <string name="general_progress_loading">लोड गर्दै</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Doneren</string>
     <string name="general_check_action">Controleren</string>
     <string name="general_close_action">Sluiten</string>
+    <string name="general_dismiss_action">Afwijzen</string>
     <string name="general_edit_action">Bewerken</string>
     <string name="general_save_action">Opslaan</string>
     <string name="general_guide_action">Handleiding</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Apparaatstatus</string>
     <string name="notification_channel_device_status_connected_label">Verbonden apparaat</string>
     <string name="monitor_notification_extra_enabled_hint">Je kunt deze melding uitschakelen in de systeeminstellingen.</string>
+    <string name="monitor_notification_starting">Aan de slag…</string>
     <string name="support_debuglog_label">Foutopsporingslogboek</string>
     <string name="support_debuglog_desc">Registreer alles wat de app doet in een tekstbestand dat je kunt delen.</string>
     <string name="debug_debuglog_size_label">Grootte</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth is uitgeschakeld, schakel het in ;)</string>
     <string name="overview_monitoring_active_label">Monitoring voor apparaten</string>
     <string name="overview_monitoring_active_description">Zorg ervoor dat je apparaat in de buurt is en actief is.</string>
+    <string name="overview_monitoring_off_label">Achtergrondmonitoring is uit</string>
+    <string name="overview_monitoring_off_description">Geen profiel heeft een gekoppeld Bluetooth-apparaat, dus CAPod werkt alleen wanneer de app open is. Selecteer er één om achtergrondmonitoring, de doorlopende melding en reacties in te schakelen.</string>
+    <string name="overview_monitoring_off_action">Selecteer gekoppeld apparaat</string>
     <string name="overview_troubleshoot_suggestion_label">Verbonden, maar geen gegevens</string>
     <string name="overview_troubleshoot_suggestion_description">Je apparaat is verbonden, maar CAPod ontvangt geen live gegevens. Je telefoon heeft mogelijk een compatibiliteitsoptie nodig — de probleemoplosser kan er automatisch een zoeken.</string>
     <string name="overview_troubleshoot_suggestion_action">Probleemoplosser starten</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbelklik om het gesprek te beëindigen</string>
     <string name="device_settings_open_cd">Apparaatinstellingen openen</string>
     <string name="overview_card_missing_paired_device">Dit profiel heeft geen gekoppeld Bluetooth-apparaat.</string>
+    <string name="overview_card_missing_paired_device_consequence">Zonder één zijn apparaatinstellingen en automatisch verbinden niet beschikbaar.</string>
     <string name="overview_reactions_hint_title">De reacties gelden per apparaat</string>
     <string name="overview_reactions_hint_body">Automatisch afspelen, automatisch pauzeren en pop-ups zijn nu per apparaat geconfigureerd. Tik op het instellingenpictogram op een kaart terwijl je hoofdtelefoon verbonden is.</string>
+    <string name="review_app_review_action">Beoordeling</string>
+    <string name="review_app_dismiss_action">Misschien later</string>
+    <string name="review_app_body">Wil je CAPod een beoordeling achterlaten? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Microfoon</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Standaardinstellingen herstellen</string>
     <string name="press_controls_reset_confirm_message">Alle drukken toewijzingen resetten naar standaard?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Drukbediening openen</string>
+    <string name="general_navigate_up_action">Navigeer omhoog</string>
+    <string name="general_progress_loading">Bezig met laden</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Wesprzyj</string>
     <string name="general_check_action">Sprawdź</string>
     <string name="general_close_action">Zamknij</string>
+    <string name="general_dismiss_action">Zamknij</string>
     <string name="general_edit_action">Edytuj</string>
     <string name="general_save_action">Zapisz</string>
     <string name="general_guide_action">Poradnik</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Status urządzenia</string>
     <string name="notification_channel_device_status_connected_label">Połączone urządzenie</string>
     <string name="monitor_notification_extra_enabled_hint">Możesz wyłączyć to powiadomienie w ustawieniach systemowych.</string>
+    <string name="monitor_notification_starting">Uruchamianie…</string>
     <string name="support_debuglog_label">Dziennik debugowania</string>
     <string name="support_debuglog_desc">Rejestruj wszystko, co robi aplikacja do pliku tekstowego, który możesz udostępnić.</string>
     <string name="debug_debuglog_size_label">Rozmiar</string>
@@ -198,6 +200,9 @@ K4r0lSz;</string>
     <string name="overview_bluetooth_disabled_description">Bluetooth jest wyłączony, włącz go ;)</string>
     <string name="overview_monitoring_active_label">Monitorowanie urządzeń</string>
     <string name="overview_monitoring_active_description">Upewnij się, że urządzenie znajduje się w pobliżu i jest aktywne.</string>
+    <string name="overview_monitoring_off_label">Monitorowanie w tle jest wyłączone</string>
+    <string name="overview_monitoring_off_description">Żaden profil nie ma sparowanego urządzenia Bluetooth, więc CAPod aktualizuje się tylko gdy aplikacja jest otwarta. Wybierz jeden, aby włączyć monitorowanie w tle, stałe powiadomienia i reakcje.</string>
+    <string name="overview_monitoring_off_action">Wybierz sparowane urządzenie</string>
     <string name="overview_troubleshoot_suggestion_label">Połączono, ale brak danych</string>
     <string name="overview_troubleshoot_suggestion_description">Twoje urządzenie jest połączone, ale CAPod nie odbiera żadnych danych na żywo. Twój telefon może potrzebować opcji zgodności — narzędzie do rozwiązywania problemów może spróbować znaleźć ją automatycznie.</string>
     <string name="overview_troubleshoot_suggestion_action">Uruchom narzędzie do rozwiązywania problemów</string>
@@ -495,8 +500,12 @@ K4r0lSz;</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Naciśnij dwukrotnie, aby zakończyć połączenie</string>
     <string name="device_settings_open_cd">Otwórz ustawienia urządzenia</string>
     <string name="overview_card_missing_paired_device">Ten profil nie ma sparowanego urządzenia Bluetooth.</string>
+    <string name="overview_card_missing_paired_device_consequence">Bez tego ustawienia urządzenia i automatyczne połączenie nie są dostępne.</string>
     <string name="overview_reactions_hint_title">Reakcje są przypisane do urządzenia</string>
     <string name="overview_reactions_hint_body">Automatyczne odtwarzanie, automatyczna pauza i wyskakujące okienka są teraz konfigurowane osobno dla każdego urządzenia. Dotknij ikony ustawień na karcie, gdy słuchawki są podłączone.</string>
+    <string name="review_app_review_action">Oceń</string>
+    <string name="review_app_dismiss_action">Może później</string>
+    <string name="review_app_body">Wystawisz opinię dla CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Ogólne</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -574,4 +583,6 @@ K4r0lSz;</string>
     <string name="press_controls_reset_label">Przywróć domyślne</string>
     <string name="press_controls_reset_confirm_message">Zresetować wszystkie mapowania naciśnięć do domyślnych?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Otwórz sterowanie przyciskami</string>
+    <string name="general_navigate_up_action">Przejdź wyżej</string>
+    <string name="general_progress_loading">Ładowanie</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Doar</string>
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Fechar</string>
+    <string name="general_dismiss_action">Dispensar</string>
     <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Salvar</string>
     <string name="general_guide_action">Guia</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Status do dispositivo</string>
     <string name="notification_channel_device_status_connected_label">Dispositivo conectado</string>
     <string name="monitor_notification_extra_enabled_hint">Você pode desativar esta notificação nas configurações do sistema.</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Log de depuração</string>
     <string name="support_debuglog_desc">Registre tudo o que o aplicativo faz em um arquivo de texto que você pode compartilhar.</string>
     <string name="debug_debuglog_size_label">Tamanho</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">O Bluetooth está desativado, ative-o ;)</string>
     <string name="overview_monitoring_active_label">Monitorando dispositivos</string>
     <string name="overview_monitoring_active_description">Certifique-se de que seu dispositivo está próximo e ativo.</string>
+    <string name="overview_monitoring_off_label">Monitoramento em segundo plano está desativado</string>
+    <string name="overview_monitoring_off_description">Nenhum perfil tem um dispositivo Bluetooth pareado, portanto CAPod apenas atualiza enquanto o app está aberto. Selecione um para ativar o monitoramento em segundo plano, a notificação contínua e as reações.</string>
+    <string name="overview_monitoring_off_action">Selecione dispositivo pareado</string>
     <string name="overview_troubleshoot_suggestion_label">Conectado, mas sem dados</string>
     <string name="overview_troubleshoot_suggestion_description">Seu dispositivo está conectado, mas o CAPod não está recebendo dados em tempo real dele. Seu telefone pode precisar de uma opção de compatibilidade — o solucionador de problemas pode tentar encontrar uma automaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Executar solucionador de problemas</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pressionar duas vezes para encerrar a chamada</string>
     <string name="device_settings_open_cd">Abrir configurações do dispositivo</string>
     <string name="overview_card_missing_paired_device">Este perfil não tem nenhum dispositivo Bluetooth pareado.</string>
+    <string name="overview_card_missing_paired_device_consequence">Sem um, as configurações do dispositivo e a conexão automática não estão disponíveis.</string>
     <string name="overview_reactions_hint_title">As reações são por dispositivo</string>
     <string name="overview_reactions_hint_body">Reprodução automática, pausa automática e pop-ups agora são configurados por dispositivo. Toque no ícone de configurações em um cartão enquanto seus fones de ouvido estiverem conectados.</string>
+    <string name="review_app_review_action">Avaliar</string>
+    <string name="review_app_dismiss_action">Talvez depois</string>
+    <string name="review_app_body">Você gostaria de deixar uma avaliação do CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Gerais</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Redefinir para padrões</string>
     <string name="press_controls_reset_confirm_message">Redefinir todos os mapeamentos de pressão para os padrões?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Abrir controles de pressão</string>
+    <string name="general_navigate_up_action">Navegar para cima</string>
+    <string name="general_progress_loading">Carregando</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Doar</string>
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Fechar</string>
+    <string name="general_dismiss_action">Dispensar</string>
     <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Guardar</string>
     <string name="general_guide_action">Guia</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Estado do dispositivo</string>
     <string name="notification_channel_device_status_connected_label">Dispositivo ligado</string>
     <string name="monitor_notification_extra_enabled_hint">Pode desativar esta notificação nas definições do sistema.</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Registo de depuração</string>
     <string name="support_debuglog_desc">Registe tudo o que a aplicação faz num ficheiro de texto que pode partilhar.</string>
     <string name="debug_debuglog_size_label">Tamanho</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">O Bluetooth está desativado, ative-o ;)</string>
     <string name="overview_monitoring_active_label">A monitorizar dispositivos</string>
     <string name="overview_monitoring_active_description">Certifique-se de que o seu dispositivo está perto e ativo.</string>
+    <string name="overview_monitoring_off_label">Monitorização em segundo plano desativada</string>
+    <string name="overview_monitoring_off_description">Nenhum perfil tem um dispositivo Bluetooth emparelhado, portanto o CAPod apenas atualiza enquanto a aplicação está aberta. Selecione um para ativar a monitorização em segundo plano, a notificação persistente e as reações.</string>
+    <string name="overview_monitoring_off_action">Selecione um dispositivo emparelhado</string>
     <string name="overview_troubleshoot_suggestion_label">Ligado, mas sem dados</string>
     <string name="overview_troubleshoot_suggestion_description">O teu dispositivo está ligado, mas o CAPod não está a receber dados em tempo real. O teu telefone pode precisar de uma opção de compatibilidade — o solucionador de problemas pode tentar encontrar uma automaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Executar solucionador de problemas</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Pressão dupla para terminar chamada</string>
     <string name="device_settings_open_cd">Abrir definições do dispositivo</string>
     <string name="overview_card_missing_paired_device">Este perfil não tem nenhum dispositivo Bluetooth emparelhado.</string>
+    <string name="overview_card_missing_paired_device_consequence">Sem um, as definições do dispositivo e a autoligação não estão disponíveis.</string>
     <string name="overview_reactions_hint_title">As reações são por dispositivo</string>
     <string name="overview_reactions_hint_body">A reprodução automática, a pausa automática e os pop-ups são agora configurados por dispositivo. Toque no ícone de definições num cartão enquanto os seus auscultadores estão ligados.</string>
+    <string name="review_app_review_action">Avaliar</string>
+    <string name="review_app_dismiss_action">Talvez mais tarde</string>
+    <string name="review_app_body">Gostaria de avaliar o CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Geral</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Repor para os padrões</string>
     <string name="press_controls_reset_confirm_message">Repor todos os mapeamentos de pressão para os padrões?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Abrir Controlos de Pressão</string>
+    <string name="general_navigate_up_action">Navegar para cima</string>
+    <string name="general_progress_loading">A carregar</string>
 </resources>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Donaziun</string>
     <string name="general_check_action">Controllar</string>
     <string name="general_close_action">Serrar</string>
+    <string name="general_dismiss_action">Dimitter</string>
     <string name="general_edit_action">Modifitgar</string>
     <string name="general_save_action">Memorisar</string>
     <string name="general_guide_action">Guida</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Stadi da l\'apparat</string>
     <string name="notification_channel_device_status_connected_label">Apparat connectà</string>
     <string name="monitor_notification_extra_enabled_hint">Vus pudais deactivar questa communicaziun en ils parameters dal sistem.</string>
+    <string name="monitor_notification_starting">A startar…</string>
     <string name="support_debuglog_label">Protocol da debugging</string>
     <string name="support_debuglog_desc">Registrar tut quai che l\'app fa en in datotec text che Vus pudais partir.</string>
     <string name="debug_debuglog_size_label">Grondezza</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth è deactivà, activai el ;)</string>
     <string name="overview_monitoring_active_label">Surveglianza dad apparats</string>
     <string name="overview_monitoring_active_description">Assicurai che Voss apparat è datiers ed activ.</string>
+    <string name="overview_monitoring_off_label">Il monitoring da fons è deactivà</string>
+    <string name="overview_monitoring_off_description">Nagin profil n\'ha in apparat Bluetooth associà, perquai che CAPod actualizescha mo cura che l\'app è averta. Tscherna ina per activar il monitoring da fons, la notificaziun continua e las reacziuns.</string>
+    <string name="overview_monitoring_off_action">Tscherna l\'apparat</string>
     <string name="overview_troubleshoot_suggestion_label">Connectà, ma nagins datas</string>
     <string name="overview_troubleshoot_suggestion_description">Tieu apparat è connectà, ma CAPod na retschaiva naginas datas en diretta. Tiu telefon sto eventualmain ina opziun da cumpatibilitad — il schliader da problems po emprovar da chattar ina automaticamain.</string>
     <string name="overview_troubleshoot_suggestion_action">Aviar il schliader da problems</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dupel presser per terminar il clom</string>
     <string name="device_settings_open_cd">Avrir ils parameters da l\'apparat</string>
     <string name="overview_card_missing_paired_device">Quest profil na ha nagin apparat Bluetooth copulà.</string>
+    <string name="overview_card_missing_paired_device_consequence">Senza in, ils parameters da l\'apparat e la connexiun automatica n\'èn betg disponiblas.</string>
     <string name="overview_reactions_hint_title">Las reacziuns èn per mintga apparat</string>
     <string name="overview_reactions_hint_body">Auto-play, auto-pausa e pop-ups vegnan ussa configurads per apparat. Tappa l\'icona da parameters sin ina carta cur che tias chascias d\'ureglia èn connectadas.</string>
+    <string name="review_app_review_action">Recenziun</string>
+    <string name="review_app_dismiss_action">Forsa pli tard</string>
+    <string name="review_app_body">Vuless ti laschar ina recenziun per CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Reinizialisar als valurs standard</string>
     <string name="press_controls_reset_confirm_message">Reinizialisar tut las assignaziuns da pressiun als valurs standard?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Avrir la controlla da pressiun</string>
+    <string name="general_navigate_up_action">Navegar en sura</string>
+    <string name="general_progress_loading">A chargia</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Donează</string>
     <string name="general_check_action">Verifică</string>
     <string name="general_close_action">Închide</string>
+    <string name="general_dismiss_action">Respinge</string>
     <string name="general_edit_action">Editează</string>
     <string name="general_save_action">Salvare</string>
     <string name="general_guide_action">Ghid</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Starea dispozitivului</string>
     <string name="notification_channel_device_status_connected_label">Dispozitiv conectat</string>
     <string name="monitor_notification_extra_enabled_hint">Puteți dezactiva această notificare în setările sistemului.</string>
+    <string name="monitor_notification_starting">Se inițiază…</string>
     <string name="support_debuglog_label">Jurnal de depanare</string>
     <string name="support_debuglog_desc">Înregistrați tot ce face aplicația într-un fișier text pe care îl puteți partaja.</string>
     <string name="debug_debuglog_size_label">Dimensiune</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth este dezactivat, activați-l ;)</string>
     <string name="overview_monitoring_active_label">Monitorizare dispozitive</string>
     <string name="overview_monitoring_active_description">Asigurați-vă că dispozitivul este în apropiere și activ.</string>
+    <string name="overview_monitoring_off_label">Monitorizarea de fundal este oprită</string>
+    <string name="overview_monitoring_off_description">Niciun profil nu are un dispozitiv Bluetooth asociat, deci CAPod se actualizează doar cât timp aplicația este deschisă. Selectează unul pentru a activa monitorizarea de fundal, notificarea continuă și reacțiile.</string>
+    <string name="overview_monitoring_off_action">Selectează dispozitivul asociat</string>
     <string name="overview_troubleshoot_suggestion_label">Conectat, dar fără date</string>
     <string name="overview_troubleshoot_suggestion_description">Dispozitivul tău este conectat, dar CAPod nu primește date în timp real de la acesta. Este posibil ca telefonul tău să aibă nevoie de o opțiune de compatibilitate — depuratorul poate încerca să găsească una automat.</string>
     <string name="overview_troubleshoot_suggestion_action">Rulează depuratorul</string>
@@ -487,8 +492,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dublă apăsare pentru a încheia apelul</string>
     <string name="device_settings_open_cd">Deschide setările dispozitivului</string>
     <string name="overview_card_missing_paired_device">Acest profil nu are niciun dispozitiv Bluetooth asociat.</string>
+    <string name="overview_card_missing_paired_device_consequence">Fără unul, setările dispozitivului și conectarea automată nu sunt disponibile.</string>
     <string name="overview_reactions_hint_title">Reacțiile sunt per dispozitiv</string>
     <string name="overview_reactions_hint_body">Redarea automată, pauza automată și ferestrele pop-up sunt acum configurate per dispozitiv. Apasă pictograma de setări de pe un card în timp ce căștile tale sunt conectate.</string>
+    <string name="review_app_review_action">Revizuire</string>
+    <string name="review_app_dismiss_action">Poate mai târziu</string>
+    <string name="review_app_body">Ți-ar plăcea să lași o recenzie pentru CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
@@ -566,4 +575,6 @@
     <string name="press_controls_reset_label">Resetare la valori implicite</string>
     <string name="press_controls_reset_confirm_message">Resetare toate mapările apăsărilor la valori implicite?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Deschide controalele apăsării</string>
+    <string name="general_navigate_up_action">Navigare în sus</string>
+    <string name="general_progress_loading">Se încarcă</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Пожертвовать</string>
     <string name="general_check_action">Проверить</string>
     <string name="general_close_action">Закрыть</string>
+    <string name="general_dismiss_action">Отклонить</string>
     <string name="general_edit_action">Редактировать</string>
     <string name="general_save_action">Сохранить</string>
     <string name="general_guide_action">Руководство</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Статус устройства</string>
     <string name="notification_channel_device_status_connected_label">Подключенное устройство</string>
     <string name="monitor_notification_extra_enabled_hint">Вы можете отключить это уведомление в системных настройках.</string>
+    <string name="monitor_notification_starting">Запуск…</string>
     <string name="support_debuglog_label">Журнал отладки</string>
     <string name="support_debuglog_desc">Запись всего, что делает приложение, в текстовый файл, которым можно поделиться.</string>
     <string name="debug_debuglog_size_label">Размер</string>
@@ -197,6 +199,9 @@ AL_Cool_T</string>
     <string name="overview_bluetooth_disabled_description">Bluetooth отключен, включите его ;)</string>
     <string name="overview_monitoring_active_label">Мониторинг устройств</string>
     <string name="overview_monitoring_active_description">Убедитесь, что Ваше устройство находится поблизости и активно.</string>
+    <string name="overview_monitoring_off_label">Фоновый мониторинг отключен</string>
+    <string name="overview_monitoring_off_description">В профилях нет спаренных устройств Bluetooth, поэтому CAPod обновляется только когда приложение открыто. Выберите профиль, чтобы включить фоновый мониторинг, постоянное уведомление и реакции.</string>
+    <string name="overview_monitoring_off_action">Выберите спаренное устройство</string>
     <string name="overview_troubleshoot_suggestion_label">Подключено, но данных нет</string>
     <string name="overview_troubleshoot_suggestion_description">Устройство подключено, но CAPod не получает от него данных в режиме реального времени. Возможно, твоему телефону нужна опция совместимости — помощник может попытаться найти её автоматически.</string>
     <string name="overview_troubleshoot_suggestion_action">Запустить помощник</string>
@@ -494,8 +499,12 @@ AL_Cool_T</string>
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двойное нажатие для завершения звонка</string>
     <string name="device_settings_open_cd">Открыть настройки устройства</string>
     <string name="overview_card_missing_paired_device">В этом профиле нет сопряженных устройств Bluetooth.</string>
+    <string name="overview_card_missing_paired_device_consequence">Без него недоступны настройки устройства и автоподключение.</string>
     <string name="overview_reactions_hint_title">Реакции настраиваются для каждого устройства</string>
     <string name="overview_reactions_hint_body">Автовоспроизведение, автопауза и всплывающие окна теперь настраиваются для каждого устройства. Нажмите значок настроек на карточке, пока наушники подключены.</string>
+    <string name="review_app_review_action">Отзыв</string>
+    <string name="review_app_dismiss_action">Возможно, позже</string>
+    <string name="review_app_body">Хочешь оставить отзыв для CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Общее</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -573,4 +582,6 @@ AL_Cool_T</string>
     <string name="press_controls_reset_label">Сброс к умолчаниям</string>
     <string name="press_controls_reset_confirm_message">Сбросить все назначения нажатий по умолчанию?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Открыть управление нажатиями</string>
+    <string name="general_navigate_up_action">Перейти вверх</string>
+    <string name="general_progress_loading">Загрузка</string>
 </resources>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -490,6 +490,7 @@
     <string name="overview_reactions_hint_title">Is reatziones sunt po cada dispositibu</string>
     <string name="overview_reactions_hint_body">Su reprodutzione automàtica, sa pausa automàtica e is pop-up sunt impostados instare po ogni dispositibu. Tocca s\'ìcona de sa cunfiguratziones subra \'e una tàtula mentres is tùas cuffietas sunt connétidas.</string>
     <string name="review_app_review_action">Revisione</string>
+    <string name="review_app_dismiss_action">Forsis prus a tardu</string>
     <string name="review_app_body">Boles làssare una revisione a CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -6,11 +6,13 @@
     <string name="general_copy_action">Còpia</string>
     <string name="general_thank_you_label">Gràtzias</string>
     <string name="general_upgrade_action">Agioma</string>
+    <string name="general_retry_action">Torra pro</string>
     <string name="common_feature_requires_pro_msg">Aggiorna pro sblocare.</string>
     <string name="common_upgrade_required_label">Richiede aggiornamentu</string>
     <string name="general_donate_action">Donare</string>
     <string name="general_check_action">Controlla</string>
     <string name="general_close_action">Serra</string>
+    <string name="general_dismiss_action">Serrare</string>
     <string name="general_edit_action">Modificare</string>
     <string name="general_save_action">Sarva</string>
     <string name="general_guide_action">Ghia</string>
@@ -77,6 +79,7 @@
     <string name="notification_channel_device_status_label">Istadu de su dispositivu</string>
     <string name="notification_channel_device_status_connected_label">Dispositivu cullegadu</string>
     <string name="monitor_notification_extra_enabled_hint">Podes disabilitare custu avisu in sas impostatziones de su sistema.</string>
+    <string name="monitor_notification_starting">Acominzande…</string>
     <string name="support_debuglog_label">Registru de debug</string>
     <string name="support_debuglog_desc">Registra totu su chi s\'app est faghende in unu file de testu chi podes cumpartzire.</string>
     <string name="debug_debuglog_size_label">Mannària</string>
@@ -195,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth est disativadu, ativa·ddu ;)</string>
     <string name="overview_monitoring_active_label">Chirchende dispositivos</string>
     <string name="overview_monitoring_active_description">Assigura·ti chi su dispositivu tuo siat acanta e ativu.</string>
+    <string name="overview_monitoring_off_label">Sa monitoritzatzione de fundo est ischizzada</string>
+    <string name="overview_monitoring_off_description">Nischun perfilu at unu dispositivu Bluetooth aparelladu, ita ca CAPod agiorna cando l\'aplicatzione est aberta. Sele unu pro abilitare sa monitoritzatzione de fundo, s\'avisu pro seghere e sas reatziones.</string>
+    <string name="overview_monitoring_off_action">Sele unu dispositivu aparelladu</string>
     <string name="overview_troubleshoot_suggestion_label">Connètidu, ma non b\'at datos</string>
     <string name="overview_troubleshoot_suggestion_description">Su tuo dispositivu est connètidu, ma CAPod non est retzende datos in diretta dae isse. Su tuo telèfonu podet avere bisòngiu de una opzione de compatibilidade — su risolvidore de problemas podet probare a nd\'agatare una autòmaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Esèghit su risolvidore de problemas</string>
@@ -480,8 +486,11 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dòpia premida pro terminare sa chiamada</string>
     <string name="device_settings_open_cd">Abri sas impostatziones de su dispositivo</string>
     <string name="overview_card_missing_paired_device">Custu profilu non tenet perunu dispositibu Bluetooth abbinadu.</string>
+    <string name="overview_card_missing_paired_device_consequence">Sena unu, sas configuratziones de su dispositivu e sa connessione automàtica non sunt disponìbiles.</string>
     <string name="overview_reactions_hint_title">Is reatziones sunt po cada dispositibu</string>
     <string name="overview_reactions_hint_body">Su reprodutzione automàtica, sa pausa automàtica e is pop-up sunt impostados instare po ogni dispositibu. Tocca s\'ìcona de sa cunfiguratziones subra \'e una tàtula mentres is tùas cuffietas sunt connétidas.</string>
+    <string name="review_app_review_action">Revisione</string>
+    <string name="review_app_body">Boles làssare una revisione a CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
@@ -559,4 +568,6 @@
     <string name="press_controls_reset_label">Reseta a sos predefinidos</string>
     <string name="press_controls_reset_confirm_message">Reseta totu sas mappature de pressione a sos predefinidos?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Abri sos Controlos de Pressione</string>
+    <string name="general_navigate_up_action">Nàviga in sus</string>
+    <string name="general_progress_loading">Carrighende</string>
 </resources>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">පරිත්‍යාග කරන්න</string>
     <string name="general_check_action">පරීක්ෂා කරන්න</string>
     <string name="general_close_action">වසන්න</string>
+    <string name="general_dismiss_action">ඉවතලන්න</string>
     <string name="general_edit_action">සංස්කරණය කරන්න</string>
     <string name="general_save_action">සුරකින්න</string>
     <string name="general_guide_action">මාර්ගෝපදේශය</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">උපාංගයේ තත්ත්වය</string>
     <string name="notification_channel_device_status_connected_label">සම්බන්ධිත උපාංගය</string>
     <string name="monitor_notification_extra_enabled_hint">ඔබට පද්ධති සැකසීම් හි මෙම දැනුම්දීම අබල කළ හැකිය.</string>
+    <string name="monitor_notification_starting">ආරම්භ කරමින් පවතී…</string>
     <string name="support_debuglog_label">දෝෂහරණ ලොගය</string>
     <string name="support_debuglog_desc">යෙදුම කරන සෑම දෙයක්ම ඔබට බෙදාගත හැකි පෙළ ගොනුවක සටහන් කරන්න.</string>
     <string name="debug_debuglog_size_label">ප්‍රමාණය</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth අක්‍රීයයි, එය සක්‍රීය කරන්න ;)</string>
     <string name="overview_monitoring_active_label">උපාංග සඳහා නිරීක්ෂණය කරමින්</string>
     <string name="overview_monitoring_active_description">ඔබගේ උපාංගය ළඟ සහ ක්‍රියාකාරී බව සහතික කරන්න.</string>
+    <string name="overview_monitoring_off_label">පසුබිම් නිරීක්ෂණය වසා ඇත</string>
+    <string name="overview_monitoring_off_description">කිසිසේත් ප්‍රොෆයිල් සම්බන්ධිත බ්ලූටූත් උපාංගයක් නොමැත, එබැවින් CAPod යෙදුම විවෘතව පවතින විට පමණක් යාවත්කාලීන කරයි. පසුබිම් නිරීක්ෂණ, ක්‍රියාත්මක දැනුම්දීම් සහ ප්‍රතිකර්ම සක්‍රිය කිරීමට එකක් තෝරන්න.</string>
+    <string name="overview_monitoring_off_action">සම්බන්ධිත උපාංගය තෝරන්න</string>
     <string name="overview_troubleshoot_suggestion_label">සම්බන්ද වී ඇත, නමුත් දත් නොමැත</string>
     <string name="overview_troubleshoot_suggestion_description">ඔබේ උපාංගය සම්බන්ද වී ඇත, නමුත් CAPod එයින් ජීවිත දත් ලබා ගනිමින් නොමැත. ඔබේ දුරකතනයට අනුකූලතා ළිකල්පයක් අවශ්‍ය ළිය හැක — දෝෂ නිරාකරණකය ස්වයංක්‍රීයව එකක් සොයා ගැනීමට උත්සාහ කළ හැක.</string>
     <string name="overview_troubleshoot_suggestion_action">දෝෂ නිරාකරණකය ධාවනය කරන්න</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">ඇමතුම අවසන් කිරීමට දෙවරක් එබන්න</string>
     <string name="device_settings_open_cd">උපාංග සැකසීම් විවර්ත කරන්න</string>
     <string name="overview_card_missing_paired_device">මෙම පැතිකඩට යුගල කළ Bluetooth උපකරණයක් නොමැත.</string>
+    <string name="overview_card_missing_paired_device_consequence">එකක් නොමැතිව, උපාංග සැකසුම් සහ ස්ව-සම්බන්ධතා ලබා ගත් නොහැක.</string>
     <string name="overview_reactions_hint_title">ප්‍රතික්‍රියා උපාංගය අනුව වෙනස් වේ</string>
     <string name="overview_reactions_hint_body">ස්වයංක්‍රීය වාදනය, ස්වයංක්‍රීය විරාමය සහ පොප්-අප් දැන් සෑම උපාංගයක් සඳහාම වින්‍යාස කර ඇත. ඔබගේ ශිරස්ත්‍රාණ සම්බන්ධිත අතරතුර කාඩ්පතක් මත සැකසුම් නිරූපකය තට්ටු කරන්න.</string>
+    <string name="review_app_review_action">සමාලෝචනය</string>
+    <string name="review_app_dismiss_action">පසුව සමහර විට</string>
+    <string name="review_app_body">ඔබ CAPod සඳහා සමාලෝචනයක් ලිවීමට කැමතිද? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">සාමාන්‍ය</string>
     <string name="device_settings_microphone_mode_label">ශබ්දවාහිනිය</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">පේරනිමි අගයන්ට යශි සකස් කරන්න</string>
     <string name="press_controls_reset_confirm_message">සියලු ඔබීම් සිතියම්ගත කිරීම් පේරනිමි අගයන්ට යශි සකස් කරන්නද?</string>
     <string name="device_settings_noise_control_open_press_controls_action">ඔබීමේ පාලන විවෘත කරන්න</string>
+    <string name="general_navigate_up_action">ඉහළට ගමන් කරන්න</string>
+    <string name="general_progress_loading">පූරණය කරමින්</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Prispieť</string>
     <string name="general_check_action">Overiť</string>
     <string name="general_close_action">Zavrieť</string>
+    <string name="general_dismiss_action">Odmietnuť</string>
     <string name="general_edit_action">Upraviť</string>
     <string name="general_save_action">Uložiť</string>
     <string name="general_guide_action">Sprievodca</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Stav zariadenia</string>
     <string name="notification_channel_device_status_connected_label">Pripojené zariadenie</string>
     <string name="monitor_notification_extra_enabled_hint">Túto notifikáciu môžete vypnúť v systémových nastaveníach.</string>
+    <string name="monitor_notification_starting">Spúšťanie…</string>
     <string name="support_debuglog_label">Ladiaci log</string>
     <string name="support_debuglog_desc">Zaznamenajte všetko, čo aplikácia robí do textového súboru, ktorý môžete zdieľať.</string>
     <string name="debug_debuglog_size_label">Veľkosť</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth je vypnutý, zapnite ho ;)</string>
     <string name="overview_monitoring_active_label">Monitorovanie zariadení</string>
     <string name="overview_monitoring_active_description">Uistite sa, že vaše zariadenie je v blízkosti a je aktívne.</string>
+    <string name="overview_monitoring_off_label">Monitorovanie na pozadí je vypnuté</string>
+    <string name="overview_monitoring_off_description">Žiadny profíl nemá spárované zariadenie Bluetooth, takže CAPod sa aktualizuje iba keď je aplikácia otvorená. Vyberte jeden na povolenie monitorovania na pozadí, trvalého oznámenia a reakcií.</string>
+    <string name="overview_monitoring_off_action">Vyberte spárované zariadenie</string>
     <string name="overview_troubleshoot_suggestion_label">Pripojené, ale žiadne dáta</string>
     <string name="overview_troubleshoot_suggestion_description">Tvoje zariadenie je pripojené, ale CAPod z neho neprijíma žiadne živé dáta. Tvoj telefón môže potrebovať možnosť kompatibility — nástroj na riešenie problémov sa ju môže pokúsiť nájsť automaticky.</string>
     <string name="overview_troubleshoot_suggestion_action">Spustiť riešenie problémov</string>
@@ -493,8 +498,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojité stlačenie na ukončenie hovoru</string>
     <string name="device_settings_open_cd">Otvoriť nastavenia zariadenia</string>
     <string name="overview_card_missing_paired_device">Tento profil nemá spárované Bluetooth zariadenie.</string>
+    <string name="overview_card_missing_paired_device_consequence">Bez neho nie sú k dispozícii nastavenia zariadenia a automatické pripojenie.</string>
     <string name="overview_reactions_hint_title">Reakcie sú nastavené pre každé zariadenie</string>
     <string name="overview_reactions_hint_body">Automatické prehrávanie, automatické pozastavenie a kontextové okná sú teraz nakonfigurované pre každé zariadenie. Klepnite na ikonu nastavení na karte, keď sú vaše slúchadlá pripojené.</string>
+    <string name="review_app_review_action">Ohodnotiť</string>
+    <string name="review_app_dismiss_action">Možno pozdejšie</string>
+    <string name="review_app_body">Chceli by ste zanechať recenziu CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Všeobecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofón</string>
@@ -572,4 +581,6 @@
     <string name="press_controls_reset_label">Obnoviť predvolené nastavenia</string>
     <string name="press_controls_reset_confirm_message">Obnoviť všetky mapovania stlačenia na predvolené nastavenia?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Otvoriť ovládanie stlačením</string>
+    <string name="general_navigate_up_action">Prejsť vyššie</string>
+    <string name="general_progress_loading">Načítava</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Daruj</string>
     <string name="general_check_action">Preveri</string>
     <string name="general_close_action">Zapri</string>
+    <string name="general_dismiss_action">Opusti</string>
     <string name="general_edit_action">Uredi</string>
     <string name="general_save_action">Shrani</string>
     <string name="general_guide_action">Vodnik</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Stanje naprave</string>
     <string name="notification_channel_device_status_connected_label">Povezana naprava</string>
     <string name="monitor_notification_extra_enabled_hint">To obvestilo lahko onemogočite v sistemskih nastavitvah.</string>
+    <string name="monitor_notification_starting">Zaganjam se…</string>
     <string name="support_debuglog_label">Dnevnik za odpravljanje napak</string>
     <string name="support_debuglog_desc">Zabeležite vse, kar počne aplikacija, v besedilno datoteko, ki jo lahko delite.</string>
     <string name="debug_debuglog_size_label">Velikost</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth je onemogočen, omogočite ga ;)</string>
     <string name="overview_monitoring_active_label">Spremljanje naprav</string>
     <string name="overview_monitoring_active_description">Prepričajte se, da je vaša naprava v bližini in aktivna.</string>
+    <string name="overview_monitoring_off_label">Spremljanje v ozadju je izklopljeno</string>
+    <string name="overview_monitoring_off_description">Noben profil nima parjenega Bluetooth naprave, zato se CAPod posodablja samo, ko je aplikacija odprta. Izberite enega, da omogočite spremljanje v ozadju, trajno obvestilo in odzive.</string>
+    <string name="overview_monitoring_off_action">Izberite parjeno napravo</string>
     <string name="overview_troubleshoot_suggestion_label">Povezano, vendar brez podatkov</string>
     <string name="overview_troubleshoot_suggestion_description">Tvoja naprava je povezana, vendar CAPod ne prejema nobenih živih podatkov iz nje. Tvoj telefon morda potrebuje možnost združljivošči — odpravljalec težav jo lahko poskusi samodejno najti.</string>
     <string name="overview_troubleshoot_suggestion_action">Zagon odpravljalca težav</string>
@@ -493,8 +498,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dvojni pritisk za končanje klica</string>
     <string name="device_settings_open_cd">Odpri nastavitve naprave</string>
     <string name="overview_card_missing_paired_device">Ta profil nima sparene naprave Bluetooth.</string>
+    <string name="overview_card_missing_paired_device_consequence">Brez tega nastavitve naprave in samodejna povezava niso na voljo.</string>
     <string name="overview_reactions_hint_title">Reakcije so nastavljene po napravi</string>
     <string name="overview_reactions_hint_body">Samodejno predvajanje, samodejni premor in pojavna okna so zdaj nastavljena za vsako napravo posebej. Tapnite ikono nastavitev na kartici, medtem ko so slušalke povezane.</string>
+    <string name="review_app_review_action">Oceni</string>
+    <string name="review_app_dismiss_action">Morda kasneje</string>
+    <string name="review_app_body">Bi radi ocenili CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Splošno</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -572,4 +581,6 @@
     <string name="press_controls_reset_label">Ponastavi na privzete vrednosti</string>
     <string name="press_controls_reset_confirm_message">Ponastavi vse prireditve pritiskov na privzete?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Odpri krmilnike pritiskov</string>
+    <string name="general_navigate_up_action">Idi gor</string>
+    <string name="general_progress_loading">Nalaganje</string>
 </resources>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Dhuroni</string>
     <string name="general_check_action">Kontrollo</string>
     <string name="general_close_action">Mbyll</string>
+    <string name="general_dismiss_action">Largoje</string>
     <string name="general_edit_action">Redakto</string>
     <string name="general_save_action">Ruaj</string>
     <string name="general_guide_action">Udhëzues</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Statusi i pajisjes</string>
     <string name="notification_channel_device_status_connected_label">Pajisja e lidhur</string>
     <string name="monitor_notification_extra_enabled_hint">Mund ta çaktivizoni këtë njoftim në cilësimet e sistemit.</string>
+    <string name="monitor_notification_starting">Po fillon…</string>
     <string name="support_debuglog_label">Regjistri i korrigjimit</string>
     <string name="support_debuglog_desc">Regjistro gjithçka që aplikacioni po bën në një skedar teksti që mund ta ndani.</string>
     <string name="debug_debuglog_size_label">Madhësia</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth është i çaktivizuar, aktivizojeni ;)</string>
     <string name="overview_monitoring_active_label">Po monitorohen pajisjet</string>
     <string name="overview_monitoring_active_description">Sigurohuni që pajisja juaj është pranë dhe aktive.</string>
+    <string name="overview_monitoring_off_label">Monitorimi në sfond është i fikur</string>
+    <string name="overview_monitoring_off_description">Asnjë profil nuk ka një pajisje të çiftuar me Bluetooth, kështu që CAPod përditësohet vetëm kur aplikacioni është i hapur. Zgjidhni njërin për të aktivizuar monitorimin në sfond, njoftimin e vazhdueshme dhe reagimet.</string>
+    <string name="overview_monitoring_off_action">Zgjidhni pajisjen e çiftuar</string>
     <string name="overview_troubleshoot_suggestion_label">I lidhur, por pa të dhëna</string>
     <string name="overview_troubleshoot_suggestion_description">Pajisja juaj është e lidhur, por CAPod nuk po merr të dhëna live prej saj. Telefoni juaj mund të ketë nevojë për një opsion përputhshmërie — zgjidhësi i problemeve mund të përpiqet të gjejë një automatikisht.</string>
     <string name="overview_troubleshoot_suggestion_action">Ekzekuto zgjidhësin e problemeve</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Shtypje e dyfishtë për të mbyllur thirrjen</string>
     <string name="device_settings_open_cd">Hap cilësimet e pajisjes</string>
     <string name="overview_card_missing_paired_device">Ky profil nuk ka asnjë pajisje Bluetooth të çiftuar.</string>
+    <string name="overview_card_missing_paired_device_consequence">Pa njërin, cilësimet e pajisjes dhe lidhja automatike nuk janë të disponueshme.</string>
     <string name="overview_reactions_hint_title">Reagimet janë për çdo pajisje</string>
     <string name="overview_reactions_hint_body">Luajtja automatike, pauzimi automatik dhe dritaret kërcyese tani konfigurohen për çdo pajisje. Trokitni ikonën e cilësimeve në një kartë ndërkohë që kufjet tuaja janë të lidhura.</string>
+    <string name="review_app_review_action">Rishikimi</string>
+    <string name="review_app_dismiss_action">Ndoshta më vonë</string>
+    <string name="review_app_body">Dëshironi t\'i lini një koment CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Gjenerik</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Rikthe te parazgjedhjet</string>
     <string name="press_controls_reset_confirm_message">Të rivendosen të gjitha hartat e shtypjes te parazgjedhjet?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Hap Kontrollet e Shtypjes</string>
+    <string name="general_navigate_up_action">Navigo lart</string>
+    <string name="general_progress_loading">Po ngarkohet</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -79,6 +79,7 @@
     <string name="notification_channel_device_status_label">Статус уређаја</string>
     <string name="notification_channel_device_status_connected_label">Повезани уређај</string>
     <string name="monitor_notification_extra_enabled_hint">Можете онемогућити ово обавештење у системским подешавањима.</string>
+    <string name="monitor_notification_starting">Покретање…</string>
     <string name="support_debuglog_label">Дневник отклањања грешака</string>
     <string name="support_debuglog_desc">Снимите све што апликација ради у текстуалну датотеку коју можете да делите.</string>
     <string name="debug_debuglog_size_label">Величина</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Донирај</string>
     <string name="general_check_action">Провери</string>
     <string name="general_close_action">Затвори</string>
+    <string name="general_dismiss_action">Одбаци</string>
     <string name="general_edit_action">Уреди</string>
     <string name="general_save_action">Сачувај</string>
     <string name="general_guide_action">Водич</string>
@@ -196,6 +197,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth је онемогућен, омогућите га ;)</string>
     <string name="overview_monitoring_active_label">Надгледање уређаја</string>
     <string name="overview_monitoring_active_description">Уверите се да је ваш уређај у близини и активан.</string>
+    <string name="overview_monitoring_off_label">Позадинско праћење је искључено</string>
+    <string name="overview_monitoring_off_description">Ниједан профил нема упарен Bluetooth уређај, зато CAPod ажурира само док је апликација отворена. Изаберите један да омогућите позадинско праћење, трајну обавест и реакције.</string>
+    <string name="overview_monitoring_off_action">Изаберите упарени уређај</string>
     <string name="overview_troubleshoot_suggestion_label">Повезан, али нема података</string>
     <string name="overview_troubleshoot_suggestion_description">Твој уређај је повезан, али CAPod не прима живе податке с њега. Можда ти треба опција компатибилности — решавање проблема може покушати да је пронађе аутоматски.</string>
     <string name="overview_troubleshoot_suggestion_action">Покрени решавање проблема</string>
@@ -487,8 +491,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Двоструко притисак за завршавање позива</string>
     <string name="device_settings_open_cd">Отворите подешавања уређаја</string>
     <string name="overview_card_missing_paired_device">Овај профил нема упарен Bluetooth уређај.</string>
+    <string name="overview_card_missing_paired_device_consequence">Без њега, подешавања уређаја и аутоматска повезивања нису доступна.</string>
     <string name="overview_reactions_hint_title">Реакције су по уређају</string>
     <string name="overview_reactions_hint_body">Аутоматско пуштање, аутоматска пауза и искачући прозори сада се подешавају по уређају. Додирните икону подешавања на картици док су ваше слушалице повезане.</string>
+    <string name="review_app_review_action">Оцени</string>
+    <string name="review_app_dismiss_action">Можда касније</string>
+    <string name="review_app_body">Желиш ли оставити рецензију за CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Oпште</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
@@ -566,4 +574,6 @@
     <string name="press_controls_reset_label">Врати на подразумевано</string>
     <string name="press_controls_reset_confirm_message">Вратити сва мапирања притисака на подразумевано?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Отвори контроле притиска</string>
+    <string name="general_navigate_up_action">Назад</string>
+    <string name="general_progress_loading">Учитавање</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Donera</string>
     <string name="general_check_action">Kontrollera</string>
     <string name="general_close_action">Stäng</string>
+    <string name="general_dismiss_action">Avfärda</string>
     <string name="general_edit_action">Redigera</string>
     <string name="general_save_action">Spara</string>
     <string name="general_guide_action">Guide</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Enhetsstatus</string>
     <string name="notification_channel_device_status_connected_label">Ansluten enhet</string>
     <string name="monitor_notification_extra_enabled_hint">Du kan inaktivera detta meddelande i systeminställningarna.</string>
+    <string name="monitor_notification_starting">Startar upp…</string>
     <string name="support_debuglog_label">Felsökningslogg</string>
     <string name="support_debuglog_desc">Spela in allt appen gör i en textfil som du kan dela.</string>
     <string name="debug_debuglog_size_label">Storlek</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth är inaktiverat, aktivera det ;)</string>
     <string name="overview_monitoring_active_label">Övervakar enheter</string>
     <string name="overview_monitoring_active_description">Se till att din enhet är i närheten och aktiv.</string>
+    <string name="overview_monitoring_off_label">Bakgrundsövervakning är inaktiverad</string>
+    <string name="overview_monitoring_off_description">Ingen profil har en kopplad Bluetooth-enhet, så CAPod uppdateras bara när appen är öppen. Välj en för att aktivera bakgrundsövervakning, den pågående aviseringen och reaktioner.</string>
+    <string name="overview_monitoring_off_action">Välj kopplad enhet</string>
     <string name="overview_troubleshoot_suggestion_label">Ansluten, men inga data</string>
     <string name="overview_troubleshoot_suggestion_description">Din enhet är ansluten, men CAPod tar inte emot några livedata från den. Din telefon kan behöva ett kompatibilitetsalternativ — felsökaren kan försöka hitta ett automatiskt.</string>
     <string name="overview_troubleshoot_suggestion_action">Kör felsökare</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Dubbeltryck för att avsluta samtal</string>
     <string name="device_settings_open_cd">Öppna enhetsinställningar</string>
     <string name="overview_card_missing_paired_device">Den här profilen har ingen kopplad Bluetooth-enhet.</string>
+    <string name="overview_card_missing_paired_device_consequence">Utan en sådan är enhetsinställningar och automatisk anslutning inte tillgängliga.</string>
     <string name="overview_reactions_hint_title">Reaktioner är per enhet</string>
     <string name="overview_reactions_hint_body">Automatisk uppspelning, automatisk paus och popup-fönster konfigureras nu per enhet. Tryck på inställningsikonen på ett kort medan dina hörlurar är anslutna.</string>
+    <string name="review_app_review_action">Recensera</string>
+    <string name="review_app_dismiss_action">Kanske senare</string>
+    <string name="review_app_body">Skulle du vilja lämna CAPod en recension? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Allmänt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Återställ till standardvärden</string>
     <string name="press_controls_reset_confirm_message">Återställa alla tryckmappningar till standardvärden?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Öppna tryckkontroller</string>
+    <string name="general_navigate_up_action">Navigera upp</string>
+    <string name="general_progress_loading">Läser in</string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Changia</string>
     <string name="general_check_action">Angalia</string>
     <string name="general_close_action">Funga</string>
+    <string name="general_dismiss_action">Ondoa</string>
     <string name="general_edit_action">Hariri</string>
     <string name="general_save_action">Hifadhi</string>
     <string name="general_guide_action">Mwongozo</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Hali ya kifaa</string>
     <string name="notification_channel_device_status_connected_label">Kifaa kimeunganishwa</string>
     <string name="monitor_notification_extra_enabled_hint">Unaweza kuzima arifa hii katika mipangilio ya mfumo.</string>
+    <string name="monitor_notification_starting">Inaanza...</string>
     <string name="support_debuglog_label">Kumbukumbu ya utatuzi</string>
     <string name="support_debuglog_desc">Rekodi kila kitu ambacho programu inafanya kwenye faili ya maandishi unayoweza kushiriki.</string>
     <string name="debug_debuglog_size_label">Ukubwa</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth imezimwa, iwashe ;)</string>
     <string name="overview_monitoring_active_label">Inafuatilia vifaa</string>
     <string name="overview_monitoring_active_description">Hakikisha kifaa chako kiko karibu na kinatumika.</string>
+    <string name="overview_monitoring_off_label">Ufuatiliaji wa nyuma umezimwa</string>
+    <string name="overview_monitoring_off_description">Hakuna profaili yenye kifaa kilichofungwa cha Bluetooth, kwa hivyo CAPod inasasisha tu wakati programu iko wazi. Chagua moja ili kuwezesha ufuatiliaji wa nyuma, ilani endelevu na matendo.</string>
+    <string name="overview_monitoring_off_action">Chagua kifaa kilichofungwa</string>
     <string name="overview_troubleshoot_suggestion_label">Imeunganishwa, lakini hakuna data</string>
     <string name="overview_troubleshoot_suggestion_description">Kifaa chako kimeunganishwa, lakini CAPod haipokei data yoyote ya moja kwa moja kutoka kwake. Simu yako inaweza kuhitaji chaguo la uoanifu — kitatuzi cha matatizo kinaweza kujaribu kupata moja kiotomatiki.</string>
     <string name="overview_troubleshoot_suggestion_action">Endesha kitatuzi cha matatizo</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Bonyeza mara mbili kumaliza simu</string>
     <string name="device_settings_open_cd">Fungua mipangilio ya kifaa</string>
     <string name="overview_card_missing_paired_device">Wasifu huu hauna kifaa cha Bluetooth kilichounganishwa.</string>
+    <string name="overview_card_missing_paired_device_consequence">Bila moja, mipangilio ya kifaa na kuunganisha kiotomatiki hayapatikani.</string>
     <string name="overview_reactions_hint_title">Mwitikio ni kwa kila kifaa</string>
     <string name="overview_reactions_hint_body">Kucheza kiotomatiki, kusimamisha kiotomatiki na madirisha ibukizi sasa yanaweza kusanidiwa kwa kila kifaa. Gonga ikoni ya mipangilio kwenye kadi wakati vifaa vyako vya kusikiliza vimeunganishwa.</string>
+    <string name="review_app_review_action">Mapitio</string>
+    <string name="review_app_dismiss_action">Labda baadaye</string>
+    <string name="review_app_body">Je, ungependa kuacha mapitio ya CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Jumla</string>
     <string name="device_settings_microphone_mode_label">Maikrofoni</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -569,4 +569,6 @@
     <string name="press_controls_reset_label">Rudisha chaguo-msingi</string>
     <string name="press_controls_reset_confirm_message">Rudisha ramani zote za kubonyeza kwa chaguo-msingi?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Fungua Udhibiti wa Kubonyeza</string>
+    <string name="general_navigate_up_action">Nenda juu</string>
+    <string name="general_progress_loading">Kupakia</string>
 </resources>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">நன்கொடை</string>
     <string name="general_check_action">சரிபார்</string>
     <string name="general_close_action">மூடு</string>
+    <string name="general_dismiss_action">நிராகரி</string>
     <string name="general_edit_action">திருத்து</string>
     <string name="general_save_action">சேமி</string>
     <string name="general_guide_action">வழிகாட்டி</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">சாதன நிலை</string>
     <string name="notification_channel_device_status_connected_label">இணைக்கப்பட்ட சாதனம்</string>
     <string name="monitor_notification_extra_enabled_hint">கணினி அமைப்புகளில் இந்த அறிவிப்பை முடக்கலாம்.</string>
+    <string name="monitor_notification_starting">தொடங்குகிறது…</string>
     <string name="support_debuglog_label">பிழைத்திருத்த பதிவு</string>
     <string name="support_debuglog_desc">ஆப்ஸ் செய்யும் அனைத்தையும் நீங்கள் பகிரக்கூடிய ஒரு உரைக் கோப்பில் பதிவுசெய்க.</string>
     <string name="debug_debuglog_size_label">அளவு</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">புளூடூத் முடக்கப்பட்டுள்ளது, இயக்கவும் ;)</string>
     <string name="overview_monitoring_active_label">சாதனங்களைக் கண்காணிக்கிறது</string>
     <string name="overview_monitoring_active_description">உங்கள் சாதனம் அருகில் மற்றும் செயலில் இருப்பதை உறுதிசெய்யவும்.</string>
+    <string name="overview_monitoring_off_label">பின்னணி கண்காணிப்பு அணைக்கப்பட்டுள்ளது</string>
+    <string name="overview_monitoring_off_description">எந்தவொரு சுயவிவரமும் இணைக்கப்பட்ட ப்லூடூத் சாதனத்தைக் கொண்டிருக்கவில்லை, எனவே CAPod ஆப்பு திறந்திருக்கும் போது மட்டுமே புதுப்பிக்கிறது. பின்னணி கண்காணிப்பு, நடந்துகொண்டிருக்கும் அறிவிப்பு மற்றும் எதிர்வினைகளை இயக்க ஒன்றைத் தேர்ந்தெடுக்கவும்.</string>
+    <string name="overview_monitoring_off_action">இணைக்கப்பட்ட சாதனத்தைத் தேர்ந்தெடுக்கவும்</string>
     <string name="overview_troubleshoot_suggestion_label">இணைக்கப்பட்டது, ஆனால் தரவு இல்லை</string>
     <string name="overview_troubleshoot_suggestion_description">உங்கள் சாதனம் இணைக்கப்பட்டுள்ளது, ஆனால் CAPod அதிலிருந்து நேரடி தரவு எதுவும் பெறவில்லை. உங்கள் தொலைபேசிக்கு இணக்கத்தன்மை விருப்பம் தேவைப்படலாம் — சிக்கல் தீர்ப்பான் தானாக ஒன்றை கண்டுபிடிக்க முயற்சிக்கும்.</string>
     <string name="overview_troubleshoot_suggestion_action">சிக்கல் தீர்ப்பானை இயக்கு</string>
@@ -481,8 +486,11 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">அழைப்பை முடிக்க இரண்டு முறை அழுத்தவும்</string>
     <string name="device_settings_open_cd">சாதன அமைப்புகளைத் திறக்கவும்</string>
     <string name="overview_card_missing_paired_device">இந்த சுயவிவரத்தில் இணைக்கப்பட்ட Bluetooth சாதனம் இல்லை.</string>
+    <string name="overview_card_missing_paired_device_consequence">அது இல்லாமல், சாதன அமைப்புகள் மற்றும் தானியங்கி இணைப்பு கிடைக்கவில்லை.</string>
     <string name="overview_reactions_hint_title">எதிர்வினைகள் சாதனத்திற்கு தனித்தனியாக உள்ளன</string>
     <string name="overview_reactions_hint_body">தானியங்கி இயக்கம், தானியங்கி இடைநிறுத்தம் மற்றும் பாப்-அப்கள் இப்போது சாதனத்திற்கு தனித்தனியாக அமைக்கப்படுகின்றன. உங்கள் ஹெட்ஃபோன்கள் இணைக்கப்பட்டிருக்கும்போது ஒரு கார்டில் உள்ள அமைப்புகள் ஐகானை தட்டவும்.</string>
+    <string name="review_app_dismiss_action">பிறகு வேளையில்</string>
+    <string name="review_app_body">நீங்கள் CAPod க்கு மதிப்புரை வழங்க விரும்புகிறீர்களா? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">பொது</string>
     <string name="device_settings_microphone_mode_label">மைக்ரோஃபோன்</string>
@@ -560,4 +568,6 @@
     <string name="press_controls_reset_label">இயல்புகளுக்கு மீட்டமை</string>
     <string name="press_controls_reset_confirm_message">அனைத்து அழுத்த வரைபடங்களையும் இயல்புகளுக்கு மீட்டமைக்கவா?</string>
     <string name="device_settings_noise_control_open_press_controls_action">அழுத்த கட்டுப்பாடுகளை திறக்கவும்</string>
+    <string name="general_navigate_up_action">மேல்நோக்கி செல்க</string>
+    <string name="general_progress_loading">ஏற்றுகிறது</string>
 </resources>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -489,6 +489,7 @@
     <string name="overview_card_missing_paired_device_consequence">அது இல்லாமல், சாதன அமைப்புகள் மற்றும் தானியங்கி இணைப்பு கிடைக்கவில்லை.</string>
     <string name="overview_reactions_hint_title">எதிர்வினைகள் சாதனத்திற்கு தனித்தனியாக உள்ளன</string>
     <string name="overview_reactions_hint_body">தானியங்கி இயக்கம், தானியங்கி இடைநிறுத்தம் மற்றும் பாப்-அப்கள் இப்போது சாதனத்திற்கு தனித்தனியாக அமைக்கப்படுகின்றன. உங்கள் ஹெட்ஃபோன்கள் இணைக்கப்பட்டிருக்கும்போது ஒரு கார்டில் உள்ள அமைப்புகள் ஐகானை தட்டவும்.</string>
+    <string name="review_app_review_action">மதிப்பாய்வு</string>
     <string name="review_app_dismiss_action">பிறகு வேளையில்</string>
     <string name="review_app_body">நீங்கள் CAPod க்கு மதிப்புரை வழங்க விரும்புகிறீர்களா? ❤️</string>
     <!-- New device settings -->

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">దానం చేయండి</string>
     <string name="general_check_action">తనిఖీ చేయి</string>
     <string name="general_close_action">మూసివేయి</string>
+    <string name="general_dismiss_action">తీసివేయండి</string>
     <string name="general_edit_action">సవరించండి</string>
     <string name="general_save_action">సేవ్ చేయి</string>
     <string name="general_guide_action">మార్గదర్శి</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">పరికర స్థితి</string>
     <string name="notification_channel_device_status_connected_label">కనెక్ట్ చేయబడిన పరికరం</string>
     <string name="monitor_notification_extra_enabled_hint">సిస్టమ్ సెట్టింగ్‌లలో ఈ నోటిఫికేషన్‌ను నిలిపివేయవచ్చు.</string>
+    <string name="monitor_notification_starting">ప్రారంభిస్తోంది…</string>
     <string name="support_debuglog_label">డీబగ్ లాగ్</string>
     <string name="support_debuglog_desc">యాప్ చేస్తున్న ప్రతిదాన్ని మీరు షేర్ చేయగల టెక్స్ట్ ఫైల్‌లో రికార్డ్ చేయండి.</string>
     <string name="debug_debuglog_size_label">పరిమాణం</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">బ్లూటూత్ నిలిపివేయబడింది, దాన్ని ఎనేబుల్ చేయండి ;)</string>
     <string name="overview_monitoring_active_label">పరికరాలను మానిటర్ చేస్తోంది</string>
     <string name="overview_monitoring_active_description">మీ పరికరం సమీపంలో మరియు యాక్టివ్‌గా ఉందని నిర్ధారించుకోండి.</string>
+    <string name="overview_monitoring_off_label">నేపథ్య పర్యవేక్షణ ఆఫ్‌లో ఉంది</string>
+    <string name="overview_monitoring_off_description">ఏ ప్రొఫైల్‌కు జత చేయబడిన Bluetooth పరికరం లేనందువల్ల, CAPod కేవలం యాప్ తెరిచి ఉన్నప్పుడు మాత్రమే నవీకరించుకుంటుంది. నేపథ్య పర్యవేక్షణ, కొనసాగుతున్న నోటిఫికేషన్ మరియు ప్రతిచర్యలను ప్రారంభించడానికి ఒకటిని ఎంచుకోండి.</string>
+    <string name="overview_monitoring_off_action">జత చేయబడిన పరికరాన్ని ఎంచుకోండి</string>
     <string name="overview_troubleshoot_suggestion_label">కనెక్ట్ అయింది, కానీ డేటా లేదు</string>
     <string name="overview_troubleshoot_suggestion_description">మీ పరికరం కనెక్ట్ అయింది, కానీ CAPod దాని నుండి ఏ లైవ్ డేటాను అందుకోవడం లేదు. మీ ఫోన్‌కు ఒక అనుకూలత ఎంపిక అవసరం కావచ్చు — ట్రబుల్షూటర్ స్వయంచాలకంగా ఒకటి కనుగొనడానికి ప్రయత్నించగలదు.</string>
     <string name="overview_troubleshoot_suggestion_action">ట్రబుల్షూటర్ అమలు చేయి</string>
@@ -481,8 +486,11 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">కాల్ ముగించడానికి రెండుసార్లు నొక్కండి</string>
     <string name="device_settings_open_cd">పరికర సెట్టింగ్‌లు తెరవండి</string>
     <string name="overview_card_missing_paired_device">ఈ ప్రొఫైల్‌కు పెయిర్ చేయబడిన Bluetooth పరికరం లేదు.</string>
+    <string name="overview_card_missing_paired_device_consequence">దీన్ని లేకుండా, పరికర సెట్టింగ్‌లు మరియు ఆటో-కనెక్ట్ అందుబాటులో లేనివి.</string>
     <string name="overview_reactions_hint_title">రియాక్షన్లు పరికరానికి నిర్దిష్టంగా ఉంటాయి</string>
     <string name="overview_reactions_hint_body">ఆటో-ప్లే, ఆటో-పాజ్ మరియు పాప్-అప్‌లు ఇప్పుడు పరికరానికి నిర్దిష్టంగా కాన్ఫిగర్ చేయబడ్డాయి. మీ హెడ్‌ఫోన్‌లు కనెక్ట్ అయి ఉన్నప్పుడు కార్డ్‌పై సెట్టింగ్‌ల చిహ్నాన్ని నొక్కండి.</string>
+    <string name="review_app_review_action">సమీక్ష</string>
+    <string name="review_app_body">మీరు CAPod కోసం సమీక్ష వ్రాయాలనుకుంటారా? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">సాధారణ</string>
     <string name="device_settings_microphone_mode_label">మైక్రోఫోన్</string>
@@ -560,4 +568,6 @@
     <string name="press_controls_reset_label">డిఫాల్ట్‌లకు రిసెట్</string>
     <string name="press_controls_reset_confirm_message">అన్ని ప్రెస్ మ్యాపింగ్‌లను డిఫాల్ట్‌లకు రిసెట్ చేయాలా?</string>
     <string name="device_settings_noise_control_open_press_controls_action">ప్రెస్ కంట్రోల్‌స్ తెరవండి</string>
+    <string name="general_navigate_up_action">పైకి నావిగేట్ చేయండి</string>
+    <string name="general_progress_loading">లోడ్ చేస్తుంది</string>
 </resources>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -490,6 +490,7 @@
     <string name="overview_reactions_hint_title">రియాక్షన్లు పరికరానికి నిర్దిష్టంగా ఉంటాయి</string>
     <string name="overview_reactions_hint_body">ఆటో-ప్లే, ఆటో-పాజ్ మరియు పాప్-అప్‌లు ఇప్పుడు పరికరానికి నిర్దిష్టంగా కాన్ఫిగర్ చేయబడ్డాయి. మీ హెడ్‌ఫోన్‌లు కనెక్ట్ అయి ఉన్నప్పుడు కార్డ్‌పై సెట్టింగ్‌ల చిహ్నాన్ని నొక్కండి.</string>
     <string name="review_app_review_action">సమీక్ష</string>
+    <string name="review_app_dismiss_action">బహుశా తర్వాత</string>
     <string name="review_app_body">మీరు CAPod కోసం సమీక్ష వ్రాయాలనుకుంటారా? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">సాధారణ</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">บริจาค</string>
     <string name="general_check_action">ตรวจสอบ</string>
     <string name="general_close_action">ปิด</string>
+    <string name="general_dismiss_action">ปิด</string>
     <string name="general_edit_action">แก้ไข</string>
     <string name="general_save_action">บันทึก</string>
     <string name="general_guide_action">คู่มือ</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">สถานะอุปกรณ์</string>
     <string name="notification_channel_device_status_connected_label">อุปกรณ์ที่เชื่อมต่อ</string>
     <string name="monitor_notification_extra_enabled_hint">คุณสามารถปิดการแจ้งเตือนนี้ได้ในการตั้งค่าระบบ</string>
+    <string name="monitor_notification_starting">กำลังเริ่มต้น…</string>
     <string name="support_debuglog_label">บันทึกการดีบัก</string>
     <string name="support_debuglog_desc">บันทึกทุกสิ่งที่แอปกำลังทำลงในไฟล์ข้อความที่คุณสามารถแบ่งปันได้</string>
     <string name="debug_debuglog_size_label">ขนาด</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth ถูกปิดใช้งาน เปิดใช้งานเลย ;)</string>
     <string name="overview_monitoring_active_label">กำลังติดตามอุปกรณ์</string>
     <string name="overview_monitoring_active_description">ตรวจสอบให้แน่ใจว่าอุปกรณ์ของคุณอยู่ใกล้และเปิดใช้งานอยู่</string>
+    <string name="overview_monitoring_off_label">ปิดการตรวจสอบพื้นหลัง</string>
+    <string name="overview_monitoring_off_description">ไม่มีโปรไฟล์ใดมีอุปกรณ์ Bluetooth ที่จับคู่ ดังนั้น CAPod จึงอัปเดตเฉพาะเมื่อแอปเปิดอยู่ เลือกอันใดอันหนึ่งเพื่อเปิดใช้งานการตรวจสอบพื้นหลัง การแจ้งเตือนต่อเนื่อง และการตอบสนอง</string>
+    <string name="overview_monitoring_off_action">เลือกอุปกรณ์ที่จับคู่</string>
     <string name="overview_troubleshoot_suggestion_label">เชื่อมต่อแล้ว แต่ไม่มีข้อมูล</string>
     <string name="overview_troubleshoot_suggestion_description">อุปกรณ์ของคุณเชื่อมต่อแล้ว แต่ CAPod ไม่ได้รับข้อมูลสดจากอุปกรณ์นั้น โทรศัพท์ของคุณอาจต้องการตัวเลือกความเข้ากันได้ — เครื่องมือแก้ปัญหาสามารถลองค้นหาตัวเลือกนั้นโดยอัตโนมัติ</string>
     <string name="overview_troubleshoot_suggestion_action">เรียกใช้เครื่องมือแก้ปัญหา</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">กดสองครั้งเพื่อวางสาย</string>
     <string name="device_settings_open_cd">เปิดการตั้งค่าอุปกรณ์</string>
     <string name="overview_card_missing_paired_device">โปรไฟล์นี้ไม่มีอุปกรณ์ Bluetooth ที่จับคู่แล้ว</string>
+    <string name="overview_card_missing_paired_device_consequence">หากไม่มี การตั้งค่าอุปกรณ์และการเชื่อมต่ออัตโนมัติจะไม่พร้อมใช้งาน</string>
     <string name="overview_reactions_hint_title">การตอบสนองแยกตามอุปกรณ์</string>
     <string name="overview_reactions_hint_body">การเล่นอัตโนมัติ การหยุดอัตโนมัติ และป๊อปอัปตั้งค่าแยกตามอุปกรณ์แล้ว แตะไอคอนการตั้งค่าบนการ์ดขณะที่หูฟังของคุณเชื่อมต่ออยู่</string>
+    <string name="review_app_review_action">รีวิว</string>
+    <string name="review_app_dismiss_action">อาจในคราวหน้า</string>
+    <string name="review_app_body">คุณต้องการให้คะแนน CAPod หรือไม่? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">ทั่วไป</string>
     <string name="device_settings_microphone_mode_label">ไมโครโฟน</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">รีเซ็ตเป็นค่าเริ่มต้น</string>
     <string name="press_controls_reset_confirm_message">รีเซ็ตการกำหนดการกดทั้งหมดเป็นค่าเริ่มต้น?</string>
     <string name="device_settings_noise_control_open_press_controls_action">เปิดการควบคุมการกด</string>
+    <string name="general_navigate_up_action">ขึ้นไป</string>
+    <string name="general_progress_loading">กำลังโหลด</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Bağış yap</string>
     <string name="general_check_action">Kontrol et</string>
     <string name="general_close_action">Kapat</string>
+    <string name="general_dismiss_action">Yoksay</string>
     <string name="general_edit_action">Düzenle</string>
     <string name="general_save_action">Kaydet</string>
     <string name="general_guide_action">Rehber</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Aygıt durumu</string>
     <string name="notification_channel_device_status_connected_label">Bağlı cihaz</string>
     <string name="monitor_notification_extra_enabled_hint">Bu bildirimi sistem ayarlarından devre dışı bırakabilirsin.</string>
+    <string name="monitor_notification_starting">Başlatılıyor…</string>
     <string name="support_debuglog_label">Hata ayıklama günlüğü</string>
     <string name="support_debuglog_desc">Uygulamanın yaptığı her şeyi paylaşabileceğiniz bir metin dosyasına kaydeder.</string>
     <string name="debug_debuglog_size_label">Boyut</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth devre dışı, etkinleştirin ;)</string>
     <string name="overview_monitoring_active_label">Cihazlar izleniyor</string>
     <string name="overview_monitoring_active_description">Cihazınızın yakınında ve etkin olduğundan emin olun.</string>
+    <string name="overview_monitoring_off_label">Arka Plan İzlemesi Kapalı</string>
+    <string name="overview_monitoring_off_description">Hiçbir profilde eşleştirilmiş bir Bluetooth cihazı yok, bu nedenle CAPod yalnızca uygulama açıkken güncellenir. Arka plan izlemesini, devam eden bildirimleri ve tepkileri etkinleştirmek için birini seçin.</string>
+    <string name="overview_monitoring_off_action">Eşleştirilmiş Cihazı Seçin</string>
     <string name="overview_troubleshoot_suggestion_label">Bağlı, ancak veri yok</string>
     <string name="overview_troubleshoot_suggestion_description">Cihazınız bağlı, ancak CAPod ondan canlı veri almıyor. Telefonunuzun bir uyumluluk seçeneğine ihtiyacı olabilir — sorun giderici otomatik olarak bir tane bulmaya çalışabilir.</string>
     <string name="overview_troubleshoot_suggestion_action">Sorun gidericiyi çalıştır</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Aramayı bitirmek için çift basım</string>
     <string name="device_settings_open_cd">Cihaz ayarlarını aç</string>
     <string name="overview_card_missing_paired_device">Bu profilde eşlenmiş bir Bluetooth cihazı yok.</string>
+    <string name="overview_card_missing_paired_device_consequence">Birisi olmadan, cihaz ayarları ve otomatik bağlantı kullanılamaz.</string>
     <string name="overview_reactions_hint_title">Tepkiler cihaz başına ayarlanır</string>
     <string name="overview_reactions_hint_body">Otomatik oynatma, otomatik duraklatma ve açılır pencereler artık cihaz başına yapılandırılmaktadır. Kulaklıklarınız bağlıyken karttaki ayarlar simgesine dokunun.</string>
+    <string name="review_app_review_action">Değerlendir</string>
+    <string name="review_app_dismiss_action">Belki daha sonra</string>
+    <string name="review_app_body">CAPod\'e bir inceleme bırakmak ister misiniz? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Genel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Varsayılanlara sıfırla</string>
     <string name="press_controls_reset_confirm_message">Tüm basma atmaları varsayılanlara sıfırlansın mı?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Basma Kontrollerini Aç</string>
+    <string name="general_navigate_up_action">Yukarı Git</string>
+    <string name="general_progress_loading">Yükleniyor</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Пожертвувати</string>
     <string name="general_check_action">Перевірити</string>
     <string name="general_close_action">Закрити</string>
+    <string name="general_dismiss_action">Відхилити</string>
     <string name="general_edit_action">Редагувати</string>
     <string name="general_save_action">Зберегти</string>
     <string name="general_guide_action">Посібник</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Статус пристрою</string>
     <string name="notification_channel_device_status_connected_label">Підключений пристрій</string>
     <string name="monitor_notification_extra_enabled_hint">Ви можете вимкнути це сповіщення в системних налаштуваннях.</string>
+    <string name="monitor_notification_starting">Запуск…</string>
     <string name="support_debuglog_label">Журнал налагодження</string>
     <string name="support_debuglog_desc">Запис всього, що робить програма, у текстовий файл, яким можна поділитися.</string>
     <string name="debug_debuglog_size_label">Розмір</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth вимкнено, увімкніть його ;)</string>
     <string name="overview_monitoring_active_label">Пошук пристроїв</string>
     <string name="overview_monitoring_active_description">Переконайтеся, що ваш пристрій поблизу та активний.</string>
+    <string name="overview_monitoring_off_label">Моніторинг у фоні вимкнено</string>
+    <string name="overview_monitoring_off_description">Жоден профіль не має пов\'язаного Bluetooth-пристрою, тому CAPod оновлюється лише при відкритому застосунку. Виберіть один, щоб увімкнути моніторинг у фоні, постійне сповіщення та реакції.</string>
+    <string name="overview_monitoring_off_action">Виберіть пов\'язаний пристрій</string>
     <string name="overview_troubleshoot_suggestion_label">Підключено, але немає даних</string>
     <string name="overview_troubleshoot_suggestion_description">Пристрій підключено, але CAPod не отримує від нього жодних актуальних даних. Вашому телефону може знадобитися параметр сумісності — засіб усунення несправностей спробує знайти його автоматично.</string>
     <string name="overview_troubleshoot_suggestion_action">Запустити засіб усунення несправностей</string>
@@ -493,8 +498,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Подвійне натискання для завершення дзвінка</string>
     <string name="device_settings_open_cd">Відкрити налаштування пристрою</string>
     <string name="overview_card_missing_paired_device">До цього профілю не підключено жодного Bluetooth-пристрою.</string>
+    <string name="overview_card_missing_paired_device_consequence">Без нього параметри пристрою та автоматичне підключення недоступні.</string>
     <string name="overview_reactions_hint_title">Реакції налаштовуються окремо для кожного пристрою</string>
     <string name="overview_reactions_hint_body">Автовідтворення, автопауза та спливаючі вікна тепер налаштовуються окремо для кожного пристрою. Торкніться значка налаштувань на картці, поки підключені навушники.</string>
+    <string name="review_app_review_action">Огляд</string>
+    <string name="review_app_dismiss_action">Можливо пізніше</string>
+    <string name="review_app_body">Бажаєш залишити відгук про CAPod? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Загальні</string>
     <string name="device_settings_microphone_mode_label">Мікрофон</string>
@@ -572,4 +581,6 @@
     <string name="press_controls_reset_label">Скинути до типових</string>
     <string name="press_controls_reset_confirm_message">Скинути всі призначення натискань до типових?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Відкрити керування натисканнями</string>
+    <string name="general_navigate_up_action">Перейти вгору</string>
+    <string name="general_progress_loading">Завантаження</string>
 </resources>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -78,6 +78,7 @@
     <string name="notification_channel_device_status_label">آلہ کی حیثیت</string>
     <string name="notification_channel_device_status_connected_label">منسلک آلہ</string>
     <string name="monitor_notification_extra_enabled_hint">آپ اس اطلاع کو سسٹم سیٹنگز میں غیر فعال کر سکتے ہیں۔</string>
+    <string name="monitor_notification_starting">شروع ہو رہا ہے…</string>
     <string name="support_debuglog_label">ڈیبگ لاگ</string>
     <string name="support_debuglog_desc">ایپ جو کچھ بھی کر رہی ہے اسے ایک ٹیکسٹ فائل میں ریکارڈ کریں جسے آپ شیئر کر سکتے ہیں۔</string>
     <string name="debug_debuglog_size_label">سائز</string>
@@ -196,6 +197,9 @@
     <string name="overview_bluetooth_disabled_description">بلوٹوتھ غیر فعال ہے، اسے فعال کریں ؛)</string>
     <string name="overview_monitoring_active_label">آلات کی نگرانی ہو رہی ہے</string>
     <string name="overview_monitoring_active_description">یقینی بنائیں کہ آپ کا آلہ قریب اور فعال ہے۔</string>
+    <string name="overview_monitoring_off_label">پس منظر کی نگرانی بند ہے</string>
+    <string name="overview_monitoring_off_description">کوئی بھی پروفائل جوڑے ہوئے Bluetooth ڈیوائس کے ساتھ نہیں ہے، اس لیے CAPod صرف اس وقت اپ ڈیٹ ہوتا ہے جب ایپ کھلی ہو۔ پس منظر کی نگرانی، مسلسل اطلاع اور رد عمل کو فعال کرنے کے لیے ایک کو منتخب کریں۔</string>
+    <string name="overview_monitoring_off_action">جوڑا ہوا ڈیوائس منتخب کریں</string>
     <string name="overview_troubleshoot_suggestion_label">متصل، لیکن کوئی ڈیٹا نہیں</string>
     <string name="overview_troubleshoot_suggestion_description">آپ کا آلہ متصل ہے، لیکن CAPod اس سے کوئی براہ راست ڈیٹا وصول نہیں کر رہا۔ آپ کے فون کو ایک مطابقت کے آپشن کی ضرورت ہو سکتی ہے — مسئلہ حل کرنے والا خود بخود ایک تلاش کرنے کی کوشش کر سکتا ہے۔</string>
     <string name="overview_troubleshoot_suggestion_action">مسئلہ حل کرنے والا چلائیں</string>
@@ -481,8 +485,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">کال ختم کرنے کے لیے دو بار دبائیں</string>
     <string name="device_settings_open_cd">ڈیوائس کی ترتیبات کھولیں</string>
     <string name="overview_card_missing_paired_device">اس پروفائل میں کوئی جوڑا بلوٹوتھ ڈیوائس نہیں ہے۔</string>
+    <string name="overview_card_missing_paired_device_consequence">اس کے بغیر، ڈیوائس کی ترتیبات اور خود کار رابطہ دستیاب نہیں ہیں۔</string>
     <string name="overview_reactions_hint_title">ردعمل فی آلہ ہیں</string>
     <string name="overview_reactions_hint_body">آٹو پلے، آٹو پاز اور پاپ اپس کو اب ہر آلے کے لیے الگ سے ترتیب دیا گیا ہے۔ اپنے ہیڈفون کو منسلک رکھتے ہوئے کسی کارڈ پر سیٹنگز کا آئیکن تھپتھپائیں۔</string>
+    <string name="review_app_review_action">ریویو</string>
+    <string name="review_app_dismiss_action">شاید بعد میں</string>
+    <string name="review_app_body">کیا آپ CAPod کے لیے ریویو چھوڑنا چاہیں گے؟ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">مائیکروفون</string>
@@ -560,4 +568,6 @@
     <string name="press_controls_reset_label">ڈیفالٹس پر ریسیٹ کریں</string>
     <string name="press_controls_reset_confirm_message">تمام پریس میپنگز ڈیفالٹس پر ریسیٹ کریں؟</string>
     <string name="device_settings_noise_control_open_press_controls_action">پریس کنٹرولز کھولیں</string>
+    <string name="general_navigate_up_action">اوپر جائیں</string>
+    <string name="general_progress_loading">لوڈ کر رہا ہے</string>
 </resources>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">عطیہ کریں</string>
     <string name="general_check_action">چیک کریں</string>
     <string name="general_close_action">بند کریں</string>
+    <string name="general_dismiss_action">مسترد کریں</string>
     <string name="general_edit_action">تبدیلی کریں</string>
     <string name="general_save_action">محفوظ کریں</string>
     <string name="general_guide_action">رہنما</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Xayriya qilish</string>
     <string name="general_check_action">Tekshirish</string>
     <string name="general_close_action">Yopish</string>
+    <string name="general_dismiss_action">Yopish</string>
     <string name="general_edit_action">Tahrirlash</string>
     <string name="general_save_action">Saqlash</string>
     <string name="general_guide_action">Qo\'llanma</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Qurilma holati</string>
     <string name="notification_channel_device_status_connected_label">Ulangan qurilma</string>
     <string name="monitor_notification_extra_enabled_hint">Bu bildirishnomani tizim sozlamalarida o\'chirib qo\'yishingiz mumkin.</string>
+    <string name="monitor_notification_starting">Boshlanilyapti…</string>
     <string name="support_debuglog_label">Nosozliklarni tuzatish jurnali</string>
     <string name="support_debuglog_desc">Ilova bajarayotgan hamma narsani ulashishingiz mumkin bo\'lgan matn fayliga yozib oling.</string>
     <string name="debug_debuglog_size_label">Hajmi</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth o\'chirilgan, uni yoqing ;)</string>
     <string name="overview_monitoring_active_label">Qurilmalar kuzatilmoqda</string>
     <string name="overview_monitoring_active_description">Qurilmangiz yaqinda va faol ekanligiga ishonch hosil qiling.</string>
+    <string name="overview_monitoring_off_label">Fonda monitoring o\'chirilgan</string>
+    <string name="overview_monitoring_off_description">Hech qanday profil juft Bluetooth qurilmasiga ega emas, shuning uchun CAPod faqat ilova ochiq bo\'lganda yangilanadi. Fonda monitoringni, davomli bildirishnomani va reaktsiyalarni yoqish uchun birini tanlang.</string>
+    <string name="overview_monitoring_off_action">Juft qurilmani tanlang</string>
     <string name="overview_troubleshoot_suggestion_label">Ulangan, lekin ma\'lumot yo\'q</string>
     <string name="overview_troubleshoot_suggestion_description">Qurilmangiz ulangan, ammo CAPod undan jonli ma\'lumot olmayapti. Telefoningizga moslik opsiyasi kerak bo\'lishi mumkin — nosozliklarni bartaraf etish vositasi uni avtomatik topishga urinib ko\'radi.</string>
     <string name="overview_troubleshoot_suggestion_action">Nosozliklarni bartaraf etish vositasini ishga tushirish</string>
@@ -481,8 +486,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Qo\'ng\'iroqni tugatish uchun ikki marta bosing</string>
     <string name="device_settings_open_cd">Qurilma sozlamalarini ochish</string>
     <string name="overview_card_missing_paired_device">Bu profilga ulangan Bluetooth qurilmasi yo\'q.</string>
+    <string name="overview_card_missing_paired_device_consequence">Uning orqasiz, qurilma sozlamalari va avtomatik ulanish mavjud emas.</string>
     <string name="overview_reactions_hint_title">Reaktsiyalar har bir qurilma uchun</string>
     <string name="overview_reactions_hint_body">Avtomatik ijro, avtomatik to\'xtatish va qalqib chiquvchi oynalar endi har bir qurilma uchun alohida sozlanadi. Quloqchinlaringiz ulanganda kartadagi sozlamalar belgisiga bosing.</string>
+    <string name="review_app_review_action">Ko\'rib chiqish</string>
+    <string name="review_app_dismiss_action">Balki keyinroq</string>
+    <string name="review_app_body">CAPod ga sharh qoldirishni xohlaysizmi? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Umumiy</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
@@ -560,4 +569,6 @@
     <string name="press_controls_reset_label">Standart sozlamalarga qaytarish</string>
     <string name="press_controls_reset_confirm_message">Barcha bosish xaritalarini standart sozlamalarga qaytarasizmi?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Bosish boshqaruvini ochish</string>
+    <string name="general_navigate_up_action">Yuqoriga qayt</string>
+    <string name="general_progress_loading">Yuklanmoqda</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Quyên góp</string>
     <string name="general_check_action">Kiểm tra</string>
     <string name="general_close_action">Đóng</string>
+    <string name="general_dismiss_action">Bỏ qua</string>
     <string name="general_edit_action">Sửa</string>
     <string name="general_save_action">Lưu</string>
     <string name="general_guide_action">Hướng dẫn</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Trạng thái thiết bị</string>
     <string name="notification_channel_device_status_connected_label">Thiết bị đã kết nối</string>
     <string name="monitor_notification_extra_enabled_hint">Bạn có thể tắt thông báo này trong cài đặt hệ thống.</string>
+    <string name="monitor_notification_starting">Khởi động...</string>
     <string name="support_debuglog_label">Nhật ký gỡ lỗi</string>
     <string name="support_debuglog_desc">Ghi lại mọi thứ ứng dụng đang làm vào một tệp văn bản mà bạn có thể chia sẻ.</string>
     <string name="debug_debuglog_size_label">Kích thước</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">Bluetooth đang tắt, hãy bật lên ;)</string>
     <string name="overview_monitoring_active_label">Đang giám sát thiết bị</string>
     <string name="overview_monitoring_active_description">Đảm bảo thiết bị của bạn ở gần và đang hoạt động.</string>
+    <string name="overview_monitoring_off_label">Theo dõi nền bị tắt</string>
+    <string name="overview_monitoring_off_description">Không có hồ sơ nào có thiết bị Bluetooth được ghép nối, vì vậy CAPod chỉ cập nhật khi ứng dụng mở. Chọn một để bật theo dõi nền, thông báo liên tục và phản ứng.</string>
+    <string name="overview_monitoring_off_action">Chọn thiết bị được ghép nối</string>
     <string name="overview_troubleshoot_suggestion_label">Đã kết nối, nhưng không có dữ liệu</string>
     <string name="overview_troubleshoot_suggestion_description">Thiết bị của bạn đã kết nối, nhưng CAPod không nhận được dữ liệu trực tiếp từ nó. Điện thoại của bạn có thể cần tùy chọn tương thích — trình khắc phục sự cố có thể tự động tìm một tùy chọn.</string>
     <string name="overview_troubleshoot_suggestion_action">Chạy trình khắc phục sự cố</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Nhấn hai lần để kết thúc cuộc gọi</string>
     <string name="device_settings_open_cd">Mở cài đặt thiết bị</string>
     <string name="overview_card_missing_paired_device">Hồ sơ này không có thiết bị Bluetooth nào được ghép nối.</string>
+    <string name="overview_card_missing_paired_device_consequence">Không có nó, cài đặt thiết bị và kết nối tự động không khả dụng.</string>
     <string name="overview_reactions_hint_title">Các phản ứng được thiết lập theo từng thiết bị</string>
     <string name="overview_reactions_hint_body">Tự động phát, tự động tạm dừng và cửa sổ bật lên hiện được cấu hình theo từng thiết bị. Nhấn vào biểu tượng cài đặt trên thẻ khi tai nghe của bạn đang kết nối.</string>
+    <string name="review_app_review_action">Đánh giá</string>
+    <string name="review_app_dismiss_action">Để sau</string>
+    <string name="review_app_body">Bạn có muốn để lại đánh giá cho CAPod không? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Chung</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">Đặt lại mặc định</string>
     <string name="press_controls_reset_confirm_message">Đặt lại tất cả ánh xạ nhấn về mặc định?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Mở Điều khiển nhấn</string>
+    <string name="general_navigate_up_action">Quay lại</string>
+    <string name="general_progress_loading">Đang tải</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">捐赠</string>
     <string name="general_check_action">检查</string>
     <string name="general_close_action">关闭</string>
+    <string name="general_dismiss_action">取消</string>
     <string name="general_edit_action">编辑</string>
     <string name="general_save_action">保存</string>
     <string name="general_guide_action">指南</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">设备状态</string>
     <string name="notification_channel_device_status_connected_label">连接的设备</string>
     <string name="monitor_notification_extra_enabled_hint">您可以在系统设置中关闭此通知。</string>
+    <string name="monitor_notification_starting">启动中…</string>
     <string name="support_debuglog_label">调试日志</string>
     <string name="support_debuglog_desc">将应用执行的所有操作记录到您可以共享的文本文件中。</string>
     <string name="debug_debuglog_size_label">大小</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">蓝牙已关闭，请开启 ;)</string>
     <string name="overview_monitoring_active_label">设备监测</string>
     <string name="overview_monitoring_active_description">请确保您的设备附近并处于活动状态。</string>
+    <string name="overview_monitoring_off_label">后台监控已关闭</string>
+    <string name="overview_monitoring_off_description">没有配置文件与配对的蓝牙设备相关联，因此 CAPod 仅在应用打开时更新。选择一个以启用后台监控、持续通知和反应。</string>
+    <string name="overview_monitoring_off_action">选择配对设备</string>
     <string name="overview_troubleshoot_suggestion_label">已连接，但无数据</string>
     <string name="overview_troubleshoot_suggestion_description">设备已连接，但 CAPod 未收到任何实时数据。你的手机可能需要一个兼容选项——故障排除程序可以尝试自动找到一个。</string>
     <string name="overview_troubleshoot_suggestion_action">运行故障排除程序</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">双按结束通话</string>
     <string name="device_settings_open_cd">打开设备设置</string>
     <string name="overview_card_missing_paired_device">此配置文件没有已配对的蓝牙设备。</string>
+    <string name="overview_card_missing_paired_device_consequence">没有它，设备设置和自动连接将不可用。</string>
     <string name="overview_reactions_hint_title">反应设置按设备分别配置</string>
     <string name="overview_reactions_hint_body">自动播放、自动暂停和弹窗现在按设备分别配置。在耳机连接时，点击卡片上的设置图标。</string>
+    <string name="review_app_review_action">评论</string>
+    <string name="review_app_dismiss_action">稍后再说</string>
+    <string name="review_app_body">想给 CAPod 写一条评论吗？❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">常规</string>
     <string name="device_settings_microphone_mode_label">麦克风</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">恢复默认设置</string>
     <string name="press_controls_reset_confirm_message">将所有按键映射重置为默认值？</string>
     <string name="device_settings_noise_control_open_press_controls_action">打开按键控制</string>
+    <string name="general_navigate_up_action">向上导航</string>
+    <string name="general_progress_loading">正在加载</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">捐贈</string>
     <string name="general_check_action">檢查</string>
     <string name="general_close_action">關閉</string>
+    <string name="general_dismiss_action">關閉</string>
     <string name="general_edit_action">編輯</string>
     <string name="general_save_action">儲存</string>
     <string name="general_guide_action">指南</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">裝置狀態</string>
     <string name="notification_channel_device_status_connected_label">已連接裝置</string>
     <string name="monitor_notification_extra_enabled_hint">您可以在系統設定中停用此通知。</string>
+    <string name="monitor_notification_starting">正在啟動…</string>
     <string name="support_debuglog_label">偵錯記錄</string>
     <string name="support_debuglog_desc">將應用程式執行的所有動作記錄到您可以分享的文字檔案中。</string>
     <string name="debug_debuglog_size_label">大小</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">藍牙已停用，請啟用 ;)</string>
     <string name="overview_monitoring_active_label">正在監測裝置</string>
     <string name="overview_monitoring_active_description">請確保您的裝置在附近並處於啟用狀態。</string>
+    <string name="overview_monitoring_off_label">背景監控已關閉</string>
+    <string name="overview_monitoring_off_description">沒有任何設定檔配對藍牙裝置，因此 CAPod 只在應用程式開啟時更新。選擇其中一個以啟用背景監控、持續通知和反應。</string>
+    <string name="overview_monitoring_off_action">選擇配對裝置</string>
     <string name="overview_troubleshoot_suggestion_label">已連接，但無資料</string>
     <string name="overview_troubleshoot_suggestion_description">您的裝置已連接，但 CAPod 未從中接收任何即時資料。您的手機可能需要相容性選項——疑難排解員可嘗試自動找到一個。</string>
     <string name="overview_troubleshoot_suggestion_action">執行疑難排解員</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">雙擊結束通話</string>
     <string name="device_settings_open_cd">開啟裝置設定</string>
     <string name="overview_card_missing_paired_device">此設定檔沒有已配對的藍牙裝置。</string>
+    <string name="overview_card_missing_paired_device_consequence">沒有配對裝置，無法使用裝置設定和自動連線。</string>
     <string name="overview_reactions_hint_title">反應功能因裝置而異</string>
     <string name="overview_reactions_hint_body">自動播放、自動暫停及彈出視窗現在可以為每部裝置分別設定。在耳機連接時，輕按卡片上的設定圖示即可。</string>
+    <string name="review_app_review_action">評論</string>
+    <string name="review_app_dismiss_action">稍後再說</string>
+    <string name="review_app_body">你想為 CAPod 留下評論嗎？ ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">重設為預設</string>
     <string name="press_controls_reset_confirm_message">將所有按壓對應重設為預設？</string>
     <string name="device_settings_noise_control_open_press_controls_action">開啟按壓控制</string>
+    <string name="general_navigate_up_action">向上導航</string>
+    <string name="general_progress_loading">正在載入</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">捐贈</string>
     <string name="general_check_action">檢查</string>
     <string name="general_close_action">關閉</string>
+    <string name="general_dismiss_action">關閉</string>
     <string name="general_edit_action">編輯</string>
     <string name="general_save_action">儲存</string>
     <string name="general_guide_action">指南</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">裝置狀態</string>
     <string name="notification_channel_device_status_connected_label">已連接裝置</string>
     <string name="monitor_notification_extra_enabled_hint">您可以在系統設定中停用此通知。</string>
+    <string name="monitor_notification_starting">啟動中…</string>
     <string name="support_debuglog_label">偵錯記錄</string>
     <string name="support_debuglog_desc">將應用程式執行的所有動作記錄到您可以分享的文字檔案中。</string>
     <string name="debug_debuglog_size_label">大小</string>
@@ -196,6 +198,9 @@
     <string name="overview_bluetooth_disabled_description">藍牙已停用，請啟用它 ;)</string>
     <string name="overview_monitoring_active_label">正在監測裝置</string>
     <string name="overview_monitoring_active_description">請確保你的裝置在附近且處於啟用狀態。</string>
+    <string name="overview_monitoring_off_label">背景監控已關閉</string>
+    <string name="overview_monitoring_off_description">尚無設定檔具有配對的藍牙裝置，因此 CAPod 只會在應用程式開啟時進行更新。請選擇一個以啟用背景監控、持續通知和反應。</string>
+    <string name="overview_monitoring_off_action">選擇已配對的裝置</string>
     <string name="overview_troubleshoot_suggestion_label">已連線，但無資料</string>
     <string name="overview_troubleshoot_suggestion_description">您的裝置已連線，但 CAPod 未收到任何即時資料。您的手機可能需要相容性選項——疑難排解員可嘗試自動找到合適的選項。</string>
     <string name="overview_troubleshoot_suggestion_action">執行疑難排解員</string>
@@ -475,8 +480,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">雙擊結束通話</string>
     <string name="device_settings_open_cd">開啟裝置設定</string>
     <string name="overview_card_missing_paired_device">此設定檔沒有已配對的藍牙裝置。</string>
+    <string name="overview_card_missing_paired_device_consequence">沒有配對的裝置，裝置設定和自動連接將無法使用。</string>
     <string name="overview_reactions_hint_title">反應設定為每部裝置獨立</string>
     <string name="overview_reactions_hint_body">自動播放、自動暫停和彈出視窗現在可依每部裝置分別設定。當您的耳機已連接時，點擊卡片上的設定圖示。</string>
+    <string name="review_app_review_action">評論</string>
+    <string name="review_app_dismiss_action">稍後再說</string>
+    <string name="review_app_body">您想為 CAPod 留下評論嗎？❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>
@@ -554,4 +563,6 @@
     <string name="press_controls_reset_label">重置為預設值</string>
     <string name="press_controls_reset_confirm_message">將所有按偵映射重置為預設值？</string>
     <string name="device_settings_noise_control_open_press_controls_action">開啟按偵控制</string>
+    <string name="general_navigate_up_action">向上導航</string>
+    <string name="general_progress_loading">正在載入</string>
 </resources>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -198,6 +198,8 @@
     <string name="overview_bluetooth_disabled_description">I-Bluetooth ikhutshaziwe, yenze isebenze ;)</string>
     <string name="overview_monitoring_active_label">Kuqashwe amadivayisi</string>
     <string name="overview_monitoring_active_description">Qinisekisa ukuthi idivayisi yakho iseduze futhi iyasebenza.</string>
+    <string name="overview_monitoring_off_label">Ukuqapha kwangemuva kuvaliwe.</string>
+    <string name="overview_monitoring_off_description">Akukho phrofayela enedivayisi ye-Bluetooth ehlangene, ngakho i-CAPod ibuyekeza kuphela ngenkathi uhlelo lokusebenza luvuliwe. Khetha eyodwa ukuze uvumele ukuqapha kwangemuva, isaziso esiqhubekayo nezenzo.</string>
     <string name="overview_monitoring_off_action">Khetha idivayisi eyotshwa</string>
     <string name="overview_troubleshoot_suggestion_label">Kuxhunyiwe, kodwa awekho idatha</string>
     <string name="overview_troubleshoot_suggestion_description">Idivayisi yakho ixhunyiwe, kodwa i-CAPod ayamukeli idatha ephilayo evela kuyona. Ifoni yakho ingadinga inketho yokufanelana — isixazululi sezinkinga singazama ukuthola enye ngokuzenzakalela.</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -12,6 +12,7 @@
     <string name="general_donate_action">Nikela</string>
     <string name="general_check_action">Hlola</string>
     <string name="general_close_action">Vala</string>
+    <string name="general_dismiss_action">Lahla</string>
     <string name="general_edit_action">Hlela</string>
     <string name="general_save_action">Londoloza</string>
     <string name="general_guide_action">Umhlahlandlela</string>
@@ -78,6 +79,7 @@
     <string name="notification_channel_device_status_label">Isimo sedivayisi</string>
     <string name="notification_channel_device_status_connected_label">Idivayisi exhunyiwe</string>
     <string name="monitor_notification_extra_enabled_hint">Ungakhubaza lesi saziso ezilungiselweni zesistemi.</string>
+    <string name="monitor_notification_starting">Iyaqala...</string>
     <string name="support_debuglog_label">Ilogi yokulungisa amaphutha</string>
     <string name="support_debuglog_desc">Rekhoda konke okwenziwa uhlelo lokusebenza kufayela lombhalo ongabelana ngalo.</string>
     <string name="debug_debuglog_size_label">Usayizi</string>
@@ -196,6 +198,7 @@
     <string name="overview_bluetooth_disabled_description">I-Bluetooth ikhutshaziwe, yenze isebenze ;)</string>
     <string name="overview_monitoring_active_label">Kuqashwe amadivayisi</string>
     <string name="overview_monitoring_active_description">Qinisekisa ukuthi idivayisi yakho iseduze futhi iyasebenza.</string>
+    <string name="overview_monitoring_off_action">Khetha idivayisi eyotshwa</string>
     <string name="overview_troubleshoot_suggestion_label">Kuxhunyiwe, kodwa awekho idatha</string>
     <string name="overview_troubleshoot_suggestion_description">Idivayisi yakho ixhunyiwe, kodwa i-CAPod ayamukeli idatha ephilayo evela kuyona. Ifoni yakho ingadinga inketho yokufanelana — isixazululi sezinkinga singazama ukuthola enye ngokuzenzakalela.</string>
     <string name="overview_troubleshoot_suggestion_action">Qalisa isixazululi sezinkinga</string>
@@ -481,8 +484,12 @@
     <string name="device_settings_end_call_mute_mic_option_b_subtitle">Cindezela kabili ukuqeda ikholi</string>
     <string name="device_settings_open_cd">Vula izilungiselelo zedivayisi</string>
     <string name="overview_card_missing_paired_device">Leli profile alinayo idivayisi ye-Bluetooth ehlanganisiwe.</string>
+    <string name="overview_card_missing_paired_device_consequence">Ngaphandle kwesinye, izilungiselelo zedivayisi kanye ne-automatic-connect azitholakali.</string>
     <string name="overview_reactions_hint_title">Izimpendulo zingawe ngayinye idivayisi</string>
     <string name="overview_reactions_hint_body">Ukudlala ngokuzenzakalelayo, ukumisa ngokuzenzakalelayo nezifasimende ezivulekayo manje zilungiselelwe ngayinye idivayisi. Thepha isithonjana sezilungiselelo ekhadi ngenkathi izinhlokwamakhanda zakho zixhunyiwe.</string>
+    <string name="review_app_review_action">Buyekeza</string>
+    <string name="review_app_dismiss_action">Mhlawumbe kamuva</string>
+    <string name="review_app_body">Ungathanda ukushiyela i-CAPod ukubuyekeza? ❤️</string>
     <!-- New device settings -->
     <string name="device_settings_category_general_label">Okujwayelekile</string>
     <string name="device_settings_microphone_mode_label">Imakrofoni</string>
@@ -560,4 +567,6 @@
     <string name="press_controls_reset_label">Buyisela ezenzakalelweni</string>
     <string name="press_controls_reset_confirm_message">Buyisela zonke izikhombo zokuchofoza ezenzakalelweni?</string>
     <string name="device_settings_noise_control_open_press_controls_action">Vula Izilawuli Zokuchofoza</string>
+    <string name="general_navigate_up_action">Iya phezulu</string>
+    <string name="general_progress_loading">Iyalayisha</string>
 </resources>


### PR DESCRIPTION
## What changed
- Pulled and validated the latest community translations from Crowdin across all supported languages
- Added translations for newly introduced strings (in-app review prompt, upgrade/Pro screen messaging, Google Play billing error handling)
- Corrected several translations that had been vandalized or corrupted upstream (raw line breaks instead of escaped ones, reversed meanings, non-standard vocabulary) across languages including Arabic, Polish, Romanian, Sardinian, Serbian, Swahili, Turkish, Urdu, and Zulu

## Technical Context
- Standard automated Crowdin pull-and-validate cycle: each locale's changes were independently checked for vandalism, broken escapes, and placeholder mismatches before being accepted
- The corrupted translations were also fixed directly on Crowdin (deleted and resubmitted), not just patched locally, so the upstream project stays clean for future pulls
- Translation-only change; no app logic touched. `assembleDebug` (both flavors) passed
