### PR TITLE
Fix: Show the Pro app title correctly in every language

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -117,12 +117,10 @@ internal fun UpgradeScreen(
         title = if (view == FossUpgradeView.PITCH) {
             AnnotatedString(stringResource(R.string.settings_upgrade_status_label))
         } else {
-            // "CAPod FOSS", not "CAPod Pro": on FOSS the flavor name IS the brand. The upgraded
-            // gate keeps the highlight for supporters only.
-            upgradeScreenTitle(
-                upgraded = view == FossUpgradeView.STATUS_UPGRADED,
-                nameRes = R.string.app_name_foss,
-            )
+            // "CAPod FOSS", not "CAPod Pro": the FOSS flavor's own qualifier resource supplies the
+            // tier word, so the title names this build. The upgraded gate keeps the highlight for
+            // supporters only.
+            upgradeScreenTitle(upgraded = view == FossUpgradeView.STATUS_UPGRADED)
         },
         onNavigateUp = onNavigateUp,
         snackbarHostState = snackbarHostState,

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="upgrade_foss_sponsor_subtitle">No ads. No tracking. No Google Play lock-in.</string>
     <string name="upgrade_foss_sponsor_returned_early">Back already? Your support keeps CAPod alive.</string>
     <string name="upgrade_badge_label" translatable="false">FOSS</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("FOSS"). Not translated:
+         the FOSS flavor pins its qualifier, so the default order is the only one it ever needs. -->
+    <string name="app_name_upgraded_template" translatable="false">%1$s %2$s</string>
     <string name="upgrade_foss_supporter_since">Supporter since %s</string>
     <string name="upgrade_foss_supporter_thanks">Thank you for supporting CAPod\'s development!</string>
     <string name="upgrade_foss_sponsor_again_action">Open sponsor page</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play meld dat jy reeds hierdie opgradering besit, maar dit kon nie herstel word nie. Maak seker jy gebruik die Google-rekening waarmee jy gekoop het. Play Store-sinkronisasie kan tyd neem — probeer herbegin, maak die Google Play-kas skoon, of wag eenvoudig \'n rukkie.</string>
     <string name="upgrade_restore_action">Herstel aankoop</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Kry %1$s</string>
     <string name="upgrade_preamble">CAPod word deur een persoon ontwikkel. Opgradering ontsluit ekstra kenmerke en help om die toepassing lewend te hou.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ይህን ማሻሻያ አስቀድመው እንደያዙ ዘግቧል፣ ነገር ግን መመለስ አልተቻለም። በገዙበት የGoogle መለያ እየተጠቀሙ መሆኑን ያረጋግጡ። የPlay Store ማመሳሰል ጊዜ ሊወስድ ይችላል — እንደገና ለማስጀመር፣ የGoogle Play መሸጎጫን ለማጽዳት ወይም በቀላሉ ለመጠበቅ ይሞክሩ።</string>
     <string name="upgrade_restore_action">ግዢን ወደነበረበት መልስ</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ያግኑ</string>
     <string name="upgrade_preamble">CAPod የሚዘጋጀው በአንድ ሰው ብቻ ነው። ማሻሻል ተጨማሪ ባህሪያትን ይከፍታል እንዲሁም መተግበሪያውን ሕያው ለማድረግ ይረዳል።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">أفادت سوق جوجل بلاي بأنّك تمتلك هذا التحديث بالفعل، ولكن تعذّر استعادته. تأكّد من استخدام حساب جوجل الذي اشتريت به التطبيق. قد تستغرق مزامنة سوق بلاي بعض الوقت — حاول إعادة تشغيل الجهاز، أو مسح ذاكرة التخزين المؤقّت لسوق جوجل بلاي، أو الانتظار ببساطة.</string>
     <string name="upgrade_restore_action">استعادة المشتريات</string>
     <string name="upgrade_badge_label">النسخة الاحترافية</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s – %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">احصل على %1$s</string>
     <string name="upgrade_preamble">تمّ تطوير كابود بواسطة شخص واحد. يتيح التحديث ميزات إضافية ويساعد في استمرار عمل التطبيق.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play bu yüksəltməyə artıq sahib olduğunuzu bildirir, lakin bərpa edilə bilmədi. Satın aldığınız Google hesabından istifadə etdiyinizə əmin olun. Play Store sinxronizasiyası bir qədər vaxt apara bilər — yenidən başlatmağı, Google Play keşini təmizləməyi və ya sadəcə gözləməyi sınayın.</string>
     <string name="upgrade_restore_action">Alışı bərpa et</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s əldə edin</string>
     <string name="upgrade_preamble">CAPod tək bir şəxs tərəfindən hazırlanır. Yüksəltmə əlavə funksiyaların kilidini açır və tətbiqin yaşamasına kömək edir.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play паведамляе, што вы ўжо валодаеце гэтым абнаўленнем, але яго не ўдалося аднавіць. Пераканайцеся, што вы выкарыстоўваеце той акаунт Google, з якім рабілі пакупку. Сінхранізацыя Play Store можа заняць час — паспрабуйце перазагрузіць прыладу, ачысціць кэш Google Play або проста пачакаць.</string>
     <string name="upgrade_restore_action">Аднавіць пакупку</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Атрымаць %1$s</string>
     <string name="upgrade_preamble">CAPod распрацоўвае адзін чалавек. Абнаўленне да Pro адкрывае дадатковыя функцыі і дапамагае падтрымліваць праграму жывой.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play съобщава, че вече притежавате тази надстройка, но тя не можа да бъде възстановена. Уверете се, че използвате акаунта в Google, с който сте направили покупката. Синхронизирането с Play Store може да отнеме време — опитайте да рестартирате устройството, да изчистите кеша на Google Play или просто изчакайте.</string>
     <string name="upgrade_restore_action">Възстановете покупката</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Получете %1$s</string>
     <string name="upgrade_preamble">CAPod се разработва от един-единствен човек. Надстройката отключва допълнителни функции и помага приложението да продължи да съществува.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play রিপোর্ট করছে যে আপনি ইতিমধ্যে এই আপগ্রেডের মালিক, কিন্তু এটি পুনরুদ্ধার করা যায়নি। আপনি যে Google অ্যাকাউন্ট দিয়ে কিনেছিলেন সেটিই ব্যবহার করছেন কিনা তা নিশ্চিত করুন। Play Store সিঙ্ক্রোনাইজেশনে সময় লাগতে পারে — রিবুট করা, Google Play ক্যাশে সাফ করা বা কিছুক্ষণ অপেক্ষা করার চেষ্টা করুন।</string>
     <string name="upgrade_restore_action">ক্রয় পুনরুদ্ধার</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s পান</string>
     <string name="upgrade_preamble">CAPod একজন মাত্র ব্যক্তি দ্বারা তৈরি। আপগ্রেড করলে অতিরিক্ত ফিচার আনলক হয় এবং অ্যাপটি সচল রাখতে সাহায্য করে।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">El Google Play informa que ja teniu aquesta actualització, però no s\'ha pogut restaurar. Assegureu-vos que feu servir el compte de Google amb què vau comprar-la. La sincronització del Play Store pot trigar una mica: proveu de reiniciar, esborreu la memòria cau del Google Play o simplement espereu.</string>
     <string name="upgrade_restore_action">Restaura la compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtingueu %1$s</string>
     <string name="upgrade_preamble">El CAPod està desenvolupat per una sola persona. La millora desbloqueja funcions addicionals i ajuda a mantenir l\'aplicació activa.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Služba Google Play hlásí, že tento upgrade již vlastníte, ale nepodařilo se ho obnovit. Ujistěte se, že používáte účet Google, se kterým jste nákup provedli. Synchronizace Obchodu Play může nějakou dobu trvat — zkuste restartovat zařízení, vymazat mezipaměť Obchodu Google Play nebo prostě počkat.</string>
     <string name="upgrade_restore_action">Obnovit nákup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Získat %1$s</string>
     <string name="upgrade_preamble">CAPod vyvíjí jediná osoba. Upgrade odemkne další funkce a pomůže udržet aplikaci naživu.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterer, at du allerede ejer denne opgradering, men den kunne ikke gendannes. Sørg for, at du bruger den Google-konto, du købte med. Synkronisering med Play Store kan tage tid — prøv at genstarte, ryd Google Play-cachen, eller vent blot.</string>
     <string name="upgrade_restore_action">Gendan køb</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Få %1$s</string>
     <string name="upgrade_preamble">CAPod udvikles af én person. En opgradering låser ekstra funktioner op og hjælper med at holde appen i live.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play meldet, dass du dieses Upgrade bereits besitzt, es konnte jedoch nicht wiederhergestellt werden. Stelle sicher, dass du das Google-Konto verwendest, mit dem du es gekauft hast. Die Synchronisierung des Play Stores kann etwas dauern – versuche dein Gerät neu zu starten, den Cache von Google Play zu leeren oder einfach abzuwarten.</string>
     <string name="upgrade_restore_action">Auswahl wiederherstellen</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Hol dir %1$s</string>
     <string name="upgrade_preamble">CAPod wird von einer einzelnen Person entwickelt. Ein Upgrade schaltet zusätzliche Funktionen frei und hilft, die App am Leben zu erhalten.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Το Google Play αναφέρει ότι έχετε ήδη αυτήν την αναβάθμιση, αλλά δεν ήταν δυνατή η επαναφορά της. Βεβαιωθείτε ότι χρησιμοποιείτε τον λογαριασμό Google με τον οποίο κάνατε την αγορά. Ο συγχρονισμός του Play Store ενδέχεται να χρειαστεί χρόνο — δοκιμάστε να επανεκκινήσετε, να διαγράψετε την κρυφή μνήμη του Google Play ή απλώς να περιμένετε.</string>
     <string name="upgrade_restore_action">Επαναφορά αγοράς</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Αποκτήστε %1$s</string>
     <string name="upgrade_preamble">Το CAPod αναπτύσσεται από ένα μόνο άτομο. Η αναβάθμιση ξεκλειδώνει επιπλέον λειτουργίες και βοηθά να διατηρείται η εφαρμογή ζωντανή.</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play informa que ya tenés esta mejora, pero no se pudo restaurar. Asegurate de usar la cuenta de Google con la que la compraste. La sincronización de Play Store puede demorar — probá reiniciar, borrar la caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_restore_action">Restaurar la compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtener %1$s</string>
     <string name="upgrade_preamble">CAPod es desarrollado por una sola persona. Actualizar desbloquea funciones adicionales y ayuda a mantener viva la app.</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play indica que ya tienes esta actualización, pero no se pudo restaurar. Asegúrate de estar usando la cuenta de Google con la que la compraste. La sincronización de Play Store puede tardar: intenta reiniciar, borrar la caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtener %1$s</string>
     <string name="upgrade_preamble">CAPod es desarrollado por una sola persona. Actualizar desbloquea funciones adicionales y ayuda a mantener viva la aplicación.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play indica que ya tienes esta mejora, pero no se pudo restaurar. Asegúrate de usar la cuenta de Google con la que la compraste. La sincronización de Play Store puede tardar: prueba a reiniciar, borrar la caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_restore_action">Restaurar la compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtén %1$s</string>
     <string name="upgrade_preamble">CAPod lo desarrolla una sola persona. Mejorar a Pro desbloquea funciones adicionales y ayuda a mantener la aplicación viva.</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play andmetel on see uuendus sul juba olemas, kuid seda ei õnnestunud taastada. Veendu, et kasutad sama Google\'i kontot, millega ostu tegid. Play poe sünkroonimine võib aega võtta — proovi taaskäivitada, tühjendada Google Play vahemälu või lihtsalt oodata.</string>
     <string name="upgrade_restore_action">Taasta ost</string>
     <string name="upgrade_badge_label">Tasuline</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%2$s %1$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Hangi %1$s</string>
     <string name="upgrade_preamble">CAPodi arendab üks inimene. Uuendamine avab lisavõimalused ja aitab rakendust arendada.</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Playk dio dagoeneko eguneratze hau baduzula, baina ezin izan da leheneratu. Ziurtatu erosketa egiteko erabili zenuen Google kontua erabiltzen ari zarela. Play Storeren sinkronizazioak denbora har dezake — saiatu berrabiarazten, Google Play-ren katxea garbitzen edo, besterik gabe, itxaroten.</string>
     <string name="upgrade_restore_action">Berreskuratu erosketa</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Lortu %1$s</string>
     <string name="upgrade_preamble">CAPod pertsona bakar batek garatzen du. Eguneratzeak eginbide gehigarriak desblokeatzen ditu eta aplikazioa bizirik mantentzen laguntzen du.</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">گوگل پلی گزارش می‌دهد که شما قبلاً این ارتقا را خریداری کرده‌اید، اما بازیابی آن ممکن نشد. مطمئن شوید که از همان حساب گوگلی که با آن خرید کرده‌اید استفاده می‌کنید. همگام‌سازی Play Store ممکن است زمان‌بر باشد — راه‌اندازی مجدد دستگاه، پاک کردن حافظه پنهان گوگل پلی یا کمی صبر کردن را امتحان کنید.</string>
     <string name="upgrade_restore_action">بازیابی خرید</string>
     <string name="upgrade_badge_label">حرفه‌ای</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">دریافت %1$s</string>
     <string name="upgrade_preamble">CAPod توسط یک نفر توسعه داده می‌شود. ارتقا امکانات اضافی را باز می‌کند و به زنده نگه داشتن این برنامه کمک می‌کند.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ilmoittaa, että omistat jo tämän päivityksen, mutta sitä ei voitu palauttaa. Varmista, että käytät samaa Google-tiliä, jolla ostit sen. Play Kaupan synkronointi voi kestää hetken — kokeile laitteen uudelleenkäynnistystä, Google Play -välimuistin tyhjentämistä tai odota hetki.</string>
     <string name="upgrade_restore_action">Palauta ostos</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Hanki %1$s</string>
     <string name="upgrade_preamble">CAPodia kehittää yksi henkilö. Päivittäminen avaa lisäominaisuuksia ja auttaa pitämään sovelluksen elossa.</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Iniuulat ng Google Play na nasa iyo na ang upgrade na ito, ngunit hindi ito ma-restore. Siguraduhing ginagamit mo ang Google account na ginamit mo sa pagbili. Maaaring magtagal ang pag-sync ng Play Store — subukang i-restart ang device, i-clear ang cache ng Google Play, o maghintay lang.</string>
     <string name="upgrade_restore_action">I-restore ang pagbili</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Kumuha ng %1$s</string>
     <string name="upgrade_preamble">Ginawa ang CAPod ng isang tao lang. Ang pag-upgrade ay nagbubukas ng karagdagang mga feature at tumutulong na mapanatiling buhay ang app.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play indique que vous possédez déjà cette mise à niveau, mais elle n’a pas pu être restaurée. Assurez-vous d’utiliser le compte Google avec lequel vous avez effectué l’achat. La synchronisation du Play Store peut prendre du temps — essayez de redémarrer, de vider le cache du Google Play ou simplement d’attendre.</string>
     <string name="upgrade_restore_action">Rétablir l’achat</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtenir %1$s</string>
     <string name="upgrade_preamble">CAPod est développée par une seule personne. Passer à la version Pro déverrouille des fonctions supplémentaires et contribue à la pérennité de l’appli.</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play indica que xa tes esta mellora, pero non se puido restaurar. Asegúrate de usar a conta de Google coa que a mercaches. A sincronización coa Play Store pode levar tempo — proba a reiniciar, borrar a caché de Google Play ou simplemente esperar.</string>
     <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">CAPod está desenvolvido por unha soa persoa. Mellorar desbloquea funcións adicionais e axuda a manter viva a aplicación.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play की रिपोर्ट है कि आपके पास पहले से यह अपग्रेड है, लेकिन इसे पुनर्स्थापित नहीं किया जा सका। सुनिश्चित करें कि आप उसी Google खाते का उपयोग कर रहे हैं जिससे आपने खरीदारी की थी। Play Store सिंक होने में समय लग सकता है — रीबूट करने, Google Play कैश साफ़ करने या बस थोड़ा इंतज़ार करने का प्रयास करें।</string>
     <string name="upgrade_restore_action">खरीदारी पुनर्स्थापित करें</string>
     <string name="upgrade_badge_label">प्रो</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s प्राप्त करें</string>
     <string name="upgrade_preamble">CAPod को एक ही व्यक्ति द्वारा विकसित किया गया है। अपग्रेड करने से अतिरिक्त सुविधाएँ अनलॉक होती हैं और ऐप को जीवित रखने में मदद मिलती है।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play javlja da već posjedujete ovu nadogradnju, ali nije ju bilo moguće vratiti. Provjerite koristite li Google račun kojim ste izvršili kupnju. Sinkronizacija Play trgovine može potrajati — pokušajte ponovno pokrenuti uređaj, izbrisati predmemoriju Google Playa ili jednostavno pričekati.</string>
     <string name="upgrade_restore_action">Obnovi kupnju</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Nabavite %1$s</string>
     <string name="upgrade_preamble">CAPod razvija jedna osoba. Nadogradnja otključava dodatne značajke i pomaže održati aplikaciju živom.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">A Google Play szerint már megvásároltad ezt a frissítést, de nem sikerült visszaállítani. Győződj meg róla, hogy azzal a Google-fiókkal vagy bejelentkezve, amellyel a vásárlást végezted. A Play Store szinkronizálása eltarthat egy ideig – próbáld meg újraindítani a készüléket, törölni a Google Play gyorsítótárát, vagy egyszerűen várj egy kicsit.</string>
     <string name="upgrade_restore_action">Vásárlás visszaállítása</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Szerezd meg a %1$s-t</string>
     <string name="upgrade_preamble">A CAPod-ot egyetlen ember fejleszti. A frissítés extra funkciókat old fel, és segít életben tartani az alkalmazást.</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play-ը հայտնում է, որ դուք արդեն ունեք այս արդիացումը, բայց այն չհաջողվեց վերականգնել: Համոզվեք, որ օգտագործում եք այն Google հաշիվը, որով կատարել եք գնումը: Play Store-ի համաժամացումը կարող է ժամանակ պահանջել․ փորձեք վերագործարկել սարքը, մաքրել Google Play-ի քեշը կամ պարզապես սպասել:</string>
     <string name="upgrade_restore_action">Վերականգնել գնումը</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Ստացեք %1$s</string>
     <string name="upgrade_preamble">CAPod-ը մշակվում է մեկ մարդու կողմից: Արդիացումը բացում է լրացուցիչ գործառույթներ և օգնում է հավելվածին մնալ ակտիվ:</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play melaporkan bahwa Anda sudah memiliki peningkatan ini, tetapi tidak dapat dipulihkan. Pastikan Anda menggunakan akun Google yang sama dengan yang digunakan untuk membeli. Sinkronisasi Play Store mungkin memerlukan waktu — coba mulai ulang perangkat, hapus cache Google Play, atau tunggu sebentar.</string>
     <string name="upgrade_restore_action">Pulihkan pembelian</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Dapatkan %1$s</string>
     <string name="upgrade_preamble">CAPod dikembangkan oleh satu orang. Melakukan peningkatan membuka fitur tambahan dan membantu menjaga aplikasi ini tetap ada.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play greinir frá því að þú eigir þegar þessa uppfærslu, en ekki tókst að endurheimta hana. Gakktu úr skugga um að þú sért að nota sama Google reikning og þú keyptir með. Samstilling Play Store getur tekið tíma — reyndu að endurræsa, hreinsa skyndiminni Google Play eða bíða einfaldlega.</string>
     <string name="upgrade_restore_action">Endurheimta kaup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Fáðu %1$s</string>
     <string name="upgrade_preamble">CAPod er þróað af einum einstaklingi. Uppfærsla opnar aukamöguleika og hjálpar til við að halda forritinu á lífi.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play segnala che possiedi già questo aggiornamento, ma non è stato possibile ripristinarlo. Assicurati di utilizzare l’account Google con cui hai effettuato l’acquisto. La sincronizzazione del Play Store potrebbe richiedere tempo: prova a riavviare, cancellare la cache di Google Play o semplicemente attendere.</string>
     <string name="upgrade_restore_action">Ripristina acquisto</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Ottieni %1$s</string>
     <string name="upgrade_preamble">CAPod è sviluppato da una sola persona. L’aggiornamento sblocca funzionalità extra e aiuta a mantenere viva l’app.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">לפי Google Play, כבר רכשת את השדרוג הזה, אך לא ניתן היה לשחזר אותו. ודא שאתה משתמש בחשבון Google שאיתו ביצעת את הרכישה. סנכרון Play Store עשוי לקחת זמן — נסה להפעיל מחדש את המכשיר, לנקות את מטמון Google Play או פשוט להמתין.</string>
     <string name="upgrade_restore_action">שחזור רכישה</string>
     <string name="upgrade_badge_label">פרו</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">קבל %1$s</string>
     <string name="upgrade_preamble">CAPod מפותחת על ידי אדם אחד בלבד. שדרוג פותח תכונות נוספות ועוזר לשמור על האפליקציה בחיים.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Playによると、このアップグレードはすでに購入済みですが、復元できませんでした。購入時に使用したGoogleアカウントを使用していることを確認してください。Playストアの同期には時間がかかる場合があります。再起動する、Google Playのキャッシュを削除する、またはしばらく待ってみてください。</string>
     <string name="upgrade_restore_action">購入を復元</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s を入手</string>
     <string name="upgrade_preamble">CAPodは一人の個人開発者によって開発されています。アップグレードすると追加機能が使えるようになり、アプリの継続的な開発を支えることができます。</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play იტყობინება, რომ ეს განახლება უკვე შეძენილი გაქვთ, მაგრამ მისი აღდგენა ვერ მოხერხდა. დარწმუნდით, რომ იყენებთ იმ Google ანგარიშს, რომლითაც შეიძინეთ. Play Store-ის სინქრონიზაციას შეიძლება დრო დასჭირდეს — სცადეთ გადატვირთვა, Google Play-ის ქეშის გასუფთავება ან უბრალოდ დაელოდეთ.</string>
     <string name="upgrade_restore_action">შეძენის აღდგენა</string>
     <string name="upgrade_badge_label">პრო</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">მიიღეთ %1$s</string>
     <string name="upgrade_preamble">CAPod-ს ერთი ადამიანი ავითარებს. განახლება ხსნის დამატებით ფუნქციებს და ეხმარება აპლიკაციის ცოცხლად შენარჩუნებაში.</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play រាយការណ៍ថាអ្នកបានទទួលកម្មសិទ្ធិការដំឡើងកម្រិតនេះរួចហើយ ប៉ុន្តែមិនអាចស្ដារវាឡើងវិញបានទេ។ សូមប្រាកដថាអ្នកកំពុងប្រើគណនី Google ដែលអ្នកបានទិញជាមួយ។ ការធ្វើសមកាលកម្ម Play Store អាចត្រូវការពេលវេលា — សូមសាកល្បងចាប់ផ្ដើមឧបករណ៍ឡើងវិញ សម្អាតឃ្លាំងសម្ងាត់ Google Play ឬគ្រាន់តែរង់ចាំ។</string>
     <string name="upgrade_restore_action">ស្តារការជាវមកវិញ</string>
     <string name="upgrade_badge_label">ប្រូ</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">ទទួលបាន %1$s</string>
     <string name="upgrade_preamble">CAPod ត្រូវបានបង្កើតឡើងដោយមនុស្សតែម្នាក់។ ការដំឡើងកម្រិតដោះសោលក្ខណៈពិសេសបន្ថែម និងជួយរក្សាកម្មវិធីនេះឲ្យបន្តដំណើរការ។</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play radigihîne ku vê nûvekirinê jixwe di destê te de ye, lê ew nehat vegerandin. Piştrast bike ku tu bi hesabê Google yê ku pê kirriye têkevî. Senkronîzasyona Play Store dibe ku demê bigire — biceribîne ku cîhazê ji nû ve bidî destpêkirin, cache\'ya Google Play paqij bike an tenê bisekine.</string>
     <string name="upgrade_restore_action">Kirînê vegerîne</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Wergir %1$s</string>
     <string name="upgrade_preamble">CAPod ji aliyê kesekî yekane ve tê pêşxistin. Nûvekirin taybetmendiyên zêde vedike û dibe alîkar ku sepan berdewam bimîne.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">ನೀವು ಈ ಅಪ್‌ಗ್ರೇಡ್ ಅನ್ನು ಈಗಾಗಲೇ ಹೊಂದಿದ್ದೀರಿ ಎಂದು Google Play ವರದಿ ಮಾಡುತ್ತದೆ, ಆದರೆ ಅದನ್ನು ಮರುಸ್ಥಾಪಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ನೀವು ಖರೀದಿಸಿದ Google ಖಾತೆಯನ್ನೇ ಬಳಸುತ್ತಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ. Play Store ಸಿಂಕ್ರೊನೈಸೇಶನ್‌ಗೆ ಸಮಯ ತೆಗೆದುಕೊಳ್ಳಬಹುದು — ಮರುಪ್ರಾರಂಭಿಸಲು, Google Play ಕ್ಯಾಶ್ ಅನ್ನು ತೆರವುಗೊಳಿಸಲು ಅಥವಾ ಸ್ವಲ್ಪ ಕಾಯಲು ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="upgrade_restore_action">ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಿ</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ಪಡೆಯಿರಿ</string>
     <string name="upgrade_preamble">CAPod ಅನ್ನು ಒಬ್ಬ ವ್ಯಕ್ತಿ ಅಭಿವೃದ್ಧಿಪಡಿಸುತ್ತಾರೆ. ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡುವುದರಿಂದ ಹೆಚ್ಚುವರಿ ವೈಶಿಷ್ಟ್ಯಗಳು ಅನ್‌ಲಾಕ್ ಆಗುತ್ತವೆ ಮತ್ತು ಅಪ್ಲಿಕೇಶನ್ ಜೀವಂತವಾಗಿರಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play에서 이미 이 업그레이드를 보유하고 있다고 알렸지만 복원할 수 없었습니다. 구매할 때 사용한 Google 계정을 사용 중인지 확인하세요. Play 스토어 동기화에는 시간이 걸릴 수 있습니다. 기기를 재부팅하거나 Google Play 캐시를 지우거나 잠시 기다려 보세요.</string>
     <string name="upgrade_restore_action">구매 복원</string>
     <string name="upgrade_badge_label">프로</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s 받기</string>
     <string name="upgrade_preamble">CAPod는 한 사람이 개발하고 있습니다. 업그레이드하면 추가 기능이 열리고 앱을 계속 운영하는 데 도움이 됩니다.</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play бул жаңыртууну мурунтан эле сатып алганыңызды билдирет, бирок аны калыбына келтирүү мүмкүн болбоду. Сатып алган Google каттоо эсебиңизди колдонуп жатканыңызды текшериңиз. Play Store синхрондоштуруусу убакытты талап кылышы мүмкүн — түзмөктү өчүрүп-күйгүзүп көрүңүз, Google Play кэшин тазалаңыз же жөн эле күтө туруңуз.</string>
     <string name="upgrade_restore_action">Сатып алууну калыбына келтирүү</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s алыңыз</string>
     <string name="upgrade_preamble">CAPod бир адам тарабынан иштелип чыгууда. Жаңыртуу кошумча мүмкүнчүлүктөрдү ачат жана колдонмонун иштешин колдоого жардам берет.</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ລາຍງານວ່າທ່ານເປັນເຈົ້າຂອງການອັບເກຣດນີ້ແລ້ວ, ແຕ່ບໍ່ສາມາດກູ້ຄືນໄດ້. ກະລຸນາກວດສອບໃຫ້ແນ່ໃຈວ່າທ່ານກຳລັງໃຊ້ບັນຊີ Google ດຽວກັນກັບທີ່ໃຊ້ຊື້. ການຊິງຄ໌ຂໍ້ມູນຂອງ Play Store ອາດຈະໃຊ້ເວລາ — ລອງຣີສະຕາດເຄື່ອງ, ລ້າງແຄດຊ໌ຂອງ Google Play ຫຼືພຽງແຕ່ລໍຖ້າ.</string>
     <string name="upgrade_restore_action">ກູ້ຄືນການຊື້</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">ຮັບ %1$s</string>
     <string name="upgrade_preamble">CAPod ຖືກພັດທະນາໂດຍຄົນຄົນດຽວ. ການອັບເກຣດຈະປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ຊ່ວຍໃຫ້ແອັບຄົງຢູ່ຕໍ່ໄປ.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">„Google Play“ praneša, kad jau turite šį atnaujinimą, tačiau jo nepavyko atkurti. Įsitikinkite, kad naudojate tą pačią „Google“ paskyrą, su kuria atlikote pirkimą. „Play Store“ sinchronizavimas gali užtrukti — pabandykite paleisti įrenginį iš naujo, išvalyti „Google Play“ talpyklą arba tiesiog palaukite.</string>
     <string name="upgrade_restore_action">Atkurti pirkimą</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Gauti %1$s</string>
     <string name="upgrade_preamble">CAPod kuria vienas žmogus. Atnaujinimas atrakina papildomas funkcijas ir padeda išlaikyti programą gyvą.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ziņo, ka tev jau ir šis jauninājums, taču to neizdevās atjaunot. Pārliecinies, ka izmanto to pašu Google kontu, ar kuru veici pirkumu. Play veikala sinhronizācija var aizņemt laiku — mēģini restartēt ierīci, notīrīt Google Play kešatmiņu vai vienkārši uzgaidi.</string>
     <string name="upgrade_restore_action">Atjaunot pirkumu</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Iegūstiet %1$s</string>
     <string name="upgrade_preamble">CAPod izstrādā viens cilvēks. Jaunināšana atbloķē papildu funkcijas un palīdz uzturēt lietotni dzīvu.</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play пријавува дека веќе ја поседуваш оваа надградба, но не можеше да се врати. Провери дали го користиш истиот Google профил со кој си купил/а. Синхронизацијата со Play Store може да потрае — обиди се со рестартирање, бришење на кешот на Google Play или едноставно почекај.</string>
     <string name="upgrade_restore_action">Обнови купувачка</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Земи %1$s</string>
     <string name="upgrade_preamble">CAPod е развиен од едно лице. Надградбата отклучува дополнителни функции и помага апликацијата да остане жива.</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">നിങ്ങൾ ഇതിനകം ഈ അപ്ഗ്രേഡ് സ്വന്തമാക്കിയിട്ടുണ്ടെന്ന് Google Play റിപ്പോർട്ട് ചെയ്യുന്നു, പക്ഷേ അത് പുനഃസ്ഥാപിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾ വാങ്ങിയ Google അക്കൗണ്ട് ഉപയോഗിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കുക. Play Store സമന്വയത്തിന് സമയമെടുത്തേക്കാം — റീബൂട്ട് ചെയ്യാൻ ശ്രമിക്കുക, Google Play കാഷെ ക്ലിയർ ചെയ്യുക അല്ലെങ്കിൽ അൽപ്പം കാത്തിരിക്കുക.</string>
     <string name="upgrade_restore_action">വാങ്ങൽ പുനഃസ്ഥാപിക്കുക</string>
     <string name="upgrade_badge_label">പ്രോ</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s നേടുക</string>
     <string name="upgrade_preamble">CAPod ഒരൊറ്റ വ്യക്തിയാണ് വികസിപ്പിക്കുന്നത്. അപ്ഗ്രേഡ് ചെയ്യുന്നത് അധിക ഫീച്ചറുകൾ അൺലോക്ക് ചെയ്യുകയും ആപ്പ് സജീവമായി നിലനിർത്താൻ സഹായിക്കുകയും ചെയ്യുന്നു.</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play нь та энэ шинэчлэлтийг аль хэдийн эзэмшиж байгааг мэдээлж байгаа ч сэргээх боломжгүй байна. Худалдан авахдаа ашигласан Google бүртгэлээ ашиглаж байгаа эсэхээ шалгана уу. Play Store-ын синхрончлол хугацаа шаардаж болзошгүй тул дахин асаах, Google Play-ийн кэшийг цэвэрлэх эсвэл хэсэг хугацаа хүлээж үзнэ үү.</string>
     <string name="upgrade_restore_action">Худалдан авалтыг сэргээх</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s авах</string>
     <string name="upgrade_preamble">CAPod-ыг ганц хүн хөгжүүлдэг. Шинэчлэл хийснээр нэмэлт боломжууд нээгдэж, аппликейшнийг тогтвортой ажиллуулахад тусална.</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play नुसार तुमच्याकडे आधीच हे अपग्रेड आहे, परंतु ते पुनर्संचयित करता आले नाही. तुम्ही ज्या Google खात्याने खरेदी केली आहे तेच वापरत असल्याची खात्री करा. Play Store समक्रमणास वेळ लागू शकतो — रीबूट करून पहा, Google Play कॅशे साफ करा किंवा फक्त थोडी प्रतीक्षा करा.</string>
     <string name="upgrade_restore_action">खरेदी पुनर्संचयित करा</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s मिळवा</string>
     <string name="upgrade_preamble">CAPod एका व्यक्तीने विकसित केले आहे. अपग्रेड केल्याने अतिरिक्त वैशिष्ट्ये अनलॉक होतात आणि अॅप सुरू ठेवण्यास मदत होते.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play melaporkan bahawa anda sudah memiliki peningkatan ini, tetapi ia tidak dapat dipulihkan. Pastikan anda menggunakan akaun Google yang digunakan semasa pembelian. Penyegerakan Play Store mungkin mengambil masa — cuba mulakan semula peranti, kosongkan cache Google Play atau tunggu sebentar.</string>
     <string name="upgrade_restore_action">Pulihkan pembelian</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Dapatkan %1$s</string>
     <string name="upgrade_preamble">CAPod dibangunkan oleh seorang individu. Peningkatan membuka kunci ciri tambahan dan membantu mengekalkan aplikasi ini.</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play က ဤအဆင့်မြှင့်တင်မှုကို သင်ပိုင်ဆိုင်ပြီးသားဖြစ်ကြောင်း သတင်းပို့ခဲ့သော်လည်း ၎င်းကို ပြန်လည်ရယူ၍မရနိုင်ခဲ့ပါ။ သင်ဝယ်ယူခဲ့သည့် Google အကောင့်ကို အသုံးပြုနေကြောင်း သေချာပါစေ။ Play Store ထပ်တူပြုမှုသည် အချိန်အနည်းငယ်ကြာနိုင်ပါသည် — ပြန်လည်စတင်ကြည့်ပါ၊ Google Play ကက်ရှ်ကို ရှင်းလင်းကြည့်ပါ (သို့) စောင့်ဆိုင်းကြည့်ပါ။</string>
     <string name="upgrade_restore_action">ဝယ်ယူမှုကို ပြန်လည်ရယူမည်</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ကို ရယူပါ</string>
     <string name="upgrade_preamble">CAPod ကို လူတစ်ဦးတည်းက ဖန်တီးထားခြင်းဖြစ်သည်။ အဆင့်မြှင့်တင်ခြင်းက ထပ်ဆောင်းအင်္ဂါရပ်များကို ဖွင့်ပေးပြီး အက်ပ်ကို ဆက်လက်တည်ရှိစေရန် ကူညီပေးပါသည်။</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterer at du allerede eier denne oppgraderingen, men den kunne ikke gjenopprettes. Sørg for at du bruker Google-kontoen du kjøpte med. Synkronisering med Play Store kan ta tid — prøv å starte på nytt, tømme Google Play-hurtigbufferen eller bare vente.</string>
     <string name="upgrade_restore_action">Gjenopprett kjøp</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Få %1$s</string>
     <string name="upgrade_preamble">CAPod er utviklet av én person. Oppgradering låser opp ekstra funksjoner og hjelper med å holde appen i live.</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ले तपाईंसँग यो अपग्रेड पहिले नै छ भनी रिपोर्ट गर्छ, तर यसलाई पुनर्स्थापना गर्न सकिएन। तपाईंले खरिद गर्दा प्रयोग गरेको Google खाता नै प्रयोग गरिरहनुभएको सुनिश्चित गर्नुहोस्। Play Store समिकरणमा समय लाग्न सक्छ — रिबुट गर्ने, Google Play क्यास खाली गर्ने वा केही समय पर्खने प्रयास गर्नुहोस्।</string>
     <string name="upgrade_restore_action">खरिद पुनर्स्थापना गर्नुहोस्</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s प्राप्त गर्नुहोस्</string>
     <string name="upgrade_preamble">CAPod एक जना व्यक्तिद्वारा विकास गरिएको हो। अपग्रेड गर्दा थप सुविधाहरू अनलक हुन्छन् र एपलाई जीवित राख्न मद्दत पुग्छ।</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play meldt dat je deze upgrade al bezit, maar deze kon niet worden hersteld. Zorg ervoor dat je het Google-account gebruikt waarmee je hebt gekocht. Synchronisatie van de Play Store kan tijd kosten — probeer opnieuw op te starten, de cache van Google Play te wissen of gewoon te wachten.</string>
     <string name="upgrade_restore_action">Herstel aankoop</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Haal %1$s</string>
     <string name="upgrade_preamble">CAPod wordt ontwikkeld door één persoon. Upgraden ontgrendelt extra functies en helpt de app in leven te houden.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Sklep Google Play zgłasza, że już posiadasz tę aktualizację, ale nie udało się jej przywrócić. Upewnij się, że używasz konta Google, na które dokonano zakupu. Synchronizacja Sklepu Google Play może chwilę potrwać — spróbuj zrestartować urządzenie, wyczyścić pamięć podręczną Sklepu Google Play lub po prostu poczekaj.</string>
     <string name="upgrade_restore_action">Przywróć zakup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Uzyskaj %1$s</string>
     <string name="upgrade_preamble">CAPod jest rozwijany przez jedną osobę. Aktualizacja odblokowuje dodatkowe funkcje i pomaga utrzymać aplikację przy życiu.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">O Google Play informa que você já possui este upgrade, mas ele não pôde ser restaurado. Verifique se você está usando a conta Google com a qual fez a compra. A sincronização da Play Store pode levar algum tempo — tente reiniciar, limpar o cache do Google Play ou simplesmente aguardar.</string>
     <string name="upgrade_restore_action">Restaurar a compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">O CAPod é desenvolvido por uma única pessoa. Fazer o upgrade desbloqueia recursos extras e ajuda a manter o aplicativo vivo.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">O Google Play indica que já possuis esta atualização, mas não foi possível restaurá-la. Certifica-te de que estás a usar a conta Google com que efetuaste a compra. A sincronização da Play Store pode demorar algum tempo — tenta reiniciar, limpar a cache do Google Play ou simplesmente aguardar.</string>
     <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">O CAPod é desenvolvido por uma única pessoa. A atualização desbloqueia funcionalidades extra e ajuda a manter a aplicação viva.</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporta che ti possedas gia quest upgrade, ma el n\'ha betg pudì vegnir restaurà. Controllescha che ti utiliseschias il conto Google cun il qual ti has cumprà. La sincronisaziun da Play Store po durar in pau temp — emprova da reaviar il apparat, svidar la cache da Google Play u simplamain spetgar.</string>
     <string name="upgrade_restore_action">Restaurar la cumpra</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtegnair %1$s</string>
     <string name="upgrade_preamble">CAPod vegn sviluppà da ina persuna suletta. In upgrade sblochescha funcziuns supplementaras ed ajuda a mantegnair l\'app en vita.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play raportează că deții deja acest upgrade, dar nu a putut fi restaurat. Asigură-te că folosești contul Google cu care ai făcut achiziția. Sincronizarea Play Store poate dura ceva timp — încearcă să repornești telefonul, să ștergi memoria cache a Google Play sau pur și simplu așteaptă.</string>
     <string name="upgrade_restore_action">Restabiliți achiziția</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obține %1$s</string>
     <string name="upgrade_preamble">CAPod este dezvoltat de o singură persoană. Upgrade-ul deblochează funcții suplimentare și ajută la menținerea aplicației în viață.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play сообщает, что Вы купили это обновление, но его не удалось восстановить. Убедитесь, что Вы используете тот же аккаунт Google, с которого была совершена покупка. Синхронизация Play Store может занять некоторое время — попробуйте перезагрузить устройство, очистить кэш Google Play или просто подождать.</string>
     <string name="upgrade_restore_action">Восстановить покупку</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Получить %1$s</string>
     <string name="upgrade_preamble">CAPod разработан одним человеком. Обновление открывает дополнительные функции и помогает поддерживать приложение.</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play informat chi tenes giai custu megioramentu, ma no est istadu possìbile lu ripristinare. Assegura·ti de impreare su contu Google chi as impreadu pro comporare. Sa sincronizatzione de su Play Store podet leare tempus — proa a torrare a allutu su dispositivu, a bogare sa memoria cache de Google Play o solu a aspetare.</string>
     <string name="upgrade_restore_action">Recùpera su cùmperu</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Otine %1$s</string>
     <string name="upgrade_preamble">CAPod est isvilupada de una persona sola. Su megioramentu isblocat funtziones in prus e agiudat a mantènnere s\'aplicatzione bia.</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">ඔබ දැනටමත් මෙම උසස් කිරීම හිමිකරගෙන ඇති බව Google Play වාර්තා කරයි, නමුත් එය ප්‍රතිසාධනය කළ නොහැකි විය. ඔබ මිලදී ගැනීමට භාවිත කළ Google ගිණුමම භාවිත කරන බව තහවුරු කරගන්න. Play Store සමමුහුර්තකරණයට කාලය ගත විය හැක — නැවත ආරම්භ කිරීම, Google Play කෑෂය හිස් කිරීම, හෝ මදක් රැඳී සිටීම උත්සාහ කරන්න.</string>
     <string name="upgrade_restore_action">මිලදී ගැනීම ප්‍රතිසාධනය කරන්න</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ලබා ගන්න</string>
     <string name="upgrade_preamble">CAPod සංවර්ධනය කරනු ලබන්නේ එක් පුද්ගලයෙකු විසිනි. උසස් කිරීම අමතර විශේෂාංග අගුළු හරින අතර යෙදුම ක්‍රියාත්මකව තබා ගැනීමට උපකාරී වේ.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play hlási, že tento upgrade už vlastníte, no nepodarilo sa ho obnoviť. Uistite sa, že používate rovnaký účet Google, s ktorým ste nákup uskutočnili. Synchronizácia Play Store môže chvíľu trvať — skúste reštartovať zariadenie, vymazať vyrovnávaciu pamäť Google Play alebo jednoducho počkať.</string>
     <string name="upgrade_restore_action">Obnoviť nákup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Získať %1$s</string>
     <string name="upgrade_preamble">CAPod vyvíja jedna osoba. Upgradom odomknete ďalšie funkcie a pomôžete udržať aplikáciu nažive.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play sporoča, da to nadgradnjo že imate, vendar je ni bilo mogoče obnoviti. Prepričajte se, da uporabljate Google račun, s katerim ste opravili nakup. Sinhronizacija Trgovine Play lahko traja nekaj časa — poskusite znova zagnati napravo, počistiti predpomnilnik Google Play ali preprosto počakajte.</string>
     <string name="upgrade_restore_action">Obnovi nakup</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Pridobite %1$s</string>
     <string name="upgrade_preamble">CAPod razvija ena sama oseba. Nadgradnja odklene dodatne funkcije in pomaga ohranjati aplikacijo pri življenju.</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play raporton se ju e zotëroni tashmë këtë përmirësim, por nuk mund të rikthehet. Sigurohuni që po përdorni llogarinë Google me të cilën keni bërë blerjen. Sinkronizimi i Play Store mund të marrë kohë — provoni ta rinisni pajisjen, të pastroni memorien e fshehtë (cache) të Google Play, ose thjesht të prisni.</string>
     <string name="upgrade_restore_action">Rivendos blerjen</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Merrni %1$s</string>
     <string name="upgrade_preamble">CAPod zhvillohet nga një person i vetëm. Përmirësimi zhbllokon veçori shtesë dhe ndihmon të mbahet aplikacioni gjallë.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play пријављује да већ поседујете ову надоградњу, али није могла да се обнови. Проверите да ли користите Google налог са којим сте извршили куповину. Синхронизација Play продавнице може потрајати — покушајте да рестартујете уређај, обришете кеш Google Play-а или једноставно сачекате.</string>
     <string name="upgrade_restore_action">Врати куповину</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Узмите %1$s</string>
     <string name="upgrade_preamble">CAPod развија једна особа. Надоградња откључава додатне функције и помаже да апликација опстане.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterar att du redan äger den här uppgraderingen, men den kunde inte återställas. Kontrollera att du använder samma Google-konto som du köpte med. Synkroniseringen med Play Butik kan ta tid — prova att starta om, rensa cacheminnet för Google Play eller helt enkelt vänta.</string>
     <string name="upgrade_restore_action">Återställ köp</string>
     <string name="upgrade_badge_label">Expert</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Skaffa %1$s</string>
     <string name="upgrade_preamble">CAPod utvecklas av en enda person. En uppgradering låser upp extra funktioner och hjälper till att hålla appen vid liv.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play inaripoti kuwa tayari unamiliki uboreshaji huu, lakini haukuweza kurejeshwa. Hakikisha unatumia akaunti ya Google uliyotumia kununua. Usawazishaji wa Play Store unaweza kuchukua muda — jaribu kuwasha upya kifaa, kufuta hifadhi ya Google Play au kusubiri tu.</string>
     <string name="upgrade_restore_action">Rejesha ununuzi</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Pata %1$s</string>
     <string name="upgrade_preamble">CAPod inatengenezwa na mtu mmoja tu. Kuboresha kunafungua vipengele vya ziada na kusaidia kuendeleza programu hii.</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">இந்த மேம்படுத்தலை நீங்கள் ஏற்கனவே வைத்திருப்பதாக Google Play தெரிவிக்கிறது, ஆனால் அதை மீட்டெடுக்க முடியவில்லை. நீங்கள் வாங்கிய Google கணக்கைப் பயன்படுத்துகிறீர்களா எனச் சரிபார்க்கவும். Play Store ஒத்திசைவு சிறிது நேரம் எடுக்கலாம் — மறுதொடக்கம் செய்யவும், Google Play தேக்ககத்தை அழிக்கவும் அல்லது சிறிது காத்திருக்கவும்.</string>
     <string name="upgrade_restore_action">வாங்குதலை மீட்டமை</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ஐப் பெறுக</string>
     <string name="upgrade_preamble">CAPod ஒரே ஒரு நபரால் உருவாக்கப்படுகிறது. மேம்படுத்துவது கூடுதல் அம்சங்களைத் திறக்கும் மற்றும் ஆப்பை உயிருடன் வைத்திருக்க உதவும்.</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">మీరు ఇప్పటికే ఈ అప్‌గ్రేడ్‌ను కలిగి ఉన్నారని Google Play నివేదిస్తోంది, కానీ దాన్ని పునరుద్ధరించడం సాధ్యం కాలేదు. మీరు కొనుగోలు చేసిన అదే Google ఖాతాను ఉపయోగిస్తున్నారని నిర్ధారించుకోండి. Play Store సమకాలీకరణకు సమయం పట్టవచ్చు — పునఃప్రారంభించడం, Google Play కాష్‌ను క్లియర్ చేయడం లేదా కొంత సమయం వేచి ఉండటం ప్రయత్నించండి.</string>
     <string name="upgrade_restore_action">కొనుగోలును పునరుద్ధరించండి</string>
     <string name="upgrade_badge_label">ప్రొ</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">పొందండి %1$s</string>
     <string name="upgrade_preamble">CAPodని ఒకే వ్యక్తి అభివృద్ధి చేస్తున్నారు. అప్‌గ్రేడ్ చేయడం అదనపు ఫీచర్లను అన్‌లాక్ చేస్తుంది మరియు యాప్‌ను సజీవంగా ఉంచడంలో సహాయపడుతుంది.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play รายงานว่าคุณเป็นเจ้าของการอัปเกรดนี้อยู่แล้ว แต่ไม่สามารถกู้คืนได้ ตรวจสอบให้แน่ใจว่าคุณใช้บัญชี Google เดียวกับที่ใช้ซื้อ การซิงค์ข้อมูลของ Play Store อาจใช้เวลาสักครู่ — ลองรีสตาร์ทเครื่อง ล้างแคชของ Google Play หรือรอสักครู่</string>
     <string name="upgrade_restore_action">กู้คืนการซื้อ</string>
     <string name="upgrade_badge_label">โปร</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">รับ %1$s</string>
     <string name="upgrade_preamble">CAPod พัฒนาโดยคนคนเดียว การอัปเกรดจะปลดล็อกฟีเจอร์เพิ่มเติมและช่วยให้แอปนี้ยังคงอยู่ต่อไป</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play, bu yükseltmeye zaten sahip olduğunu bildiriyor ancak geri yüklenemedi. Satın alırken kullandığın Google hesabını kullandığından emin ol. Play Store senkronizasyonu zaman alabilir — yeniden başlatmayı, Google Play önbelleğini temizlemeyi veya biraz beklemeyi dene.</string>
     <string name="upgrade_restore_action">Satın almayı geri yükle</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s\'i Al</string>
     <string name="upgrade_preamble">CAPod bir kişi tarafından geliştirilmiştir. Yükseltme ekstra özelliklerin kilidini açar ve uygulamanın canlı kalabilmesine yardımcı olur.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play повідомляє, що ви вже маєте це оновлення, але його не вдалося відновити. Переконайтеся, що ви використовуєте обліковий запис Google, з яким здійснили покупку. Синхронізація Play Store може тривати деякий час — спробуйте перезавантажити пристрій, очистити кеш Google Play або просто зачекати.</string>
     <string name="upgrade_restore_action">Відновити покупку</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Отримати %1$s</string>
     <string name="upgrade_preamble">CAPod розробляє одна людина. Оновлення розблоковує додаткові функції та допомагає підтримувати розвиток застосунку.</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">گوگل پلے کے مطابق آپ پہلے ہی یہ اپ گریڈ خرید چکے ہیں، لیکن اسے بحال نہیں کیا جا سکا۔ یقینی بنائیں کہ آپ وہی گوگل اکاؤنٹ استعمال کر رہے ہیں جس سے آپ نے خریداری کی تھی۔ پلے سٹور کی ہم آہنگی میں وقت لگ سکتا ہے — دوبارہ شروع کرنے، گوگل پلے کیشے صاف کرنے یا محض انتظار کرنے کی کوشش کریں۔</string>
     <string name="upgrade_restore_action">خریداری بحال کریں</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s حاصل کریں</string>
     <string name="upgrade_preamble">CAPod ایک ہی شخص کی طرف سے تیار کیا گیا ہے۔ اپ گریڈ کرنے سے اضافی خصوصیات کھلتی ہیں اور ایپ کو زندہ رکھنے میں مدد ملتی ہے۔</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play ushbu yangilanishga allaqachon ega ekanligingizni bildiradi, ammo uni tiklab bo\'lmadi. Xarid qilgan Google hisobingizdan foydalanayotganingizga ishonch hosil qiling. Play Store sinxronizatsiyasi vaqt olishi mumkin — qurilmani qayta ishga tushirib ko\'ring, Google Play keshini tozalang yoki shunchaki kuting.</string>
     <string name="upgrade_restore_action">Xaridni tiklash</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s-ni oling</string>
     <string name="upgrade_preamble">CAPod yagona shaxs tomonidan ishlab chiqilmoqda. Yangilash qo\'shimcha funksiyalarni ochadi va ilovani tirik saqlashga yordam beradi.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play cho biết bạn đã sở hữu bản nâng cấp này, nhưng không thể khôi phục. Hãy đảm bảo bạn đang sử dụng đúng tài khoản Google mà bạn đã dùng để mua. Việc đồng bộ hóa Play Store có thể mất chút thời gian — hãy thử khởi động lại thiết bị, xóa bộ nhớ đệm của Google Play hoặc đơn giản là chờ đợi.</string>
     <string name="upgrade_restore_action">Khôi phục thanh toán</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Nhận %1$s</string>
     <string name="upgrade_preamble">CAPod được phát triển bởi một người duy nhất. Việc nâng cấp sẽ mở khóa thêm các tính năng và giúp duy trì ứng dụng.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play 显示您已拥有此升级,但无法恢复。请确保您使用的是购买时所用的 Google 账号。Play 商店同步可能需要一些时间——请尝试重启设备、清除 Google Play 缓存,或耐心等待。</string>
     <string name="upgrade_restore_action">恢复购买</string>
     <string name="upgrade_badge_label">专业版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">获取 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一个人独立开发。升级可解锁更多功能,并帮助这款应用持续维护下去。</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play 顯示你已經擁有此升級項目，但無法還原。請確保你使用購買時所用的 Google 帳戶。Play 商店同步可能需要一些時間——你可以嘗試重新啟動裝置、清除 Google Play 快取，或耐心等候。</string>
     <string name="upgrade_restore_action">恢復購買</string>
     <string name="upgrade_badge_label">專業版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">取得 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一個人開發。升級可解鎖額外功能，並有助維持應用程式繼續運作。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play 回報您已擁有此升級項目，但無法還原。請確認您使用的是購買時所用的 Google 帳戶。Play 商店同步可能需要一些時間 — 請嘗試重新啟動裝置、清除 Google Play 快取或稍候片刻。</string>
     <string name="upgrade_restore_action">還原購買</string>
     <string name="upgrade_badge_label">專業版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">取得 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一人獨立開發。升級可解鎖額外功能，並協助維持應用程式的運作。</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">I-Google Play ibika ukuthi usuvele unalolu shintsho olusheshisiwe, kodwa alukwazanga ukubuyiselwa. Qinisekisa ukuthi usebenzisa i-akhawunti ye-Google owathenga ngayo. Ukuvumelanisa kwe-Play Store kungase kuthathe isikhathi — zama ukuqala kabusha idivayisi, ukususa i-cache ye-Google Play noma ulinde nje.</string>
     <string name="upgrade_restore_action">Buyisela ukuthenga</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Thola %1$s</string>
     <string name="upgrade_preamble">I-CAPod yenziwe umuntu oyedwa. Ukuthuthukisa kuvula izici ezengeziwe futhi kusize ukugcina uhlelo lokusebenza luphila.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="upgrades_gplay_already_owned_description">Google Play reports that you already own this upgrade, but it couldn\'t be restored. Make sure you are using the Google account you purchased with. Play Store synchronization may take time — try rebooting, clearing the Google Play cache or simply waiting.</string>
     <string name="upgrade_restore_action">Restore purchase</string>
     <string name="upgrade_badge_label">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" / "FOSS").
+         Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Get %1$s</string>
     <string name="upgrade_preamble">CAPod is developed by a single person. Upgrading unlocks extra features and helps keep the app alive.</string>

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -92,34 +92,67 @@ internal object UpgradeScreenTags {
     const val HERO = "upgrade_hero"
 }
 
-// Composed app title with the flavor postfix highlighted in the upgraded color while Pro is
-// active — the same treatment the dashboard title card uses.
+// The app's brand title, composed through the flavor's title template so translators own the word
+// order and punctuation instead of the code assuming "name, space, qualifier". Replaces a split on
+// spaces that required exactly two tokens: Arabic ("كابود – النسخة الاحترافية") had four and lost
+// its branding entirely, while Estonian puts the qualifier FIRST ("Tasuline CAPod") and so passed
+// the token count while highlighting the wrong word.
+//
+// The two flags are deliberately separate. `includeQualifier` decides whether the tier word is part
+// of the title at all (the toolbar drops it while free); `highlightQualifier` only decides whether
+// it is colored.
+//
+// `highlightColor` exists because capod tints by flavor: the toolbar paints FOSS on brand_secondary
+// and Pro on brand_tertiary, so the color cannot be baked in the way the upstream app bakes it.
 @Composable
-internal fun upgradeScreenTitle(
-    upgraded: Boolean,
-    @StringRes nameRes: Int = R.string.app_name_pro,
+internal fun brandTitle(
+    includeQualifier: Boolean,
+    highlightQualifier: Boolean,
+    highlightColor: Color = colorResource(R.color.brand_tertiary),
 ): AnnotatedString {
-    // capod ships the composed "CAPod Pro" as one translatable string so translations can reorder
-    // the words; the postfix is the trailing part and gets the upgraded highlight. FOSS passes its
-    // own "CAPod FOSS" instead — the flavor name is the brand there, Pro is not a thing.
-    val parts = stringResource(nameRes).split(" ").filter { it.isNotEmpty() }
-    val highlight = colorResource(R.color.brand_tertiary)
-    return buildAnnotatedString {
-        if (parts.size == 2) {
-            append("${parts[0]} ")
-            if (upgraded) pushStyle(SpanStyle(color = highlight))
-            append(parts[1])
-            if (upgraded) pop()
-        } else {
-            append(stringResource(nameRes))
-        }
+    val name = AnnotatedString(stringResource(R.string.app_name))
+    if (!includeQualifier) return name
+
+    val qualifier = buildAnnotatedString {
+        if (highlightQualifier) pushStyle(SpanStyle(color = highlightColor))
+        append(stringResource(R.string.upgrade_badge_label))
+        if (highlightQualifier) pop()
     }
+    return spliceTitleTemplate(
+        formatted = stringResource(
+            R.string.app_name_upgraded_template,
+            BRAND_TITLE_MARKER,
+            BRAND_QUALIFIER_MARKER,
+        ),
+        name = name,
+        qualifier = qualifier,
+    )
 }
+
+// Same composition for call sites that need a plain String. Routed through brandTitle so the two
+// forms cannot drift apart.
+@Composable
+internal fun brandTitleText(includeQualifier: Boolean): String =
+    brandTitle(includeQualifier = includeQualifier, highlightQualifier = false).text
+
+// Composed app title with the flavor qualifier highlighted in the upgraded color while Pro is
+// active — the same treatment the toolbar uses.
+@Composable
+internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = brandTitle(
+    // Unconditional: this title names the flavor even when the screen is showing the free state.
+    includeQualifier = true,
+    highlightQualifier = upgraded,
+)
 
 // Marker char for brand-title splicing: formatted into the translated pattern via the normal
 // Android format path (so %1$s vs %s, argument reordering, and %% all behave), then replaced
 // with the styled brand. U+FFFC (object replacement) cannot occur in a real translation.
 internal const val BRAND_TITLE_MARKER = "￼"
+
+// The title template's second slot. U+FFF9 (interlinear annotation anchor) is likewise absent from
+// real translations, and being distinct from BRAND_TITLE_MARKER is what lets the splice tell the
+// two slots apart after the formatter has reordered them.
+internal const val BRAND_QUALIFIER_MARKER = "￹"
 
 internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): AnnotatedString = buildAnnotatedString {
     var rest = formatted
@@ -137,6 +170,71 @@ internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): Annota
         // Defensive: a translation that lost its placeholder still shows the brand.
         append(" ")
         append(brand)
+    }
+}
+
+// Splices the two title slots into an already-formatted template. Stricter than spliceBrandTitle on
+// purpose: that one splices a brand into a *sentence*, where a repeated marker is a legitimate (if
+// odd) translation. A *title* template has exactly two slots, so anything else is damage — and once
+// a slot is missing or doubled the template can no longer tell us the intended order or
+// punctuation, which is the whole reason it exists. So a broken template is discarded whole and the
+// default title is rebuilt from the parts; patching it up piecewise would emit a title no
+// translator wrote.
+internal fun spliceTitleTemplate(
+    formatted: String,
+    name: AnnotatedString,
+    qualifier: AnnotatedString,
+): AnnotatedString {
+    val slots = listOf(
+        BRAND_TITLE_MARKER to name,
+        BRAND_QUALIFIER_MARKER to qualifier,
+    ).map { (marker, value) -> Triple(formatted.indexOf(marker), marker, value) }
+
+    val intact = slots.all { (index, marker, _) ->
+        index >= 0 && formatted.indexOf(marker, index + marker.length) < 0
+    }
+    if (!intact) {
+        return buildAnnotatedString {
+            append(name)
+            append(" ")
+            append(qualifier)
+        }
+    }
+
+    return buildAnnotatedString {
+        var cursor = 0
+        slots.sortedBy { it.first }.forEach { (index, marker, value) ->
+            append(formatted.substring(cursor, index))
+            append(value)
+            cursor = index + marker.length
+        }
+        append(formatted.substring(cursor))
+    }
+}
+
+// All three flag combinations the app actually uses, in one place — the pair (true, false) is the
+// one that reads as a mistake at a glance, so seeing it render the qualifier in plain text is what
+// documents it.
+@Preview2
+@Composable
+private fun BrandTitlePreview() {
+    PreviewWrapper {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(text = brandTitle(includeQualifier = false, highlightQualifier = false))
+            Text(text = brandTitle(includeQualifier = true, highlightQualifier = false))
+            Text(text = brandTitle(includeQualifier = true, highlightQualifier = true))
+            Text(
+                text = brandTitle(
+                    includeQualifier = true,
+                    highlightQualifier = true,
+                    highlightColor = colorResource(R.color.brand_secondary),
+                ),
+            )
+            Text(text = brandTitleText(includeQualifier = true))
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/OverviewScreen.kt
@@ -35,9 +35,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,6 +51,7 @@ import eu.darken.capod.common.error.ErrorEventHandler
 import eu.darken.capod.common.navigation.NavigationEventHandler
 import eu.darken.capod.common.permissions.Permission
 import eu.darken.capod.common.upgrade.UpgradeRepo
+import eu.darken.capod.common.upgrade.ui.brandTitle
 import eu.darken.capod.main.core.MonitorMode
 import eu.darken.capod.main.ui.overview.cards.BackgroundMonitoringOffCard
 import eu.darken.capod.main.ui.overview.cards.BluetoothDisabledCard
@@ -613,35 +611,18 @@ private fun OverviewScreenMonitoringOffPreview() = PreviewWrapper {
 
 @Composable
 private fun ToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
-    val appName = stringResource(R.string.app_name)
-    val proName = stringResource(R.string.app_name_pro)
-    val fossName = stringResource(R.string.app_name_foss)
-
-    val titleParts = when (upgradeInfo.type) {
-        UpgradeRepo.Type.GPLAY -> {
-            if (upgradeInfo.isPro) proName else appName
-        }
-
-        UpgradeRepo.Type.FOSS -> {
-            if (upgradeInfo.isPro) fossName else appName
-        }
-    }.split(" ").filter { it.isNotEmpty() }
-
-    if (titleParts.size == 2) {
-        val suffixColor = when (upgradeInfo.type) {
-            UpgradeRepo.Type.FOSS -> colorResource(R.color.brand_secondary)
-            else -> colorResource(R.color.brand_tertiary)
-        }
-
-        Text(
-            text = buildAnnotatedString {
-                append("${titleParts[0]} ")
-                withStyle(SpanStyle(color = suffixColor)) {
-                    append(titleParts[1])
-                }
-            },
-        )
-    } else {
-        Text(text = appName)
+    // The tier word and its wording come from the flavor's own resources, so the title no longer
+    // needs a per-type string lookup — only the tint still differs between the two.
+    val highlight = when (upgradeInfo.type) {
+        UpgradeRepo.Type.FOSS -> colorResource(R.color.brand_secondary)
+        UpgradeRepo.Type.GPLAY -> colorResource(R.color.brand_tertiary)
     }
+
+    Text(
+        text = brandTitle(
+            includeQualifier = upgradeInfo.isPro,
+            highlightQualifier = upgradeInfo.isPro,
+            highlightColor = highlight,
+        ),
+    )
 }

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Jy kan opgradeer na CAPod Pro om ekstra kenmerke te kry en ontwikkeling te ondersteun.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Fout</string>
     <string name="general_grant_permission_action">Gee toestemming</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">ተጨማሪ ባህሪያትን ለማግኘት እና ልማትን ለመደገፍ ወደ CAPod Pro ማሻሻል ይችላሉ።</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">አይገኝም</string>
     <string name="general_error_label">ስህተት</string>
     <string name="general_grant_permission_action">ፈቃድ ስጥ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">يمكنك الترقية إلى النسخة الاحترافية للحصول على ميزات إضافية ودعم التطوير.</string>
     <!-- Strings from app-common -->
     <string name="app_name">كابود</string>
-    <string name="app_name_pro">كابود – النسخة الاحترافية</string>
     <string name="general_value_not_available_label">غ/م</string>
     <string name="general_error_label">خطأ</string>
     <string name="general_grant_permission_action">منح الإذن</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Əlavə xüsusiyyətlər əldə etmək və inkişafı dəstəkləmək üçün CAPod Pro-ya yüksəldə bilərsiniz.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Mövcud deyil</string>
     <string name="general_error_label">Xəta</string>
     <string name="general_grant_permission_action">İcazə ver</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Вы можаце абнавіцца да CAPod Pro, каб атрымаць дадатковыя функцыі і падтрымаць распрацоўку.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Памылка</string>
     <string name="general_grant_permission_action">Даць дазвол</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Можете да надстроите до CAPod Pro, за да получите допълнителни функции и да подкрепите разработката.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Н/П</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_grant_permission_action">Дай разрешение</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">অতিরিক্ত বৈশিষ্ট্য পেতে এবং উন্নয়ন সমর্থন করতে আপনি CAPod Pro-তে আপগ্রেড করতে পারেন।</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">প্রযোজ্য নয়</string>
     <string name="general_error_label">ত্রুটি</string>
     <string name="general_grant_permission_action">অনুমতি দিন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -185,7 +185,6 @@
     <string name="onboarding_body4">Podeu actualitzar a CAPod Pro per obtenir funcions addicionals i donar suport al desenvolupament.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Concedeix el permís</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Chcete-li získat speciální funkce a podpořit vývoj, můžete přejít na verzi CAPod Pro.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_grant_permission_action">Udělit oprávnění</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Du kan opgradere til CAPod Pro for at få ekstra funktioner og støtte udviklingen.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">I/T</string>
     <string name="general_error_label">Fejl</string>
     <string name="general_grant_permission_action">Giv tilladelse</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Du kannst auf CAPod Pro upgraden, um zusätzliche Funktionen zu erhalten und die Entwicklung zu unterstützen.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">K.A.</string>
     <string name="general_error_label">Fehler</string>
     <string name="general_grant_permission_action">Berechtigungen erteilen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Μπορείτε να κάνετε αναβάθμιση σε CAPod Pro για να αποκτήσετε επιπλέον λειτουργίες και να υποστηρίξετε την ανάπτυξη.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Μ/Δ</string>
     <string name="general_error_label">Σφάλμα</string>
     <string name="general_grant_permission_action">Παραχώρηση άδειας</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Podés actualizar a CAPod Pro para obtener funciones adicionales y apoyar el desarrollo.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">No disponible</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Conceder el permiso</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Puedes actualizar a CAPod Pro para obtener funciones adicionales y apoyar el desarrollo.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">No disponible</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Conceder el permiso</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Puedes actualizar a CAPod Pro para obtener funciones adicionales y apoyar el desarrollo.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">No disponible</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Conceder el permiso</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Lisavõimaluste saamiseks ja arendamise toetamiseks soetage CAPod Pro.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">Tasuline CAPod</string>
     <string name="general_value_not_available_label">Pole saadaval</string>
     <string name="general_error_label">Viga</string>
     <string name="general_grant_permission_action">Anna õigus</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">CAPod Pro-ra bertsio-berritu dezakezu ezaugarri gehigarriak lortzeko eta garapena laguntzeko.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">E/E</string>
     <string name="general_error_label">Errorea</string>
     <string name="general_grant_permission_action">Eman baimena</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">می‌توانید برای دریافت ویژگی‌های اضافی و حمایت از توسعه، به CAPod Pro ارتقا دهید.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">ندارد</string>
     <string name="general_error_label">خطا</string>
     <string name="general_grant_permission_action">اعطای مجوز</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Voit päivittää CAPod Prohon saadaksesi lisäominaisuuksia ja tukeaksesi kehitystä.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Ei saatavilla</string>
     <string name="general_error_label">Virhe</string>
     <string name="general_grant_permission_action">Myönnä lupa</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Maaari kang mag-upgrade sa CAPod Pro para makakuha ng mga dagdag na feature at suportahan ang development.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Hindi Available</string>
     <string name="general_error_label">Error</string>
     <string name="general_grant_permission_action">Ibigay ang pahintulot</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Vous pouvez passer à CAPod Pro pour obtenir des fonctions supplémentaires et soutenir le développement.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N.D.</string>
     <string name="general_error_label">Erreur</string>
     <string name="general_grant_permission_action">Accorder l’autorisation</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Podes actualizar a CAPod Pro para obter funcións adicionais e apoiar o desenvolvemento.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Erro</string>
     <string name="general_grant_permission_action">Conceder permiso</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">अतिरिक्त सुविधाएँ प्राप्त करने और विकास का समर्थन करने के लिए आप CAPod Pro में अपग्रेड कर सकते हैं।</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">उपलब्ध नहीं</string>
     <string name="general_error_label">त्रुटि</string>
     <string name="general_grant_permission_action">अनुमति दें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Možete nadograditi na CAPod Pro kako biste dobili dodatne značajke i podržali razvoj.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Pogreška</string>
     <string name="general_grant_permission_action">Odobri dozvolu</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">A CAPod Pro verzióra frissítése további funkciókat adhat és támogatja a fejlesztést.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Hiba</string>
     <string name="general_grant_permission_action">Engedély megadása</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Դուք կարող եք թարմացնել CAPod Pro-ին՝ լրացուցիչ գործառույթներ ստանալու և մշակմանն աջակցելու համար։</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Հասանելի չէ</string>
     <string name="general_error_label">Սխալ</string>
     <string name="general_grant_permission_action">Տալ թույլտվություն</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Anda dapat meningkatkan ke CAPod Pro untuk mendapatkan fitur tambahan dan mendukung pengembangan.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Tidak Tersedia</string>
     <string name="general_error_label">Kesalahan</string>
     <string name="general_grant_permission_action">Berikan izin</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Þú getur uppfært í CAPod Pro til að fá viðbótareiginleika og styðja við þróun.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Ekki tiltækt</string>
     <string name="general_error_label">Villa</string>
     <string name="general_grant_permission_action">Veita heimild</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Puoi passare a CAPod Pro per ottenere funzionalità aggiuntive e supportare lo sviluppo.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Errore</string>
     <string name="general_grant_permission_action">Concedi permesso</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">אתה יכול לשדרג ל-CAPod Pro כדי לקבל תכונות נוספות ותמיכה בפיתוח.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">לא זמין</string>
     <string name="general_error_label">שגיאה</string>
     <string name="general_grant_permission_action">הענק הרשאה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">追加機能を利用して開発をサポートするために、CAPod Proにアップグレードできます。</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">該当なし</string>
     <string name="general_error_label">エラー</string>
     <string name="general_grant_permission_action">権限を付与</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">შეგიძლიათ განაახლოთ CAPod Pro-ზე დამატებითი ფუნქციების მისაღებად და განვითარების მხარდასაჭერად.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">მიუწვდომელი</string>
     <string name="general_error_label">შეცდომა</string>
     <string name="general_grant_permission_action">ნებართვის მინიჭება</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">អ្នកអាចដំឡើងកំណែទៅ CAPod Pro ដើម្បីទទួលបានមុខងារបន្ថែម និងគាំទ្រការអភិវឌ្ឍន៍។</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">មិនមាន</string>
     <string name="general_error_label">កំហុស</string>
     <string name="general_grant_permission_action">ផ្តល់ការអនុញ្ញាត</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Hûn dikarin ji bo bidestxistina taybetmendiyên zêde û piştgirîkirina pêşveçûnê nûjen bikin CAPod Pro.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Xeletî</string>
     <string name="general_grant_permission_action">Destûr bide</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">ಹೆಚ್ಚುವರಿ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಪಡೆಯಲು ಮತ್ತು ಅಭಿವೃದ್ಧಿಯನ್ನು ಬೆಂಬಲಿಸಲು ನೀವು CAPod Pro ಗೆ ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಬಹುದು.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">ಲಭ್ಯವಿಲ್ಲ</string>
     <string name="general_error_label">ದೋಷ</string>
     <string name="general_grant_permission_action">ಅನುಮತಿ ನೀಡಿ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">추가 기능을 얻고 개발을 지원하려면 CAPod Pro로 업그레이드할 수 있습니다.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">값 없음</string>
     <string name="general_error_label">오류</string>
     <string name="general_grant_permission_action">권한 부여</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Сиз CAPod Pro\'го жаңыртып, кошумча функцияларды алып, иштеп чыгууну колдой аласыз.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Жок</string>
     <string name="general_error_label">Ката</string>
     <string name="general_grant_permission_action">Уруксат берүү</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">ທ່ານສາມາດອັບເກຣດເປັນ CAPod Pro ເພື່ອຮັບຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ສະໜັບສະໜູນການພັດທະນາ.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">ຜິດພາດ</string>
     <string name="general_grant_permission_action">ອະນຸຍາດ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Galite naujinti į „CAPod Pro\", kad gautumėte papildomų funkcijų ir palaikytumėte plėtrą.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Nėra</string>
     <string name="general_error_label">Klaida</string>
     <string name="general_grant_permission_action">Suteikti leidimą</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Jūs varat jaunināt uz CAPod Pro, lai iegūtu papildu funkcijas un atbalstītu izstrādi.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Kļūda</string>
     <string name="general_grant_permission_action">Piešķirt atļauju</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Можете да надградите на CAPod Pro за да добиете дополнителни функции и да го поддржите развојот.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_grant_permission_action">Дозволи дозвола</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">അധിക സവിശേഷതകൾ നേടാനും വികസനത്തെ പിന്തുണയ്ക്കാനും നിങ്ങൾക്ക് CAPod Pro-ലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യാം.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">ലഭ്യമല്ല</string>
     <string name="general_error_label">പിശക്</string>
     <string name="general_grant_permission_action">അനുമതി നൽകുക</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Нэмэлт функцуудыг авах, хөгжүүлэлтийг дэмжихийн тулд CAPod Pro руу шинэчилж болно.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Байхгүй</string>
     <string name="general_error_label">Алдаа</string>
     <string name="general_grant_permission_action">Зөвшөөрөл олгох</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">अतिरिक्त वैशिष्ट्ये मिळवण्यासाठी आणि विकासाला समर्थन देण्यासाठी तुम्ही CAPod Pro वर श्रेणीसुधारित करू शकता.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">उपलब्ध नाही</string>
     <string name="general_error_label">त्रुटी</string>
     <string name="general_grant_permission_action">परवानगी द्या</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Anda boleh menaik taraf kepada CAPod Pro untuk mendapatkan ciri tambahan dan menyokong pembangunan.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Tidak tersedia</string>
     <string name="general_error_label">Ralat</string>
     <string name="general_grant_permission_action">Beri kebenaran</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">အပိုအင်္ဂါရပ်များရယူရန်နှင့် ဖွံ့ဖြိုးတိုးတက်မှုကိုထောက်ပံ့ရန် သင် CAPod Pro သို့ အဆင့်မြှင့်နိုင်သည်။</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">အမှား</string>
     <string name="general_grant_permission_action">ခွင့်ပြုချက်ပေးရန်</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Du kan oppgradere til CAPod Pro for å få ekstra funksjoner og støtte utviklingen.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Feil</string>
     <string name="general_grant_permission_action">Gi tillatelse</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">थप सुविधाहरू प्राप्त गर्न र विकासलाई समर्थन गर्न तपाईं CAPod Pro मा अपग्रेड गर्न सक्नुहुन्छ।</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">उपलब्ध छैन</string>
     <string name="general_error_label">त्रुटि</string>
     <string name="general_grant_permission_action">अनुमति दिनुहोस्</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Je kunt upgraden naar CAPod Pro om extra functies te krijgen en de ontwikkeling te ondersteunen.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Fout</string>
     <string name="general_grant_permission_action">Toestemming verlenen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -186,7 +186,6 @@ K4r0lSz;</string>
     <string name="onboarding_body4">Możesz uaktualni do CAPod Pro, by uzyskać dodatkowe funkcje i wesprzeć rozwój.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Błąd</string>
     <string name="general_grant_permission_action">Udziel uprawnień</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Você pode atualizar para o CAPod Pro para obter recursos extras e apoiar o desenvolvimento.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Erro</string>
     <string name="general_grant_permission_action">Conceder permissão</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Pode atualizar para o CAPod Pro para obter funcionalidades adicionais e apoiar o desenvolvimento.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Erro</string>
     <string name="general_grant_permission_action">Conceder permissão</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Vus pudais actualisar sin CAPod Pro per obtegnair funcziuns supplementaras e sustegnair il svilup.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Errur</string>
     <string name="general_grant_permission_action">Conceder permissiun</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Puteți face upgrade la CAPod Pro pentru a obține funcții suplimentare și pentru a sprijini dezvoltarea.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Eroare</string>
     <string name="general_grant_permission_action">Acordă permisiunea</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -185,7 +185,6 @@ AL_Cool_T</string>
     <string name="onboarding_body4">Вы можете обновиться до CAPod Pro для дополнительных функций и поддержки разработки.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Недоступно</string>
     <string name="general_error_label">Ошибка</string>
     <string name="general_grant_permission_action">Предоставить разрешение</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Podes agiornare a CAPod Pro pro otènnere funtziones extra e sustènnere s\'isvilupu.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/D</string>
     <string name="general_error_label">Errore</string>
     <string name="general_grant_permission_action">Cuntze permissu</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">අමතර විශේෂාංග ලබා ගැනීමට සහ සංවර්ධනයට සහාය වීමට ඔබට CAPod Pro වෙත යාවත්කාලීන කළ හැකිය.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">ලබා ගත නොහැක</string>
     <string name="general_error_label">දෝෂය</string>
     <string name="general_grant_permission_action">අවසරය ලබා දෙන්න</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Môžete upgradovať na CAPod Pro, aby ste získali ďalšie funkcie a podporili vývoj.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Nedostupné</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_grant_permission_action">Udeliť povolenie</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Za dodatne funkcije in podporo razvoju lahko nadgradite na CAPod Pro.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Ni podatka</string>
     <string name="general_error_label">Napaka</string>
     <string name="general_grant_permission_action">Odobri dovoljenje</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Mund të përmirësoni në CAPod Pro për të fituar veçori shtesë dhe për të mbështetur zhvillimin.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Gabim</string>
     <string name="general_grant_permission_action">Jep lejen</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Можете надоградити на CAPod Pro да бисте добили додатне функције и подржали развој.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_grant_permission_action">Дај дозволу</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Du kan uppgradera till CAPod Pro för att få extra funktioner och stödja utvecklingen.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Ej tillgängligt</string>
     <string name="general_error_label">Fel</string>
     <string name="general_grant_permission_action">Bevilja behörighet</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Unaweza kuboresha hadi CAPod Pro kupata vipengele vya ziada na kusaidia maendeleo.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Haipatikani</string>
     <string name="general_error_label">Hitilafu</string>
     <string name="general_grant_permission_action">Toa ruhusa</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">கூடுதல் அம்சங்களைப் பெறவும் மேம்பாட்டை ஆதரிக்கவும் நீங்கள் CAPod Pro க்கு மேம்படுத்தலாம்.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">கிடைக்கவில்லை</string>
     <string name="general_error_label">பிழை</string>
     <string name="general_grant_permission_action">அனுமதி வழங்கு</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">అదనపు ఫీచర్లను పొందడానికి మరియు అభివృద్ధికి మద్దతు ఇవ్వడానికి మీరు CAPod Proకి అప్‌గ్రేడ్ చేయవచ్చు.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">అందుబాటులో లేదు</string>
     <string name="general_error_label">లోపం</string>
     <string name="general_grant_permission_action">అనుమతి ఇవ్వు</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">คุณสามารถอัปเกรดเป็น CAPod Pro เพื่อรับคุณสมบัติเพิ่มเติมและสนับสนุนการพัฒนา</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">ไม่พร้อมใช้งาน</string>
     <string name="general_error_label">ข้อผิดพลาด</string>
     <string name="general_grant_permission_action">ให้สิทธิ์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Ekstra özellikler kazanmak ve geliştirmeyi desteklemek için CAPod Pro\'ya yükseltebilirsiniz.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Hata</string>
     <string name="general_grant_permission_action">İzin ver</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Ви можете оновитись до CAPod Pro, щоб отримати підтримку додаткових функцій та підтримати розробку.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Н/Д</string>
     <string name="general_error_label">Помилка</string>
     <string name="general_grant_permission_action">Надати дозвіл</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">آپ اضافی خصوصیات حاصل کرنے اور ترقی کی حمایت کرنے کے لئے CAPod Pro میں اپ گریڈ کر سکتے ہیں۔</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">دستیاب نہیں</string>
     <string name="general_error_label">خرابی</string>
     <string name="general_grant_permission_action">اجازت دیں</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Qo\'shimcha xususiyatlarni olish va rivojlanishni qo\'llab-quvvatlash uchun CAPod Pro\'ga yangilashingiz mumkin.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Xato</string>
     <string name="general_grant_permission_action">Ruxsat berish</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Bạn có thể nâng cấp lên CAPod Pro để có thêm các tính năng và hỗ trợ phát triển.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Không có</string>
     <string name="general_error_label">Lỗi</string>
     <string name="general_grant_permission_action">Cấp quyền</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">您可以升级 CAPod Pro 以获得额外功能和支持开发者。</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">错误</string>
     <string name="general_grant_permission_action">授予权限</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">您可以升級到 CAPod Pro 以獲得額外功能並支援開發。</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">不適用</string>
     <string name="general_error_label">錯誤</string>
     <string name="general_grant_permission_action">授予權限</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">您可以升級到 CAPod Pro 以獲得額外功能並支援開發。</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">不適用</string>
     <string name="general_error_label">錯誤</string>
     <string name="general_grant_permission_action">授予權限</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -184,7 +184,6 @@
     <string name="onboarding_body4">Ungathuthukela ku-CAPod Pro ukuze uthole izici ezengeziwe futhi usekele ukuthuthukiswa.</string>
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
     <string name="general_value_not_available_label">Ayitholakali</string>
     <string name="general_error_label">Iphutha</string>
     <string name="general_grant_permission_action">Nika imvume</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,8 +209,6 @@
 
     <!-- Strings from app-common -->
     <string name="app_name">CAPod</string>
-    <string name="app_name_pro">CAPod Pro</string>
-    <string name="app_name_foss" translatable="false">CAPod FOSS</string>
 
     <string name="general_value_not_available_label">N/A</string>
     <string name="general_error_label">Error</string>

--- a/app/src/test/java/eu/darken/capod/common/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/upgrade/ui/BrandTitleTest.kt
@@ -2,6 +2,7 @@ package eu.darken.capod.common.upgrade.ui
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.capod.R
@@ -72,6 +73,31 @@ class BrandTitleTest : BaseComposeRobolectricTest() {
         // Not just "a span exists" — the bug class this replaces put the highlight on the app name
         // while rendering perfectly correct text.
         result.text.substring(span.start, span.end) shouldBe qualifier
+    }
+
+    @Test
+    fun `the highlight defaults to the upgraded brand color`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.spanStyles.single().item.color shouldBe Color(context.getColor(R.color.brand_tertiary))
+    }
+
+    // The toolbar tints by flavor — FOSS on brand_secondary, Pro on brand_tertiary — so the color
+    // is a parameter rather than a constant. Without this, hardcoding the default back into
+    // brandTitle would keep every other assertion green while the FOSS toolbar lost its tint.
+    @Test
+    fun `a caller-supplied highlight color is the one applied`() {
+        val custom = Color(context.getColor(R.color.brand_secondary))
+
+        val result = capture {
+            brandTitle(includeQualifier = true, highlightQualifier = true, highlightColor = custom)
+        }
+
+        result.spanStyles.single().item.color shouldBe custom
+        result.text.substring(
+            result.spanStyles.single().start,
+            result.spanStyles.single().end,
+        ) shouldBe qualifier
     }
 
     // The markers are injected as format arguments, so a template or formatter that mangled them

--- a/app/src/test/java/eu/darken/capod/common/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/upgrade/ui/BrandTitleTest.kt
@@ -1,0 +1,103 @@
+package eu.darken.capod.common.upgrade.ui
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * Resolves the real flavor resources rather than a sample pattern, so this also proves the two
+ * markers survive Android's format path and never reach the user.
+ *
+ * Flavor-agnostic on purpose: it asserts against whatever this variant's qualifier resource says
+ * ("Pro" on GPLAY, "FOSS" on FOSS) so the one test guards both. The resources are flavor-owned, so
+ * a variant that compiles proves nothing about the other.
+ */
+class BrandTitleTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val name: String
+        get() = context.getString(R.string.app_name)
+
+    private val qualifier: String
+        get() = context.getString(R.string.upgrade_badge_label)
+
+    private val composed: String
+        get() = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+
+    private fun capture(block: @Composable () -> AnnotatedString): AnnotatedString {
+        lateinit var captured: AnnotatedString
+        composeRule.setContent {
+            PreviewWrapper { captured = block() }
+        }
+        composeRule.waitForIdle()
+        return captured
+    }
+
+    @Test
+    fun `without the qualifier the title is the bare app name`() {
+        val result = capture { brandTitle(includeQualifier = false, highlightQualifier = false) }
+
+        result.text shouldBe name
+        result.spanStyles.size shouldBe 0
+    }
+
+    // The regression guard for the two-flag split: the qualifier is present but NOT colored.
+    // Collapsing the flags drops it; highlighting on `includeQualifier` alone colors it. Both would
+    // still produce plausible-looking text, so the span count is the assertion that matters.
+    @Test
+    fun `an included but unhighlighted qualifier is present and carries no span`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = false) }
+
+        result.text shouldBe composed
+        result.text.contains(qualifier) shouldBe true
+        result.spanStyles.size shouldBe 0
+    }
+
+    @Test
+    fun `a highlighted qualifier carries exactly one span covering the qualifier only`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.text shouldBe composed
+        result.spanStyles.size shouldBe 1
+        val span = result.spanStyles.single()
+        // Not just "a span exists" — the bug class this replaces put the highlight on the app name
+        // while rendering perfectly correct text.
+        result.text.substring(span.start, span.end) shouldBe qualifier
+    }
+
+    // The markers are injected as format arguments, so a template or formatter that mangled them
+    // would leak U+FFFC / U+FFF9 into the toolbar.
+    @Test
+    fun `neither splice marker survives into the rendered title`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.text shouldNotContain BRAND_TITLE_MARKER
+        result.text shouldNotContain BRAND_QUALIFIER_MARKER
+    }
+
+    @Test
+    fun `the string form matches the annotated form`() {
+        val result = capture { AnnotatedString(brandTitleText(includeQualifier = true)) }
+
+        result.text shouldBe composed
+    }
+
+    // upgradeScreenTitle is the thin wrapper both upgrade screens title themselves with: it must
+    // keep naming the flavor even while the screen shows the free state.
+    @Test
+    fun `the upgrade screen title keeps the qualifier when not upgraded`() {
+        val result = capture { upgradeScreenTitle(upgraded = false) }
+
+        result.text shouldBe composed
+        result.spanStyles.size shouldBe 0
+    }
+}

