### PR TITLE
Fix: Settings and upgrade screen agree on the Pro label

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -47,6 +47,13 @@ internal enum class FossUpgradeView {
     STATUS_UPGRADED,
 }
 
+// The Settings row and the PITCH title both read this one resource, so they cannot name the tier
+// differently — unlike the composed brand title, this stays a support ask ("Sponsor CAPod") rather
+// than naming the flavor. gplay's counterpart in UpgradeScreen.kt composes from brandTitleText
+// instead; each flavor implementation lives only in its own source set.
+@Composable
+internal fun settingsUpgradeStatusTitle(): String = stringResource(R.string.upgrade_foss_sponsor_label)
+
 @Composable
 fun UpgradeScreenHost(
     route: Nav.Main.Upgrade = Nav.Main.Upgrade(),
@@ -115,7 +122,7 @@ internal fun UpgradeScreen(
         // Status views describe the existing install, not a support ask — they get the composed
         // flavor title, with the postfix highlighted for supporters like the dashboard does it.
         title = if (view == FossUpgradeView.PITCH) {
-            AnnotatedString(stringResource(R.string.settings_upgrade_status_label))
+            AnnotatedString(settingsUpgradeStatusTitle())
         } else {
             // "CAPod FOSS", not "CAPod Pro": the FOSS flavor's own qualifier resource supplies the
             // tier word, so the title names this build. The upgraded gate keeps the highlight for

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Ondersteuner sedert %s</string>
     <string name="upgrade_foss_supporter_thanks">Dankie dat jy CAPod se ontwikkeling ondersteun!</string>
     <string name="upgrade_foss_sponsor_again_action">Maak borgblad oop</string>
-    <string name="settings_upgrade_status_label">Ondersteun CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Ondersteun CAPod</string>
     <string name="settings_upgrade_status_description">Jou ondersteunersstatus.</string>
     <string name="upgrade_screen_why_title">Opgraderingsvoordele</string>
     <string name="upgrade_screen_how_title">Hoe om te help</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">ደጋፊ ከ%s ጀምሮ</string>
     <string name="upgrade_foss_supporter_thanks">የCAPod ልማትን ስለደገፉ እናመሰግናለን!</string>
     <string name="upgrade_foss_sponsor_again_action">የስፖንሰር ገጽን ክፈት</string>
-    <string name="settings_upgrade_status_label">CAPod ን ደግፍ</string>
+    <string name="upgrade_foss_sponsor_label">CAPod ን ደግፍ</string>
     <string name="settings_upgrade_status_description">የእርስዎ ደጋፊ ሁኔታ።</string>
     <string name="upgrade_screen_why_title">የማሻሻል ጥቅማጥቅሞች</string>
     <string name="upgrade_screen_how_title">እንዴት መርዳት እንደሚችሉ</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">داعم منذ %s</string>
     <string name="upgrade_foss_supporter_thanks">شكرًا لدعمك تطوير CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">فتح صفحة الرعاية</string>
-    <string name="settings_upgrade_status_label">دعم كابود</string>
+    <string name="upgrade_foss_sponsor_label">دعم كابود</string>
     <string name="settings_upgrade_status_description">حالة دعمك.</string>
     <string name="upgrade_screen_why_title">مزايا الترقية</string>
     <string name="upgrade_screen_how_title">كيفية المساعدة</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s tarixindən bəri dəstəkçi</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-un inkişafını dəstəklədiyiniz üçün təşəkkürlər!</string>
     <string name="upgrade_foss_sponsor_again_action">Sponsor səhifəsini aç</string>
-    <string name="settings_upgrade_status_label">CAPod-u sponsorlaşdırın</string>
+    <string name="upgrade_foss_sponsor_label">CAPod-u sponsorlaşdırın</string>
     <string name="settings_upgrade_status_description">Sizin tərəfdar statusu.</string>
     <string name="upgrade_screen_why_title">Yüksəltmə üstünləri</string>
     <string name="upgrade_screen_how_title">Necə kömək etmək</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Спонсар з %s</string>
     <string name="upgrade_foss_supporter_thanks">Дзякуй за падтрымку развіцця CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Адкрыць старонку спонсарства</string>
-    <string name="settings_upgrade_status_label">Спонсараваць CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Спонсараваць CAPod</string>
     <string name="settings_upgrade_status_description">Ваш статус прыхільніка.</string>
     <string name="upgrade_screen_why_title">Перавагі абнаўлення</string>
     <string name="upgrade_screen_how_title">Як дапамагчы</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Поддържник от %s</string>
     <string name="upgrade_foss_supporter_thanks">Благодарим ви, че подкрепяте развитието на CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Отвори страницата за спонсорство</string>
-    <string name="settings_upgrade_status_label">Спонсорирайте CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Спонсорирайте CAPod</string>
     <string name="settings_upgrade_status_description">Вашият статус на поддръжник.</string>
     <string name="upgrade_screen_why_title">Преимущества на надстройката</string>
     <string name="upgrade_screen_how_title">Как да помогнете</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s থেকে সমর্থক</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-এর উন্নয়নে সমর্থন করার জন্য আপনাকে ধন্যবাদ!</string>
     <string name="upgrade_foss_sponsor_again_action">স্পনসর পৃষ্ঠা খুলুন</string>
-    <string name="settings_upgrade_status_label">CAPod-কে স্পন্সর করুন</string>
+    <string name="upgrade_foss_sponsor_label">CAPod-কে স্পন্সর করুন</string>
     <string name="settings_upgrade_status_description">আপনার সমর্থক স্থিতি।</string>
     <string name="upgrade_screen_why_title">আপগ্রেড সুবিধা</string>
     <string name="upgrade_screen_how_title">কিভাবে সাহায্য করতে পারি</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Col·laborador des de %s</string>
     <string name="upgrade_foss_supporter_thanks">Gràcies per donar suport al desenvolupament del CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Obre la pàgina del patrocinador</string>
-    <string name="settings_upgrade_status_label">Patrocineu el CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Patrocineu el CAPod</string>
     <string name="settings_upgrade_status_description">El vostre estat de col·laborador.</string>
     <string name="upgrade_screen_why_title">Beneficis de la millora</string>
     <string name="upgrade_screen_how_title">Com ajudar</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Podporovatel od %s</string>
     <string name="upgrade_foss_supporter_thanks">Děkujeme za podporu vývoje CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Otevřít stránku sponzora</string>
-    <string name="settings_upgrade_status_label">Sponzorovat CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponzorovat CAPod</string>
     <string name="settings_upgrade_status_description">Váš stav podporovatele.</string>
     <string name="upgrade_screen_why_title">Výhody upgradu</string>
     <string name="upgrade_screen_how_title">Jak pomoci</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Støtte siden %s</string>
     <string name="upgrade_foss_supporter_thanks">Tak fordi du støtter udviklingen af CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Åbn sponsorside</string>
-    <string name="settings_upgrade_status_label">Sponsor CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsor CAPod</string>
     <string name="settings_upgrade_status_description">Din supporterstatus.</string>
     <string name="upgrade_screen_why_title">Opgraderingens fordele</string>
     <string name="upgrade_screen_how_title">Sådan hjælper du</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Unterstützer seit %s</string>
     <string name="upgrade_foss_supporter_thanks">Vielen Dank, dass du die Entwicklung von CAPod unterstützt!</string>
     <string name="upgrade_foss_sponsor_again_action">Sponsoring-Seite öffnen</string>
-    <string name="settings_upgrade_status_label">CAPod unterstützen</string>
+    <string name="upgrade_foss_sponsor_label">CAPod unterstützen</string>
     <string name="settings_upgrade_status_description">Dein Unterstützerstatus.</string>
     <string name="upgrade_screen_why_title">Vorteile des Upgrades</string>
     <string name="upgrade_screen_how_title">Wie man hilft</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Υποστηρικτής από %s</string>
     <string name="upgrade_foss_supporter_thanks">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη του CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Άνοιγμα σελίδας χορηγίας</string>
-    <string name="settings_upgrade_status_label">Χορηγήστε το CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Χορηγήστε το CAPod</string>
     <string name="settings_upgrade_status_description">Η κατάστασή σας ως υποστηρικτή.</string>
     <string name="upgrade_screen_why_title">Πλεονεκτήματα αναβάθμισης</string>
     <string name="upgrade_screen_how_title">Πώς να βοηθήσετε</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">¡Gracias por apoyar el desarrollo de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocinio</string>
-    <string name="settings_upgrade_status_label">Apoyá CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Apoyá CAPod</string>
     <string name="settings_upgrade_status_description">Tu estado de patrocinador.</string>
     <string name="upgrade_screen_why_title">Beneficios de la mejora</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">¡Gracias por apoyar el desarrollo de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocinio</string>
-    <string name="settings_upgrade_status_label">Patrocina CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Patrocina CAPod</string>
     <string name="settings_upgrade_status_description">Tu estado de patrocinador.</string>
     <string name="upgrade_screen_why_title">Beneficios de la actualización</string>
     <string name="upgrade_screen_how_title">Cómo ayudar</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">¡Gracias por apoyar el desarrollo de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocinio</string>
-    <string name="settings_upgrade_status_label">Patrocinar CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Patrocinar CAPod</string>
     <string name="settings_upgrade_status_description">Tu estado como patrocinador.</string>
     <string name="upgrade_screen_why_title">Beneficios de la actualización</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Toetaja alates %s</string>
     <string name="upgrade_foss_supporter_thanks">Täname, et toetad CAPodi arendust!</string>
     <string name="upgrade_foss_sponsor_again_action">Ava sponsorlehekülg</string>
-    <string name="settings_upgrade_status_label">Rahasta CAPodi</string>
+    <string name="upgrade_foss_sponsor_label">Rahasta CAPodi</string>
     <string name="settings_upgrade_status_description">Sinu toetaja staatus.</string>
     <string name="upgrade_screen_why_title">Uuendamise eelised</string>
     <string name="upgrade_screen_how_title">Kuidas aidata?</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Laguntzaile %s(e)tik aurrera</string>
     <string name="upgrade_foss_supporter_thanks">Eskerrik asko CAPod-en garapena babesten duzulako!</string>
     <string name="upgrade_foss_sponsor_again_action">Ireki babesle-orria</string>
-    <string name="settings_upgrade_status_label">CAPod babeslatu</string>
+    <string name="upgrade_foss_sponsor_label">CAPod babeslatu</string>
     <string name="settings_upgrade_status_description">Zure babesle egoera</string>
     <string name="upgrade_screen_why_title">Hobekuntza-onurak</string>
     <string name="upgrade_screen_how_title">Nola lagundu</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">حامی از %s</string>
     <string name="upgrade_foss_supporter_thanks">از حمایت شما از توسعه CAPod سپاسگزاریم!</string>
     <string name="upgrade_foss_sponsor_again_action">باز کردن صفحه حمایت مالی</string>
-    <string name="settings_upgrade_status_label">حمایت از CAPod</string>
+    <string name="upgrade_foss_sponsor_label">حمایت از CAPod</string>
     <string name="settings_upgrade_status_description">وضعیت حمایتی شما.</string>
     <string name="upgrade_screen_why_title">مزایای ارتقا</string>
     <string name="upgrade_screen_how_title">چگونه کمک کنیم</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Tukija %s lähtien</string>
     <string name="upgrade_foss_supporter_thanks">Kiitos, että tuet CAPodin kehitystä!</string>
     <string name="upgrade_foss_sponsor_again_action">Avaa sponsorisivu</string>
-    <string name="settings_upgrade_status_label">Tue CAPodia</string>
+    <string name="upgrade_foss_sponsor_label">Tue CAPodia</string>
     <string name="settings_upgrade_status_description">Kannattajantila</string>
     <string name="upgrade_screen_why_title">Päivityksen edut</string>
     <string name="upgrade_screen_how_title">Kuinka auttaa</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Tagasuporta simula %s</string>
     <string name="upgrade_foss_supporter_thanks">Salamat sa pagsuporta sa development ng CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Buksan ang sponsor page</string>
-    <string name="settings_upgrade_status_label">Suportahan ang CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Suportahan ang CAPod</string>
     <string name="settings_upgrade_status_description">Ang iyong status bilang supporter.</string>
     <string name="upgrade_screen_why_title">Mga benepisyo ng upgrade</string>
     <string name="upgrade_screen_how_title">Paano tumulong</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Soutien depuis %s</string>
     <string name="upgrade_foss_supporter_thanks">Merci de soutenir le développement de CAPod !</string>
     <string name="upgrade_foss_sponsor_again_action">Ouvrir la page de parrainage</string>
-    <string name="settings_upgrade_status_label">Soutenir CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Soutenir CAPod</string>
     <string name="settings_upgrade_status_description">Votre statut de supporter.</string>
     <string name="upgrade_screen_why_title">Avantages de la mise à niveau</string>
     <string name="upgrade_screen_how_title">Comment aider</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Colaborador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">Grazas por apoiar o desenvolvemento de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir a páxina de patrocinio</string>
-    <string name="settings_upgrade_status_label">Apoia CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Apoia CAPod</string>
     <string name="settings_upgrade_status_description">O teu estado de apoiador.</string>
     <string name="upgrade_screen_why_title">Vantaxes da actualización</string>
     <string name="upgrade_screen_how_title">Como axudar</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s से समर्थक</string>
     <string name="upgrade_foss_supporter_thanks">CAPod के विकास का समर्थन करने के लिए धन्यवाद!</string>
     <string name="upgrade_foss_sponsor_again_action">स्पॉन्सर पेज खोलें</string>
-    <string name="settings_upgrade_status_label">CAPod को प्रायोजित करें</string>
+    <string name="upgrade_foss_sponsor_label">CAPod को प्रायोजित करें</string>
     <string name="settings_upgrade_status_description">आपकी समर्थक स्थिति।</string>
     <string name="upgrade_screen_why_title">अपग्रेड के लाभ</string>
     <string name="upgrade_screen_how_title">कैसे सहायता करें</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Podržavatelj od %s</string>
     <string name="upgrade_foss_supporter_thanks">Hvala vam što podržavate razvoj CAPoda!</string>
     <string name="upgrade_foss_sponsor_again_action">Otvori stranicu za sponzoriranje</string>
-    <string name="settings_upgrade_status_label">Sponzorirajte CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponzorirajte CAPod</string>
     <string name="settings_upgrade_status_description">Vaš status sponzora</string>
     <string name="upgrade_screen_why_title">Prednosti nadogradnje</string>
     <string name="upgrade_screen_how_title">Kako pomoći</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Támogató %s óta</string>
     <string name="upgrade_foss_supporter_thanks">Köszönjük, hogy támogatod a CAPod fejlesztését!</string>
     <string name="upgrade_foss_sponsor_again_action">Támogatói oldal megnyitása</string>
-    <string name="settings_upgrade_status_label">Támogasson CAPod-ot</string>
+    <string name="upgrade_foss_sponsor_label">Támogasson CAPod-ot</string>
     <string name="settings_upgrade_status_description">Az Ön támogató státusza.</string>
     <string name="upgrade_screen_why_title">Frissítési előnyök</string>
     <string name="upgrade_screen_how_title">Hogyan lehet segíteni</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Հովանավոր է %s-ից</string>
     <string name="upgrade_foss_supporter_thanks">Շնորհակալություն CAPod-ի զարգացումն աջակցելու համար!</string>
     <string name="upgrade_foss_sponsor_again_action">Բացել հովանավորության էջը</string>
-    <string name="settings_upgrade_status_label">Աջակեք CAPod-ին</string>
+    <string name="upgrade_foss_sponsor_label">Աջակեք CAPod-ին</string>
     <string name="settings_upgrade_status_description">Ձեր աջակցողի վիճակը:</string>
     <string name="upgrade_screen_why_title">Թարմացման առավելությունները</string>
     <string name="upgrade_screen_how_title">Ինչպես օգնել</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Pendukung sejak %s</string>
     <string name="upgrade_foss_supporter_thanks">Terima kasih karena telah mendukung pengembangan CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Buka halaman sponsor</string>
-    <string name="settings_upgrade_status_label">Sponsori CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsori CAPod</string>
     <string name="settings_upgrade_status_description">Status pendukung Anda.</string>
     <string name="upgrade_screen_why_title">Manfaat upgrade</string>
     <string name="upgrade_screen_how_title">Cara membantu</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Styrktaraðili síðan %s</string>
     <string name="upgrade_foss_supporter_thanks">Takk fyrir að styðja þróun CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Opna styrktarsíðu</string>
-    <string name="settings_upgrade_status_label">Styrktu CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Styrktu CAPod</string>
     <string name="settings_upgrade_status_description">Staða þín sem stuðningsmaður</string>
     <string name="upgrade_screen_why_title">Uppfærslukostir</string>
     <string name="upgrade_screen_how_title">Hvernig á að hjálpa</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Sostenitore dal %s</string>
     <string name="upgrade_foss_supporter_thanks">Grazie per supportare lo sviluppo di CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Apri la pagina sponsor</string>
-    <string name="settings_upgrade_status_label">Sponsorizza CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsorizza CAPod</string>
     <string name="settings_upgrade_status_description">Il tuo status di sostenitore.</string>
     <string name="upgrade_screen_why_title">Vantaggi dell\'aggiornamento</string>
     <string name="upgrade_screen_how_title">Come aiutare</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">תומך מאז %s</string>
     <string name="upgrade_foss_supporter_thanks">תודה שאתה תומך בפיתוח של CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">פתח את דף התמיכה</string>
-    <string name="settings_upgrade_status_label">תמוך ב-CAPod</string>
+    <string name="upgrade_foss_sponsor_label">תמוך ב-CAPod</string>
     <string name="settings_upgrade_status_description">סטטוס התומך שלך.</string>
     <string name="upgrade_screen_why_title">יתרונות השדרוג</string>
     <string name="upgrade_screen_how_title">איך לעזור</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%sからのサポーター</string>
     <string name="upgrade_foss_supporter_thanks">CAPodの開発を支援していただきありがとうございます!</string>
     <string name="upgrade_foss_sponsor_again_action">スポンサーページを開く</string>
-    <string name="settings_upgrade_status_label">CAPod をスポンサーする</string>
+    <string name="upgrade_foss_sponsor_label">CAPod をスポンサーする</string>
     <string name="settings_upgrade_status_description">サポーターステータス。</string>
     <string name="upgrade_screen_why_title">アップグレードの特典</string>
     <string name="upgrade_screen_how_title">協力するには</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">მხარდამჭერი %s-დან</string>
     <string name="upgrade_foss_supporter_thanks">მადლობა CAPod-ის განვითარების მხარდაჭერისთვის!</string>
     <string name="upgrade_foss_sponsor_again_action">სპონსორის გვერდის გახსნა</string>
-    <string name="settings_upgrade_status_label">მხარი დაუჭიროთ CAPod-ს</string>
+    <string name="upgrade_foss_sponsor_label">მხარი დაუჭიროთ CAPod-ს</string>
     <string name="settings_upgrade_status_description">თქვენი მხარდამჭერის მდგომარეობა.</string>
     <string name="upgrade_screen_why_title">განახლების უპირატესობები</string>
     <string name="upgrade_screen_how_title">როგორ დაგეხმაროთ</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">អ្នកគាំទ្រតាំងពី %s</string>
     <string name="upgrade_foss_supporter_thanks">សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍ CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">បើកទំព័រឧបត្ថម្ភ</string>
-    <string name="settings_upgrade_status_label">ឧបត្ថម្ភ CAPod</string>
+    <string name="upgrade_foss_sponsor_label">ឧបត្ថម្ភ CAPod</string>
     <string name="settings_upgrade_status_description">ស្ថានភាពអ្នកគាំទ្ររបស់អ្នក។</string>
     <string name="upgrade_screen_why_title">អត្ថប្រយោជន៍លើកកម្ពស់</string>
     <string name="upgrade_screen_how_title">របៀបជួយ</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Piştgir ji %s ve</string>
     <string name="upgrade_foss_supporter_thanks">Spas ji bo piştgiriya te ya pêşxistina CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Rûpela piştgiriyê veke</string>
-    <string name="settings_upgrade_status_label">CAPod-ê piştgirî bike</string>
+    <string name="upgrade_foss_sponsor_label">CAPod-ê piştgirî bike</string>
     <string name="settings_upgrade_status_description">Rewşa piştgiriya te.</string>
     <string name="upgrade_screen_why_title">Feydeyên Bardiyê</string>
     <string name="upgrade_screen_how_title">Çawa Alîkarî Bike</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s ರಿಂದ ಬೆಂಬಲಿಗ</string>
     <string name="upgrade_foss_supporter_thanks">CAPod ಅಭಿವೃದ್ಧಿಗೆ ಬೆಂಬಲ ನೀಡಿದ್ದಕ್ಕಾಗಿ ಧನ್ಯವಾದಗಳು!</string>
     <string name="upgrade_foss_sponsor_again_action">ಪ್ರಾಯೋಜಕ ಪುಟ ತೆರೆಯಿರಿ</string>
-    <string name="settings_upgrade_status_label">CAPod ಬೆಂಬಲಿಸಿ</string>
+    <string name="upgrade_foss_sponsor_label">CAPod ಬೆಂಬಲಿಸಿ</string>
     <string name="settings_upgrade_status_description">ನಿಮ್ಮ ಬೆಂಬಲಕಾರ ಸ್ಥಿತಿ.</string>
     <string name="upgrade_screen_why_title">ನವೀಕರಣ ಪ್ರಯೋಜನಗಳು</string>
     <string name="upgrade_screen_how_title">ಸಹಾಯ ಮಾಡುವುದು ಹೇಗೆ</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s부터 후원자</string>
     <string name="upgrade_foss_supporter_thanks">CAPod 개발을 후원해 주셔서 감사합니다!</string>
     <string name="upgrade_foss_sponsor_again_action">후원 페이지 열기</string>
-    <string name="settings_upgrade_status_label">CAPod 후원하기</string>
+    <string name="upgrade_foss_sponsor_label">CAPod 후원하기</string>
     <string name="settings_upgrade_status_description">후원자 상태</string>
     <string name="upgrade_screen_why_title">업그레이드 혜택</string>
     <string name="upgrade_screen_how_title">도움 주기</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s\'дан бери колдоочу</string>
     <string name="upgrade_foss_supporter_thanks">CAPod\'дун өнүгүшүн колдогонуңуз үчүн рахмат!</string>
     <string name="upgrade_foss_sponsor_again_action">Демөөрчүлүк баракчасын ачуу</string>
-    <string name="settings_upgrade_status_label">CAPod-ды спонсорлоо</string>
+    <string name="upgrade_foss_sponsor_label">CAPod-ды спонсорлоо</string>
     <string name="settings_upgrade_status_description">Колдоочу абалы</string>
     <string name="upgrade_screen_why_title">Жогорулоонун пайдалары</string>
     <string name="upgrade_screen_how_title">Жардам бергүүнүн жолу</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">ຜູ້ສະໜັບສະໜູນຕັ້ງແຕ່ %s</string>
     <string name="upgrade_foss_supporter_thanks">ຂອບຊູ່ສຳລັບການສະໜັບສະໜູນການພັດທະນາຂອງ CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">ເປິດໝ້າສະໜັບສະໜູນ</string>
-    <string name="settings_upgrade_status_label">ສະໜັບສະໜູນ CAPod</string>
+    <string name="upgrade_foss_sponsor_label">ສະໜັບສະໜູນ CAPod</string>
     <string name="settings_upgrade_status_description">ສະຖານະຜູ້ສະໜັບສະໜູນຂອງທ່ານ</string>
     <string name="upgrade_screen_why_title">ປະໂຫຍດຂອງການອັບເກຣດ</string>
     <string name="upgrade_screen_how_title">ວິທີການຊ່ວຍເຫຼືອ</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Rėmėjas nuo %s</string>
     <string name="upgrade_foss_supporter_thanks">Ačiū, kad remiate CAPod kūrimą!</string>
     <string name="upgrade_foss_sponsor_again_action">Atidaryti rėmėjo puslapį</string>
-    <string name="settings_upgrade_status_label">Remti CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Remti CAPod</string>
     <string name="settings_upgrade_status_description">Jūsų rėmėjo statusas.</string>
     <string name="upgrade_screen_why_title">Atnaujinimo privalumai</string>
     <string name="upgrade_screen_how_title">Kaip padėti</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Atbalstītājs kopš %s</string>
     <string name="upgrade_foss_supporter_thanks">Paldies, ka atbalsti CAPod izstrādi!</string>
     <string name="upgrade_foss_sponsor_again_action">Atvērt sponsorēšanas lapu</string>
-    <string name="settings_upgrade_status_label">Atbalstīt CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Atbalstīt CAPod</string>
     <string name="settings_upgrade_status_description">Jūsu atbalstītāja statuss.</string>
     <string name="upgrade_screen_why_title">Jaunināšanas priekšrocības</string>
     <string name="upgrade_screen_how_title">Kā palīdzēt</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Поддржувач од %s</string>
     <string name="upgrade_foss_supporter_thanks">Ти благодариме што го поддржуваш развојот на CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Отвори ја страницата за спонзорство</string>
-    <string name="settings_upgrade_status_label">Поддржи CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Поддржи CAPod</string>
     <string name="settings_upgrade_status_description">Твојот статус на поддржувач.</string>
     <string name="upgrade_screen_why_title">Предности на надградување</string>
     <string name="upgrade_screen_how_title">Како да помогнете</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s മുതൽ പിന്തുണക്കാൻ</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-ന്റെ വികസനത്തെ പിന്തുണച്ചതിന് നന്ദി!</string>
     <string name="upgrade_foss_sponsor_again_action">സ്പോൺസർ പേജ് തുറക്കുക</string>
-    <string name="settings_upgrade_status_label">CAPod നെ സ്പോൺസർ ചെയ്യുക</string>
+    <string name="upgrade_foss_sponsor_label">CAPod നെ സ്പോൺസർ ചെയ്യുക</string>
     <string name="settings_upgrade_status_description">നിങ്ങളുടെ പിന്തുണയ സ്ഥിതി.</string>
     <string name="upgrade_screen_why_title">അപ്‌ഗ്രേഡ് നേട്ടങ്ങൾ</string>
     <string name="upgrade_screen_how_title">എങ്ങനെ സഹായിക്കാം</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s-с хойш дэмжигч</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-ын хөгжлийг дэмжсэнд баярлалаа!</string>
     <string name="upgrade_foss_sponsor_again_action">Дэмжигчийн хуудсыг нээх</string>
-    <string name="settings_upgrade_status_label">CAPod-ыг спонсорлох</string>
+    <string name="upgrade_foss_sponsor_label">CAPod-ыг спонсорлох</string>
     <string name="settings_upgrade_status_description">Таны дэмжигч статус.</string>
     <string name="upgrade_screen_why_title">Давуу талууд</string>
     <string name="upgrade_screen_how_title">Хэрхэн тусламж үзүүлэх</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s पासून समर्थक</string>
     <string name="upgrade_foss_supporter_thanks">CAPod च्या विकासाला पाठिंबा दिल्याबद्दल धन्यवाद!</string>
     <string name="upgrade_foss_sponsor_again_action">प्रायोजक पृष्ठ उघडा</string>
-    <string name="settings_upgrade_status_label">CAPod ला प्रायोजित करा</string>
+    <string name="upgrade_foss_sponsor_label">CAPod ला प्रायोजित करा</string>
     <string name="settings_upgrade_status_description">आपल्या समर्थक स्थिती.</string>
     <string name="upgrade_screen_why_title">अपग्रेड लाभ</string>
     <string name="upgrade_screen_how_title">मदत कसे करायची</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Penyokong sejak %s</string>
     <string name="upgrade_foss_supporter_thanks">Terima kasih kerana menyokong pembangunan CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Buka halaman penaja</string>
-    <string name="settings_upgrade_status_label">Menajakan CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Menajakan CAPod</string>
     <string name="settings_upgrade_status_description">Status penyokong anda.</string>
     <string name="upgrade_screen_why_title">Manfaat peningkatan</string>
     <string name="upgrade_screen_how_title">Bagaimana untuk membantu</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s မှစ၍ ပံ့ပိုးသူ</string>
     <string name="upgrade_foss_supporter_thanks">CAPod ၏ ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည်!</string>
     <string name="upgrade_foss_sponsor_again_action">ပံ့ပိုးသူစာမျက်နှာကို ဖွင့်ပါ</string>
-    <string name="settings_upgrade_status_label">CAPod ကို ပံ့ပိုးပါ</string>
+    <string name="upgrade_foss_sponsor_label">CAPod ကို ပံ့ပိုးပါ</string>
     <string name="settings_upgrade_status_description">သင်၏ ပံ့ပိုးသူ အခြေအနေ။</string>
     <string name="upgrade_screen_why_title">အဆင့်မြှင့်တင်မှု အကျိုးအကျေးမများ</string>
     <string name="upgrade_screen_how_title">ကူညီနည်းလမ်း</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Støttespiller siden %s</string>
     <string name="upgrade_foss_supporter_thanks">Takk for at du støtter utviklingen av CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Åpne sponsorside</string>
-    <string name="settings_upgrade_status_label">Støtt CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Støtt CAPod</string>
     <string name="settings_upgrade_status_description">Din status som støtter.</string>
     <string name="upgrade_screen_why_title">Oppgraderingsfordeler</string>
     <string name="upgrade_screen_how_title">Hvordan hjelpe</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s देखि समर्थक</string>
     <string name="upgrade_foss_supporter_thanks">CAPod को विकासलाई समर्थन गर्नुभएकोमा धन्यवाद!</string>
     <string name="upgrade_foss_sponsor_again_action">प्रायोजक पृष्ठ खोल्नुहोस्</string>
-    <string name="settings_upgrade_status_label">CAPod को प्रायोजन गर्नुहोस्</string>
+    <string name="upgrade_foss_sponsor_label">CAPod को प्रायोजन गर्नुहोस्</string>
     <string name="settings_upgrade_status_description">आफ्नो समर्थक स्थिति।</string>
     <string name="upgrade_screen_why_title">अपग्रेड लाभहरु</string>
     <string name="upgrade_screen_how_title">कसरी मद्दत गर्ने</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Supporter sinds %s</string>
     <string name="upgrade_foss_supporter_thanks">Bedankt voor je steun aan de ontwikkeling van CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Open de sponsorpagina</string>
-    <string name="settings_upgrade_status_label">Sponsor CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsor CAPod</string>
     <string name="settings_upgrade_status_description">Je ondersteunersstatus.</string>
     <string name="upgrade_screen_why_title">Voordelen van de upgrade</string>
     <string name="upgrade_screen_how_title">Hoe kun je helpen</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Wspierający od %s</string>
     <string name="upgrade_foss_supporter_thanks">Dziękuję za wsparcie rozwoju CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Otwórz stronę wspierającego</string>
-    <string name="settings_upgrade_status_label">Sponsoruj CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsoruj CAPod</string>
     <string name="settings_upgrade_status_description">Status twojego wsparcia.</string>
     <string name="upgrade_screen_why_title">Korzyści z uaktualnienia</string>
     <string name="upgrade_screen_how_title">Jak pomóc</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Apoiador desde %s</string>
     <string name="upgrade_foss_supporter_thanks">Obrigado por apoiar o desenvolvimento do CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocínio</string>
-    <string name="settings_upgrade_status_label">Patrocine o CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Patrocine o CAPod</string>
     <string name="settings_upgrade_status_description">Seu status de apoiador.</string>
     <string name="upgrade_screen_why_title">Benefícios da atualização</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Apoiante desde %s</string>
     <string name="upgrade_foss_supporter_thanks">Obrigado por apoiares o desenvolvimento do CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Abrir página de patrocínio</string>
-    <string name="settings_upgrade_status_label">Apoie o CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Apoie o CAPod</string>
     <string name="settings_upgrade_status_description">O seu estado de apoiante.</string>
     <string name="upgrade_screen_why_title">Benefícios da atualização</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Sustegnider dapi %s</string>
     <string name="upgrade_foss_supporter_thanks">Grazia per sustegnair il svilup da CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Avrir la pagina da sponsurisaziun</string>
-    <string name="settings_upgrade_status_label">Sponsurar CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsurar CAPod</string>
     <string name="settings_upgrade_status_description">Tes status da supporter.</string>
     <string name="upgrade_screen_why_title">Bials da l\'upgrade</string>
     <string name="upgrade_screen_how_title">Sco gidar</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Susținător din %s</string>
     <string name="upgrade_foss_supporter_thanks">Mulțumim că sprijini dezvoltarea CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Deschide pagina de sponsorizare</string>
-    <string name="settings_upgrade_status_label">Sponsorizează CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsorizează CAPod</string>
     <string name="settings_upgrade_status_description">Statusul tău de susținător.</string>
     <string name="upgrade_screen_why_title">Beneficiile upgrade-ului</string>
     <string name="upgrade_screen_how_title">Cum să ajuți</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Спонсор с %s</string>
     <string name="upgrade_foss_supporter_thanks">Спасибо за поддержку разработки CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Открыть страницу спонсорства</string>
-    <string name="settings_upgrade_status_label">Поддержать CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Поддержать CAPod</string>
     <string name="settings_upgrade_status_description">Статус Вашей поддержки.</string>
     <string name="upgrade_screen_why_title">Преимущества обновления</string>
     <string name="upgrade_screen_how_title">Как помочь</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Sustentadore dae su %s</string>
     <string name="upgrade_foss_supporter_thanks">Gràtzias pro sustènnere s\'isvilupu de CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Aberi sa pàgina de sponsorizatzione</string>
-    <string name="settings_upgrade_status_label">Sostene CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sostene CAPod</string>
     <string name="settings_upgrade_status_description">S\'istadu tuo de sustentadore.</string>
     <string name="upgrade_screen_why_title">Benefitzios de s\'agiornamentu</string>
     <string name="upgrade_screen_how_title">Comente agiudare</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s සිට අනුග්‍රාහකයෙකි</string>
     <string name="upgrade_foss_supporter_thanks">CAPod හි සංවර්ධනයට සහාය දැක්වූ ඔබට ස්තූතියි!</string>
     <string name="upgrade_foss_sponsor_again_action">අනුග්‍රාහක පිටුව විවෘත කරන්න</string>
-    <string name="settings_upgrade_status_label">CAPod සඳහා අනුග්‍රහක්</string>
+    <string name="upgrade_foss_sponsor_label">CAPod සඳහා අනුග්‍රහක්</string>
     <string name="settings_upgrade_status_description">ඔබේ සහයෝගිතා තත්‍වය.</string>
     <string name="upgrade_screen_why_title">උඩ්ග්‍රේඩ් ප්‍රතිලාභ</string>
     <string name="upgrade_screen_how_title">උදව් කරන්නේ කෙසේද</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Podporovateľ od %s</string>
     <string name="upgrade_foss_supporter_thanks">Ďakujeme, že podporujete vývoj CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Otvoriť stránku sponzorstva</string>
-    <string name="settings_upgrade_status_label">Podporiť CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Podporiť CAPod</string>
     <string name="settings_upgrade_status_description">Váš status podporovateľa.</string>
     <string name="upgrade_screen_why_title">Výhody upgradu</string>
     <string name="upgrade_screen_how_title">Ako pomôcť</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Podpornik od %s</string>
     <string name="upgrade_foss_supporter_thanks">Hvala, ker podpirate razvoj CAPod-a!</string>
     <string name="upgrade_foss_sponsor_again_action">Odpri stran za sponzorstvo</string>
-    <string name="settings_upgrade_status_label">Podpri CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Podpri CAPod</string>
     <string name="settings_upgrade_status_description">Tvoj status podpornika.</string>
     <string name="upgrade_screen_why_title">Prednosti nadgradnje</string>
     <string name="upgrade_screen_how_title">Kako pomagati.</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Mbështetës që nga %s</string>
     <string name="upgrade_foss_supporter_thanks">Faleminderit për mbështetjen e zhvillimit të CAPod-it!</string>
     <string name="upgrade_foss_sponsor_again_action">Hap faqen e sponsorizimit</string>
-    <string name="settings_upgrade_status_label">Mbështesni CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Mbështesni CAPod</string>
     <string name="settings_upgrade_status_description">Statusi juaj si mbështetës.</string>
     <string name="upgrade_screen_why_title">Përfitime të përmirësimit</string>
     <string name="upgrade_screen_how_title">Si të ndihmoj</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Подржавалац од %s</string>
     <string name="upgrade_foss_supporter_thanks">Хвала вам што подржавате развој CAPod-а!</string>
     <string name="upgrade_foss_sponsor_again_action">Отворите страницу за спонзорство</string>
-    <string name="settings_upgrade_status_label">Подржите CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Подржите CAPod</string>
     <string name="settings_upgrade_status_description">Статус вашег подржавања.</string>
     <string name="upgrade_screen_why_title">Предности надградње</string>
     <string name="upgrade_screen_how_title">Како помоћи</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Supporter sedan %s</string>
     <string name="upgrade_foss_supporter_thanks">Tack för att du stödjer utvecklingen av CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Öppna sponsorsidan</string>
-    <string name="settings_upgrade_status_label">Sponsra CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsra CAPod</string>
     <string name="settings_upgrade_status_description">Din supporterstatus.</string>
     <string name="upgrade_screen_why_title">Uppgraderingsfördelar</string>
     <string name="upgrade_screen_how_title">Hur du kan hjälpa</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Msaidizi tangu %s</string>
     <string name="upgrade_foss_supporter_thanks">Asante kwa kuunga mkono maendeleo ya CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Fungua ukurasa wa udhamini</string>
-    <string name="settings_upgrade_status_label">Kuunga mkono CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Kuunga mkono CAPod</string>
     <string name="settings_upgrade_status_description">Hali yako ya kuunga mkono.</string>
     <string name="upgrade_screen_why_title">Faida za kuboreshwa</string>
     <string name="upgrade_screen_how_title">Jinsi ya kusaidia</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s முதல் ஆதரவாளர்</string>
     <string name="upgrade_foss_supporter_thanks">CAPod-இன் மேம்பாட்டை ஆதரித்ததற்கு நன்றி!</string>
     <string name="upgrade_foss_sponsor_again_action">ஸ்பான்சர் பக்கத்தைத் திற</string>
-    <string name="settings_upgrade_status_label">CAPod ஐ ஆதரிக்கவும்</string>
+    <string name="upgrade_foss_sponsor_label">CAPod ஐ ஆதரிக்கவும்</string>
     <string name="settings_upgrade_status_description">உங்கள் ஆதரவாளர் நிலை.</string>
     <string name="upgrade_screen_why_title">மேம்படுத்தல் நன்மைகள்</string>
     <string name="upgrade_screen_how_title">எப்படி உதவுவது</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s నుండి సపోర్టర్</string>
     <string name="upgrade_foss_supporter_thanks">CAPod అభివృద్ధికి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు!</string>
     <string name="upgrade_foss_sponsor_again_action">స్పాన్సర్ పేజీని తెరవండి</string>
-    <string name="settings_upgrade_status_label">CAPodకు స్పాన్సర్ చేయండి</string>
+    <string name="upgrade_foss_sponsor_label">CAPodకు స్పాన్సర్ చేయండి</string>
     <string name="settings_upgrade_status_description">మీ సపోర్టర్ స్థితి.</string>
     <string name="upgrade_screen_why_title">అప్‌గ్రేడ్ ప్రయోజనాలు</string>
     <string name="upgrade_screen_how_title">ఎలా సహాయం చేయాలి</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">ผู้สนับสนุนตั้งแต่ %s</string>
     <string name="upgrade_foss_supporter_thanks">ขอบคุณที่สนับสนุนการพัฒนา CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">เปิดหน้าสนับสนุน</string>
-    <string name="settings_upgrade_status_label">สนับสนุน CAPod</string>
+    <string name="upgrade_foss_sponsor_label">สนับสนุน CAPod</string>
     <string name="settings_upgrade_status_description">สถานะผู้สนับสนุนของคุณ</string>
     <string name="upgrade_screen_why_title">ประโยชน์ของการอัปเกรด</string>
     <string name="upgrade_screen_how_title">วิธีการช่วยเหลือ</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s tarihinden beri destekçi</string>
     <string name="upgrade_foss_supporter_thanks">CAPod\'un geliştirilmesini desteklediğin için teşekkürler!</string>
     <string name="upgrade_foss_sponsor_again_action">Sponsor sayfasını aç</string>
-    <string name="settings_upgrade_status_label">CAPod\'u destekle</string>
+    <string name="upgrade_foss_sponsor_label">CAPod\'u destekle</string>
     <string name="settings_upgrade_status_description">Destekçi durumun.</string>
     <string name="upgrade_screen_why_title">Yükseltme Avantajları</string>
     <string name="upgrade_screen_how_title">Nasıl yardım edilir</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Підтримує з %s</string>
     <string name="upgrade_foss_supporter_thanks">Дякуємо за підтримку розробки CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Відкрити сторінку спонсорства</string>
-    <string name="settings_upgrade_status_label">Спонсорувати CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Спонсорувати CAPod</string>
     <string name="settings_upgrade_status_description">Ваш статус прихильника.</string>
     <string name="upgrade_screen_why_title">Переваги оновлення</string>
     <string name="upgrade_screen_how_title">Як допомогти</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s سے سپورٹر</string>
     <string name="upgrade_foss_supporter_thanks">CAPod کی ترقی کی حمایت کرنے کا شکریہ!</string>
     <string name="upgrade_foss_sponsor_again_action">سپانسر پیج کھولیں</string>
-    <string name="settings_upgrade_status_label">CAPod کی سرپرستی کریں</string>
+    <string name="upgrade_foss_sponsor_label">CAPod کی سرپرستی کریں</string>
     <string name="settings_upgrade_status_description">آپ کی حامی حالت۔</string>
     <string name="upgrade_screen_why_title">اپ گریڈ کے فوائد</string>
     <string name="upgrade_screen_how_title">کیسے مدد کریں</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">%s dan beri homiy</string>
     <string name="upgrade_foss_supporter_thanks">CAPod rivojlanishini qo\'llab-quvvatlaganingiz uchun rahmat!</string>
     <string name="upgrade_foss_sponsor_again_action">Homiylik sahifasini ochish</string>
-    <string name="settings_upgrade_status_label">CAPod ni homiylik qiling</string>
+    <string name="upgrade_foss_sponsor_label">CAPod ni homiylik qiling</string>
     <string name="settings_upgrade_status_description">Sizning homiy holati.</string>
     <string name="upgrade_screen_why_title">Yangilashning afzalliklari</string>
     <string name="upgrade_screen_how_title">Qanday yordam berish</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Người ủng hộ từ %s</string>
     <string name="upgrade_foss_supporter_thanks">Cảm ơn bạn đã ủng hộ sự phát triển của CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Mở trang tài trợ</string>
-    <string name="settings_upgrade_status_label">Tài trợ cho CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Tài trợ cho CAPod</string>
     <string name="settings_upgrade_status_description">Trạng thái nhà tài trợ của bạn.</string>
     <string name="upgrade_screen_why_title">Lợi ích nâng cấp</string>
     <string name="upgrade_screen_how_title">Làm thế nào để giúp đỡ</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">自 %s 起成为支持者</string>
     <string name="upgrade_foss_supporter_thanks">感谢您支持 CAPod 的开发!</string>
     <string name="upgrade_foss_sponsor_again_action">打开赞助页面</string>
-    <string name="settings_upgrade_status_label">赞助 CAPod</string>
+    <string name="upgrade_foss_sponsor_label">赞助 CAPod</string>
     <string name="settings_upgrade_status_description">您的赞助者身份。</string>
     <string name="upgrade_screen_why_title">升级优势</string>
     <string name="upgrade_screen_how_title">如何帮助我们</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">自 %s 起成為贊助者</string>
     <string name="upgrade_foss_supporter_thanks">感謝你支持 CAPod 的開發！</string>
     <string name="upgrade_foss_sponsor_again_action">開啟贊助頁面</string>
-    <string name="settings_upgrade_status_label">贊助 CAPod</string>
+    <string name="upgrade_foss_sponsor_label">贊助 CAPod</string>
     <string name="settings_upgrade_status_description">您的贊助者身份。</string>
     <string name="upgrade_screen_why_title">升級優勢</string>
     <string name="upgrade_screen_how_title">如何協助</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">自 %s 起成為贊助者</string>
     <string name="upgrade_foss_supporter_thanks">感謝您支持 CAPod 的開發！</string>
     <string name="upgrade_foss_sponsor_again_action">開啟贊助頁面</string>
-    <string name="settings_upgrade_status_label">贊助 CAPod</string>
+    <string name="upgrade_foss_sponsor_label">贊助 CAPod</string>
     <string name="settings_upgrade_status_description">您的贊助狀態。</string>
     <string name="upgrade_screen_why_title">升級優勢</string>
     <string name="upgrade_screen_how_title">如何協助</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -10,7 +10,7 @@
     <string name="upgrade_foss_supporter_since">Umsekeli kusukela ngo-%s</string>
     <string name="upgrade_foss_supporter_thanks">Ngiyabonga ngokusekela ukuthuthukiswa kwe-CAPod!</string>
     <string name="upgrade_foss_sponsor_again_action">Vula ikhasi lomxhasi</string>
-    <string name="settings_upgrade_status_label">Uxhasa i-CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Uxhasa i-CAPod</string>
     <string name="settings_upgrade_status_description">Isimo sakho sokusekela.</string>
     <string name="upgrade_screen_why_title">Imikhulu yokuphucula</string>
     <string name="upgrade_screen_how_title">Indlela yokusiza</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="upgrade_foss_supporter_since">Supporter since %s</string>
     <string name="upgrade_foss_supporter_thanks">Thank you for supporting CAPod\'s development!</string>
     <string name="upgrade_foss_sponsor_again_action">Open sponsor page</string>
-    <string name="settings_upgrade_status_label">Sponsor CAPod</string>
+    <string name="upgrade_foss_sponsor_label">Sponsor CAPod</string>
     <string name="settings_upgrade_status_description">Your supporter status.</string>
     <string name="upgrade_screen_why_title">Upgrade benefits</string>
     <string name="upgrade_screen_how_title">How to help</string>

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -42,6 +42,12 @@ import eu.darken.capod.common.error.ErrorEventHandler
 import eu.darken.capod.common.navigation.NavigationEventHandler
 import eu.darken.capod.common.navigation.Nav
 
+// The Settings row reads this so it can't name the tier differently than this screen's own
+// composed title does. FOSS's counterpart in its own UpgradeScreen.kt stays a support ask instead
+// of the composed brand title; each flavor implementation lives only in its own source set.
+@Composable
+internal fun settingsUpgradeStatusTitle(): String = brandTitleText(includeQualifier = true)
+
 @Composable
 fun UpgradeScreenHost(
     route: Nav.Main.Upgrade = Nav.Main.Upgrade(),

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod het Google Play nou-nou gekontroleer, maar geen Pro-aankoop kon bevestig word vir die rekening wat Google Play vir hierdie app gebruik nie.</string>
     <string name="upgrade_screen_restore_contact_hint">Nog steeds vas? Neem kontak op met ondersteuning van die e-posadres wat die aankoop gemaak het en voeg jou Google Play-ordernommer by.</string>
     <string name="upgrade_screen_contact_support_action">Neem kontak op met ondersteuning</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Jou upgrade- en aankoopstatus.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en opgedateer? Is jou Google-rekening aangemeld? Probeer om die kas van die Google Play-toepassing skoon te maak en jou toestel herlaai.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod አሁን Google Play አረጋገጠ፣ ነገር ግን Google Play ለዚህ መተግበሪያ ጥቅም ላይ ስለሚውለው መለያ Pro ግዢ ማረጋገጥ አልተቻለም።</string>
     <string name="upgrade_screen_restore_contact_hint">አሁንም ችግር ካጋጠመዎት? ግዢውን ያደረገው ኢሜይል በመጠቀም ድጋፍ ያግኙ እና Google Play ትዕዛዝ ቁጥርዎን ያካትቱ።</string>
     <string name="upgrade_screen_contact_support_action">ድጋፍ ለማነጋገር</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">የእርስዎ ማሻሻያ እና ግዢ ሁኔታ።</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ከGoogle Play ጋር መገናኘት አይችልም። Google Play ተጭኖ እና ወቅታዊ ነው? የGoogle መለያዎ ገብቷል? የGoogle Play መተግበሪያ መሸጎጫ ማጥራት እና መሳሪያዎን እንደገና ማስጀመር ይሞክሩ።</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">تحقَّق كابود من جوجل بلاي، ولكن لم يتمّ تأكيد أيّ عملية اشتراء للنسخة الاحترافية للحساب الذي يستخدمه جوجل بلاي لهذا التطبيق.</string>
     <string name="upgrade_screen_restore_contact_hint">هل ما زلت تواجه مشكلة؟ تواصل مع الدعم من خلال البريد الإلكتروني الذي استخدمته لإتمام عملية الشراء، وضمّن رقم طلبك من سوق جوجل بلاي.</string>
     <string name="upgrade_screen_contact_support_action">التواصُل مع الدعم</string>
-    <string name="settings_upgrade_status_label">النسخة الاحترافية من كابود</string>
     <string name="settings_upgrade_status_description">حالة الترقية والاشتراء الخاصّة بك.</string>
     <string name="upgrades_gplay_unavailable_error_description">لا يمكن لكابود الاتّصال بسوق جوجل بلاي. هل سوق جوجل بلاي مُثبَّتة ومُحدَّثة؟ هل حساب جوجل الخاصّ بك مُسجَّل الدخول؟ حاول مسح ذاكرة التخزين المؤقّت لتطبيق جوجل بلاي وإعادة تشغيل جهازك.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod yeni Google Play-i yoxladı, lakin bu tətbiq üçün Google Play istifadə etdiyi hesab üçün heç bir Pro alışı təsdiq edilə bilmədi.</string>
     <string name="upgrade_screen_restore_contact_hint">Hələ də sıkışmısınız? Alışı edən e-poçtdan dəstək xidmətinə müraciət edin və Google Play sifariş nömrənizi daxil edin.</string>
     <string name="upgrade_screen_contact_support_action">Dəstək xidmətinə müraciət edin</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Sizin yüksəltmə və alış statusu.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play-ə qoşula bilmir. Google Play quraşdırılıb və yenilənib? Google hesabınız daxil olub? Google Play tətbiqinin keşini təmizləməyi və cihazınızı yenidən başlatmağı sınayın.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod толькі што праверыў Google Play, але Pro-пакупка не была пацверджана для акаўнта, які Google Play выкарыстоўвае для гэтай праграмы.</string>
     <string name="upgrade_screen_restore_contact_hint">Усё яшчэ ёсць праблемы? Звяжыцеся з падтрымкай з адрасу электроннай пошты, з якой была зроблена пакупка, і ўкажыце нумар заказу Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Звязацца з падтрымкай</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ваш статус абнаўлення і пакупкі.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod не можа падключыцца да Google Play. Ці ўсталяваны і абноўлены Google Play? Вы ўвайшлі ў свой уліковы запіс Google? Паспрабуйце ачысціць кэш праграмы Google Play і перазагрузіць прыладу.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod току-що провери Google Play, но не можа да бъде потвърдена Pro покупка за акаунта, който Google Play използва за това приложение.</string>
     <string name="upgrade_screen_restore_contact_hint">Все още имате проблем? Свържете се с поддръжката от имейла, с който сте направили покупката, и включете номера на поръчката си в Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Свържете се с поддръжката</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Вашият статус на надграждане и закупуване.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod не може да се свърже с Google Play. Инсталиран ли е Google Play и актуален ли е? Влязъл ли е вашият Google акаунт? Опитайте да изчистите кеша на приложението Google Play и да рестартирате устройството си.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod সবেমাত্র গুগল প্লে চেক করেছে, কিন্তু এই অ্যাপের জন্য গুগল প্লে যে অ্যাকাউন্ট ব্যবহার করছে তার জন্য কোনো প্রো ক্রয় নিশ্চিত করা যায়নি।</string>
     <string name="upgrade_screen_restore_contact_hint">এখনও সমস্যা হচ্ছে? যে ইমেল থেকে ক্রয় করেছেন সেখান থেকে সহায়তার সাথে যোগাযোগ করুন এবং আপনার গুগল প্লে অর্ডার নম্বর অন্তর্ভুক্ত করুন।</string>
     <string name="upgrade_screen_contact_support_action">সহায়তার সাথে যোগাযোগ করুন</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">আপনার আপগ্রেড এবং ক্রয় স্থিতি।</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play এর সাথে সংযোগ করতে পারছে না। Google Play কি ইনস্টল এবং আপ টু ডেট? আপনার Google অ্যাকাউন্ট লগ ইন আছে? Google Play অ্যাপের ক্যাশ সাফ করে এবং আপনার ডিভাইস রিবুট করে চেষ্টা করুন।</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">El CAPod acaba de comprovar el Google Play, però no s\'ha pogut confirmar cap compra Pro per al compte que Google Play utilitza per a aquesta aplicació.</string>
     <string name="upgrade_screen_restore_contact_hint">Encara teniu problemes? Contacteu amb l\'assistència des del correu amb què heu fet la compra i incloeu el número de comanda del Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contacta amb el suport</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Estat de la vostra actualització i compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat sessió amb el vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod právě zkontroloval Google Play, ale pro účet, který Google Play pro tuto aplikaci používá, nelze potvrdit nákup Pro.</string>
     <string name="upgrade_screen_restore_contact_hint">Stále máte problémy? Kontaktujte podporu z e-mailu, který realizoval nákup, a uveďte své číslo objednávky z Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Kontaktovat podporu</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Váš stav upgradu a nákupu.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod se nemůže připojit k Obchodu Google Play. Je Obchod Google Play nainstalován a aktualizován? Jste přihlášeni k účtu Google? Zkuste vymazat mezipaměť Obchodu Google Play a restartovat zařízení.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod har netop checket Google Play, men intet Pro-køb kunne bekræftes for den konto, som Google Play bruger til denne app.</string>
     <string name="upgrade_screen_restore_contact_hint">Stadig problemer? Kontakt support fra den mailadresse, der foretog købet, og inkluder dit Google Play-ordrenummer.</string>
     <string name="upgrade_screen_contact_support_action">Kontakt support</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Din opgraderings- og købsstatus.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kan ikke oprette forbindelse til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prøv at rydde cachen i Google Play-appen og genstarte din enhed.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod hat gerade Google Play überprüft, aber für das Konto, das Google Play für diese App verwendet, konnte kein Pro-Kauf bestätigt werden.</string>
     <string name="upgrade_screen_restore_contact_hint">Immer noch nicht weiter? Kontaktiere den Support von der E-Mail-Adresse aus, mit der der Kauf getätigt wurde, und gib deine Google-Play-Bestellnummer an.</string>
     <string name="upgrade_screen_contact_support_action">Support kontaktieren</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Dein Upgrade- und Kaufstatus.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und auf dem neuesten Stand? Ist dein Google-Konto angemeldet? Versuche, den Cache der Google-Play-App zu leeren und dein Gerät neu zu starten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">Το CAPod έλεγξε μόλις το Google Play, αλλά δεν ήταν δυνατή η επιβεβαίωση κάποιας αγοράς Pro για τον λογαριασμό που χρησιμοποιεί το Google Play γι\' αυτήν την εφαρμογή.</string>
     <string name="upgrade_screen_restore_contact_hint">Ακόμα έχετε πρόβλημα; Επικοινωνήστε με την υποστήριξη από το email που έκανε την αγορά και συμπεριλάβετε τον αριθμό παραγγελίας Google Play σας.</string>
     <string name="upgrade_screen_contact_support_action">Επικοινωνήστε με την υποστήριξη</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Η κατάσταση αναβάθμισης και αγοράς σας.</string>
     <string name="upgrades_gplay_unavailable_error_description">Το CAPod δεν μπορεί να συνδεθεί με το Google Play. Είναι το Google Play εγκατεστημένο και ενημερωμένο; Έχετε συνδεθεί με τον λογαριασμό σας Google; Δοκιμάστε να διαγράψετε την προσωρινή μνήμη της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod acaba de verificar con Google Play, pero no se pudo confirmar ninguna compra Pro para la cuenta que Google Play está usando en esta aplicación.</string>
     <string name="upgrade_screen_restore_contact_hint">¿Seguís teniendo problemas? Contactá al soporte desde el correo que realizó la compra e incluí tu número de pedido de Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contactá al soporte</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tu estado de actualización y compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod no puede conectarse a Google Play. ¿Está instalada y actualizada Google Play? ¿Iniciaste sesión con tu cuenta de Google? Probá a borrar la caché de la aplicación de Google Play y reiniciar tu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod acaba de revisar Google Play, pero no se pudo confirmar ninguna compra Pro en la cuenta que Google Play está utilizando para esta aplicación.</string>
     <string name="upgrade_screen_restore_contact_hint">¿Aún tienes problemas? Contacta al soporte desde el correo electrónico que realizó la compra e incluye tu número de pedido de Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contactar soporte</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tu estado de actualización y compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod no puede conectarse a Google Play. ¿Está instalada y actualizada Google Play? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación de Google Play y reiniciar tu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod acaba de revisar Google Play, pero no se pudo confirmar ninguna compra Pro en la cuenta que Google Play utiliza para esta aplicación.</string>
     <string name="upgrade_screen_restore_contact_hint">¿Aún tienes problemas? Contacta con soporte desde el correo electrónico que realizó la compra e incluye tu número de pedido de Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contactar con soporte</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tu estado de mejora y compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod no puede conectarse a Google Play. ¿Está instalada y actualizada Google Play? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación de Google Play y reiniciar tu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod just kontrollis Google Playd, kuid selle rakenduse kasutatava konto jaoks ei saanud Pro ostmist kinnitada.</string>
     <string name="upgrade_screen_restore_contact_hint">Olete endiselt jännis? Suhelge toega ostmisel kasutatu meiliaadressi kaudu, ja lisage oma Google Play tellimuse number.</string>
     <string name="upgrade_screen_contact_support_action">Suhelge toega</string>
-    <string name="settings_upgrade_status_label">Tasuline CAPod</string>
     <string name="settings_upgrade_status_description">Sinu täienduse ja ostu olek.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ei suuda ühenduda Google Playga. Kas Google Play on paigaldatud ja uuendatud? Olete Google\'i kontole sisse logitud? Üritage tühjendada Google Play rakenduse vahemälu ja taaskäivitada oma seadet.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod-ek Google Play begiratu du, baina ez da Pro erosketaren bat baieztatu ahal izan kontu honetarako.</string>
     <string name="upgrade_screen_restore_contact_hint">Oraino traba? Laguntzarekin jarri harremanetan erosketaren e-maila erabilita eta zure Google Play eskaera zenbakia gehitu.</string>
     <string name="upgrade_screen_contact_support_action">Laguntzarekin jarri harremanetan</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Zure bertsio hobetzea eta erosketaren egoera.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ezin da Google Playrekin konektatu. Google Play instalatuta eta eguneratuta dago? Zure Google kontua sartu da? Saiatu Google Play aplikazioaren katxea garbitzen eta zure gailua berrabiarazten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod به‌تازگی Google Play را بررسی کرد، اما نتوانست خریدی Pro را برای حسابی که Google Play برای این برنامه استفاده می‌کند تأیید کند.</string>
     <string name="upgrade_screen_restore_contact_hint">هنوز مشکل دارید؟ از ایمیلی که خرید را انجام داده‌اید با پشتیبانی تماس بگیرید و شماره سفارش Google Play خود را بیان کنید.</string>
     <string name="upgrade_screen_contact_support_action">تماس با پشتیبانی</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">وضعیت ارتقاء و خرید شما.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod نمی‌تواند به Google Play متصل شود. آیا Google Play نصب شده و به‌روز است؟ آیا حساب Google شما وارد شده است؟ سعی کنید کش برنامه Google Play را پاک کنید و دستگاه خود را مجدداً راه‌اندازی کنید.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod tarkisti juuri Google Playä, mutta Pro-ostoa ei voitu vahvistaa tälle sovellukselle käytettävällä tilillä.</string>
     <string name="upgrade_screen_restore_contact_hint">Ongelma jatkuu? Ota yhteyttä tukeen sähköpostiosoitteesta, jolla teit oston, ja sisällytä Google Play -tilausnumerosi.</string>
     <string name="upgrade_screen_contact_support_action">Ota yhteyttä tukeen</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Päivityksen ja ostojen tila</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautunut sisään? Kokeile tyhjentää Google Play -sovelluksen välimuisti ja käynnistä laitteesi uudelleen.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">Ang CAPod ay nag-check sa Google Play, ngunit walang Pro purchase na nahanap para sa account na ginagamit ng Google Play para sa app na ito.</string>
     <string name="upgrade_screen_restore_contact_hint">Nandito pa rin? Makipag-ugnayan sa suporta gamit ang email na ginamit sa pagbili at isama ang iyong Google Play order number.</string>
     <string name="upgrade_screen_contact_support_action">Makipag-ugnayan sa suporta</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ang status ng iyong upgrade at pagbili.</string>
     <string name="upgrades_gplay_unavailable_error_description">Ang CAPod ay hindi maka-konekta sa Google Play. Naka-installed ba ang Google Play at na-update? Naka-logged in ba ang iyong Google Account? Subukan ang paglilinis ng cache ng Google Play app at i-reboot ang iyong aparato.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod vient de vérifier Google Play, mais aucun achat Pro n’a pu être confirmé pour le compte que Google Play utilise pour cette appli.</string>
     <string name="upgrade_screen_restore_contact_hint">Toujours du mal ? Contactez le support depuis l’adresse e-mail qui a effectué l’achat et incluez votre numéro de commande Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contacter le support</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Votre statut de mise à niveau et d’achat.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ne peut pas se connecter à Google Play. Google Play est-il installé et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l\'appli Google Play et de redémarrer votre appareil.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod acaba de comprobar Google Play, pero non se puido confirmar ningunha compra Pro para a conta que Google Play usa para esta aplicación.</string>
     <string name="upgrade_screen_restore_contact_hint">¿Aínda con problemas? Ponte en contacto con soporte desde o correo electrónico que fixo a compra e inclúe o número de pedido de Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Ponte en contacto con soporte</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">O teu estado de actualización e compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod non pode conectar con Google Play. Está Google Play instalado e actualizado? A túa conta de Google está conectada? Proba a limpar a caché da aplicación Google Play e reinicia o teu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ने अभी Google Play से जांच की है, लेकिन इस ऐप के लिए Google Play द्वारा उपयोग किए जा रहे खाते के लिए कोई Pro खरीद की पुष्टि नहीं की जा सकी।</string>
     <string name="upgrade_screen_restore_contact_hint">अभी भी फंसे हुए हैं? उस ईमेल से सहायता संपर्क करें जिसने खरीद की थी और अपना Google Play ऑर्डर नंबर शामिल करें।</string>
     <string name="upgrade_screen_contact_support_action">सहायता से संपर्क करें</string>
-    <string name="settings_upgrade_status_label">कैपोड प्रो</string>
     <string name="settings_upgrade_status_description">आपकी अपग्रेड और खरीद स्थिति।</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play से कनेक्ट नहीं हो सकता। क्या Google Play इंस्टॉल और अप-टू-डेट है? क्या आपका Google खाता लॉग इन है? Google Play ऐप का कैश साफ़ करने और अपने डिवाइस को रीबूट करने का प्रयास करें।</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod je upravo provjerio Google Play, ali se Pro kupnja nije mogla potvrditi za račun koji je povezan s ovom aplikacijom.</string>
     <string name="upgrade_screen_restore_contact_hint">Još uvijek zaglavljen? Kontaktirajte podršku s e-mailom koji ste koristili za kupnju i uključite vaš broj narudžbe Google Playa.</string>
     <string name="upgrade_screen_contact_support_action">Kontaktirajte podršku</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Vaš status nadogradnje i kupnje.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod se ne može povezati s Google Playem. Je li Google Play instaliran i ažuriran? Jeste li prijavljeni na svoj Google račun? Pokušajte očistiti predmemoriju Google Play aplikacije i ponovno pokrenuti uređaj.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">A CAPod éppen ellenőrizte a Google Play-t, de nem lehetett megerősíteni a Pro vásárlást az olyan fiók esetén, amelyet a Google Play használ ehhez az alkalmazáshoz.</string>
     <string name="upgrade_screen_restore_contact_hint">Még mindig nem működik? Vegye fel a kapcsolatot az ügyfélszolgálattal abból az e-mail-fiókból, amely a vásárlást végezte, és adja meg Google Play rendelésszámát.</string>
     <string name="upgrade_screen_contact_support_action">Lépjen kapcsolatba az ügyfélszolgálattal</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Az Ön frissítésének és vásárlásának állapota.</string>
     <string name="upgrades_gplay_unavailable_error_description">A CAPod nem tud csatlakozni a Google Playhez. Telepítve és naprakész a Google Play? Be vagy jelentkezve Google-fiókkal? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod-ը պարզապես ստուգեց Google Play-ը, բայց այս հավելվածի համար օգտագործվող Google Play հաշվում Pro գնում հաստատել չեղավ:</string>
     <string name="upgrade_screen_restore_contact_hint">Դեռ շարունակումներ՞ Աջակցության հետ կապ հաստատեք այն էմեյլից, որից կատարվել է գնումը, և ներառեք Google Play պատվերի համարը:</string>
     <string name="upgrade_screen_contact_support_action">Աջակցության հետ կապ</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ձեր թարմացման և գնման վիճակը:</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod-ը չի կարող կապվել Google Play-ի հետ: Google Play-ը տեղադրվա՞ծ է և արդիացվա՞ծ: Ձեր Google հաշիվը մուտք գործա՞ծ է: Փորձեք մաքրել Google Play հավելվածի քեշը և վերագործարկել ձեր սարքը:</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod baru saja memeriksa Google Play, tetapi tidak ada pembelian Pro yang dapat dikonfirmasi untuk akun yang Google Play gunakan untuk aplikasi ini.</string>
     <string name="upgrade_screen_restore_contact_hint">Masih bermasalah? Hubungi dukungan dari email yang melakukan pembelian dan sertakan nomor pesanan Google Play Anda.</string>
     <string name="upgrade_screen_contact_support_action">Hubungi dukungan</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Status upgrade dan pembelian Anda.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod tidak dapat terhubung ke Google Play. Apakah Google Play sudah terpasang dan diperbarui? Apakah Akun Google Anda sudah masuk? Coba hapus cache aplikasi Google Play dan mulai ulang perangkat Anda.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod athugaði nýlega hjá Google Play, en engin Pro kaup gætu verið staðfest fyrir reikninginn sem Google Play notar fyrir þessa forrit.</string>
     <string name="upgrade_screen_restore_contact_hint">Ennþá fastur? Hafðu samband við stuðning frá tölvupósti sem gerði kaupin og tiltaktu Google Play pöntunarnúmeri þinn.</string>
     <string name="upgrade_screen_contact_support_action">Hafðu samband við stuðning</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Staða þinnar uppfærslu og kaupa</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod getur ekki tengst Google Play. Er Google Play uppsett og uppfært? Er Google reikningurinn þinn skráður inn? Reyndu að hreinsa skyndiminni Google Play appsins og endurræstu tækið þitt.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ha appena controllato Google Play, ma non è stato possibile confermare alcun acquisto Pro per l’account che Google Play utilizza per questa app.</string>
     <string name="upgrade_screen_restore_contact_hint">Ancora bloccato? Contatta il supporto dall’email che ha effettuato l’acquisto e includi il tuo numero d’ordine di Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contatta il supporto</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Lo stato del tuo upgrade e dell’acquisto.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod non può connettersi a Google Play. Controllare che Google Play sia installato e aggiornato, che il tuo account Google sia connesso. Prova a cancellare la cache dell\'app Google Play e riavviare il dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod בדיוק בדק את Google Play, אך לא ניתן היה לאשר קנייה של Pro עבור החשבון שבו משתמש Google Play לאפליקציה זו.</string>
     <string name="upgrade_screen_restore_contact_hint">עדיין תקוע? צור קשר עם התמיכה מהדוא\"ל שביצע את הרכישה וכלול את מספר ההזמנה של Google Play שלך.</string>
     <string name="upgrade_screen_contact_support_action">צור קשר עם התמיכה</string>
-    <string name="settings_upgrade_status_label">CAPod פרו</string>
     <string name="settings_upgrade_status_description">סטטוס השדרוג והרכישה שלך.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod לא יכול להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולאתחל את המכשיר שלך.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod が Google Play を確認しましたが、このアプリが使用しているアカウントの Pro 購入を確認できませんでした。</string>
     <string name="upgrade_screen_restore_contact_hint">まだ問題がありますか?購入を行ったメールアドレスからサポートに連絡し、Google Play の注文番号を含めてください。</string>
     <string name="upgrade_screen_contact_support_action">サポートに連絡</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">アップグレードと購入ステータス。</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod は Google Play に接続できません。Google Play はインストールされており、最新の状態ですか？Google アカウントにログインしていますか？Google Play アプリのキャッシュをクリアしてデバイスを再起動してみてください。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ახლახან შეამოწმა Google Play-ს, მაგრამ Pro ყიდვა ვერ დადასტურდა იმ ანგარიშისთვის, რომელსაც Google Play იყენებს ამ აპლიკაციისთვის.</string>
     <string name="upgrade_screen_restore_contact_hint">ჯერ კიდევ დაჭერილი? დაუკავშირდით მხარდამჭერს იმ ელფოსტიდან, რომელმაც შეიძინა და მიუთითეთ თქვენი Google Play შეკვეთის ნომერი.</string>
     <string name="upgrade_screen_contact_support_action">მხარდამჭერთან დაკავშირება</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">თქვენი განახლებისა და ყიდვის მდგომარეობა.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ვერ უკავშირდება Google Play-ს. დაინსტალირებულია და განახლებულია Google Play? შესულია თქვენი Google ანგარიში? სცადეთ Google Play აპლიკაციის ქეშის გასუფთავება და თქვენი მოწყობილობის გადატვირთვა.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ទើបតែពិនិត្យ Google Play ប៉ុណ្ណោះ ប៉ុន្ដែ មិនមានការទិញ Pro ដែលអាចបញ្ជាក់បានសម្រាប់គណនីដែល Google Play ប្រើប្រាស់សម្រាប់កម្មវិធីនេះទេ។</string>
     <string name="upgrade_screen_restore_contact_hint">នៅតែមាន​បញ្ហា? ទាក់ទងក្រុមគាំទ័របន្ថែមដោយប្រើលិខិតអ៊ីមែលដែលបានប្រើក្នុងការទិញ ហើយរួមបញ្ចូលលេខលំដាប់របស់អ្នក Google Play។</string>
     <string name="upgrade_screen_contact_support_action">ទាក់ទងក្រុមគាំទ័របន្ថែម</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">ស្ថានភាពនៃការឡើងកម្រិត និងការទិញរបស់អ្នក។</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ តើ Google Play បានដំឡើង និងធ្វើបច្ចុប្បន្នភាពឬទេ? តើគណនី Google របស់អ្នកបានចូលហើយឬនៅ? សាកល្បងសម្អាតឃ្លាំងសម្ងាត់កម្មវិធី Google Play និងចាប់ផ្តើមឧបករណ៍របស់អ្នកឡើងវិញ។</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod Google Play kontrol kir, lê ji bo hesaba ku Google Play ji bo vê sepandinê bikar tîne, kiryara Pro tesdîq nebû.</string>
     <string name="upgrade_screen_restore_contact_hint">Hîn jî kelî mabû? Pîştgirê peywendî bin û e-nameya kiryara û hejmar berneya Google Play xwe tê de bîn.</string>
     <string name="upgrade_screen_contact_support_action">Pîştgirê peywendî bin</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Rewşa nûvekirin û kirîna te.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod nikare bi Google Play-ê ve girêbe. Google Play sazkirî û nûve ye? Hesaba Googleya we têketî ye? Mîzgîna appê Google Play paqij bike û amûra xwe ji nû ve xebitîne.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">ಸಿಎಪಿಒಡ್ ಇತ್ತೀಚೆಗೆ ಗೂಗಲ್ ಪ್ಲೇಯನ್ನು ಪರಿಶೀಲಿಸಿದೆ, ಆದರೆ ಗೂಗಲ್ ಪ್ಲೇ ಈ ಅ್ಯಾಪ್‍ಗೆ ಬಳಸುತ್ತಿರುವ ಖಾತೆಗೆ ಯಾವುದೇ ಪ್ರೊ ಕ್ರಯವನ್ನು ದೃಢೀಕರಿಸಲಾಗಿಲ್ಲ.</string>
     <string name="upgrade_screen_restore_contact_hint">ಇನ್ನೂ ಸಿಕ್ಕಿಬಿದ್ದಿರಾ? ಕ್ರಯವನ್ನು ಮಾಡಿದ ಇಮೇಲ್‍ನಿಂದ ಸಹಾಯವನ್ನು ಸಂಪರ್ಕಿಸಿ ಮತ್ತು ನಿಮ್ಮ ಗೂಗಲ್ ಪ್ಲೇ ಆದೇಶ ಸಂಖ್ಯೆ ಸೇರಿಸಿ.</string>
     <string name="upgrade_screen_contact_support_action">ಸಹಾಯವನ್ನು ಸಂಪರ್ಕಿಸಿ</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">ನಿಮ್ಮ ಅಪ್‍ಗ್ರೇಡ್ ಮತ್ತು ಖರೀದಿ ಸ್ಥಿತಿ.</string>
     <string name="upgrades_gplay_unavailable_error_description">ಸಿಎಪಿಪಾಡ್ ಗೂಗಲ್ ಪ್ಲೇಗೆ ಸಂಪರ್ಕ ಸ್ಥಾಪಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ. ಗೂಗಲ್ ಪ್ಲೇ ಸ್ಥಾಪಿಸಲಾಗಿದೆಯೇ ಮತ್ತು ಇತ್ತೀಚೆಗೆ ನವೀಕರಿಸಲಾಗಿದೆಯೇ? ನಿಮ್ಮ ಗೂಗಲ್ ಖಾತೆ ಲಾಗ್ ಇನ್ ಆಗಿದೆಯೇ? ಗೂಗಲ್ ಪ್ಲೇ ಅಪ್ಲಿಕೇಶನ್‌ನ ಕ್ಯಾಶ್ ತೆರವು ಮಾಡಲು ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಮರುಬೂಟ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod가 Google Play를 확인했지만 이 앱이 사용 중인 계정의 Pro 구매를 확인할 수 없습니다.</string>
     <string name="upgrade_screen_restore_contact_hint">계속 문제가 있으신가요? 구매를 한 이메일에서 지원팀에 문의하고 Google Play 주문 번호를 포함하세요.</string>
     <string name="upgrade_screen_contact_support_action">지원팀 문의</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">업그레이드 및 구매 상태</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 버전인가요? Google 계정이 로그인되어 있나요? Google Play 앱의 캐시를 지우고 기기를 재시작해 보세요.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod жаңы эле Google Play текшерди, бирок бул колдонмо үчүн Google Play колдонулган аккаунт үчүн Pro сатып алуусу ырастаналган жок.</string>
     <string name="upgrade_screen_restore_contact_hint">Дагы эле мүмкүн эмес беле? Сатып алуу жасаган электронды почтадан колдоо менен байланышын жана Google Play заказынын номерин коюңуз.</string>
     <string name="upgrade_screen_contact_support_action">Колдоо менен байланышуу</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Жакштыруу жана сатып алуу абалы</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play менен туташтыра албайт. Google Play орнотулгандыбы жана актуалдаштырылгандыбы? Google Аккаунтуңуз кирген болсоңузбу? Google Play приложениесинин кэшин тазалап, түзмөгүңүздү кайра жүктөңүз.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ຫາກໍ່ກວດກາ Google Play ແຕ່ບໍ່ສາມາດຢືນຢັນການຊື້ Pro ສໍາລັບບັນຊີທີ່ Google Play ໃຊ້ສໍາລັບແອັບນີ້ໄດ້.</string>
     <string name="upgrade_screen_restore_contact_hint">ຍັງມີບັນຫາຢູ່ບໍ? ຕິດຕໍ່ຝ່າຍສະໜັບສະໜູນໂດຍໃຊ້ອີເມວທີ່ໃຊ້ສໍາລັບການຊື້ ແລະລວມເອົາເລກອໍາເລີຍ Google Play ຂອງທ່ານ.</string>
     <string name="upgrade_screen_contact_support_action">ຕິດຕໍ່ຝ່າຍສະໜັບສະໜູນ</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">ສະຖານະການອັບເກຣດແລະການຊື້ຂອງທ່ານ</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ Google Play ໄດ້. Google Play ຖືກຕິດຕັ້ງ ແລະອັບເດດແລ້ວບໍ? ບັນຊີ Google ຂອງທ່ານເຂົ້າສູ່ລະບົບແລ້ວບໍ? ລອງລ້າງແຄສຂອງແອັບ Google Play ແລະຣີບູດອຸປະກອນຂອງທ່ານ.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod patikrino Google Play, tačiau Pro pirkimo negalėjo patvirtinti paskyroje, kurią Google Play naudoja šiai programai.</string>
     <string name="upgrade_screen_restore_contact_hint">Vis dar nepadėjo? Susisiekite su palaikymu iš el. pašto, kuris atliko pirkimą, ir pridėkite savo Google Play užsakymo numerį.</string>
     <string name="upgrade_screen_contact_support_action">Susisiekti su palaikymu</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Jūsų atnaujinimo ir pirkimo būsena.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod negali prisijungti prie Google Play. Ar Google Play įdiegtas ir atnaujintas? Ar jūsų Google paskyra prisijungusi? Pabandykite išvalyti Google Play programos talpyklą ir paleisti įrenginį iš naujo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod nesen pārbaudīja Google Play, taču Pro pirkums nevar tikt apstiprināts kontam, ko Google Play izmanto šai programmai.</string>
     <string name="upgrade_screen_restore_contact_hint">Joprojām problēma? Sazinieties ar atbalstu no e-pasta, kas veica pirkumu, un iekļaujiet jūsu Google Play pasūtījuma numuru.</string>
     <string name="upgrade_screen_contact_support_action">Sazinieties ar atbalstu</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Jūsu jaunināšanas un pirkuma statuss.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai jūsu Google konts ir pieteicies? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un restartēt ierīci.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod штотуку провери Google Play, но не можеше да се потврди Pro куповина за сметката која Google Play ја користи за оваа апликација.</string>
     <string name="upgrade_screen_restore_contact_hint">Сè уште заглавено? Контактирај ја поддршката од имејлот со кој направи куповина и вклучи го твојот број на нарачката од Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Контактирај поддршка</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Статусот на твоето надградување и купување.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod не може да се поврзе со Google Play. Дали Google Play е инсталиран и ажуриран? Дали вашата Google сметка е најавена? Обидете се да ја исчистите кеш меморијата на апликацијата Google Play и рестартирајте го вашиот уред.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -67,7 +67,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ഇപ്പോൾ Google Play പരിശോധിച്ചു, എന്നാൽ ഈ ആപ്ലിക്കേഷനിനായി Google Play ഉപയോഗിക്കുന്ന അക്കൗണ്ടിനായി Pro വാങ്ങൽ സ്ഥിരീകരിക്കാൻ കഴിഞ്ഞില്ല.</string>
     <string name="upgrade_screen_restore_contact_hint">ഇനിയും കുടുങ്ങിയിരിക്കുന്നുണ്ടോ? വാങ്ങൽ നടത്തിയ ഇമെയിൽ വിലാസത്തിൽ നിന്ന് പിന്തുണയ്ക്കായി ബന്ധപ്പെടുക കൂടാതെ നിങ്ങളുടെ Google Play ഓർഡർ നമ്പർ ചേർക്കുക.</string>
     <string name="upgrade_screen_contact_support_action">പിന്തുണയ്ക്കായി ബന്ധപ്പെടുക</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">നിങ്ങളുടെ അപ്ഗ്രേഡിന്റെയും വാങ്ങലിന്റെയും സ്ഥിതി.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod-നിന് Google Play-യുമായി കണക്റ്റുചെയ്യാൻ കഴിയുന്നില്ല. Google Play ഇൻസ്റ്റാൾ ചെയ്‌ത് അപ്‌ഡേറ്റ് ചെയ്‌തിട്ടുണ്ടോ? നിങ്ങളുടെ Google അക്കൗണ്ട് ലോഗിൻ ചെയ്‌തിട്ടുണ്ടോ? Google Play ആപ്പിന്റെ കാഷെ മായ്‌ക്കാനും നിങ്ങളുടെ ഉപകരണം റീബൂട്ട് ചെയ്യാനും ശ്രമിക്കുക.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod саяхан Google Play-г шалгасан боловч энэ програмын хувьд Google Play ашигладаг акаунтын Pro худалдан авалтыг баталгаажуулах боломжгүй байв.</string>
     <string name="upgrade_screen_restore_contact_hint">Хоцорч байна уу? Худалдан авалт хийсэн имэйл хаягаас дэмжлэг авахыг хүсээд Google Play захиалгын дугаарыг оруулна уу.</string>
     <string name="upgrade_screen_contact_support_action">Дэмжлэгтэй холбоо барих</string>
-    <string name="settings_upgrade_status_label">CAPod Про</string>
     <string name="settings_upgrade_status_description">Таны шинэчлэл ба худалдан авалтын статус.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play-тэй холбогдож чадахгүй байна. Google Play суулгасан бөгөөд шинэчлэгдсэн үү? Таны Google бүртгэл нэвтэрсэн үү? Google Play аппын кэшийг цэвэрлэж, төхөөрөмжөө дахин эхлүүлэхийг оролдоно уу.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ने Google Play तपास केला, पण या अॅपसाठी Google Play च्या खात्यात कोणतीही Pro खरेदी पुष्टी केली जाणू शकली नाही.</string>
     <string name="upgrade_screen_restore_contact_hint">अजून अडकले आहे? खरेदी केलेल्या ईमेलवरून समर्थन संपर्क करा आणि आपल्या Google Play ऑर्डर क्रमांक समाविष्ट करा.</string>
     <string name="upgrade_screen_contact_support_action">समर्थन संपर्क करा</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">आपल्या अपग्रेड आणि खरेदी स्थिती.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play ला कनेक्ट होऊ शकत नाही. Google Play इंस्टॉल केलेले आहे आणि अद्ययावत आहे का? आपले Google Account लॉग इन केलेले आहे का? Google Play अ‍ॅप्लिकेशनचे कॅश साफ करण्याचा प्रयत्न करा आणि आपले डिव्हाइस रीबूट करा.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod baru sahaja menyemak Google Play, tetapi tiada pembelian Pro dapat disahkan untuk akaun yang Google Play gunakan untuk aplikasi ini.</string>
     <string name="upgrade_screen_restore_contact_hint">Masih tersekat? Hubungi sokongan daripada e-mel yang membuat pembelian dan sertakan nombor pesanan Google Play anda.</string>
     <string name="upgrade_screen_contact_support_action">Hubungi Sokongan</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Status peningkatan dan pembelian anda.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod tidak dapat menyambung ke Google Play. Adakah Google Play dipasang dan dikemaskini? Adakah Akaun Google anda log masuk? Cuba kosongkan cache aplikasi Google Play dan but semula peranti anda.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod သည် အခုခါ Google Play ကို စစ်ဆေးခဲ့သည်သော်လည်း ဤအပ်ပလီကေးရှင်းအတွက် Google Play အသုံးပြုနေသော အကောင့်အတွက် Pro ဝယ်ယူမှုကို အတည်ပြုနိုင်ခြင်းမရှိသည်။</string>
     <string name="upgrade_screen_restore_contact_hint">အဆမပြေသေးသလား။ ဝယ်ယူမှုကိုပြုလုပ်သော အီမေးလ်မှ အကူအညီအတွက် ဆက်သွယ်ပြီး သင်၏ Google Play အမှာစာအမှတ်ကို ထည့်သွင်းပါ။</string>
     <string name="upgrade_screen_contact_support_action">အကူအညီ ဆက်သွယ်ပါ</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">သင်၏ အဆင့်မြင့်တင်ခြင်း နှင့် ဝယ်ယူမှု အခြေအနေ။</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod သည် Google Play နှင့် ချိတ်ဆက်၍မရပါ။ Google Play ကို ထည့်သွင်းပြီး အပ်ဒိတ်လုပ်ထားပါသလား။ သင့် Google အကောင့် ဝင်ရောက်ထားပါသလား။ Google Play အက်ပ်၏ cache ကို ရှင်းလင်းပြီး သင့်စက်ကို ပြန်လည်စတင်ကြည့်ပါ။</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod sjekket nettopp Google Play, men ingen Pro-kjøp kunne bekreftes for kontoen Google Play bruker for denne appen.</string>
     <string name="upgrade_screen_restore_contact_hint">Sitter du fast? Kontakt support fra e-posten som gjorde kjøpet, og ta med Google Play-ordrenummeret ditt.</string>
     <string name="upgrade_screen_contact_support_action">Kontakt support</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Status for din oppgradering og kjøp.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din pålogget? Prøv å tømme hurtigbufferen for Google Play-appen og start enheten på nytt.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ले भर्खर Google Play जाँच गरेको छ, तर यो अनुप्रयोगको लागि Google Play द्वारा प्रयोग गरिएको खाताको लागि कुनै Pro खरिद पुष्टि गर्न सकिएन।</string>
     <string name="upgrade_screen_restore_contact_hint">अझै पनि समस्या छ? खरिद गरेको इमेलबाट समर्थन सम्पर्क गर्नुहोस् र आफ्नो Google Play अर्डर नम्बर समावेश गर्नुहोस्।</string>
     <string name="upgrade_screen_contact_support_action">समर्थन सम्पर्क गर्नुहोस्</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">आफ्नो अपग्रेड र खरिद स्थिति।</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play सँग जडान गर्न सक्दैन। के Google Play स्थापना र अद्यावधिक गरिएको छ? के तपाईंको Google खाता लग इन गरिएको छ? Google Play एपको क्यास खाली गरेर र तपाईंको उपकरण रिबुट गर्ने प्रयास गर्नुहोस्।</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod heeft zojuist Google Play gecontroleerd, maar er kon geen Pro-aankoop worden bevestigd voor het Google Play-account dat voor deze app wordt gebruikt.</string>
     <string name="upgrade_screen_restore_contact_hint">Zit je nog steeds vast? Neem dan contact op met de klantenservice via het e-mailadres waarmee je de aankoop hebt gedaan en vermeld je Google Play-bestelnummer.</string>
     <string name="upgrade_screen_contact_support_action">Neem contact op met ondersteuning</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Je upgrade- en aankoopstatus.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Ben je ingelogd met je Google-account? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod właśnie sprawdził Sklep Google Play, ale nie udało się potwierdzić zakupu wersji Pro dla konta, którego Sklep Google Play używa do tej aplikacji.</string>
     <string name="upgrade_screen_restore_contact_hint">Nadal masz problem? Skontaktuj się z pomocą techniczną z adresu e-mail, z którego dokonano zakupu, podając numer zamówienia Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Skontaktuj się z pomocą techniczną</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Stan twojego zakupu i aktualizacji.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod nie może połączyć się z Sklepem Google Play. Czy Sklep Google Play jest zainstalowany i aktualny? Czy jesteś zalogowany na koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Sklepu Google Play i zrestartuj urządzenie.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">O CAPod verificou o Google Play, mas nenhuma compra Pro pôde ser confirmada para a conta que o Google Play está usando para este aplicativo.</string>
     <string name="upgrade_screen_restore_contact_hint">Ainda com problemas? Entre em contato com o suporte usando o e-mail que realizou a compra e inclua seu número de pedido do Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contatar suporte</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Seu status de atualização e compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod não pode conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">O CAPod acabou de verificar o Google Play, mas não foi possível confirmar qualquer compra Pro na conta que o Google Play está a usar para esta aplicação.</string>
     <string name="upgrade_screen_restore_contact_hint">Continua sem solução? Contacte o apoio através do endereço de e-mail usado na compra e inclua o número da encomenda do Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contactar o apoio</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">O seu estado de atualização e compra.</string>
     <string name="upgrades_gplay_unavailable_error_description">O CAPod não consegue se conectar ao Google Play. O Google Play está instalado e atualizado? Você está conectado à sua Conta do Google? Tente limpar o cache do aplicativo Google Play e reiniciar o seu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ha controlà Google Play, ma nagina acquista Pro n\'ha pudi vegnir confermada per il cunt chi Google Play utilisescha per questa app.</string>
     <string name="upgrade_screen_restore_contact_hint">Anc incordat? Contactescha il support cun l\'email che ha fatg l\'acquista ed includ il numer dal comonda da Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contactar il support</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tes status dal upgrade e da l\'acquista.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod n\'uschia connectar a Google Play. Es Google Play installà e actualizà? Es tia conta Google connectada? Emprova a svida il cache da l\'app Google Play e a restartar tes apparat.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod tocmai a verificat Google Play, dar nu a putut confirma nicio achiziție Pro pentru contul pe care Google Play îl folosește pentru această aplicație.</string>
     <string name="upgrade_screen_restore_contact_hint">Ești încă blocat? Contactează suportul din email-ul care a făcut achiziția și include numărul comenzii Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Contactează suportul</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Statusul tău de actualizare și achiziție.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod nu se poate conecta la Google Play. Este Google Play instalat și actualizat? Contul tău Google este conectat? Încearcă să ștergi memoria cache a aplicației Google Play și să repornești dispozitivul.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod только что проверил Google Play, но для аккаунта, используемого этим приложением, не удалось подтвердить покупку Pro.</string>
     <string name="upgrade_screen_restore_contact_hint">Всё ещё не получается? Свяжитесь с поддержкой с адреса электронной почты, который произвёл покупку, и укажите номер заказа Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Связаться с поддержкой</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ваш статус обновления и покупки.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod не может подключиться к Google Play. Проверьте, установлен ли Google Play и обновлен ли до последней версии? Выполнен ли вход с Вашей учетной записью Google? Попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod at pena controlladu Google Play, ma perunu comporu Pro at pòtzidu èssere cunfirmadu pro su contu chi Google Play est impreende pro custa aplicatzione.</string>
     <string name="upgrade_screen_restore_contact_hint">Ancora blocau? Cunta sos suportu dae s\'email chi at fetu sa compra e inclui su numeru de s\'ordine Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Cunta sos suportu</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">S\'istadu de su megioramentu e de sa comporadura tua.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod non podet si connètere a Google Play. Google Play est installadu e agiornadu? Su contu Google tuo est intradu? Proa a limpiare sa cache de s\'aplicatzione Google Play e a torrare a allùghere su dispositivu tuo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ඉකමණින් Google Play පරීක්ෂා කර ඇත, නමුත් Google Play මෙම යෙදුම සඩහා භාවිතා කරන ගිණුම සඩහා Pro ගිණුමක් තහවුරු කරිය නොහැකි විය.</string>
     <string name="upgrade_screen_restore_contact_hint">තවමත් විළවටිර්නෙද? ගිණුම සිදු කරන ලද ඊමේල්වලින් සහාය සම්බන්ධ කරන්න සහ ඔබේ Google Play ඇණවුම් අංකය ඇතුළත් කරන්න.</string>
     <string name="upgrade_screen_contact_support_action">සහාය සම්බන්ධ කරන්න</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">ඔබේ වැඩිදුම් සහ ගිණුම් තත්‍වය.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod හට Google Play වෙත සම්බන්ධ විය නොහැක. Google Play ස්ථාපනය කර යාවත්කාලීන කර තිබේද? ඔබගේ Google ගිණුම පුරනය වී තිබේද? Google Play යෙදුමේ හැඹිලිය මකා ඔබගේ උපාංගය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod práve skontrolovala Google Play, ale nákup verzie Pro sa nepodarilo potvrdiť pre účet, ktorý Google Play používa pre túto aplikáciu.</string>
     <string name="upgrade_screen_restore_contact_hint">Stále máte problém? Kontaktujte podporu z e-mailu, ktorého ste použili na nákup, a uveďte číslo objednávky Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Kontaktovať podporu</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Váš stav upgradu a nákupu.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod sa nemôže pripojiť k službe Google Play. Je Google Play nainštalovaný a aktuálny? Je váš účet Google prihlásený? Skúste vymazať vyrovnávaciu pamäť aplikácie Google Play a reštartujte zariadenie.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod je pravkar preveril Google Play, vendar Pro nakupa ni bilo mogoče potrditi za račun, ki ga Google Play uporablja za to aplikacijo.</string>
     <string name="upgrade_screen_restore_contact_hint">Še vedno zaglavljen? Kontaktiraj podporo z e-poštnega naslova, s katerim si naredil nakup, in vključi svojo številko naročila Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Kontaktiraj podporo</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Tvoj status nadgradnje in nakupa.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod se ne more povezati z Googlom Play. Ali je nameščen in posodobljen? Ali ste prijavljeni v Googlov račun? Poizkusite počistiti predpomnilnik programa Google Play in napravo ponovno zagnati.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod sapo kontrolloi Google Play, por asnjë blerje Pro nuk mund të konfirmohej për konten që Google Play po përdor për këtë aplikacion.</string>
     <string name="upgrade_screen_restore_contact_hint">Ende i bllokuar? Kontaktoni mbështetjen nga emaili që ka bërë blerjen dhe përfshini numërin e porosës tuaj Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Kontaktoni mbështetjen</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Statusi juaj i përmirësimit dhe blerjes.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod nuk mund të lidhet me Google Play dyqanin. A është Google Play dyqani i instaluar dhe i përditësuar? A është identifikuar llogaria juaj e Google? Provoni të pastroni cache-in e aplikacionit Google Play dhe të rindizni pajisjen tuaj.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod је управо проверио Google Play, али Pro куповина није потврђена за налог који Google Play користи за ову апликацију.</string>
     <string name="upgrade_screen_restore_contact_hint">Још увек имате проблем? Контактирајте подршку са имејла који је направио куповину и укључите ваш редни број из Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Контактирајте подршку</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Статус ваше надоградње и куповине.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod не може да се повеже са Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли сте пријављени на свој Google налог? Покушајте да очистите кеш Google Play апликације и поново покрените уређај.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod kontrollerade precis Google Play, men ingen Pro-köp kunde bekräftas för det konto som Google Play använder för denna app.</string>
     <string name="upgrade_screen_restore_contact_hint">Fortfarande problem? Kontakta support från e-postadressen som gjorde köpet och ta med ditt Google Play-ordernummer.</string>
     <string name="upgrade_screen_contact_support_action">Kontakta support</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Din uppgraderings- och köpstatus.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod imekagua Google Play tu, lakini hakuna ununuzi wa Pro unaoweza kuthibitishwa kwa akaunti ambayo Google Play inatumia kwa programu hii.</string>
     <string name="upgrade_screen_restore_contact_hint">Bado una tatizo? Wasiliana na msaada kutoka kwa barua pepe ambayo ilifanya ununuzi na jumuisha namba yako ya agizo la Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Wasiliana na msaada</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Hali yako ya Upgrade na Ununuzi.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod haiwezi kuunganisha na Google Play. Je, Google Play imesakinishwa na imesasishwa? Je, akaunti yako ya Google imeingia? Jaribu kusafisha akiba ya programu ya Google Play na uanzishe upya kifaa chako.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod இப்போது Google Play ஐ சரிபார்த்தது, ஆனால் Google Play இந்த பயன்பாட்டிற்குப் பயன்படுத்தும் கணக்குக் Pro வாங்குதல் உறுதிப்படுத்தப்படவில்லை.</string>
     <string name="upgrade_screen_restore_contact_hint">இன்னும் சிக்கலாக உள்ளதா? வாங்குதல் செய்த மின்னஞ்சலிலிருந்து ஆதரவைத் தொடர்பு கொள்ளவும் மற்றும் உங்கள் Google Play ஆணை எண்ணைச் சேர்க்கவும்.</string>
     <string name="upgrade_screen_contact_support_action">ஆதரவைத் தொடர்பு கொள்ளவும்</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">உங்கள் மேம்பாடு மற்றும் வாங்குதல் நிலை.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play உடன் இணைக்க முடியவில்லை. Google Play நிறுவப்பட்டு புதுப்பிக்கப்பட்டுள்ளதா? உங்கள் Google கணக்கு உள்நுழைந்துள்ளதா? Google Play ஆப்பின் தற்காலிக சேமிப்பை அழித்து உங்கள் சாதனத்தை மறுதொடக்கம் செய்ய முயற்சிக்கவும்.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod ఇప్పుడే Google Play ను చెక్ చేసింది, కానీ Google Play ఈ యాప్ కోసం ఉపయోగిస్తున్న ఖాతా కోసం Pro కొనుగోలు నిర్ధారించబడలేదు.</string>
     <string name="upgrade_screen_restore_contact_hint">ఇంకా సమస్య ఉందా? కొనుగోలు చేసిన ఈ-మెయిల్ నుండి సపోర్టుకు సంప్రదించండి మరియు మీ Google Play ఆర్డర్ నంబర్‌ను చేర్చండి.</string>
     <string name="upgrade_screen_contact_support_action">సపోర్టుకు సంప్రదించండి</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">మీ అప్‌గ్రేడ్ మరియు కొనుగోలు స్థితి.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Playకి కనెక్ట్ చేయలేదు. Google Play ఇన్‌స్టాల్ చేయబడి నవీకరించబడిందా? మీ Google ఖాతా లాగిన్ చేయబడిందా? Google Play యాప్ యొక్క కాష్‌ని క్లియర్ చేసి మీ పరికరాన్ని రీబూట్ చేయడానికి ప్రయత్నించండి.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod เพิ่งตรวจสอบ Google Play แต่ไม่สามารถยืนยันการซื้อ Pro สำหรับบัญชีที่ Google Play ใช้สำหรับแอปนี้ได้</string>
     <string name="upgrade_screen_restore_contact_hint">ยังติดขัดอยู่หรือ? ติดต่อฝ่ายสนับสนุนจากอีเมลที่ทำการซื้อและแนบหมายเลขคำสั่งซื้อ Google Play ของคุณด้วย</string>
     <string name="upgrade_screen_contact_support_action">ติดต่อฝ่ายสนับสนุน</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">สถานะการอัปเกรดและการซื้อของคุณ</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod Google Play\'i kontrol etti, ancak Google Play\'in bu uygulama için kullandığı hesapta Pro satın alması doğrulanmadı.</string>
     <string name="upgrade_screen_restore_contact_hint">Hâlâ sorun mu yaşıyorsunuz? Satın almayı yapan e-posta adresinden desteğe başvurun ve Google Play sipariş numaranızı ekleyin.</string>
     <string name="upgrade_screen_contact_support_action">Desteğe başvur</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Yükseltme ve satın alma durumunuz.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod щойно перевірив Google Play, але не вдалося підтвердити покупку Pro для облікового запису, який Google Play використовує для цього додатка.</string>
     <string name="upgrade_screen_restore_contact_hint">Досі не вдається? Зв\'яжіться з підтримкою з електронної пошти, якою було здійснено покупку, і вкажіть номер замовлення Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Зв\'язок з підтримкою</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Ваш статус оновлення та покупки.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod не може підключитися до Google Play. Чи встановлено та оновлено Google Play? Ви ввійшли до свого облікового запису Google? Спробуйте очистити кеш застосунку Google Play і перезавантажити пристрій.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod نے ابھی Google Play کو چیک کیا، لیکن اس اکاؤنٹ کے لیے کوئی Pro خریداری تصدیق نہیں ہو سکی جو Google Play اس ایپ کے لیے استعمال کر رہا ہے۔</string>
     <string name="upgrade_screen_restore_contact_hint">ابھی بھی مسائل ہیں؟ اس ای میل سے معاونت سے رابطہ کریں جو خریداری میں استعمال ہوا اور اپنا Google Play آرڈر نمبر شامل کریں۔</string>
     <string name="upgrade_screen_contact_support_action">معاونت سے رابطہ کریں</string>
-    <string name="settings_upgrade_status_label">سی اے پوڈ پرو</string>
     <string name="settings_upgrade_status_description">آپ کی اپ گریڈ اور خریداری کی حالت۔</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play سے رابطہ نہیں کر سکتا۔ کیا Google Play انسٹال اور اپ ڈیٹ ہے؟ کیا آپ کا Google اکاؤنٹ لاگ ان ہے؟ Google Play ایپ کی کیش صاف کرنے اور اپنا ڈیوائس دوبارہ شروع کرنے کی کوشش کریں۔</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod hozirgina Google Play ni tekshirdi, lekin ushbu ilovaning Google Play hisobi uchun hech qanday Pro sotib olish tasdiqlanmadi.</string>
     <string name="upgrade_screen_restore_contact_hint">Hali qiyin holatdami? Sotib olish qilgan elektron pochtadan qo\'llab-quvvatlashga murojaat qiling va Google Play buyurtma raqamingizni kiriting.</string>
     <string name="upgrade_screen_contact_support_action">Qo\'llab-quvvatlash</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Sizning yangilash va sotib olish holati.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod Google Play-ga ulanib bo\'lmaydi. Google Play o\'rnatilgan va yangilanganmi? Google hisobingiz tizimga kirilganmi? Google Play ilovasining keshini tozalashni va qurilmangizni qayta ishga tushirishni sinab ko\'ring.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod vừa kiểm tra Google Play, nhưng không thể xác nhận mua hàng Pro nào cho tài khoản mà Google Play sử dụng cho ứng dụng này.</string>
     <string name="upgrade_screen_restore_contact_hint">Vẫn gặp vấn đề? Vui lòng liên hệ bộ phận hỗ trợ từ email đã thực hiện mua hàng và cung cấp số đơn hàng Google Play của bạn.</string>
     <string name="upgrade_screen_contact_support_action">Liên hệ hỗ trợ</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Trạng thái nâng cấp và mua hàng của bạn.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Tài khoản Google của bạn đã đăng nhập chưa? Hãy thử xóa bộ nhớ đệm của ứng dụng Google Play và khởi động lại thiết bị của bạn.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod 刚刚检查了 Google Play，但未能确认当前账户上的专业版购买。</string>
     <string name="upgrade_screen_restore_contact_hint">仍然遇到问题？请使用进行购买的电子邮件地址联系支持，并包括您的 Google Play 订单号。</string>
     <string name="upgrade_screen_contact_support_action">联系支持</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">您的升级和购买状态。</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod 无法连接到 Google Play。Google Play 是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 应用的缓存，然后重启您的设备。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod 已檢查 Google Play,但無法確認此帳戶的專業版購買紀錄。</string>
     <string name="upgrade_screen_restore_contact_hint">仍有問題？請使用進行購買的電郵聯絡支援，並提供您的 Google Play 訂單編號。</string>
     <string name="upgrade_screen_contact_support_action">聯絡支援</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">您的升級和購買狀態。</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod 無法連線至 Google Play。請確認 Google Play 已安裝且為最新版本，同時確保已經登入 Google 帳戶。您可以嘗試清除 Google Play 應用程式的快取或重新啟動您的裝置以修正此問題。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod 剛檢查了 Google Play，但無法為此應用程式所使用的帳戶確認 Pro 購買。</string>
     <string name="upgrade_screen_restore_contact_hint">仍然無法解決？請使用購買時的電子郵件聯繫支援，並提供您的 Google Play 訂單號碼。</string>
     <string name="upgrade_screen_contact_support_action">聯絡支援</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">您的升級和購買狀態。</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">I-CAPod isanda kuhlola i-Google Play, kodwa akukho kuthenga kwe-Pro okuqinisekiswe kule akhawunti i-Google Play eyisebenzisayo kulolu hlelo lokusebenza.</string>
     <string name="upgrade_screen_restore_contact_hint">Usabambeke? Xhumana nosizo usuka ku-imeyili eyenza ukuthenga futhi ufake inombolo ye-oda ye-Google Play.</string>
     <string name="upgrade_screen_contact_support_action">Xhumana nolungiselelo</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Isimo sokuthuthukiswa nokuthenga kwakho.</string>
     <string name="upgrades_gplay_unavailable_error_description">I-CAPod ayikwazi ukuxhuma ku-Google Play. Ingabe Google Play ifakiwe futhi isesikhathini? Ingabe i-akhawunti yakho ye-Google ingene? Zama ukusula i-cache yohlelo lokusebenza lwe-Google Play futhi uphinde uqalise idivayisi yakho.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -66,7 +66,6 @@
     <string name="upgrade_screen_restore_checked_message">CAPod just checked Google Play, but no Pro purchase could be confirmed for the account Google Play is using for this app.</string>
     <string name="upgrade_screen_restore_contact_hint">Still stuck? Contact support from the email that made the purchase and include your Google Play order number.</string>
     <string name="upgrade_screen_contact_support_action">Contact support</string>
-    <string name="settings_upgrade_status_label">CAPod Pro</string>
     <string name="settings_upgrade_status_description">Your upgrade and purchase status.</string>
     <string name="upgrades_gplay_unavailable_error_description">CAPod can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/SettingsScreen.kt
@@ -34,6 +34,7 @@ import eu.darken.capod.common.navigation.Nav
 import eu.darken.capod.common.navigation.NavigationEventHandler
 import eu.darken.capod.common.settings.SettingsBaseItem
 import eu.darken.capod.common.settings.SettingsCategoryHeader
+import eu.darken.capod.common.upgrade.ui.settingsUpgradeStatusTitle
 
 @Composable
 fun SettingsScreenHost(vm: SettingsViewModel = hiltViewModel()) {
@@ -129,10 +130,12 @@ fun SettingsScreen(
             }
             item {
                 // Always visible: owners need a way to check their Pro/supporter status, and
-                // non-owners get another path to the upgrade screen. The label/description
-                // resources are flavor-overridden (foss vs gplay values).
+                // non-owners get another path to the upgrade screen. settingsUpgradeStatusTitle()
+                // has a separate implementation per flavor source set, reading the same resource
+                // its own upgrade screen titles itself with — so this row can't drift from it.
+                // The subtitle resource is flavor-overridden (foss vs gplay values) directly.
                 SettingsBaseItem(
-                    title = stringResource(R.string.settings_upgrade_status_label),
+                    title = settingsUpgradeStatusTitle(),
                     subtitle = stringResource(R.string.settings_upgrade_status_description),
                     icon = Icons.TwoTone.Stars,
                     onClick = onUpgradeStatus,

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -12,6 +12,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.compose.ui.semantics.SemanticsActions
 import eu.darken.capod.R
 import eu.darken.capod.common.compose.PreviewWrapper
+import eu.darken.capod.main.ui.settings.SettingsScreen
+import eu.darken.capod.main.ui.settings.SettingsViewModel
 import io.kotest.matchers.shouldBe
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -42,7 +44,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen()
         }
 
-        composeRule.onAllNodesWithText(context.getString(R.string.settings_upgrade_status_label)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_sponsor_label)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_preamble)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
@@ -172,6 +174,33 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             assertTrue(clicked)
             assertFalse(armed)
         }
+    }
+
+    // Regression guard for retiring settings_upgrade_status_label: the Settings row and the PITCH
+    // title both read settingsUpgradeStatusTitle() now, so this proves the two ACTUAL screens render
+    // identical text, not just that they call the same function. The PITCH-side half of the
+    // invariant is covered above ("renders redesigned foss content without duplicated app bar
+    // title" asserts the PITCH title equals upgrade_foss_sponsor_label exactly once).
+    @Test
+    fun `the settings row shows the same text as the pitch screen title`() {
+        composeRule.setUpgradeContent {
+            SettingsScreen(
+                state = SettingsViewModel.State(isPro = false, sponsorUrl = null),
+                onNavigateUp = {},
+                onGeneralSettings = {},
+                onDeviceManager = {},
+                onUpgradeStatus = {},
+                onSupport = {},
+                onWiki = {},
+                onChangelog = {},
+                onHelpTranslate = {},
+                onAcknowledgements = {},
+                onPrivacyPolicy = {},
+                onSponsor = {},
+            )
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_foss_sponsor_label)).assertCountEquals(1)
     }
 }
 

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -20,10 +20,13 @@ import eu.darken.capod.R
 import eu.darken.capod.common.compose.PreviewWrapper
 import eu.darken.capod.common.upgrade.core.OurSku
 import eu.darken.capod.common.upgrade.core.billing.SkuDetails
+import eu.darken.capod.main.ui.settings.SettingsScreen
+import eu.darken.capod.main.ui.settings.SettingsViewModel
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 
 class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
@@ -692,6 +695,36 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onNodeWithText(context.getString(R.string.general_retry_action)).performClick()
         composeRule.runOnIdle { retries shouldBe 1 }
+    }
+
+    // Regression guard for retiring settings_upgrade_status_label: the Settings row and this
+    // screen's own status title both read settingsUpgradeStatusTitle()/upgradeScreenTitle() from the
+    // same brandTitle composition, so this proves the two ACTUAL screens render identical text, not
+    // just that they call the same function. The status-title half of the invariant is covered above
+    // ("renewing subscription owner..." and the grace tests already assert appNameWithPostfix).
+    // Arabic, not the default locale: the retired raw label and the composed template both said
+    // "CAPod Pro" in English, so a default-locale test would pass even with the old drift bug intact.
+    @Config(qualifiers = "ar")
+    @Test
+    fun `the settings row shows the same text as the status screen title`() {
+        composeRule.setUpgradeContent {
+            SettingsScreen(
+                state = SettingsViewModel.State(isPro = true, sponsorUrl = null),
+                onNavigateUp = {},
+                onGeneralSettings = {},
+                onDeviceManager = {},
+                onUpgradeStatus = {},
+                onSupport = {},
+                onWiki = {},
+                onChangelog = {},
+                onHelpTranslate = {},
+                onAcknowledgements = {},
+                onPrivacyPolicy = {},
+                onSponsor = {},
+            )
+        }
+
+        composeRule.onAllNodesWithText(appNameWithPostfix).assertCountEquals(1)
     }
 
     @Test


### PR DESCRIPTION
## What changed

On Google Play, the Settings screen's "CAPod Pro" status row and the upgrade screen it opens
could show the tier name differently depending on language — in 15 of 75 locales the Settings
row (a raw translated string) used different word order or fell back to untranslated English
("CAPod Pro") where the upgrade screen's own title (already composed from the app name and the
tier word) showed the correct localized form. The Settings row now uses the exact same
composition as the upgrade screen, so the two can no longer disagree, in any locale.

On the FOSS/sponsor build, the Settings row and the upgrade screen already agreed and keep
showing the same "Sponsor CAPod" wording as before, word for word, in all 75 locales — nothing
changes there for users.

## Technical Context

- Root cause: `settings_upgrade_status_label` was a second, independently-translated copy of the
  same brand+tier text the upgrade screen already composed from `app_name` +
  `upgrade_badge_label` through `app_name_upgraded_template`. Translators could — and did —
  translate the two differently.
- gplay: the Settings row now calls the same `brandTitleText(includeQualifier = true)`
  composition gplay's own upgrade screen title already used. The retired key is deleted outright
  (base + all 75 locale overrides); no replacement translatable string is needed since it
  composes from resources that are already fully translated.
- foss: FOSS's value was a support ask ("Sponsor CAPod"), not a composed brand title — very
  recent commits deliberately kept FOSS's pitch-view title as a separate raw string from the
  composed brand title used elsewhere on that screen, specifically so it keeps reading as a call
  to action rather than naming the flavor. Composing it through the template would have silently
  reverted that decision and changed visible wording for FOSS users, so instead the key is
  renamed to `upgrade_foss_sponsor_label` with byte-identical text preserved across all 75
  locales, and both FOSS call sites (Settings row, pitch title) now read that one resource.
- Mechanism for the shared Settings screen: `SettingsScreen.kt` (in the shared `main` source set)
  needs different behavior per flavor at this one call site. Both flavors implement the same
  `internal fun settingsUpgradeStatusTitle(): String` signature independently in their own source
  set's existing `UpgradeScreen.kt` — the same per-flavor-source-set pattern the codebase already
  uses for `UpgradeRepo`. Each flavor build only ever compiles its own implementation, so no
  runtime flavor check is needed at the call site.
- Accepted cost: composing gplay's title from the template instead of a freely-translated string
  loses some translator flourish in the locales that previously drifted — e.g. Arabic's genitive
  construction becomes the template's dash-separated form, Hindi's fully-localized brand becomes
  mixed-script, and Mongolian's translated qualifier reverts to English (its `upgrade_badge_label`
  translation was never filled in, a separate pre-existing gap this PR doesn't address). The two
  surfaces agreeing was judged worth more than preserving per-string translator wording the
  template can't express.
- Tests directly render the Settings screen and the flavor's own upgrade screen and assert they
  emit identical title text. The gplay test runs under an Arabic locale qualifier specifically
  because the default English locale wouldn't have caught the original drift (both old and new
  text were "CAPod Pro" in English there).