--- a/app/src/test/java/eu/darken/capod/common/upgrade/ui/TitleTemplateSpliceTest.kt
+++ b/app/src/test/java/eu/darken/capod/common/upgrade/ui/TitleTemplateSpliceTest.kt
@@ -1,0 +1,159 @@
+package eu.darken.capod.common.upgrade.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The title template lets translators own word order and punctuation, so the styled qualifier has
+ * to land on the right offsets wherever they put it. Assertions are on span boundaries, not just on
+ * the concatenated text: the Estonian defect this replaces rendered the correct characters with the
+ * highlight sitting on the wrong word.
+ */
+class TitleTemplateSpliceTest : BaseTest() {
+
+    private val qualifierColor = Color.Red
+
+    private val name = AnnotatedString("CAPod")
+
+    private val qualifier: AnnotatedString = buildAnnotatedString {
+        pushStyle(SpanStyle(color = qualifierColor))
+        append("Pro")
+        pop()
+    }
+
+    private fun template(pattern: String) = pattern
+        .replace("%1\$s", BRAND_TITLE_MARKER)
+        .replace("%2\$s", BRAND_QUALIFIER_MARKER)
+
+    @Test
+    fun `the default order highlights the trailing qualifier`() {
+        val result = spliceTitleTemplate(template("%1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+        result.text.substring(6, 9) shouldBe "Pro"
+    }
+
+    // Estonian: "Tasuline CAPod". The old split-on-space code passed its two-token guard here and
+    // then styled the SECOND token, highlighting the brand instead of the tier.
+    @Test
+    fun `a reordered template highlights the leading qualifier`() {
+        val result = spliceTitleTemplate(template("%2\$s %1\$s"), name, qualifier)
+
+        result.text shouldBe "Pro CAPod"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 0
+        result.spanStyles.single().end shouldBe 3
+        result.text.substring(0, 3) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a custom separator shifts the qualifier without entering the span`() {
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), name, qualifier)
+
+        result.text shouldBe "CAPod – Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 8
+        result.spanStyles.single().end shouldBe 11
+        result.text.substring(8, 11) shouldBe "Pro"
+    }
+
+    // Arabic: "كابود – النسخة الاحترافية". Four space-separated tokens, so the old code's guard
+    // failed and dropped the branding entirely rather than mis-styling it.
+    @Test
+    fun `a multi-word qualifier is highlighted whole`() {
+        val multiWord = buildAnnotatedString {
+            pushStyle(SpanStyle(color = qualifierColor))
+            append("النسخة الاحترافية")
+            pop()
+        }
+
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), AnnotatedString("كابود"), multiWord)
+
+        result.text shouldBe "كابود – النسخة الاحترافية"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 8
+        result.spanStyles.single().end shouldBe 25
+        result.text.substring(8, 25) shouldBe "النسخة الاحترافية"
+    }
+
+    // Span offsets are UTF-16 indices, so a supplementary character ahead of a slot shifts it by
+    // two. Pins that the splice arithmetic counts code units and not code points.
+    @Test
+    fun `a supplementary character before the slots shifts the span by two`() {
+        val result = spliceTitleTemplate(template("🎧 %1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "🎧 CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 9
+        result.spanStyles.single().end shouldBe 12
+        result.text.substring(9, 12) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a duplicated name marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+    }
+
+    @Test
+    fun `a duplicated qualifier marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+    }
+
+    @Test
+    fun `a missing name marker falls back rather than rendering the qualifier alone`() {
+        val result = spliceTitleTemplate("Get $BRAND_QUALIFIER_MARKER", name, qualifier)
+
+        result.text shouldBe "CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+    }
+
+    @Test
+    fun `a missing qualifier marker falls back rather than dropping the tier`() {
+        val result = spliceTitleTemplate("Get $BRAND_TITLE_MARKER", name, qualifier)
+
+        result.text shouldBe "CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+    }
+
+    @Test
+    fun `a template with neither marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate("CAPod Pro", name, qualifier)
+
+        result.text shouldBe "CAPod Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 6
+        result.spanStyles.single().end shouldBe 9
+    }
+}

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.compose.ui.semantics.SemanticsActions
 import eu.darken.capod.R
 import eu.darken.capod.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,6 +26,15 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
+
+    // "CAPod FOSS" — the composed flavor title, built the way production builds it: the app name
+    // through the FOSS title template, with the flavor's own qualifier resource.
+    private val composedTitle: String
+        get() = context.getString(
+            R.string.app_name_upgraded_template,
+            context.getString(R.string.app_name),
+            context.getString(R.string.upgrade_badge_label),
+        )
 
     @Test
     fun `renders redesigned foss content without duplicated app bar title`() {
@@ -70,9 +80,10 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
         }
 
-        // "CAPod FOSS", not "CAPod Pro": the status views describe a FOSS install.
-        composeRule.onAllNodesWithText(context.getString(R.string.app_name_foss)).assertCountEquals(1)
-        composeRule.onAllNodesWithText(context.getString(R.string.app_name_pro)).assertCountEquals(0)
+        // "CAPod FOSS", not "CAPod Pro": the status views describe a FOSS install, and the title
+        // takes its qualifier from the FOSS flavor's own resource.
+        composeRule.onAllNodesWithText(composedTitle).assertCountEquals(1)
+        context.getString(R.string.upgrade_badge_label) shouldBe "FOSS"
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_FREE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
@@ -107,7 +118,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
-        composeRule.onAllNodesWithText(context.getString(R.string.app_name_foss)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(composedTitle).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_supporter_thanks))
             .assertCountEquals(1)

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleLocaleTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleLocaleTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.capod.common.upgrade.ui
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import eu.darken.capod.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The two locales that broke the old split-on-space title, resolved through the real translated
+ * resources rather than a sample pattern.
+ *
+ * Both assert on the span boundary, not on text alone: Estonian rendered the correct characters
+ * with the highlight on the wrong word, so a text-only assertion would have passed throughout.
+ */
+abstract class BrandTitleLocaleTest : BaseComposeRobolectricTest() {
+
+    protected val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    protected val name: String
+        get() = context.getString(R.string.app_name)
+
+    protected val qualifier: String
+        get() = context.getString(R.string.upgrade_badge_label)
+
+    protected val composed: String
+        get() = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+
+    protected fun capture(block: @Composable () -> AnnotatedString): AnnotatedString {
+        lateinit var captured: AnnotatedString
+        composeRule.setContent {
+            PreviewWrapper { captured = block() }
+        }
+        composeRule.waitForIdle()
+        return captured
+    }
+
+    /**
+     * Arabic composes the title with an en-dash separator and a two-word qualifier
+     * ("كابود – النسخة الاحترافية"). The old code split on spaces and bailed out unless it saw
+     * exactly two tokens, so four tokens meant the Pro branding vanished from the toolbar entirely
+     * and the upgrade screen showed the name uncolored.
+     */
+    @Config(qualifiers = "ar")
+    class Arabic : BrandTitleLocaleTest() {
+
+        @Test
+        fun `the multi-word qualifier is present and highlighted whole`() {
+            val result = capture { upgradeScreenTitle(upgraded = true) }
+
+            result.text shouldBe composed
+            // The qualifier is genuinely multi-word here — that is what defeated the token count.
+            qualifier.contains(" ") shouldBe true
+            result.spanStyles.size shouldBe 1
+            val span = result.spanStyles.single()
+            result.text.substring(span.start, span.end) shouldBe qualifier
+        }
+
+        @Test
+        fun `the separator stays outside the highlight`() {
+            val result = capture { upgradeScreenTitle(upgraded = true) }
+
+            val span = result.spanStyles.single()
+            // The name and its separator precede the qualifier and must not be colored.
+            result.text.substring(0, span.start) shouldBe composed.removeSuffix(qualifier)
+            result.text.substring(0, span.start).contains(name) shouldBe true
+        }
+    }
+
+    /**
+     * Estonian puts the qualifier FIRST ("Tasuline CAPod"). That splits to exactly two tokens, so
+     * the old guard passed and then styled the second one — highlighting the brand and leaving the
+     * tier plain. Silently backwards, with no fallback to catch it.
+     */
+    @Config(qualifiers = "et-rEE")
+    class Estonian : BrandTitleLocaleTest() {
+
+        @Test
+        fun `the leading qualifier carries the highlight, not the app name`() {
+            val result = capture { upgradeScreenTitle(upgraded = true) }
+
+            result.text shouldBe composed
+            result.spanStyles.size shouldBe 1
+            val span = result.spanStyles.single()
+            result.text.substring(span.start, span.end) shouldBe qualifier
+        }
+
+        @Test
+        fun `the qualifier really does precede the app name in this locale`() {
+            val result = capture { upgradeScreenTitle(upgraded = true) }
+
+            // Pins the reordering itself: if the template ever regressed to the default order this
+            // would still highlight the right word, so without this the locale's whole point is
+            // untested.
+            val span = result.spanStyles.single()
+            span.start shouldBe 0
+            result.text.indexOf(name) shouldBe qualifier.length + 1
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleTemplateLocalesTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleTemplateLocalesTest.kt
@@ -63,16 +63,26 @@ class BrandTitleTemplateLocalesTest {
         locales shouldHaveAtLeastSize 60
     }
 
+    // Asserted against the FORMATTER'S OUTPUT rather than against the template text, because the
+    // format grammar is bigger than it looks: `%1$s %2$s %<s` reuses the previous argument and so
+    // emits the qualifier twice, which no reasonable "does it contain %1$s and %2$s" check spots.
+    // Each marker landing exactly once is precisely the condition spliceTitleTemplate requires, so
+    // checking it here is both stronger and simpler than modelling the grammar.
     @Test
-    fun `every locale template declares exactly the two title placeholders`() {
+    fun `every locale template places each slot exactly once when formatted`() {
         val offenders = locales.mapNotNull { tag ->
-            val template = localized(tag).getString(R.string.app_name_upgraded_template)
-            val specifiers = FORMAT_SPECIFIER
-                .findAll(template.replace("%%", ""))
-                .map { it.value }
-                .sorted()
-                .toList()
-            if (specifiers == listOf("%1\$s", "%2\$s")) null else "$tag -> $template"
+            val formatted = localized(tag).getString(
+                R.string.app_name_upgraded_template,
+                BRAND_TITLE_MARKER,
+                BRAND_QUALIFIER_MARKER,
+            )
+            val names = formatted.split(BRAND_TITLE_MARKER).size - 1
+            val qualifiers = formatted.split(BRAND_QUALIFIER_MARKER).size - 1
+            if (names == 1 && qualifiers == 1) {
+                null
+            } else {
+                "$tag -> name x$names, qualifier x$qualifiers in '$formatted'"
+            }
         }
 
         offenders shouldBe emptyList()
@@ -89,11 +99,17 @@ class BrandTitleTemplateLocalesTest {
             val result = compose(ctx)
 
             val span = result.spanStyles.singleOrNull()
+            // What Android itself produces for this template. Comparing against it is what proves
+            // the splice REPRODUCED the translator's arrangement rather than quietly discarding a
+            // damaged template and rebuilding the default — a fallback renders a plausible title
+            // with exactly one correctly-styled qualifier, so every other assertion here passes
+            // straight through it.
+            val expected = ctx.getString(R.string.app_name_upgraded_template, name, qualifier)
             when {
                 name.isBlank() || qualifier.isBlank() -> "$tag -> blank part"
                 result.text.contains(BRAND_TITLE_MARKER) -> "$tag -> name marker leaked"
                 result.text.contains(BRAND_QUALIFIER_MARKER) -> "$tag -> qualifier marker leaked"
-                !result.text.contains(name) -> "$tag -> name missing from '${result.text}'"
+                result.text != expected -> "$tag -> rendered '${result.text}', formatter says '$expected'"
                 span == null -> "$tag -> expected one span, got ${result.spanStyles.size}"
                 result.text.substring(span.start, span.end) != qualifier ->
                     "$tag -> span covers '${result.text.substring(span.start, span.end)}', want '$qualifier'"
@@ -103,9 +119,5 @@ class BrandTitleTemplateLocalesTest {
         }
 
         offenders shouldBe emptyList()
-    }
-
-    companion object {
-        private val FORMAT_SPECIFIER = Regex("""%(\d+\$)?[a-zA-Z]""")
     }
 }

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleTemplateLocalesTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/BrandTitleTemplateLocalesTest.kt
@@ -1,0 +1,111 @@
+package eu.darken.capod.common.upgrade.ui
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.capod.R
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.TestApplication
+import java.util.Locale
+
+/**
+ * Sweeps every shipped locale through the real Android format path.
+ *
+ * A translated template is code the formatter executes, not inert text: a stray `%`, a `%3$s` or a
+ * `%1$d` throws inside `getString` *before* the splice fallback can run, so no amount of defensive
+ * splicing protects against it. This is the only place that failure mode is caught.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class BrandTitleTemplateLocalesTest {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun localized(tag: String): Context = context.createConfigurationContext(
+        Configuration(context.resources.configuration).apply { setLocale(Locale.forLanguageTag(tag)) },
+    )
+
+    private val locales: List<String>
+        get() = context.assets.locales.filter { it.isNotBlank() }.sorted()
+
+    // Mirrors brandTitle's composition without Compose, so all locales can be swept cheaply.
+    private fun compose(ctx: Context): AnnotatedString {
+        val qualifier = buildAnnotatedString {
+            pushStyle(SpanStyle(color = Color.Red))
+            append(ctx.getString(R.string.upgrade_badge_label))
+            pop()
+        }
+        return spliceTitleTemplate(
+            formatted = ctx.getString(
+                R.string.app_name_upgraded_template,
+                BRAND_TITLE_MARKER,
+                BRAND_QUALIFIER_MARKER,
+            ),
+            name = AnnotatedString(ctx.getString(R.string.app_name)),
+            qualifier = qualifier,
+        )
+    }
+
+    // Guards the sweep itself: if locale enumeration ever silently returned one entry, every
+    // assertion below would still pass while testing nothing.
+    @Test
+    fun `the locale sweep actually covers the shipped translations`() {
+        locales shouldHaveAtLeastSize 60
+    }
+
+    @Test
+    fun `every locale template declares exactly the two title placeholders`() {
+        val offenders = locales.mapNotNull { tag ->
+            val template = localized(tag).getString(R.string.app_name_upgraded_template)
+            val specifiers = FORMAT_SPECIFIER
+                .findAll(template.replace("%%", ""))
+                .map { it.value }
+                .sorted()
+                .toList()
+            if (specifiers == listOf("%1\$s", "%2\$s")) null else "$tag -> $template"
+        }
+
+        offenders shouldBe emptyList()
+    }
+
+    @Test
+    fun `every locale resolves to a title that highlights exactly its qualifier`() {
+        val offenders = locales.mapNotNull { tag ->
+            val ctx = localized(tag)
+            val name = ctx.getString(R.string.app_name)
+            val qualifier = ctx.getString(R.string.upgrade_badge_label)
+            // Throws here rather than failing an assertion if a template is malformed — which is
+            // exactly the production failure being guarded against.
+            val result = compose(ctx)
+
+            val span = result.spanStyles.singleOrNull()
+            when {
+                name.isBlank() || qualifier.isBlank() -> "$tag -> blank part"
+                result.text.contains(BRAND_TITLE_MARKER) -> "$tag -> name marker leaked"
+                result.text.contains(BRAND_QUALIFIER_MARKER) -> "$tag -> qualifier marker leaked"
+                !result.text.contains(name) -> "$tag -> name missing from '${result.text}'"
+                span == null -> "$tag -> expected one span, got ${result.spanStyles.size}"
+                result.text.substring(span.start, span.end) != qualifier ->
+                    "$tag -> span covers '${result.text.substring(span.start, span.end)}', want '$qualifier'"
+
+                else -> null
+            }
+        }
+
+        offenders shouldBe emptyList()
+    }
+
+    companion object {
+        private val FORMAT_SPECIFIER = Regex("""%(\d+\$)?[a-zA-Z]""")
+    }
+}

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -34,9 +34,15 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     // capod's hero bodies name the app inline instead of taking a format argument.
     private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(bodyRes)
 
-    // "CAPod Pro" — the composed flavor title the screen renders for owners and grace users.
+    // "CAPod Pro" — the composed flavor title the screen renders for owners and grace users, built
+    // the way production builds it: the app name through the title template, with the flavor's own
+    // qualifier resource.
     private val appNameWithPostfix: String
-        get() = context.getString(R.string.app_name_pro)
+        get() = context.getString(
+            R.string.app_name_upgraded_template,
+            context.getString(R.string.app_name),
+            context.getString(R.string.upgrade_badge_label),
+        )
 
     // What the acquisition top bar must render: the translated pitch pattern with the composed
     // brand formatted into it.
@@ -72,9 +78,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             .fetchSemanticsNode()
             .config[SemanticsProperties.Text]
             .single()
-        // Derived like the production title does it: the postfix is the trailing word of the
-        // composed brand.
-        val postfix = appNameWithPostfix.split(" ")[1]
+        // Read from the qualifier resource, not split back out of the composed title: the template
+        // is free to put it first or separate it with something other than a space.
+        val postfix = context.getString(R.string.upgrade_badge_label)
 
         rendered.text shouldBe acquisitionTitle
         rendered.spanStyles.size shouldBe 1


### PR DESCRIPTION
## What changed

CAPod shows its name with the tier word appended and highlighted — "CAPod Pro" on Google Play, "CAPod FOSS" on the F-Droid build — in the main toolbar and on the upgrade screen. Two languages rendered this wrongly:

- **Arabic** — the Pro branding disappeared entirely. The toolbar showed a bare "كابود", with no tier word and no highlight, while the upgrade screen showed the full name with no highlight. The two surfaces disagreed with each other.
- **Estonian** — Estonian puts the tier first ("Tasuline CAPod"). The app highlighted "CAPod" and left "Tasuline" plain, so the highlight sat on the brand instead of the tier. Nothing looked broken; it was simply backwards.

Titles are now assembled from a translatable template, so each language decides word order and punctuation for itself, and the tier word keeps its highlight wherever the translation puts it.

Two further visible changes, both intended:

- 13 languages showed an English "Pro" in the title while the Pro badge shown elsewhere in the app was already translated — Korean "프로", Simplified Chinese "专业版", Swedish "Expert", plus Persian, Hindi, Hebrew, Georgian, Khmer, Malayalam, Telugu, Thai and both Traditional Chinese variants. Title and badge now agree, using the translated word in both places.
- On the F-Droid build in Arabic the title becomes "كابود FOSS", because Arabic is the only language that translates the app name and both builds now share one brand source.

Every other language and both builds render byte-identically to before.

## Technical Context

- **Root cause.** The title came from a single pre-composed translated string that was split on spaces, with the tier assumed to be the second of exactly two tokens. Arabic composes to four tokens, so the guard failed and fell through to rendering the name unstyled. Estonian composes to exactly two, so the guard *passed* and then styled `[1]` — which in Estonian is the brand. The Estonian shape is the dangerous one: correct characters, wrong span, and no fallback ever fires.
- **Why a template rather than smarter parsing.** No parse of a composed string can recover which part is the tier once a language reorders it or uses a multi-word qualifier. The template inverts the dependency: translators declare the arrangement, and the code never guesses. Placeholders go through Android's normal format path, so numbering, reordering and escaping all behave as translators expect.
- **Two markers, not one.** The name and qualifier slots are filled with distinct sentinels (U+FFFC and U+FFF9) that cannot occur in real translations. Being distinct is what lets the splice identify each slot *after* the formatter has already reordered them, which is what makes `%2$s %1$s` work.
- **The splice is deliberately strict, and there are two splicers.** `spliceTitleTemplate` requires each marker exactly once and otherwise discards the template whole, rebuilding the default title from its parts. A half-repaired template would emit an arrangement no translator wrote. This is a different contract from the pre-existing `spliceBrandTitle`, which splices a brand into a *sentence* and deliberately tolerates a repeated marker; the two are kept separate on purpose.
- **Two independent booleans.** `includeQualifier` decides whether the tier word appears at all (the toolbar drops it while free); `highlightQualifier` decides only whether it is coloured. Collapsing them would drop the tier from screens that must name the build even in the free state.
- **`highlightColor` is a parameter because capod tints by flavour** — the toolbar paints FOSS on `brand_secondary` and Pro on `brand_tertiary`, so unlike the sibling implementation this colour cannot be baked into the composable.
- **No new qualifier key.** `%2$s` reads the existing per-flavour `upgrade_badge_label`, already translated in all 75 languages, whose value is exactly the tier portion of the old composed name where it matters. That is why no human translation was discarded and only the template itself needed translating. It also means one string now feeds both the badge chip and the title, which is where the 13-language change above comes from.
- **Retiring the old keys was staged across two Crowdin syncs** — the replacement key was uploaded and translated while the old keys were still present, so translators kept their context, and the old keys were removed only afterwards. Removing and adding in one sync does not transfer translations.
- **Assertions are on span boundaries, not text.** The Estonian defect produced perfectly correct text, so any text-only assertion passes straight through it. The Arabic and Estonian regression tests resolve the real locale resources and were confirmed to fail against the pre-fix code: Estonian reported `expected:<"Tasuline"> but was:<"CAPod">`, Arabic reported one expected span versus zero.
- A sweep over every shipped locale resolves each template through Android `Resources` and asserts placeholder cardinality and span placement. A malformed template (`%3$s`, `%1$d`, a stray `%`) throws inside `getString` *before* any splice fallback can run, so that failure mode is only catchable here.

## Review checklist

- [ ] Arabic toolbar and upgrade screen both show "كابود – النسخة الاحترافية" with the qualifier highlighted
- [ ] Estonian shows "Tasuline CAPod" with **Tasuline** highlighted, not CAPod
- [ ] FOSS build still titles its status screens with the tier word present but uncoloured while unsupported
- [ ] The 13 languages adopting the translated tier word read correctly in context
