### PR TITLE
Show when a Google Play payment is still being processed

### DIFF
--- a/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -42,8 +42,10 @@ class UpgradeViewModel @Inject constructor(
 
     // Which presentation the screen shows. The manage route (settings "upgrade status" entry)
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
-    // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
-    // land on the upgraded status, not back on the ask. null until the route is bound.
+    // options. Upgrading wins on EVERY route, not just manage: forced routes (Pro-locked settings)
+    // stay open after the sponsor flow completes, and the pitch with its live sponsor button reads
+    // as "sponsoring didn't work" to a fresh supporter — the toast alone is too transient for a
+    // money moment without a receipt behind it. null until the route is bound.
     internal val state: StateFlow<State?> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
@@ -51,7 +53,7 @@ class UpgradeViewModel @Inject constructor(
     ) { route, info, showOptions ->
         val view = when {
             route == null -> null
-            route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/UpgradeRepoGplay.kt
@@ -2,7 +2,6 @@ package eu.darken.capod.common.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
-import com.android.billingclient.api.Purchase
 import eu.darken.capod.common.coroutine.AppScope
 import eu.darken.capod.common.datastore.value
 import eu.darken.capod.common.debug.logging.Logging.Priority.ERROR
@@ -18,6 +17,7 @@ import eu.darken.capod.common.upgrade.core.billing.BillingData
 import eu.darken.capod.common.upgrade.core.billing.BillingManager
 import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.capod.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.capod.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.capod.common.upgrade.core.billing.PurchasedSku
 import eu.darken.capod.common.upgrade.core.billing.Sku
 import eu.darken.capod.common.upgrade.core.billing.SkuDetails
@@ -284,9 +284,18 @@ class UpgradeRepoGplay @Inject constructor(
                     // Reconciled only if the restore actually returned the SKU Play claims is
                     // owned — a grace-only isPro doesn't count, the entitlement is still missing.
                     if (restored?.upgrades?.any { it.sku == sku } != true) {
-                        // Couldn't reconcile the entitlement (pending purchase, account mismatch,
-                        // Play quirk) — fall back to the already-owned dialog with restore tips.
-                        onError(e)
+                        if (restored?.pendingSkus?.isNotEmpty() == true) {
+                            // Play blocks re-purchasing a product whose payment it is still
+                            // processing. "Already owned" is technically what Play said, but the
+                            // dialog's restore tips are the wrong advice: nothing to restore, and
+                            // the entitlement lands by itself once the payment clears.
+                            log(TAG, INFO) { "Already-owned recovery found a pending payment" }
+                            onError(PendingPurchaseBillingException(e))
+                        } else {
+                            // Couldn't reconcile the entitlement (account mismatch, Play quirk) —
+                            // fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
                     }
                 }
 
@@ -329,12 +338,15 @@ class UpgradeRepoGplay @Inject constructor(
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
 
-    // Strict subscription lookup for the pre-purchase gate: fresh SUBS-only query with explicit
-    // failure. No grace substitution and no cross-product-type tolerance (unlike refresh() and
+    // Strict purchase-state lookup for the pre-purchase gates: a fresh COMPLETE round-trip with
+    // explicit failure. No grace substitution and no partial tolerance (unlike refresh() and
     // restorePurchaseNow()) — callers must treat any error as "couldn't verify" and fail closed.
-    suspend fun queryCurrentSubscriptions(): Collection<Purchase> {
-        log(TAG) { "queryCurrentSubscriptions()" }
-        return billingManager.querySubscriptions()
+    // Covers both product types and pending payments, because both can make a purchase wrong: a
+    // renewing subscription (double billing) and a payment Play is still processing (Play rejects
+    // the re-purchase).
+    suspend fun verifyPurchaseStateNow(): Info {
+        log(TAG) { "verifyPurchaseStateNow()" }
+        return Info(billingData = billingManager.refreshStrict(), isSettled = true)
     }
 
     override suspend fun refresh() {
@@ -496,8 +508,8 @@ class UpgradeRepoGplay @Inject constructor(
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
     // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
-    // settled comes from the caller, never from billingData nullness: the grace branch returns an
-    // Info with billingData = null that may well be settled (built from a real empty snapshot).
+    // settled comes from the caller, never from billingData nullness: a null-data Info can be
+    // perfectly settled (a real empty snapshot), and the grace branch carries data through anyway.
     private suspend fun BillingData?.toUpgradeInfo(settled: Boolean): Info {
         // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products
         // this app doesn't know maps to zero upgrades and must fall through to the grace check —
@@ -513,7 +525,11 @@ class UpgradeRepoGplay @Inject constructor(
         return when {
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                Info(gracePeriod = true, billingData = null, isSettled = settled)
+                // billingData is carried through, not dropped: this branch is only reached when the
+                // mapped upgrades are empty, so entitlement stays empty either way — but a pending
+                // payment must stay visible, and a grace user waiting on one is exactly who needs
+                // the explanation.
+                Info(gracePeriod = true, billingData = this, isSettled = settled)
             }
 
             else -> mapped
@@ -557,6 +573,34 @@ class UpgradeRepoGplay @Inject constructor(
             }
             ?.flatten()
             ?: emptySet()
+
+        // Products with a payment Play is still processing. Deliberately NOT part of [isPro] or
+        // [upgrades]: a pending payment grants nothing. It exists so the UI can explain the wait
+        // and lock the purchase buttons — buying the alternative product now would double-charge.
+        val pendingSkus: Collection<Sku> = billingData?.pendingPurchases
+            ?.map { purchase ->
+                purchase.products.mapNotNull { productId ->
+                    val sku = OurSku.PRO_SKUS.singleOrNull { it.id == productId }
+                    if (sku == null) {
+                        log(TAG, WARN) { "Unknown pending product: $productId (${purchase.redacted()})" }
+                        return@mapNotNull null
+                    }
+                    sku
+                }
+            }
+            ?.flatten()
+            ?: emptySet()
+
+        // Any owned purchase Play still bills on a schedule. Deliberately computed from the RAW
+        // PURCHASED purchases instead of [upgrades]: the mapping drops products this app doesn't
+        // know, and the pre-purchase gate must keep blocking on a renewing subscription with an
+        // unknown or legacy product ID — being wrong there means billing the user twice for Pro.
+        // Both product types are scanned; a one-time purchase reports isAutoRenewing = false, so
+        // the broader input cannot produce a false positive.
+        // Computed on access, not in the initializer: an Info is built for every mapping pass, and
+        // only the purchase gate needs this.
+        val hasAutoRenewingSubscription: Boolean
+            get() = billingData?.purchases?.any { it.isAutoRenewing } == true
 
         override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
 

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/BillingData.kt
@@ -1,7 +1,28 @@
 package eu.darken.capod.common.upgrade.core.billing
 
 import com.android.billingclient.api.Purchase
+import eu.darken.capod.common.upgrade.core.billing.client.isPurchased
+import eu.darken.capod.common.upgrade.core.billing.client.isRelevant
 
+/**
+ * Play's purchase state, split by what it may be used for. [purchases] is the entitlement carrier
+ * and PURCHASED-only by construction, so no consumer can grant Pro (or stamp the grace cache) from
+ * a payment Play is still processing; [pendingPurchases] keeps that payment visible to the UI.
+ */
 data class BillingData(
-    val purchases: Collection<Purchase>
-)
+    val purchases: Collection<Purchase>,
+    val pendingPurchases: Collection<Purchase> = emptyList(),
+) {
+
+    companion object {
+        // The one place raw Play data becomes a BillingData: splitting here (instead of at each
+        // consumer) is what keeps "pending never grants Pro" a property of the type. Anything
+        // that is neither PURCHASED nor PENDING is dropped — it is not an entitlement and not a
+        // payment in progress.
+        fun from(raw: Collection<Purchase>): BillingData {
+            val relevant = raw.filter { it.isRelevant }
+            val (purchased, pending) = relevant.partition { it.isPurchased }
+            return BillingData(purchases = purchased, pendingPurchases = pending)
+        }
+    }
+}

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManager.kt
@@ -418,17 +418,12 @@ class BillingManager @Inject constructor(
         }
     }
 
-    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
-    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
-    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
-    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
-    // useConnection's).
-    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
-        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
-        // instead of throwing), so the teardown that used to ride the throw path happens here.
-        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
-        // Deliberately no holder CAS: the failing connection may already have been replaced, and
-        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+    // A partial refresh no longer reaches useConnection's dead-binder detection (it returns instead
+    // of throwing), so the teardown that used to ride the throw path happens here. Cause chain, not
+    // the exception itself: the failure arrives user-friendly-mapped. Deliberately no holder CAS:
+    // the failing connection may already have been replaced, and the accepted cost of that rare
+    // race is one extra failed action while the loop reconnects.
+    private fun invalidateOnDeadConnection(refresh: BillingConnection.PurchaseRefresh) {
         val clientError = refresh.partialError?.let {
             (it as? BillingClientException) ?: (it.cause as? BillingClientException)
         }
@@ -436,6 +431,15 @@ class BillingManager @Inject constructor(
             log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
             invalidations.trySend(Unit)
         }
+    }
+
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        invalidateOnDeadConnection(refresh)
 
         if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
             // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
@@ -535,6 +539,11 @@ class BillingManager @Inject constructor(
     suspend fun refreshStrict(): BillingData {
         log(TAG) { "refreshStrict()" }
         val fresh = useConnection { refreshPurchases() }
+        // A gate that hit a dying connection must still trigger the reconnect (the throw below
+        // bypasses useConnection's detection, which already returned), or every later purchase
+        // check keeps reusing the corpse. No-op on a complete refresh. The episode clock stays out
+        // of this path: an aborted gate is not a reconciliation outcome.
+        invalidateOnDeadConnection(fresh)
         if (!fresh.isComplete) {
             // partialError is set for every incomplete refresh; the fallback only exists so a
             // future incompleteness without a captured cause still fails closed instead of passing.

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManager.kt
@@ -14,6 +14,7 @@ import eu.darken.capod.common.flow.setupCommonEventHandlers
 import eu.darken.capod.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.capod.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.capod.common.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.capod.common.upgrade.core.billing.client.isPurchased
 import eu.darken.capod.common.upgrade.core.billing.client.redacted
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -73,13 +74,13 @@ class BillingManager @Inject constructor(
     private val failedOnce = MutableStateFlow(false)
     val isFailureSettled: Flow<Boolean> = failedOnce
 
-    // Fires once per failed connect-loop iteration: connection setup failure, the mandatory initial
-    // refreshPurchases erroring or timing out, an established connection dropping, an action-level
-    // invalidation (SERVICE_DISCONNECTED/SERVICE_TIMEOUT from any useConnection call), or an
-    // unexpected provider completion. Every one is a fresh reconciliation that couldn't confirm Pro.
-    // The connect loop retries these internally and downstream flows just go quiet, so without this
-    // explicit signal the grace episode clock (UpgradeRepoGplay.proUnconfirmedSince) would only
-    // advance on an explicit ON_RESUME refresh().
+    // Fires once per reconciliation that couldn't confirm Pro: a failed connect-loop iteration
+    // (connection setup failure, the mandatory initial refreshPurchases erroring or timing out, an
+    // established connection dropping, an action-level invalidation, an unexpected provider
+    // completion) — and, via processReconciliation, a refresh that COMPLETED but only partially,
+    // without a confirmed Pro purchase. The connect loop retries its failures internally and
+    // downstream flows just go quiet, so without this explicit signal the grace episode clock
+    // (UpgradeRepoGplay.proUnconfirmedSince) would only advance on an explicit ON_RESUME refresh().
     //
     // Each value is the failure's OCCURRENCE time (epoch millis). It has to be, not a bare Unit: the
     // channel buffers, and this feed and freshBillingData are separate flows with no cross-stream
@@ -121,13 +122,18 @@ class BillingManager @Inject constructor(
                                 // isFailureSettled forever with no retry. withTimeoutOrNull, NOT
                                 // withTimeout: TimeoutCancellationException is a
                                 // CancellationException and would kill this loop.
-                                withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
+                                val initialRefresh = withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
                                     connection.refreshPurchases()
                                 } ?: throw BillingException("Initial purchase refresh timed out")
 
                                 failStreak = 0
                                 connectionHolder.value = connection
                                 log(TAG, INFO) { "Billing connection established" }
+                                // AFTER publishing: a partial refresh is still a usable connection
+                                // (a pending-only cold start must not starve billingData), but its
+                                // bookkeeping — episode clock, dead-binder teardown — has to run,
+                                // and an invalidation may only tear down an INSTALLED connection.
+                                processReconciliation(initialRefresh)
                             }
                             // The provider flow stays open for the connection's lifetime; a normal
                             // completion means the connection is gone without an error — treat it
@@ -214,7 +220,7 @@ class BillingManager @Inject constructor(
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val billingData: Flow<BillingData> = purchases
-        .map { BillingData(purchases = it) }
+        .map { BillingData.from(it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val purchaseFailures: Flow<BillingResult> = connectionHolder
@@ -235,7 +241,10 @@ class BillingManager @Inject constructor(
                 // every emission here is a real Play round-trip the grace bookkeeping needs.
                 .resubscribeOnFailure("freshBillingData")
         }
-        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
+        // Through from() like every other exit, although the connection only ever puts PURCHASED
+        // purchases on this stream: if that invariant ever broke, splitting keeps the grace
+        // bookkeeping from stamping a pending payment as a confirmation.
+        .map { FreshData(data = BillingData.from(it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
         .setupCommonEventHandlers(TAG) { "freshBillingData" }
         // Same belt as `purchases`: an Eagerly shared flow that dies stays dead, and this one feeds
         // both the grace bookkeeping and the ack collector's re-drive signal.
@@ -292,6 +301,14 @@ class BillingManager @Inject constructor(
     // -data signals.
     private suspend fun runAckPass(purchases: Collection<Purchase>) {
         val needAck = purchases.filter {
+            // The canonical list carries pending payments too. Play rejects acknowledging one
+            // PERMANENTLY, so an unfiltered pass would fire a bug report for every pending purchase,
+            // every pass — and there is nothing to acknowledge until the payment completes anyway.
+            if (!it.isPurchased) {
+                log(TAG) { "Not acknowledgeable yet: ${it.redacted()}" }
+                return@filter false
+            }
+
             val needsAck = !it.isAcknowledged
 
             if (needsAck) log(TAG) { "Needs ACK: ${it.redacted()}" }
@@ -401,6 +418,35 @@ class BillingManager @Inject constructor(
         }
     }
 
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
+        // instead of throwing), so the teardown that used to ride the throw path happens here.
+        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
+        // Deliberately no holder CAS: the failing connection may already have been replaced, and
+        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+        val clientError = refresh.partialError?.let {
+            (it as? BillingClientException) ?: (it.cause as? BillingClientException)
+        }
+        if (clientError != null && clientError.result.responseCode in INVALIDATING_CODES) {
+            log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
+            invalidations.trySend(Unit)
+        }
+
+        if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
+            // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
+            // never now-at-send: a confirmation that committed between this refresh and the send
+            // (e.g. a pending payment completing) must stay NEWER than this failure, or the grace
+            // episode it closed would be reopened.
+            log(TAG, WARN) { "Partial refresh without a confirmed Pro purchase at ${refresh.occurredAt}" }
+            connectionFailuresChannel.trySend(refresh.occurredAt)
+        }
+    }
+
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
         // Every caller here is active demand (opening the upgrade screen, restore/buy taps,
         // purchase acks) — cut a pending reconnect backoff short. A no-op while healthy.
@@ -479,18 +525,24 @@ class BillingManager @Inject constructor(
         // shared upgradeInfo replay cache. The freshBillingData emission happens inside the
         // reducer's commit, in commit order — not here.
         val fresh = useConnection { refreshPurchases() }
-        return BillingData(purchases = fresh.purchases)
+        processReconciliation(fresh)
+        return BillingData.from(fresh.purchases)
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refresh(), a failure
-    // here propagates (user-friendly-mapped) instead of being masked by the other product type.
-    suspend fun querySubscriptions(): Collection<Purchase> = try {
-        useConnection { querySubscriptions() }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        log(TAG, WARN) { "querySubscriptions() failed: ${e.asLog()}" }
-        throw e.tryMapUserFriendly()
+    // Strict variant for the pre-purchase gates: unlike refresh(), anything short of a COMPLETE
+    // reconciliation throws (user-friendly-mapped) instead of returning what it happened to find —
+    // a gate must be able to tell "not owned" apart from "couldn't verify" and fail closed.
+    suspend fun refreshStrict(): BillingData {
+        log(TAG) { "refreshStrict()" }
+        val fresh = useConnection { refreshPurchases() }
+        if (!fresh.isComplete) {
+            // partialError is set for every incomplete refresh; the fallback only exists so a
+            // future incompleteness without a captured cause still fails closed instead of passing.
+            val error = fresh.partialError ?: BillingException("Purchase refresh was incomplete")
+            log(TAG, WARN) { "refreshStrict() incomplete: ${error.asLog()}" }
+            throw error.tryMapUserFriendly()
+        }
+        return BillingData.from(fresh.purchases)
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/PendingPurchaseBillingException.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/PendingPurchaseBillingException.kt
@@ -1,0 +1,11 @@
+package eu.darken.capod.common.upgrade.core.billing
+
+/**
+ * A purchase can't proceed because the account already has a payment Play is still processing.
+ *
+ * Typed so the UI can answer with the informational pending dialog instead of the already-owned
+ * error and its restore tips: restoring cannot help — Play refuses to re-sell a product with a
+ * pending payment, and the entitlement arrives on its own once the payment clears.
+ */
+class PendingPurchaseBillingException(cause: Throwable? = null) :
+    BillingException("A purchase with a pending payment already exists.", cause)

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/client/BillingClientExtensions.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/client/BillingClientExtensions.kt
@@ -9,6 +9,21 @@ internal val BillingResult.isSuccess: Boolean
     get() = responseCode == BillingClient.BillingResponseCode.OK
 
 /**
+ * Owned right now. The ONLY state that may grant an entitlement, stamp the Pro grace cache or be
+ * acknowledged — a PENDING purchase is a payment Play is still processing, and acknowledging one is
+ * rejected permanently.
+ */
+internal val Purchase.isPurchased: Boolean
+    get() = purchaseState == Purchase.PurchaseState.PURCHASED
+
+/**
+ * Worth carrying in our state at all: owned, or a payment in progress the user should see. Anything
+ * else (UNSPECIFIED_STATE) is dropped at ingestion — it is neither.
+ */
+internal val Purchase.isRelevant: Boolean
+    get() = isPurchased || purchaseState == Purchase.PurchaseState.PENDING
+
+/**
  * Log-safe rendering of a [Purchase].
  *
  * `Purchase.toString()` dumps the original response JSON, which carries the purchase token and the

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/core/billing/client/BillingConnection.kt
@@ -7,7 +7,6 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
@@ -41,11 +40,11 @@ class BillingConnection(
     private val skuTypeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
 ) {
 
-    // A purchase proven by an onPurchasesUpdated success event. Additive only: events prove
-    // ownership, never absence. `gen` orders it against queries (a query that STARTED before this
-    // event must not clear it); `type` is resolved at ingestion so a later per-type query that
-    // confirms absence can supersede it (null = product unknown to this app, only a complete
-    // refresh may clear it).
+    // A purchase (owned or with a pending payment) proven by an onPurchasesUpdated success event.
+    // Additive only: events prove existence, never absence. `gen` orders it against queries (a
+    // query that STARTED before this event must not clear it); `type` is resolved at ingestion so a
+    // later per-type query that confirms absence can supersede it (null = product unknown to this
+    // app, only a complete refresh may clear it).
     data class OverlayEntry(
         val purchase: Purchase,
         val gen: Long,
@@ -64,11 +63,11 @@ class BillingConnection(
     ) {
 
         internal fun withEvent(
-            purchased: Collection<Purchase>,
+            relevant: Collection<Purchase>,
             typeOf: (String) -> Sku.Type?,
         ): ReducerState {
             val gen = eventGen + 1
-            val entries = purchased.map { purchase ->
+            val entries = relevant.map { purchase ->
                 OverlayEntry(
                     purchase = purchase,
                     gen = gen,
@@ -169,10 +168,13 @@ class BillingConnection(
                 "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, " +
                     "purchases=${purchases?.redacted()})"
             }
-            // PENDING purchases must never surface as owned (or stamp the Pro grace cache).
-            val purchased = purchases.orEmpty().filter { it.purchaseState == PurchaseState.PURCHASED }
+            // The reducer carries PENDING purchases too (the UI must be able to show a payment in
+            // progress), but the fresh stream stays PURCHASED-only: it feeds the entitlement and
+            // grace bookkeeping, which must never see a payment Play hasn't completed.
+            val relevant = purchases.orEmpty().filter { it.isRelevant }
+            val purchased = relevant.filter { it.isPurchased }
             synchronized(reducerLock) {
-                state.value = state.value.withEvent(purchased, skuTypeOf)
+                state.value = state.value.withEvent(relevant, skuTypeOf)
                 if (purchased.isNotEmpty()) {
                     freshUpdatesChannel.trySend(FreshUpdate(purchased, isFullSnapshot = false))
                 }
@@ -193,12 +195,29 @@ class BillingConnection(
         failureChannel.close()
     }
 
-    // The purchases of a refresh plus whether it covered both product types: a partial result (one
-    // query failed) is still authoritative for what it FOUND, but must not be treated as proof of
-    // absence for the type that couldn't be checked.
+    // The full outcome of a refresh: what it committed, what it actually CONFIRMED, and how far it
+    // got. A partial result (one query failed) is still authoritative for what it found, but must
+    // not be treated as proof of absence for the type that couldn't be checked — so callers that
+    // need to fail closed, or to feed the grace episode clock, get the provenance instead of having
+    // to infer it from the merged view.
     data class PurchaseRefresh(
+        // The committed reducer state (queries merged with retained snapshots and surviving
+        // events) — the same view the reactive purchases flow emits.
         val purchases: Collection<Purchase>,
+        // ONLY what these queries returned: never retained state of a failed type, so a consumer
+        // can tell "Play said so just now" from "we still remember this".
+        val confirmed: Collection<Purchase> = emptyList(),
+        // A confirmed PURCHASED purchase of a product this app knows. Fail-safe default: "we
+        // couldn't confirm Pro" is the direction that keeps the grace bookkeeping honest.
+        val hasConfirmedProPurchase: Boolean = false,
         val isComplete: Boolean,
+        // Commit time under reducerLock — the same instant stamped on this refresh's FreshUpdate,
+        // so a confirmation and a later failure signal are ordered by when they HAPPENED.
+        val occurredAt: Long = System.currentTimeMillis(),
+        // Why the refresh is incomplete (the failed type's already user-friendly-mapped
+        // exception), null when complete. Carried rather than thrown: a partial refresh that found
+        // something is still useful, only the caller can decide whether partial is good enough.
+        val partialError: Throwable? = null,
     )
 
     // Serializes concurrent refreshes (manual, background, auto-restore): an older query that got
@@ -214,8 +233,8 @@ class BillingConnection(
         coroutineScope {
             log(TAG) { "refreshPurchases()" }
             val genAtQueryStart = state.value.eventGen
-            val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
-            val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
+            val iapJob = async { queryRelevantProducts(BillingClient.ProductType.INAPP) }
+            val subJob = async { queryRelevantProducts(BillingClient.ProductType.SUBS) }
             val iap = iapJob.await()
             val sub = subJob.await()
             log(TAG) { "Refreshed IAPs=${iap.getOrNull()?.redacted()}, SUBs=${sub.getOrNull()?.redacted()}" }
@@ -224,6 +243,12 @@ class BillingConnection(
             // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
             // must not be discarded just because the SUB query errored.
             val isComplete = iap.isSuccess && sub.isSuccess
+            // Only what the queries CONFIRMED as owned — retained stale data of a failed type, and
+            // pending payments, stay out (both would keep re-stamping the grace window).
+            val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
+                .filter { it.isPurchased }
+                .sortedByDescending { it.purchaseTime }
+            var committedAt = 0L
             val committed = synchronized(reducerLock) {
                 val next = state.value.withQueryResults(
                     iap = iap.getOrNull(),
@@ -231,17 +256,18 @@ class BillingConnection(
                     genAtQueryStart = genAtQueryStart,
                 )
                 state.value = next
+                committedAt = System.currentTimeMillis()
                 if (iap.isSuccess || sub.isSuccess) {
-                    // Only what the queries CONFIRMED — retained stale data of a failed type stays
-                    // out of the fresh stream (it would keep re-stamping the grace window).
-                    val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
-                        .sortedByDescending { it.purchaseTime }
-                    // A surviving overlay entry (purchase event newer than the query start, or of
-                    // a failed type) means this result does NOT prove total absence: it must not
-                    // count as a full snapshot, or an empty query racing a fresh purchase event
-                    // would start a false unconfirmed-grace episode.
-                    val provesAbsence = isComplete && next.overlay.isEmpty()
-                    freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = provesAbsence))
+                    // A surviving OWNED overlay entry (purchase event newer than the query start,
+                    // or of a failed type) means this result does NOT prove total absence: it must
+                    // not count as a full snapshot, or an empty query racing a fresh purchase event
+                    // would start a false unconfirmed-grace episode. A surviving PENDING entry
+                    // proves nothing about ownership, so it must not suppress the bookkeeping
+                    // either — a payment in progress would otherwise freeze the episode clock.
+                    val provesAbsence = isComplete && next.overlay.none { it.purchase.isPurchased }
+                    freshUpdatesChannel.trySend(
+                        FreshUpdate(confirmed, isFullSnapshot = provesAbsence, occurredAt = committedAt)
+                    )
                 }
                 next
             }
@@ -249,31 +275,42 @@ class BillingConnection(
             // Support-log anchor, at INFO because purchase complaints arrive as debug recordings.
             // Logs what these queries CONFIRMED, kept distinct from the committed view: merged()
             // retains a failed type's previous purchases, so reporting it as "what Play returned"
-            // would be the same false-certainty trap the copy elsewhere had to fix. Product IDs
-            // only -- never the Purchase, which carries order and token data.
+            // would be the same false-certainty trap the copy elsewhere had to fix. Pending ids are
+            // listed separately — "bought it, still not Pro" reports are exactly this state.
+            // Product IDs only -- never the Purchase, which carries order and token data.
             log(TAG, INFO) {
-                val confirmedIds = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()).flatMap { it.products }
-                "refreshPurchases(): confirmed=$confirmedIds, isComplete=$isComplete, " +
+                val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+                val confirmedIds = returned.filter { it.isPurchased }.flatMap { it.products }
+                val pendingIds = returned.filterNot { it.isPurchased }.flatMap { it.products }
+                "refreshPurchases(): confirmed=$confirmedIds, pending=$pendingIds, isComplete=$isComplete, " +
                     "iapOk=${iap.isSuccess}, subOk=${sub.isSuccess}, merged=${committed.merged().size}"
             }
 
             // Throws when nothing was found and a query failed, so the caller can tell "not
             // owned" apart from "couldn't verify".
-            combinePurchaseResults(iap, sub)
+            combinePurchaseResults(iap, sub, skuTypeOf)
 
             PurchaseRefresh(
                 purchases = committed.merged(),
+                confirmed = confirmed,
+                hasConfirmedProPurchase = confirmed.any { purchase ->
+                    purchase.products.any { skuTypeOf(it) != null }
+                },
                 isComplete = isComplete,
+                occurredAt = committedAt,
+                partialError = iap.exceptionOrNull() ?: sub.exceptionOrNull(),
             )
         }
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel
     // the sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
-    private suspend fun queryPurchasedProducts(
+    // Returns owned AND pending purchases; the split by state happens where it matters (fresh
+    // stream, entitlement mapping), so a pending payment stays visible instead of vanishing here.
+    private suspend fun queryRelevantProducts(
         @BillingClient.ProductType type: String,
     ): Result<Collection<Purchase>> = try {
-        Result.success(queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED })
+        Result.success(queryPurchases(type).filter { it.isRelevant })
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
@@ -307,37 +344,6 @@ class BillingConnection(
         return purchaseData
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refreshPurchases(),
-    // a failure propagates (no cross-type tolerance) — callers must be able to fail closed on
-    // "couldn't verify". Commits through the reducer like any query, so the reactive purchases
-    // flow picks up the fresh renewal state, and emits a partial fresh update: it proves what the
-    // SUBS query found, never the absence of anything it didn't cover.
-    suspend fun querySubscriptions(): Collection<Purchase> = refreshMutex.withLock {
-        log(TAG) { "querySubscriptions()" }
-        val genAtQueryStart = state.value.eventGen
-        val subs = queryPurchases(BillingClient.ProductType.SUBS)
-            .filter { it.purchaseState == PurchaseState.PURCHASED }
-        val committed = synchronized(reducerLock) {
-            val next = state.value.withQueryResults(
-                iap = null,
-                sub = subs,
-                genAtQueryStart = genAtQueryStart,
-            )
-            state.value = next
-            freshUpdatesChannel.trySend(FreshUpdate(subs, isFullSnapshot = false))
-            next
-        }
-        // The COMMITTED view, not the raw response: a purchase event that arrived after the query
-        // started survives the commit as a newer overlay and must reach the gate too — otherwise a
-        // just-purchased renewing sub could slip past the fail-closed double-billing check.
-        // Non-IAP overlays only; untyped (unknown product) entries stay in on the safe side.
-        val byToken = LinkedHashMap<String, Purchase>()
-        subs.forEach { byToken[it.purchaseToken] = it }
-        committed.overlay
-            .filter { it.type != Sku.Type.IAP }
-            .forEach { byToken[it.purchase.purchaseToken] = it.purchase }
-        byToken.values.sortedByDescending { it.purchaseTime }
-    }
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
         val ack = AcknowledgePurchaseParams.newBuilder().apply {
             setPurchaseToken(purchase.purchaseToken)
@@ -529,16 +535,22 @@ class BillingConnection(
             OurSku.PRO_SKUS.singleOrNull { it.id == productId }?.type
         }
 
-        // Combines the two product-type query results: a purchase found by either type is
-        // authoritative; an error is only propagated when nothing was found, so callers can tell
-        // "not owned" apart from "couldn't verify one product type". Treating any found purchase
-        // as authoritative is safe because every product this app sells is a Pro SKU (see
-        // OurSku.PRO_SKUS). Pure and unit-tested.
+        // Combines the two product-type query results: an error is only propagated when the refresh
+        // learned nothing usable, so callers can tell "not owned" apart from "couldn't verify one
+        // product type". A PURCHASED result of ANY product suppresses the error — every product
+        // this app sells is a Pro SKU (see OurSku.PRO_SKUS), so it is by construction relevant. A
+        // PENDING result only counts when it maps to a KNOWN Pro SKU: it grants nothing, and an
+        // unknown pending product says nothing about the type whose query failed, so treating it
+        // as a find would swallow a real "couldn't verify". Pure and unit-tested.
         internal fun combinePurchaseResults(
             iap: Result<Collection<Purchase>>,
             sub: Result<Collection<Purchase>>,
+            typeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
         ): Collection<Purchase> {
-            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val found = returned.filter { purchase ->
+                purchase.isPurchased || purchase.products.any { typeOf(it) != null }
+            }
             return when {
                 found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
                 else -> {

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeEvents.kt
@@ -13,5 +13,14 @@ sealed class UpgradeEvents {
      */
     data object RestoreInconclusive : UpgradeEvents()
     data object SubscriptionStillRenewing : UpgradeEvents()
-    data object SubscriptionCheckFailed : UpgradeEvents()
+
+    /**
+     * Play answered, no completed purchase exists, but a payment is still being processed. Purely
+     * informational: nothing to fix, nothing to restore — Pro unlocks by itself once Play clears
+     * the payment, and a new purchase would be rejected (or double-charge) in the meantime.
+     */
+    data object PurchasePending : UpgradeEvents()
+
+    /** The pre-purchase check with Play didn't finish, so the purchase was not started. */
+    data object PurchaseCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeOwnership.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Autorenew
+import androidx.compose.material.icons.twotone.HourglassTop
 import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
@@ -101,8 +102,10 @@ internal fun UpgradeOwnershipContent(
                 Button(
                     onClick = onIap,
                     // Not gated on iapEnabled: prices may have failed to load while the purchase
-                    // itself would work (the billing flow re-queries details on launch).
-                    enabled = switchUnlocked && uiState.busy == null,
+                    // itself would work (the billing flow re-queries details on launch). A pending
+                    // payment does lock it — Play would reject the purchase, and the pending card
+                    // above carries the explanation.
+                    enabled = switchUnlocked && uiState.busy == null && !uiState.hasPendingPurchase,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_IAP),
@@ -236,6 +239,38 @@ internal fun UpgradeGraceCard(
                 Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
             }
         }
+    }
+}
+
+// Shown to EVERY audience while Google Play is still processing a payment: an acquisition user who
+// just bought, an owner buying the other product, and a grace user whose Pro is running out — all
+// three have purchase actions locked and need the same explanation. Calm reassurance styling like
+// the grace card: nothing is wrong, the payment just isn't done.
+@Composable
+internal fun PendingPurchaseCard(
+    modifier: Modifier = Modifier,
+) {
+    UpgradeSectionCard(
+        title = stringResource(R.string.upgrade_screen_pending_card_title),
+        icon = Icons.TwoTone.HourglassTop,
+        modifier = modifier.testTag(UpgradeScreenTags.GPLAY_PENDING),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_pending_card_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun PendingPurchaseCardPreview() {
+    PreviewWrapper {
+        PendingPurchaseCard()
     }
 }
 

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeScreen.kt
@@ -70,6 +70,7 @@ fun UpgradeScreenHost(
     var showRestoreInconclusive by rememberSaveable { mutableStateOf(false) }
     var showStillRenewing by rememberSaveable { mutableStateOf(false) }
     var showCheckFailed by rememberSaveable { mutableStateOf(false) }
+    var showPurchasePending by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(vm) {
         vm.events.collect { event ->
@@ -83,7 +84,8 @@ fun UpgradeScreenHost(
                 UpgradeEvents.RestoreFailed -> showRestoreFailed = true
                 UpgradeEvents.RestoreInconclusive -> showRestoreInconclusive = true
                 UpgradeEvents.SubscriptionStillRenewing -> showStillRenewing = true
-                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchaseCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchasePending -> showPurchasePending = true
             }
         }
     }
@@ -134,13 +136,17 @@ fun UpgradeScreenHost(
     if (showCheckFailed) {
         AlertDialog(
             onDismissRequest = { showCheckFailed = false },
-            text = { Text(text = stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+            text = { Text(text = stringResource(R.string.upgrade_screen_purchase_check_failed_message)) },
             confirmButton = {
                 TextButton(onClick = { showCheckFailed = false }) {
                     Text(text = stringResource(R.string.general_close_action))
                 }
             },
         )
+    }
+
+    if (showPurchasePending) {
+        PurchasePendingDialog(onDismiss = { showPurchasePending = false })
     }
 
     val uiState by vm.state.collectAsStateWithLifecycle()
@@ -185,6 +191,34 @@ internal fun RestoreFailedDialog(
             }
         },
     )
+}
+
+/**
+ * Shown when Play is still processing a payment. Purely informational: there is nothing to fix, no
+ * purchase to restore and no support case — the entitlement arrives on its own once the payment
+ * clears, so the dialog offers only a dismiss.
+ */
+@Composable
+internal fun PurchasePendingDialog(
+    onDismiss: () -> Unit = {},
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { Text(text = stringResource(R.string.upgrade_screen_pending_dialog_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.general_close_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@Composable
+private fun PurchasePendingDialogPreview() {
+    PreviewWrapper {
+        PurchasePendingDialog()
+    }
 }
 
 /**
@@ -280,6 +314,12 @@ internal fun UpgradeScreen(
                     )
                 }
             }
+
+            // Above the ownership/acquisition split, because a pending payment cuts across it: the
+            // buyer waiting for their first Pro purchase, the owner switching products and the
+            // grace user (whose offers box is hidden entirely) all need it, and it is the reason
+            // their purchase buttons are locked.
+            if (loaded?.hasPendingPurchase == true) PendingPurchaseCard()
 
             if (ownedState != null) {
                 UpgradeOwnershipContent(
@@ -481,6 +521,24 @@ private fun UpgradeScreenReturningBuyerPreview() {
                 iapEnabled = true,
                 iapPrice = "$24.99",
                 wasPreviouslyPro = true,
+            ),
+        )
+    }
+}
+
+// The acquisition variant of the pending state: card above the offers, both buy buttons locked.
+@Preview2
+@Composable
+private fun UpgradeScreenPendingPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.STANDARD,
+                subscriptionEnabled = false,
+                subscriptionPrice = "$12.99",
+                iapEnabled = false,
+                iapPrice = "$24.99",
+                hasPendingPurchase = true,
             ),
         )
     }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeUiState.kt
@@ -23,6 +23,9 @@ internal sealed interface GplayUpgradeUiState {
         val ownership: Ownership = Ownership(),
         val grace: GraceHint? = null,
         val wasPreviouslyPro: Boolean = false,
+        // A payment Google Play is still processing. SKU-agnostic on purpose: the card explains the
+        // wait and both purchase actions lock, regardless of which product is pending.
+        val hasPendingPurchase: Boolean = false,
         val busy: BusyOp? = null,
     ) : GplayUpgradeUiState
 }
@@ -73,12 +76,18 @@ internal fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
         ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
 )
 
+// Any Pro payment Play is still processing. No per-product flag: the one-time purchase and the
+// subscription are alternatives, so a pending payment for either one must lock both — completing
+// both would charge the user twice for the same thing.
+internal fun UpgradeRepoGplay.Info.toPendingFlag(): Boolean = pendingSkus.isNotEmpty()
+
 internal fun toLoadedState(
     iap: SkuDetails?,
     sub: SkuDetails?,
     ownership: Ownership,
     grace: GraceHint? = null,
     wasPreviouslyPro: Boolean = false,
+    hasPendingPurchase: Boolean = false,
     busy: BusyOp? = null,
 ): GplayUpgradeUiState.Loaded {
     val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
@@ -97,15 +106,18 @@ internal fun toLoadedState(
         },
         // Any running entitlement operation (restore, manual or the invisible already-owned
         // recovery, and purchases) pauses the buy actions too — starting a purchase while an
-        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED.
+        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED. A pending
+        // payment locks BOTH offers for the same reason the card explains: Play refuses the
+        // re-purchase, and the alternative product would double-charge for the same features.
         subscriptionEnabled = (subOffer != null || subOfferTrial != null) &&
-            ownership.subscription == null && busy == null,
+            ownership.subscription == null && busy == null && !hasPendingPurchase,
         subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null,
+        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null && !hasPendingPurchase,
         iapPrice = iapOffer?.formattedPrice,
         ownership = ownership,
         grace = grace,
         wasPreviouslyPro = wasPreviouslyPro,
+        hasPendingPurchase = hasPendingPurchase,
         busy = busy,
     )
 }

--- a/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/capod/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.capod.common.upgrade.core.OurSku
 import eu.darken.capod.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.capod.common.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.capod.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.capod.common.upgrade.core.billing.Sku
 import eu.darken.capod.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -161,8 +162,10 @@ class UpgradeViewModel @Inject constructor(
             null
         }
         // Owners and grace users don't depend on offer prices: their status and management
-        // actions render immediately and price problems are not their problem.
-        val priceIndependent = ownership.ownsAnything || grace != null
+        // actions render immediately and price problems are not their problem. A user waiting on a
+        // pending payment is in the same position — the card is their answer, and both offers are
+        // locked anyway, so a price failure must not replace it with an error screen.
+        val priceIndependent = ownership.ownsAnything || grace != null || current.pendingSkus.isNotEmpty()
 
         val done = queries as? SkuQueries.Done
         if (done == null) {
@@ -258,6 +261,7 @@ class UpgradeViewModel @Inject constructor(
             ownership = ownership,
             grace = grace,
             wasPreviouslyPro = wasEverPro && !current.isPro,
+            hasPendingPurchase = current.toPendingFlag(),
             // This ViewModel's own action wins; otherwise a launch started elsewhere (previous VM
             // instance, e.g. across a rotation — the launch lives on AppScope) or the repo's
             // invisible already-owned auto-restore still pauses the entitlement actions here.
@@ -303,44 +307,78 @@ class UpgradeViewModel @Inject constructor(
         return true
     }
 
+    // Outcome of the pre-purchase check with Play. Both purchase paths share it: they buy
+    // alternatives of the same entitlement from the same account, so a check only one of them runs
+    // is exactly how a double charge slips through. [Blocked] means the user was already told why.
+    private sealed interface PurchaseGate {
+        data class Clear(val info: UpgradeRepoGplay.Info) : PurchaseGate
+        data object Blocked : PurchaseGate
+    }
+
+    // Fails closed: no fresh, complete answer from Play (error, timeout) means no purchase. Bounded,
+    // because the repo waits for a healthy connection indefinitely and a tap must not park the
+    // single-flight guard through an outage.
+    private suspend fun runPurchaseGate(): PurchaseGate {
+        val info = try {
+            withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.verifyPurchaseStateNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Purchase verification errored: ${e.asLog()}" }
+            errorEvents.tryEmit(e)
+            return PurchaseGate.Blocked
+        }
+        if (info == null) {
+            log(TAG, WARN) { "Purchase verification timed out" }
+            events.tryEmit(UpgradeEvents.PurchaseCheckFailed)
+            return PurchaseGate.Blocked
+        }
+        if (info.pendingSkus.isNotEmpty()) {
+            // Play rejects a purchase while it is still processing a payment for this account, and
+            // the alternative product would charge twice for the same features.
+            log(TAG, INFO) { "Purchase blocked: a payment is still pending" }
+            events.tryEmit(UpgradeEvents.PurchasePending)
+            return PurchaseGate.Blocked
+        }
+        return PurchaseGate.Clear(info)
+    }
+
+    // A launch that failed on a pending payment is not an error the user can act on: it gets the
+    // informational dialog instead of the already-owned copy and its restore tips.
+    private fun onLaunchError(error: Throwable) {
+        if (error is PendingPurchaseBillingException) {
+            events.tryEmit(UpgradeEvents.PurchasePending)
+        } else {
+            errorEvents.tryEmit(error)
+        }
+    }
+
     fun onGoIap(activity: Activity) {
         log(TAG) { "onGoIap($activity)" }
         launch {
             // Single-flight: repeated taps must not stack verifications or billing launches.
             if (!acquireOp(BusyOp.IAP)) return@launch
             try {
-                // Hard gate against double-billing: verify against a FRESH SUBS-only query — the
-                // replayed upgradeInfo can be stale or built from partial results. Fails closed:
-                // no verified "not set to renew" (or no sub at all), no one-time purchase.
-                val subscriptions = try {
-                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Subscription verification errored: ${e.asLog()}" }
-                    errorEvents.tryEmit(e)
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // Hard gate against double-billing, against the FRESH result — the replayed
+                // upgradeInfo can be stale or built from partial results. Asked of the RAW
+                // purchases (see Info.hasAutoRenewingSubscription), never of the mapped upgrades:
+                // a renewing subscription with an unknown or legacy product ID must block the
+                // one-time purchase too, or the user pays for Pro twice.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
                     return@launch
                 }
-                when {
-                    subscriptions == null -> {
-                        log(TAG, WARN) { "Subscription verification timed out" }
-                        events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
-                    }
-
-                    subscriptions.any { it.isAutoRenewing } -> {
-                        log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
-                        events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
-                    }
-
-                    // Suspends until the Play sheet launch resolved, so the single-flight guard
-                    // covers the whole tap-to-sheet window, not just the verification.
-                    else -> upgradeRepo.launchBillingFlowNow(
-                        activity,
-                        OurSku.Iap.PRO_UPGRADE,
-                        null,
-                        onError = errorEvents::tryEmit,
-                    )
-                }
+                // Suspends until the Play sheet launch resolved, so the single-flight guard covers
+                // the whole tap-to-sheet window, not just the verification.
+                upgradeRepo.launchBillingFlowNow(
+                    activity,
+                    OurSku.Iap.PRO_UPGRADE,
+                    null,
+                    onError = ::onLaunchError,
+                )
             } finally {
                 activeOp.value = null
             }
@@ -361,6 +399,32 @@ class UpgradeViewModel @Inject constructor(
         launch {
             if (!acquireOp(BusyOp.SUBSCRIPTION)) return@launch
             try {
+                // Same fresh check as the one-time path: a pending payment (for either product)
+                // must block this launch too — Play would reject it, or bill it on top.
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // The reactive UI can be stale (the purchase was made on another device), and Play
+                // happily sells the subscription alongside an owned one-time purchase — the user
+                // would pay for Pro twice. The strict refresh already committed into the shared
+                // billing data, so the screen re-renders to the ownership state, and the
+                // restore-success toast explains why nothing launched. Deliberately the MAPPED
+                // upgrades, not isPro: grace users (mapped upgrades empty) may legitimately
+                // re-purchase.
+                if (gate.info.upgrades.isNotEmpty()) {
+                    log(TAG, INFO) { "Subscription purchase blocked: fresh check found an owned upgrade" }
+                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                    return@launch
+                }
+                // Same breadth as the one-time path's renewal guard: an auto-renewing subscription
+                // with an unknown or legacy product ID (which maps to zero upgrades, so the block
+                // above passed) must still block a new subscription — two renewing subscriptions
+                // for the same features is the same double-billing. Reuses the existing
+                // manage-subscription dialog.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(TAG, INFO) { "Subscription purchase blocked: another subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
+                    return@launch
+                }
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
                 // screen mid-launch doesn't abort the purchase.
@@ -368,7 +432,7 @@ class UpgradeViewModel @Inject constructor(
                     activity,
                     OurSku.Sub.PRO_UPGRADE,
                     offer,
-                    onError = errorEvents::tryEmit,
+                    onError = ::onLaunchError,
                 )
             } finally {
                 activeOp.value = null
@@ -430,6 +494,14 @@ class UpgradeViewModel @Inject constructor(
                     // Explicit feedback: on the ownership screen a successful restore changes
                     // nothing visible (the user already is Pro), so silence reads as "broken".
                     events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                }
+
+                restored.info.pendingSkus.isNotEmpty() -> {
+                    // Play answered and found the purchase — it just hasn't been paid for yet.
+                    // RestoreFailed would send this user chasing account and support advice for
+                    // something that resolves itself.
+                    log(TAG, INFO) { "Restore found a purchase with a pending payment" }
+                    events.tryEmit(UpgradeEvents.PurchasePending)
                 }
 
                 else -> {

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dit is \'n aparte aankoop — dit kanselleer of vergoed nie jou intekening nie. Gebruik dieselfde Google-rekening.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Intekening steeds aktief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Jou intekening is steeds gestel om te hernu. Kanselleer dit eers in Google Play, en wissel dan na die eenmalige aankoop. Pas gekanselleer? Gee Google Play \'n oomblik en probeer weer.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Intekeningkontrole het misluk</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kon nie jou intekeningstatus by Google Play nagaan nie. Probeer binnekort weer om \'n dubbele aankoop te vermy.</string>
     <string name="upgrade_screen_grace_title">Jou aankoop word bevestig</string>
     <string name="upgrade_screen_grace_body_short">Google Play het jou aankoop nog nie bevestig nie. Pro is steeds aktief — geen aksie nodig nie.</string>
     <string name="upgrade_screen_grace_body">Google Play het jou aankoop al \'n rukkie nie bevestig nie. Pro is steeds aktief. Maak seker jy is aanlyn en aangemeld met die Google-rekening wat vir die aankoop gebruik is, en probeer dan herstel.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ይህ የተለየ ግዢ ነው — ምዝገባውን አይሰርዝም ወይም አይመልስም። ተመሳሳይ የGoogle መለያ ይጠቀሙ።</string>
     <string name="upgrade_screen_sub_still_renewing_title">ምዝገባ አሁነም ንቁ ነው</string>
     <string name="upgrade_screen_sub_still_renewing_message">ምዝገባዎ አሁንም ለማደስ ተዘጋጅቷል። መጀመሪያ በGoogle Play ውስጥ ይሰርዙት፣ ከዚያ ወደ አንድ ጊዜ ግዢ ይቀይሩ። አሁን ገና ሰርዘውታል? ለGoogle Play ትንሽ ጊዜ ይስጡ እና እንደገና ይሞክሩ።</string>
-    <string name="upgrade_screen_sub_check_failed_title">የምዝገባ ማረጋገጫ አልተሳካም</string>
-    <string name="upgrade_screen_sub_check_failed_message">የምዝገባ ሁኔታዎን ከGoogle Play ጋር ማረጋገጥ አልተቻለም። ድርብ ግዢን ለማስቀረት፣ ትንሽ ቆይተው እንደገና ይሞክሩ።</string>
     <string name="upgrade_screen_grace_title">ግዢዎን በማረጋገጥ ላይ</string>
     <string name="upgrade_screen_grace_body_short">Google Play ግዢዎን እስካሁን አላረጋገጠም። Pro አሁንም ንቁ ነው — ምንም እርምጃ አያስፈልግም።</string>
     <string name="upgrade_screen_grace_body">Google Play ለተወሰነ ጊዜ ግዢዎን አላረጋገጠም። Pro አሁንም ንቁ ነው። መስመር ላይ መሆንዎን እና ለግዢው ጥቅም ላይ በዋለው የGoogle መለያ መግባትዎን ያረጋግጡ፣ ከዚያ ወደነበረበት ለመመለስ ይሞክሩ።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">هذا شراء منفصل — لا يؤدي إلى إلغاء اشتراكك أو استرداد قيمته. استخدم نفس حساب Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">الاشتراك لا يزال نشطًا</string>
     <string name="upgrade_screen_sub_still_renewing_message">اشتراكك لا يزال مضبوطًا على التجديد. ألغه في Google Play أولًا، ثم بدّل إلى الشراء لمرة واحدة. هل ألغيته للتو؟ امنح Google Play بعض الوقت وحاول مرة أخرى.</string>
-    <string name="upgrade_screen_sub_check_failed_title">فشل التحقق من الاشتراك</string>
-    <string name="upgrade_screen_sub_check_failed_message">تعذّر التحقق من حالة اشتراكك لدى Google Play. لتجنب الشراء المزدوج، حاول مرة أخرى بعد قليل.</string>
     <string name="upgrade_screen_grace_title">جارٍ تأكيد عملية الشراء</string>
     <string name="upgrade_screen_grace_body_short">لم يؤكّد Google Play عملية الشراء الخاصة بك بعد. لا يزال Pro نشطًا — لا حاجة لاتخاذ أي إجراء.</string>
     <string name="upgrade_screen_grace_body">لم يؤكّد Google Play عملية الشراء الخاصة بك منذ فترة. لا يزال Pro نشطًا. تأكد من اتصالك بالإنترنت وتسجيل دخولك بحساب Google المستخدم في عملية الشراء، ثم حاول استعادة الشراء.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bu ayrı bir satınalmadır — abunəliyinizi ləğv etmir və ya geri ödəmir. Eyni Google hesabından istifadə edin.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abunəlik hələ də aktivdir</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abunəliyiniz hələ də yenilənməyə təyin edilib. Əvvəlcə onu Google Play-də ləğv edin, sonra birdəfəlik satınalmaya keçin. Bu yaxınlarda ləğv etmisiniz? Google Play-ə bir az vaxt verin və yenidən cəhd edin.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Abunəlik yoxlaması uğursuz oldu</string>
-    <string name="upgrade_screen_sub_check_failed_message">Abunəlik statusunuz Google Play ilə yoxlanıla bilmədi. İkiqat satınalmanın qarşısını almaq üçün bir az sonra yenidən cəhd edin.</string>
     <string name="upgrade_screen_grace_title">Satınalmanız təsdiqlənir</string>
     <string name="upgrade_screen_grace_body_short">Google Play hələ satınalmanızı təsdiqləməyib. Pro hələ də aktivdir — heç bir əməliyyat lazım deyil.</string>
     <string name="upgrade_screen_grace_body">Google Play bir müddətdir satınalmanızı təsdiqləməyib. Pro hələ də aktivdir. Onlayn olduğunuzdan və satınalma üçün istifadə edilən Google hesabı ilə daxil olduğunuzdan əmin olun, sonra bərpa etməyi sınayın.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Гэта асобная пакупка — яна не скасоўвае падпіску і не вяртае за яе грошы. Выкарыстоўвайце той жа акаунт Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Падпіска ўсё яшчэ актыўная</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша падпіска ўсё яшчэ будзе аўтаматычна прадоўжана. Спачатку скасуйце яе ў Google Play, а потым пераключацеся на аднаразовую пакупку. Толькі што скасавалі? Дайце Google Play крыху часу і паспрабуйце зноў.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Не ўдалося праверыць падпіску</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не ўдалося праверыць статус вашай падпіскі ў Google Play. Каб пазбегнуць падвойнай пакупкі, паспрабуйце зноў праз хвіліну.</string>
     <string name="upgrade_screen_grace_title">Пацвярджэнне вашай пакупкі</string>
     <string name="upgrade_screen_grace_body_short">Google Play яшчэ не пацвердзіў вашу пакупку. Pro па-ранейшаму актыўны — дзеянні не патрабуюцца.</string>
     <string name="upgrade_screen_grace_body">Google Play ужо некаторы час не пацвярджае вашу пакупку. Pro па-ранейшаму актыўны. Пераканайцеся, што вы падключаны да інтэрнэту і ўвайшлі ў акаунт Google, які выкарыстоўваўся для пакупкі, а потым паспрабуйце аднавіць пакупку.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Това е отделна покупка — тя не отменя и не възстановява средства по абонамента ви. Използвайте същия акаунт в Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Абонаментът все още е активен</string>
     <string name="upgrade_screen_sub_still_renewing_message">Абонаментът ви все още е настроен да се подновява. Първо го отменете в Google Play, а след това преминете към еднократната покупка. Току-що отменихте? Изчакайте малко Google Play и опитайте отново.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Проверката на абонамента се провали</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не можа да се провери статусът на абонамента ви с Google Play. За да избегнете двойна покупка, опитайте отново след малко.</string>
     <string name="upgrade_screen_grace_title">Потвърждаване на покупката ви</string>
     <string name="upgrade_screen_grace_body_short">Google Play все още не е потвърдил покупката ви. Pro все още е активен — не са необходими действия.</string>
     <string name="upgrade_screen_grace_body">Google Play не е потвърдил покупката ви от известно време. Pro все още е активен. Уверете се, че сте онлайн и влезли с акаунта в Google, използван за покупката, след което опитайте да възстановите.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">এটি একটি আলাদা ক্রয় — এটি আপনার সাবস্ক্রিপশন বাতিল বা ফেরত দেয় না। একই Google অ্যাকাউন্ট ব্যবহার করুন।</string>
     <string name="upgrade_screen_sub_still_renewing_title">সাবস্ক্রিপশন এখনও সক্রিয়</string>
     <string name="upgrade_screen_sub_still_renewing_message">আপনার সাবস্ক্রিপশন এখনও নবায়ন হওয়ার জন্য সেট করা আছে। প্রথমে Google Play-তে এটি বাতিল করুন, তারপর এককালীন ক্রয়ে পরিবর্তন করুন। এইমাত্র বাতিল করেছেন? Google Play-কে কিছুটা সময় দিন এবং আবার চেষ্টা করুন।</string>
-    <string name="upgrade_screen_sub_check_failed_title">সাবস্ক্রিপশন যাচাই ব্যর্থ হয়েছে</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play-এর সাথে আপনার সাবস্ক্রিপশনের স্থিতি যাচাই করা যায়নি। দ্বিগুণ কেনাকাটা এড়াতে, একটু পরে আবার চেষ্টা করুন।</string>
     <string name="upgrade_screen_grace_title">আপনার কেনাকাটা নিশ্চিত করা হচ্ছে</string>
     <string name="upgrade_screen_grace_body_short">Google Play এখনও আপনার কেনাকাটা নিশ্চিত করেনি। Pro এখনও সক্রিয় আছে — কোনো পদক্ষেপের প্রয়োজন নেই।</string>
     <string name="upgrade_screen_grace_body">Google Play অনেকক্ষণ ধরে আপনার কেনাকাটা নিশ্চিত করেনি। Pro এখনও সক্রিয় আছে। আপনি অনলাইনে আছেন এবং কেনাকাটার জন্য ব্যবহৃত Google অ্যাকাউন্ট দিয়ে সাইন ইন করা আছেন কিনা তা নিশ্চিত করুন, তারপর পুনরুদ্ধার করার চেষ্টা করুন।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Aquesta és una compra separada: no cancel·la ni reemborsa la vostra subscripció. Feu servir el mateix compte de Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">La subscripció encara està activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">La vostra subscripció encara està configurada per renovar-se. Cancel·leu-la primer al Google Play i després canvieu a la compra única. Acabeu de cancel·lar-la? Doneu un moment al Google Play i torneu-ho a provar.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Ha fallat la comprovació de la subscripció</string>
-    <string name="upgrade_screen_sub_check_failed_message">No s\'ha pogut comprovar l\'estat de la vostra subscripció amb el Google Play. Per evitar una compra duplicada, torneu-ho a provar d\'aquí a una estona.</string>
     <string name="upgrade_screen_grace_title">S\'està confirmant la vostra compra</string>
     <string name="upgrade_screen_grace_body_short">El Google Play encara no ha confirmat la vostra compra. El Pro segueix actiu, no cal fer res.</string>
     <string name="upgrade_screen_grace_body">Fa temps que el Google Play no confirma la vostra compra. El Pro segueix actiu. Assegureu-vos que teniu connexió i heu iniciat sessió amb el compte de Google que vau fer servir per a la compra, i després proveu de restaurar-la.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Toto je samostatný nákup — nezruší ani nevrátí peníze za vaše předplatné. Použijte stejný účet Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Předplatné je stále aktivní</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále nastaveno na obnovování. Nejprve ho zrušte v Google Play a poté přejděte na jednorázový nákup. Právě jste ho zrušili? Dejte Google Play chvilku a zkuste to znovu.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontrola předplatného se nezdařila</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepodařilo se zkontrolovat stav vašeho předplatného u Google Play. Abyste se vyhnuli dvojímu nákupu, zkuste to za chvíli znovu.</string>
     <string name="upgrade_screen_grace_title">Potvrzování vašeho nákupu</string>
     <string name="upgrade_screen_grace_body_short">Google Play zatím nepotvrdil váš nákup. Pro je stále aktivní — není potřeba nic dělat.</string>
     <string name="upgrade_screen_grace_body">Google Play už delší dobu nepotvrdil váš nákup. Pro je stále aktivní. Ujistěte se, že jste online a přihlášeni k účtu Google použitému při nákupu, a poté zkuste nákup obnovit.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dette er et separat køb — det opsiger eller refunderer ikke dit abonnement. Brug den samme Google-konto.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement stadig aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig indstillet til at blive fornyet. Opsig det først i Google Play, og skift derefter til engangskøbet. Lige opsagt? Giv Google Play et øjeblik, og prøv igen.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontrol af abonnement mislykkedes</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke kontrollere din abonnementsstatus hos Google Play. For at undgå et dobbeltkøb kan du prøve igen om et øjeblik.</string>
     <string name="upgrade_screen_grace_title">Bekræfter dit køb</string>
     <string name="upgrade_screen_grace_body_short">Google Play har endnu ikke bekræftet dit køb. Pro er stadig aktivt — ingen handling nødvendig.</string>
     <string name="upgrade_screen_grace_body">Google Play har ikke bekræftet dit køb i et stykke tid. Pro er stadig aktivt. Sørg for, at du er online og logget ind med den Google-konto, der blev brugt til købet, og prøv derefter at gendanne.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dies ist ein separater Kauf — er kündigt oder erstattet dein Abonnement nicht. Verwende dasselbe Google-Konto.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement noch aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dein Abonnement ist weiterhin so eingestellt, dass es sich verlängert. Kündige es zuerst in Google Play und wechsle erst dann zum Einmalkauf. Gerade gekündigt? Gib Google Play einen Moment Zeit und versuche es erneut.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Abonnementprüfung fehlgeschlagen</string>
-    <string name="upgrade_screen_sub_check_failed_message">Dein Abonnementstatus konnte nicht bei Google Play überprüft werden. Um einen doppelten Kauf zu vermeiden, versuch es gleich noch einmal.</string>
     <string name="upgrade_screen_grace_title">Dein Kauf wird bestätigt</string>
     <string name="upgrade_screen_grace_body_short">Google Play hat deinen Kauf noch nicht bestätigt. Pro ist weiterhin aktiv — du musst nichts tun.</string>
     <string name="upgrade_screen_grace_body">Google Play hat deinen Kauf seit einer Weile nicht bestätigt. Pro ist weiterhin aktiv. Stelle sicher, dass du online und mit dem Google-Konto angemeldet bist, das für den Kauf verwendet wurde, und versuche dann die Wiederherstellung.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Αυτή είναι μια ξεχωριστή αγορά — δεν ακυρώνει ούτε επιστρέφει τα χρήματα της συνδρομής σας. Χρησιμοποιήστε τον ίδιο λογαριασμό Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Η συνδρομή εξακολουθεί να είναι ενεργή</string>
     <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σας εξακολουθεί να έχει οριστεί να ανανεωθεί. Ακυρώστε την πρώτα στο Google Play και έπειτα μεταβείτε στην εφάπαξ αγορά. Μόλις ακυρώσατε; Δώστε λίγο χρόνο στο Google Play και δοκιμάστε ξανά.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Ο έλεγχος συνδρομής απέτυχε</string>
-    <string name="upgrade_screen_sub_check_failed_message">Δεν ήταν δυνατός ο έλεγχος της κατάστασης της συνδρομής σας με το Google Play. Για να αποφύγετε διπλή αγορά, δοκιμάστε ξανά σε λίγο.</string>
     <string name="upgrade_screen_grace_title">Επιβεβαίωση της αγοράς σας</string>
     <string name="upgrade_screen_grace_body_short">Το Google Play δεν έχει επιβεβαιώσει ακόμα την αγορά σας. Το Pro παραμένει ενεργό — δεν απαιτείται καμία ενέργεια.</string>
     <string name="upgrade_screen_grace_body">Το Google Play δεν έχει επιβεβαιώσει την αγορά σας εδώ και καιρό. Το Pro παραμένει ενεργό. Βεβαιωθείτε ότι είστε συνδεδεμένοι στο διαδίκτυο και συνδεδεμένοι με τον λογαριασμό Google που χρησιμοποιήσατε για την αγορά, και μετά δοκιμάστε να την επαναφέρετε.</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta es una compra separada — no cancela ni reembolsa tu suscripción. Usá la misma cuenta de Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancelala primero en Google Play y después cambiá a la compra única. ¿La acabás de cancelar? Dale un momento a Google Play y probá de nuevo.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Falló la verificación de la suscripción</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar el estado de tu suscripción con Google Play. Para evitar una compra doble, probá de nuevo en un momento.</string>
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body_short">Google Play todavía no confirmó tu compra. Pro sigue activo — no es necesario hacer nada.</string>
     <string name="upgrade_screen_grace_body">Google Play no confirmó tu compra desde hace un tiempo. Pro sigue activo. Asegurate de estar conectado a internet y de haber iniciado sesión con la cuenta de Google que usaste para la compra, y después probá restaurar.</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta es una compra independiente; no cancela ni reembolsa tu suscripción. Usa la misma cuenta de Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancélala primero en Google Play y luego cambia a la compra única. ¿Acabas de cancelarla? Dale un momento a Google Play e inténtalo de nuevo.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Error al verificar la suscripción</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar el estado de tu suscripción con Google Play. Para evitar una compra duplicada, inténtalo de nuevo en un momento.</string>
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body_short">Google Play todavía no ha confirmado tu compra. Pro sigue activo; no necesitas hacer nada.</string>
     <string name="upgrade_screen_grace_body">Google Play no ha confirmado tu compra desde hace un tiempo. Pro sigue activo. Asegúrate de estar conectado a internet y de haber iniciado sesión con la cuenta de Google que usaste para la compra, y luego intenta restaurarla.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta es una compra independiente: no cancela ni reembolsa tu suscripción. Usa la misma cuenta de Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">La suscripción sigue activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancélala primero en Google Play y luego cambia a la compra única. ¿Acabas de cancelarla? Dale un momento a Google Play e inténtalo de nuevo.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Error al comprobar la suscripción</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo comprobar el estado de tu suscripción con Google Play. Para evitar una compra duplicada, inténtalo de nuevo en un momento.</string>
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body_short">Google Play todavía no ha confirmado tu compra. Pro sigue activo; no es necesario hacer nada.</string>
     <string name="upgrade_screen_grace_body">Google Play no ha confirmado tu compra desde hace tiempo. Pro sigue activo. Asegúrate de estar conectado a internet y de haber iniciado sesión con la cuenta de Google usada para la compra, y prueba a restaurarla.</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">See on eraldi ost — see ei tühista ega tagasta sinu tellimust. Kasuta sama Google\'i kontot.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Tellimus on endiselt kasutusel</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tellimus uueneb ikka veel ise. Tühista see kõigepealt Google Plays ja lülitu seejärel ühekordsele ostule. Just tühistasid? Anna Google Playle hetk aega ja proovi uuesti.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Tellimuse kontroll nurjus</string>
-    <string name="upgrade_screen_sub_check_failed_message">Sinu tellimuse olekut ei õnnestunud Google Playl kontrollida. Topeltostu vältimiseks proovi mõne hetke pärast uuesti.</string>
     <string name="upgrade_screen_grace_title">Ostu kinnitamine</string>
     <string name="upgrade_screen_grace_body_short">Google Play pole ostu veel kinnitanud. Pro on endiselt kasutatav — midagi ette võtta pole vaja.</string>
     <string name="upgrade_screen_grace_body">Google Play pole ostu juba mõnda aega kinnitanud. Pro on endiselt kasutatav. Veendu, et oled võrgus ja sisse logitud Google\'i kontoga, millega ostsid, ning proovi seejärel taastada.</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Beste erosketa bat da — ez du zure harpidetza bertan behera uzten edo itzultzen. Erabili Google kontu bera.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Harpidetza oraindik aktibo</string>
     <string name="upgrade_screen_sub_still_renewing_message">Zure harpidetza oraindik berritzeko ezarrita dago. Utzi lehenengo Google Playn, eta gero aldatu aldi bateko erosketara. Duela gutxi utzi duzu? Eman Google Play-ri unetxo bat eta saiatu berriro.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Harpidetzaren egiaztapenak huts egin du</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ezin izan da zure harpidetzaren egoera Google Playrekin egiaztatu. Bikoiztutako erosketa bat saihesteko, saiatu berriro unetxo batean.</string>
     <string name="upgrade_screen_grace_title">Zure erosketa berresten</string>
     <string name="upgrade_screen_grace_body_short">Google Playk oraindik ez du zure erosketa berretsi. Pro aktibo dago oraindik — ez da ekintzarik behar.</string>
     <string name="upgrade_screen_grace_body">Google Playk denbora luzez ez du zure erosketa berretsi. Pro aktibo dago oraindik. Ziurtatu konektatuta zaudela eta erosketa egiteko erabilitako Google kontuarekin saioa hasita duzula, eta gero saiatu leheneratzen.</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">این یک خرید جداگانه است — اشتراک شما را لغو یا بازپرداخت نمی‌کند. از همان حساب گوگل استفاده کنید.</string>
     <string name="upgrade_screen_sub_still_renewing_title">اشتراک همچنان فعال است</string>
     <string name="upgrade_screen_sub_still_renewing_message">اشتراک شما همچنان برای تمدید تنظیم شده است. ابتدا آن را در گوگل پلی لغو کنید، سپس به خرید یک‌باره تغییر دهید. تازه لغو کرده‌اید؟ کمی به گوگل پلی زمان بدهید و دوباره امتحان کنید.</string>
-    <string name="upgrade_screen_sub_check_failed_title">بررسی اشتراک ناموفق بود</string>
-    <string name="upgrade_screen_sub_check_failed_message">بررسی وضعیت اشتراک شما با گوگل پلی ممکن نشد. برای جلوگیری از خرید دوباره، کمی بعد دوباره امتحان کنید.</string>
     <string name="upgrade_screen_grace_title">در حال تأیید خرید شما</string>
     <string name="upgrade_screen_grace_body_short">گوگل پلی هنوز خرید شما را تأیید نکرده است. Pro همچنان فعال است — نیازی به اقدام نیست.</string>
     <string name="upgrade_screen_grace_body">گوگل پلی مدتی است خرید شما را تأیید نکرده است. Pro همچنان فعال است. مطمئن شوید که آنلاین هستید و با همان حساب گوگلی که خرید را با آن انجام داده‌اید وارد شده‌اید، سپس بازیابی را امتحان کنید.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Tämä on erillinen ostos — se ei peruuta eikä hyvitä tilaustasi. Käytä samaa Google-tiliä.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Tilaus on yhä aktiivinen</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tilauksesi on yhä asetettu uusiutumaan. Peruuta se ensin Google Playssa ja vaihda sitten kertaostokseen. Peruitko juuri? Anna Google Playlle hetki aikaa ja yritä uudelleen.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Tilauksen tarkistus epäonnistui</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tilauksesi tilaa ei voitu tarkistaa Google Playsta. Vältä kaksinkertainen ostos yrittämällä uudelleen hetken kuluttua.</string>
     <string name="upgrade_screen_grace_title">Vahvistetaan ostostasi</string>
     <string name="upgrade_screen_grace_body_short">Google Play ei ole vielä vahvistanut ostostasi. Pro on yhä aktiivinen — mitään ei tarvitse tehdä.</string>
     <string name="upgrade_screen_grace_body">Google Play ei ole vahvistanut ostostasi hetkeen. Pro on yhä aktiivinen. Varmista, että olet verkossa ja kirjautuneena sillä Google-tilillä, jolla teit ostoksen, ja yritä sitten palauttaa se.</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ito ay hiwalay na pagbili — hindi nito kinakansela o nire-refund ang iyong subscription. Gamitin ang parehong Google account.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Aktibo pa rin ang subscription</string>
     <string name="upgrade_screen_sub_still_renewing_message">Nakatakda pa ring mag-renew ang iyong subscription. Kanselahin muna ito sa Google Play, pagkatapos ay lumipat sa one-time na pagbili. Bagong-kansela lang? Bigyan ng oras ang Google Play at subukan muli.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Nabigo ang pagsusuri ng subscription</string>
-    <string name="upgrade_screen_sub_check_failed_message">Hindi masuri ang katayuan ng iyong subscription gamit ang Google Play. Para maiwasan ang dobleng pagbili, subukan muli sa ilang sandali.</string>
     <string name="upgrade_screen_grace_title">Kinukumpirma ang iyong pagbili</string>
     <string name="upgrade_screen_grace_body_short">Hindi pa nakukumpirma ng Google Play ang iyong pagbili. Aktibo pa rin ang Pro — walang kailangang gawin.</string>
     <string name="upgrade_screen_grace_body">Matagal nang hindi nakukumpirma ng Google Play ang iyong pagbili. Aktibo pa rin ang Pro. Siguraduhing online ka at naka-sign in sa Google account na ginamit sa pagbili, pagkatapos ay subukang i-restore.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Il s’agit d’un achat distinct — il n’annule ni ne rembourse votre abonnement. Utilisez le même compte Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement toujours actif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours configuré pour se renouveler. Annulez-le d’abord dans Google Play, puis passez à l’achat unique. Vous venez de l’annuler ? Laissez un peu de temps à Google Play et réessayez.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Échec de la vérification de l’abonnement</string>
-    <string name="upgrade_screen_sub_check_failed_message">Impossible de vérifier le statut de votre abonnement auprès de Google Play. Pour éviter un double achat, réessayez dans un instant.</string>
     <string name="upgrade_screen_grace_title">Confirmation de votre achat</string>
     <string name="upgrade_screen_grace_body_short">Google Play n’a pas encore confirmé votre achat. Pro reste actif — aucune action requise.</string>
     <string name="upgrade_screen_grace_body">Google Play n’a pas confirmé votre achat depuis un moment. Pro reste actif. Assurez-vous d’être connecté à Internet et au compte Google utilisé pour l’achat, puis essayez de restaurer.</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta é unha compra separada — non cancela nin reembolsa a túa subscrición. Usa a mesma conta de Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">A subscrición aínda está activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">A túa subscrición aínda está configurada para renovarse. Cancélaa primeiro en Google Play e despois cambia á compra única. Acabas de cancelala? Dálle un momento a Google Play e téntao de novo.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Fallou a comprobación da subscrición</string>
-    <string name="upgrade_screen_sub_check_failed_message">Non se puido comprobar o estado da túa subscrición con Google Play. Para evitar unha compra dobre, téntao de novo nun momento.</string>
     <string name="upgrade_screen_grace_title">Confirmando a túa compra</string>
     <string name="upgrade_screen_grace_body_short">Google Play aínda non confirmou a túa compra. Pro segue activo — non se require ningunha acción.</string>
     <string name="upgrade_screen_grace_body">Google Play leva un tempo sen confirmar a túa compra. Pro segue activo. Asegúrate de estar conectado e con sesión iniciada coa conta de Google usada para a compra, e despois proba a restaurala.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">यह एक अलग खरीद है — यह आपकी सदस्यता को रद्द या रिफंड नहीं करता। उसी Google खाते का उपयोग करें।</string>
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अभी भी सक्रिय है</string>
     <string name="upgrade_screen_sub_still_renewing_message">आपकी सदस्यता अभी भी नवीनीकरण के लिए सेट है। पहले इसे Google Play में रद्द करें, फिर एकमुश्त खरीद पर स्विच करें। अभी-अभी रद्द किया? Google Play को थोड़ा समय दें और फिर से कोशिश करें।</string>
-    <string name="upgrade_screen_sub_check_failed_title">सदस्यता जांच विफल रही</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play के साथ आपकी सदस्यता की स्थिति जांची नहीं जा सकी। दोहरे खरीद से बचने के लिए, थोड़ी देर में फिर से कोशिश करें।</string>
     <string name="upgrade_screen_grace_title">आपकी खरीदारी की पुष्टि की जा रही है</string>
     <string name="upgrade_screen_grace_body_short">Google Play ने अभी तक आपकी खरीदारी की पुष्टि नहीं की है। Pro अभी भी सक्रिय है — कोई कार्रवाई जरूरी नहीं।</string>
     <string name="upgrade_screen_grace_body">Google Play ने काफ़ी समय से आपकी खरीदारी की पुष्टि नहीं की है। Pro अभी भी सक्रिय है। सुनिश्चित करें कि आप ऑनलाइन हैं और उसी Google खाते से साइन इन हैं जिससे खरीदारी की गई थी, फिर पुनर्स्थापित करने का प्रयास करें।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ovo je zasebna kupnja — ona ne otkazuje niti vraća novac za vašu pretplatu. Koristite isti Google račun.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Pretplata je i dalje aktivna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaša pretplata je i dalje postavljena za obnavljanje. Prvo je otkažite u Google Playu, a zatim prijeđite na jednokratnu kupnju. Upravo ste otkazali? Dajte Google Playu trenutak i pokušajte ponovno.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Provjera pretplate nije uspjela</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nije bilo moguće provjeriti status vaše pretplate s Google Playom. Kako biste izbjegli dvostruku kupnju, pokušajte ponovno za trenutak.</string>
     <string name="upgrade_screen_grace_title">Potvrđivanje vaše kupnje</string>
     <string name="upgrade_screen_grace_body_short">Google Play još nije potvrdio vašu kupnju. Pro je i dalje aktivan — nije potrebna nikakva radnja.</string>
     <string name="upgrade_screen_grace_body">Google Play već neko vrijeme nije potvrdio vašu kupnju. Pro je i dalje aktivan. Provjerite jeste li povezani s internetom i prijavljeni s Google računom koji ste koristili za kupnju, a zatim pokušajte vratiti kupnju.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ez egy külön vásárlás – nem mondja le és nem téríti vissza az előfizetésedet. Használd ugyanazt a Google-fiókot.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Az előfizetés még aktív</string>
     <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed még mindig megújulásra van állítva. Először mondd le a Google Playben, majd válts át az egyszeri vásárlásra. Most mondtad le? Adj egy kis időt a Google Playnek, és próbáld újra.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Az előfizetés ellenőrzése sikertelen</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed állapotát a Google Playnél. A kétszeres vásárlás elkerülése érdekében próbáld újra egy kicsit később.</string>
     <string name="upgrade_screen_grace_title">A vásárlásod megerősítése</string>
     <string name="upgrade_screen_grace_body_short">A Google Play még nem erősítette meg a vásárlásodat. A Pro továbbra is aktív – nincs teendő.</string>
     <string name="upgrade_screen_grace_body">A Google Play egy ideje nem erősítette meg a vásárlásodat. A Pro továbbra is aktív. Győződj meg róla, hogy online vagy, és be vagy jelentkezve a vásárláshoz használt Google-fiókkal, majd próbáld meg visszaállítani.</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Սա առանձին գնում է․ այն չի չեղարկում կամ վերադարձնում ձեր բաժանորդագրության գումարը: Օգտագործեք նույն Google հաշիվը:</string>
     <string name="upgrade_screen_sub_still_renewing_title">Բաժանորդագրությունը դեռ ակտիվ է</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ձեր բաժանորդագրությունը դեռ նորոգվելու է: Նախ չեղարկեք այն Google Play-ում, ապա անցեք միանգամյա գնմանը: Հենց նոր չեղարկե՞լ եք: Տվեք Google Play-ին մի փոքր ժամանակ և կրկին փորձեք:</string>
-    <string name="upgrade_screen_sub_check_failed_title">Բաժանորդագրության ստուգումը ձախողվեց</string>
-    <string name="upgrade_screen_sub_check_failed_message">Չհաջողվեց ստուգել ձեր բաժանորդագրության կարգավիճակը Google Play-ի հետ: Կրկնակի գնմաններից խուսափելու համար կրկին փորձեք մի փոքր ուշ:</string>
     <string name="upgrade_screen_grace_title">Հաստատում ենք ձեր գնումը</string>
     <string name="upgrade_screen_grace_body_short">Google Play-ը դեռ չի հաստատել ձեր գնումը: Pro-ն դեռ ակտիվ է․ գործողություն պահանջվող չէ:</string>
     <string name="upgrade_screen_grace_body">Google Play-ը որոշ ժամանակ է, ինչ չի հաստատել ձեր գնումը: Pro-ն դեռ ակտիվ է: Համոզվեք, որ առցանց եք և մուտք գործած այն Google հաշվով, որով կատարվել է գնումը, ապա փորձեք վերականգնել:</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ini adalah pembelian terpisah — tidak membatalkan atau mengembalikan dana langganan Anda. Gunakan akun Google yang sama.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Langganan Anda masih diatur untuk diperpanjang. Batalkan dulu di Google Play, lalu beralih ke sekali bayar. Baru saja membatalkan? Beri waktu sebentar untuk Google Play lalu coba lagi.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Pemeriksaan langganan gagal</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tidak dapat memeriksa status langganan Anda dengan Google Play. Untuk menghindari pembelian ganda, coba lagi sebentar lagi.</string>
     <string name="upgrade_screen_grace_title">Mengonfirmasi pembelian Anda</string>
     <string name="upgrade_screen_grace_body_short">Google Play belum mengonfirmasi pembelian Anda. Pro masih aktif — tidak perlu tindakan apa pun.</string>
     <string name="upgrade_screen_grace_body">Google Play belum mengonfirmasi pembelian Anda untuk beberapa waktu. Pro masih aktif. Pastikan Anda daring dan masuk dengan akun Google yang digunakan untuk pembelian, lalu coba pulihkan.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Þessi eru sérstök kaup — þau segja ekki upp áskrift þínni né endurgreiða hana. Notaðu sama Google reikning.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Áskrift enn virk</string>
     <string name="upgrade_screen_sub_still_renewing_message">Áskrift þín er enn stillt á að endurnýjast. Segðu henni fyrst upp í Google Play og skiptu svo yfir í einskiptiskaup. Nýlega sagt upp? Gefðu Google Play smástund og reyndu aftur.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Athugun á áskrift mistókst</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ekki tókst að athuga stöðu áskriftar þínnar hjá Google Play. Til að forðast tvíkaup skaltu reyna aftur eftir smástund.</string>
     <string name="upgrade_screen_grace_title">Staðfesti kaupin þín</string>
     <string name="upgrade_screen_grace_body_short">Google Play hefur ekki staðfest kaupin þín ennþá. Pro er áfram virkt — engra aðgerða er þörf.</string>
     <string name="upgrade_screen_grace_body">Google Play hefur ekki staðfest kaupin þín um nokkurt skeið. Pro er áfram virkt. Gakktu úr skugga um að þú sért nettengd(ur) og skráð(ur) inn með Google reikningnum sem notaður var við kaupin, og reyndu svo að endurheimta.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Si tratta di un acquisto separato: non annulla né rimborsa il tuo abbonamento. Usa lo stesso account Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abbonamento ancora attivo</string>
     <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora impostato per il rinnovo. Annullalo prima su Google Play, poi passa all’acquisto una tantum. Hai appena annullato? Dai un momento a Google Play e riprova.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Verifica dell’abbonamento non riuscita</string>
-    <string name="upgrade_screen_sub_check_failed_message">Non è stato possibile verificare lo stato del tuo abbonamento con Google Play. Per evitare un doppio acquisto, riprova tra poco.</string>
     <string name="upgrade_screen_grace_title">Conferma del tuo acquisto in corso</string>
     <string name="upgrade_screen_grace_body_short">Google Play non ha ancora confermato il tuo acquisto. Pro è ancora attivo: nessuna azione necessaria.</string>
     <string name="upgrade_screen_grace_body">Google Play non ha confermato il tuo acquisto da un po’ di tempo. Pro è ancora attivo. Assicurati di essere online e di aver effettuato l’accesso con l’account Google utilizzato per l’acquisto, poi prova a ripristinare.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">זוהי רכישה נפרדת — היא אינה מבטלת או מזכה את המינוי שלך. השתמש באותו חשבון Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">המינוי עדיין פעיל</string>
     <string name="upgrade_screen_sub_still_renewing_message">המינוי שלך עדיין מוגדר להתחדש. בטל אותו קודם ב-Google Play, ולאחר מכן עבור לרכישה החד-פעמית. בטלת הרגע? תן ל-Google Play רגע ונסה שוב.</string>
-    <string name="upgrade_screen_sub_check_failed_title">בדיקת המינוי נכשלה</string>
-    <string name="upgrade_screen_sub_check_failed_message">לא ניתן היה לבדוק את סטטוס המינוי שלך מול Google Play. כדי להימנע מרכישה כפולה, נסה שוב בעוד רגע.</string>
     <string name="upgrade_screen_grace_title">מאשר את הרכישה שלך</string>
     <string name="upgrade_screen_grace_body_short">Google Play עדיין לא אישר את הרכישה שלך. Pro עדיין פעיל — אין צורך בפעולה.</string>
     <string name="upgrade_screen_grace_body">Google Play לא אישר את הרכישה שלך כבר זמן מה. Pro עדיין פעיל. ודא שאתה מחובר לאינטרנט ומחובר עם חשבון ה-Google שבו בוצעה הרכישה, ולאחר מכן נסה לשחזר.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">これは別の購入です。サブスクリプションのキャンセルや返金は行われません。同じGoogleアカウントを使用してください。</string>
     <string name="upgrade_screen_sub_still_renewing_title">サブスクリプションはまだ有効です</string>
     <string name="upgrade_screen_sub_still_renewing_message">サブスクリプションはまだ更新するように設定されています。まずGoogle Playで解約してから、1回限りの購入に切り替えてください。解約したばかりの場合は、Google Playの反映を少々待ってからもう一度お試しください。</string>
-    <string name="upgrade_screen_sub_check_failed_title">サブスクリプションの確認に失敗しました</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Playでサブスクリプションのステータスを確認できませんでした。二重購入を避けるため、しばらくしてからもう一度お試しください。</string>
     <string name="upgrade_screen_grace_title">購入を確認中</string>
     <string name="upgrade_screen_grace_body_short">Google Playがまだ購入を確認していません。Proは引き続き有効です。特に操作は必要ありません。</string>
     <string name="upgrade_screen_grace_body">Google Playがしばらく購入を確認していません。Proは引き続き有効です。オンラインになっていること、購入時に使用したGoogleアカウントでサインインしていることを確認してから、復元をお試しください。</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ეს ცალკე შესყიდვაა — ის არ აუქმებს და არ აბრუნებს თანხას თქვენს გამოწერაზე. გამოიყენეთ იგივე Google ანგარიში.</string>
     <string name="upgrade_screen_sub_still_renewing_title">გამოწერა კვლავ აქტიურია</string>
     <string name="upgrade_screen_sub_still_renewing_message">თქვენი გამოწერა კვლავ დაყენებულია განახლებაზე. ჯერ გააუქმეთ ის Google Play-ში, შემდეგ გადადით ერთჯერად შესყიდვაზე. ახლახან გააუქმეთ? მიეცით Google Play-ს დრო და სცადეთ ხელახლა.</string>
-    <string name="upgrade_screen_sub_check_failed_title">გამოწერის შემოწმება ვერ მოხერხდა</string>
-    <string name="upgrade_screen_sub_check_failed_message">თქვენი გამოწერის სტატუსის შემოწმება Google Play-სთან ვერ მოხერხდა. ორმაგი შესყიდვის თავიდან ასაცილებლად, სცადეთ ხელახლა მოკლე ხანში.</string>
     <string name="upgrade_screen_grace_title">თქვენი შესყიდვის დადასტურება</string>
     <string name="upgrade_screen_grace_body_short">Google Play-მ ჯერ არ დაადასტურა თქვენი შესყიდვა. Pro კვლავ აქტიურია — არანაირი მოქმედება არ არის საჭირო.</string>
     <string name="upgrade_screen_grace_body">Google Play-მ დიდი ხანია არ დაუდასტურებია თქვენი შესყიდვა. Pro კვლავ აქტიურია. დარწმუნდით, რომ ხართ ონლაინ და შესული ხართ იმ Google ანგარიშით, რომლითაც შესყიდვა განახორციელეთ, შემდეგ სცადეთ აღდგენა.</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">នេះជាការទិញផ្សេងដាច់ដោយឡែក — វាមិនលុបចោល ឬបង្វិលប្រាក់ការជាវរបស់អ្នកទេ។ សូមប្រើគណនី Google ដូចគ្នា។</string>
     <string name="upgrade_screen_sub_still_renewing_title">ការជាវនៅតែសកម្ម</string>
     <string name="upgrade_screen_sub_still_renewing_message">ការជាវរបស់អ្នកនៅតែត្រូវបានកំណត់ឲ្យបន្ត។ សូមលុបចោលវានៅក្នុង Google Play ជាមុនសិន រួចប្ដូរទៅការទិញតែម្ដង។ ទើបតែលុបចោលមែនទេ? សូមរង់ចាំ Google Play បន្តិច រួចសាកល្បងម្ដងទៀត។</string>
-    <string name="upgrade_screen_sub_check_failed_title">ការត្រួតពិនិត្យការជាវបានបរាជ័យ</string>
-    <string name="upgrade_screen_sub_check_failed_message">មិនអាចត្រួតពិនិត្យស្ថានភាពការជាវរបស់អ្នកជាមួយ Google Play បានទេ។ ដើម្បីជៀសវាងការទិញស្ទួន សូមសាកល្បងម្ដងទៀតបន្តិចទៀត។</string>
     <string name="upgrade_screen_grace_title">កំពុងបញ្ជាក់ការទិញរបស់អ្នក</string>
     <string name="upgrade_screen_grace_body_short">Google Play មិនទាន់បានបញ្ជាក់ការទិញរបស់អ្នកនៅឡើយទេ។ Pro នៅតែសកម្ម — មិនចាំបាច់ធ្វើសកម្មភាពអ្វីទេ។</string>
     <string name="upgrade_screen_grace_body">Google Play មិនទាន់បានបញ្ជាក់ការទិញរបស់អ្នកជាយូរមកហើយ។ Pro នៅតែសកម្ម។ សូមប្រាកដថាអ្នកកំពុងអនឡាញ និងបានចូលគណនីជាមួយគណនី Google ដែលបានប្រើសម្រាប់ការទិញ រួចសាកល្បងស្ដារឡើងវិញ។</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ev kirîneke cuda ye — ew aboneya te betal nake û pereyê wê venagerîne. Heman hesabê Google bi kar bîne.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abone hîn jî çalak e</string>
     <string name="upgrade_screen_sub_still_renewing_message">Aboneya te hîn jî ji bo nûkirinê hatiye mêhengkirin. Berî her tiştî wê li Google Play betal bike, paşê derbasî kirîna carekî bibe. Heke te niha betal kir? Demekê bide Google Play û dîsa biceribîne.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontrola aboneyê bi ser neket</string>
-    <string name="upgrade_screen_sub_check_failed_message">Rewşa aboneya te ya bi Google Play re nehat kontrolkirin. Ji bo ku ne du caran bikire, piştî demekê dîsa biceribîne.</string>
     <string name="upgrade_screen_grace_title">Kirîna te tê pejirandin</string>
     <string name="upgrade_screen_grace_body_short">Google Play hê kirîna te napejirîne. Pro hîn jî çalak e — ne hewce ye tu tiştekî bikî.</string>
     <string name="upgrade_screen_grace_body">Google Play demek e kirîna te napejirîne. Pro hîn jî çalak e. Piştrast bike ku tu girêdayî înternetê yî û bi hesabê Google yê ku pê kirî têkevî, paşê kirînê vegerîne.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ಇದು ಪ್ರತ್ಯೇಕ ಖರೀದಿಯಾಗಿದೆ — ಇದು ನಿಮ್ಮ ಚಂದಾದಾರಿಕೆಯನ್ನು ರದ್ದುಗೊಳಿಸುವುದಿಲ್ಲ ಅಥವಾ ಮರುಪಾವತಿಸುವುದಿಲ್ಲ. ಅದೇ Google ಖಾತೆಯನ್ನು ಬಳಸಿ.</string>
     <string name="upgrade_screen_sub_still_renewing_title">ಚಂದಾದಾರಿಕೆ ಇನ್ನೂ ಸಕ್ರಿಯವಾಗಿದೆ</string>
     <string name="upgrade_screen_sub_still_renewing_message">ನಿಮ್ಮ ಚಂದಾದಾರಿಕೆ ಇನ್ನೂ ನವೀಕರಿಸಲು ಹೊಂದಿಸಲಾಗಿದೆ. ಮೊದಲು Google Play ನಲ್ಲಿ ಅದನ್ನು ರದ್ದುಗೊಳಿಸಿ, ನಂತರ ಒಂದು ಬಾರಿಯ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಿ. ಈಗಷ್ಟೇ ರದ್ದುಗೊಳಿಸಿದ್ದೀರಾ? Google Play ಗೆ ಸ್ವಲ್ಪ ಸಮಯ ನೀಡಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
-    <string name="upgrade_screen_sub_check_failed_title">ಚಂದಾದಾರಿಕೆ ಪರಿಶೀಲನೆ ವಿಫಲವಾಗಿದೆ</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ನೊಂದಿಗೆ ನಿಮ್ಮ ಚಂದಾದಾರಿಕೆ ಸ್ಥಿತಿಯನ್ನು ಪರಿಶೀಲಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ಎರಡು ಬಾರಿ ಖರೀದಿಸುವುದನ್ನು ತಪ್ಪಿಸಲು, ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="upgrade_screen_grace_title">ನಿಮ್ಮ ಖರೀದಿಯನ್ನು ದೃಢೀಕರಿಸಲಾಗುತ್ತಿದೆ</string>
     <string name="upgrade_screen_grace_body_short">Google Play ಇನ್ನೂ ನಿಮ್ಮ ಖರೀದಿಯನ್ನು ದೃಢೀಕರಿಸಿಲ್ಲ. Pro ಇನ್ನೂ ಸಕ್ರಿಯವಾಗಿದೆ — ಯಾವುದೇ ಕ್ರಮದ ಅಗತ್ಯವಿಲ್ಲ.</string>
     <string name="upgrade_screen_grace_body">Google Play ಸ್ವಲ್ಪ ಸಮಯದಿಂದ ನಿಮ್ಮ ಖರೀದಿಯನ್ನು ದೃಢೀಕರಿಸಿಲ್ಲ. Pro ಇನ್ನೂ ಸಕ್ರಿಯವಾಗಿದೆ. ನೀವು ಆನ್‌ಲೈನ್‌ನಲ್ಲಿದ್ದೀರಿ ಮತ್ತು ಖರೀದಿಗೆ ಬಳಸಿದ Google ಖಾತೆಯೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಆಗಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಂಡು, ನಂತರ ಮರುಸ್ಥಾಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">이는 별도의 구매이며 기존 구독을 취소하거나 환불하지 않습니다. 동일한 Google 계정을 사용하세요.</string>
     <string name="upgrade_screen_sub_still_renewing_title">구독이 아직 활성 상태입니다</string>
     <string name="upgrade_screen_sub_still_renewing_message">구독이 아직 갱신되도록 설정되어 있습니다. 먼저 Google Play에서 구독을 취소한 다음 일회성 구매로 전환하세요. 방금 취소하셨나요? Google Play가 처리할 시간을 조금 준 다음 다시 시도해 보세요.</string>
-    <string name="upgrade_screen_sub_check_failed_title">구독 확인 실패</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play에서 구독 상태를 확인할 수 없었습니다. 이중 구매를 피하려면 잠시 후 다시 시도하세요.</string>
     <string name="upgrade_screen_grace_title">구매 확인 중</string>
     <string name="upgrade_screen_grace_body_short">Google Play에서 아직 구매를 확인하지 않았습니다. Pro는 계속 활성 상태이며 별도 조치가 필요하지 않습니다.</string>
     <string name="upgrade_screen_grace_body">Google Play에서 한동안 구매를 확인하지 않았습니다. Pro는 계속 활성 상태입니다. 온라인 상태인지, 구매에 사용한 Google 계정으로 로그인되어 있는지 확인한 다음 복원을 시도해 보세요.</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Бул өзүнчө сатып алуу — ал жазылууңузду жокко чыгарбайт же акчаны кайтарбайт. Ошол эле Google каттоо эсебин колдонуңуз.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Жазылуу дагы эле активдүү</string>
     <string name="upgrade_screen_sub_still_renewing_message">Жазылууңуз дагы эле жаңылануучу кылып койулган. Адегенде аны Google Play\'де жокко чыгарыңыз, андан кийин бир жолку сатып алууга которулуңуз. Жаңы эле жокко чыгардыңызбы? Google Play\'ге бир аз убакыт бериңиз жана кайра аракет кылыңыз.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Жазылууну текшерүү ишке ашкан жок</string>
-    <string name="upgrade_screen_sub_check_failed_message">Жазылуу статусуңузду Google Play менен текшерүү мүмкүн болбоду. Эки жолу сатып алуудан качуу үчүн бир аздан кийин кайра аракет кылыңыз.</string>
     <string name="upgrade_screen_grace_title">Сатып алууңуз ырасталууда</string>
     <string name="upgrade_screen_grace_body_short">Google Play сатып алууңузду азырынча ырастаган жок. Pro дагы эле активдүү — эч нерсе кылуунун кереги жок.</string>
     <string name="upgrade_screen_grace_body">Google Play сатып алууңузду бир далай убакыттан бери ырастаган жок. Pro дагы эле активдүү. Онлайн экениңизди жана сатып алуу үчүн колдонулган Google каттоо эсеби менен кирип турганыңызды текшериңиз, андан кийин калыбына келтирип көрүңүз.</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ນີ້ແມ່ນການຊື້ແຍກຕ່າງໜາກ — ມັນບໍ່ໄດ້ຍົກເລີກ ຫືລ ຄືນເງິນການສະໝັກສະມາຊິກຂອງທ່ານ. ໃຊ້ບັນຊີ Google ດຽວກັນ.</string>
     <string name="upgrade_screen_sub_still_renewing_title">ການສະໝັກສະມາຊິກຍັງໃຊ້ງານຍູ່</string>
     <string name="upgrade_screen_sub_still_renewing_message">ການສະໝັກສະມາຊິກຂອງທ່ານຍັງຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸຍູ່. ຍົກເລີກມັນໃນ Google Play ກ່ອນ, ແລ້ວຈຶ່ງປ່ຍນໄປໃຊ້ການຊື້ຄັ້ງດຽວ. ໜາກໍ່ຍົກເລີກບໍ? ໃຫ້ເວລາ Google Play ຊັກໝ້ອຍແລ້ວລອງໃໝ່.</string>
-    <string name="upgrade_screen_sub_check_failed_title">ການກວດສອບການສະໝັກສະມາຊິກລ໌ມເໜລວ</string>
-    <string name="upgrade_screen_sub_check_failed_message">ບໍ່ສາມາດກວດສອບສະຖານະການສະໝັກສະມາຊິກຂອງທ່ານກັບ Google Play ໄດ້. ເພື່ອໜຼີກລ່າງການຊື້ຊ້ຳ, ລອງໃໝ່ອີກຄັ້ງໃນໄວ່ໆນີ້.</string>
     <string name="upgrade_screen_grace_title">ກຳລັງຍືນຍັນການຊື້ຂອງທ່ານ</string>
     <string name="upgrade_screen_grace_body_short">Google Play ຍັງບໍ່ໄດ້ຍືນຍັນການຊື້ຂອງທ່ານ. Pro ຍັງໃຊ້ງານໄດ້ຍູ່ — ບໍ່ຈຳເປັນຕ້ອງເຮັດໜັຍັງ.</string>
     <string name="upgrade_screen_grace_body">Google Play ຍັງບໍ່ໄດ້ຍືນຍັນການຊື້ຂອງທ່ານມາໄລຍະໝຶ່ງແລ້ວ. Pro ຍັງໃຊ້ງານໄດ້ຍູ່. ກະລຸນາກວດສອບໃຫ້ແນ່ໃຈວ່າທ່ານອອນລາຍ ແລະ ເຂົ້າສູ່ລະບົບດ້ວຍບັນຊີ Google ດຽວກັນກັບທີ່ໃຊ້ຊື້, ແລ້ວລອງກູ້ຄືນ.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Tai atskiras pirkimas — jis neatšaukia ir negrąžina pinigų už jūsų prenumeratą. Naudokite tą pačią „Google“ paskyrą.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Prenumerata vis dar aktyvi</string>
     <string name="upgrade_screen_sub_still_renewing_message">Jūsų prenumerata vis dar bus atnaujinta. Pirmiausia atšaukite ją „Google Play“, tada pereikite prie vienkartinio pirkimo. Ką tik atšaukėte? Palaukite kiek laiko, kol „Google Play“ apdoros, ir bandykite dar kartą.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Nepavyko patikrinti prenumeratos</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepavyko patikrinti jūsų prenumeratos būsenos „Google Play“. Kad išvengtumėte dvigubo pirkimo, po kurio laiko bandykite dar kartą.</string>
     <string name="upgrade_screen_grace_title">Patvirtinamas jūsų pirkimas</string>
     <string name="upgrade_screen_grace_body_short">„Google Play“ dar nepatvirtino jūsų pirkimo. „Pro“ vis dar aktyvus — jokių veiksmų atlikti nereikia.</string>
     <string name="upgrade_screen_grace_body">„Google Play“ jau kurį laiką nepatvirtina jūsų pirkimo. „Pro“ vis dar aktyvus. Įsitikinkite, kad esate prisijungę prie interneto ir naudojate „Google“ paskyrą, kuria atlikote pirkimą, tuomet pabandykite atkurti.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Šis ir atsevišķis pirkums — tas neatceļ un neatmaksā tavu abonementu. Izmanto to pašu Google kontu.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonements joprojām aktīvs</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tavs abonements joprojām ir iestatīts atjaunoties. Vispirms atceļ to Google Play, tad pāriet uz vienreizējo pirkumu. Tikko atcēli? Dod Google Play brīdi un mēģini vēlreiz.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Abonementa pārbaude neizdevās</string>
-    <string name="upgrade_screen_sub_check_failed_message">Neizdevās pārbaudīt tavu abonementa statusu Google Play. Lai izvairītos no dubulta pirkuma, mēģini vēlreiz pēc brīža.</string>
     <string name="upgrade_screen_grace_title">Notiek pirkuma apstiprināšana</string>
     <string name="upgrade_screen_grace_body_short">Google Play vēl nav apstiprinājis tavu pirkumu. Pro joprojām ir aktīvs — nekas nav jādara.</string>
     <string name="upgrade_screen_grace_body">Google Play jau kādu laiku nav apstiprinājis tavu pirkumu. Pro joprojām ir aktīvs. Pārliecinies, ka esi tiešsaistē un pieteicies ar Google kontu, kas izmantots pirkumam, tad mēģini atjaunot pirkumu.</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ова е одделна куповка — не ја откажува ниту ти ги враќа парите за претплатата. Користи го истиот Google профил.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Претплатата сеуште е активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Твојата претплата сеуште е поставена да се обновува. Прво откажи ја во Google Play, па потоа премини на еднократната куповка. Штотуку ја откажа? Дај и на Google Play малку време и обиди се повторно.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Проверката на претплатата не успеа</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не можеше да се провери статусот на твојата претплата со Google Play. За да избегнеш двојна куповка, обиди се повторно за момент.</string>
     <string name="upgrade_screen_grace_title">Потврдување на твојата куповка</string>
     <string name="upgrade_screen_grace_body_short">Google Play сè уште не ја потврди твојата куповка. Pro е сè уште активен — не е потребно дејство.</string>
     <string name="upgrade_screen_grace_body">Google Play веќе подолго време не ја потврдува твојата куповка. Pro е сè уште активен. Провери дали си на интернет и најавен/а со Google профилот користен за куповката, па обиди се да ја вратиш.</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ഇത് ഒരു പ്രത്യേക വാങ്ങലാണ് — ഇത് നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ റദ്ദാക്കുകയോ റീഫണ്ട് ചെയ്യുകയോ ചെയ്യില്ല. അതേ Google അക്കൗണ്ട് ഉപയോഗിക്കുക.</string>
     <string name="upgrade_screen_sub_still_renewing_title">സബ്സ്ക്രിപ്ഷൻ ഇപ്പോഴും സജീവമാണ്</string>
     <string name="upgrade_screen_sub_still_renewing_message">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ ഇപ്പോഴും പുതുക്കാൻ സജ്ജീകരിച്ചിരിക്കുന്നു. ആദ്യം Google Play-യിൽ അത് റദ്ദാക്കുക, എന്നിട്ട് ഒറ്റത്തവണ വാങ്ങലിലേക്ക് മാറുക. ഇപ്പോൾ റദ്ദാക്കിയോ? Google Play-ക്ക് അൽപ്പം സമയം നൽകി വീണ്ടും ശ്രമിക്കുക.</string>
-    <string name="upgrade_screen_sub_check_failed_title">സബ്സ്ക്രിപ്ഷൻ പരിശോധന പരാജയപ്പെട്ടു</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play-യിൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ നില പരിശോധിക്കാൻ കഴിഞ്ഞില്ല. ഇരട്ട വാങ്ങൽ ഒഴിവാക്കാൻ അൽപ്പം കഴിഞ്ഞ് വീണ്ടും ശ്രമിക്കുക.</string>
     <string name="upgrade_screen_grace_title">നിങ്ങളുടെ വാങ്ങൽ സ്ഥിരീകരിക്കുന്നു</string>
     <string name="upgrade_screen_grace_body_short">Google Play ഇതുവരെ നിങ്ങളുടെ വാങ്ങൽ സ്ഥിരീകരിച്ചിട്ടില്ല. Pro ഇപ്പോഴും സജീവമാണ് — ഒരു നടപടിയും ആവശ്യമില്ല.</string>
     <string name="upgrade_screen_grace_body">കുറച്ച് സമയമായി Google Play നിങ്ങളുടെ വാങ്ങൽ സ്ഥിരീകരിച്ചിട്ടില്ല. Pro ഇപ്പോഴും സജീവമാണ്. നിങ്ങൾ ഓൺലൈനിലാണെന്നും വാങ്ങലിനായി ഉപയോഗിച്ച 

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Энэ бол тусдаа худалдан авалт бөгөөд таны захиалгыг цуцлахгүй, мөнгийг буцаан олгохгүй. Ижил Google бүртгэлийг ашиглана уу.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Захиалга хэвээр идэвхтэй байна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Таны захиалга шинэчлэгдэхээр тохируулагдсан хэвээр байна. Эхлээд Google Play дээр цуцалж, дараа нь нэг удаагийн худалдан авалт руу шилжинэ үү. Дөнгөж сая цуцалсан уу? Google Play-д бага зэрэг хугацаа өгөөд дахин оролдоно уу.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Захиалгын шалгалт амжилтгүй боллоо</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play дээр таны захиалгын төлөвийг шалгаж чадсангүй. Хоёр удаа төлөхөөс зайлсхийхийн тулд бага зэрэг хүлээгээд дахин оролдоно уу.</string>
     <string name="upgrade_screen_grace_title">Таны худалдан авалтыг баталгаажуулж байна</string>
     <string name="upgrade_screen_grace_body_short">Google Play таны худалдан авалтыг одоохондоо баталгаажуулаагүй байна. Pro хэвээр идэвхтэй байгаа тул юу ч хийх шаардлагагүй.</string>
     <string name="upgrade_screen_grace_body">Google Play таны худалдан авалтыг удаан хугацаанд баталгаажуулаагүй байна. Pro хэвээр идэвхтэй байна. Та онлайн байгаа эсэх, худалдан авалт хийхдээ ашигласан Google бүртгэлээр нэвтэрсэн эсэхээ шалгаад дараа нь сэргээхийг оролдоно уу.</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ही एक वेगळी खरेदी आहे — ती तुमचे सदस्यत्व रद्द किंवा परत करत नाही. तेच Google खाते वापरा.</string>
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यत्व अजूनही सक्रिय आहे</string>
     <string name="upgrade_screen_sub_still_renewing_message">तुमचे सदस्यत्व अजूनही नूतनीकरणासाठी सेट केलेले आहे. आधी ते Google Play मध्ये रद्द करा, नंतर एकवेळच्या खरेदीवर स्विच करा. नुकतेच रद्द केले? Google Play ला थोडा वेळ द्या आणि पुन्हा प्रयत्न करा.</string>
-    <string name="upgrade_screen_sub_check_failed_title">सदस्यत्व तपासणी अयशस्वी झाली</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play सह तुमची सदस्यत्व स्थिती तपासता आली नाही. दुहेरी खरेदी टाळण्यासाठी, थोड्या वेळाने पुन्हा प्रयत्न करा.</string>
     <string name="upgrade_screen_grace_title">तुमची खरेदी निश्चित केली जात आहे</string>
     <string name="upgrade_screen_grace_body_short">Google Play ने अद्याप तुमची खरेदी निश्चित केलेली नाही. Pro अजूनही सक्रिय आहे — कोणतीही कारवाई आवश्यक नाही.</string>
     <string name="upgrade_screen_grace_body">Google Play ने बर्‍याच वेळेपासून तुमची खरेदी निश्चित केलेली नाही. Pro अजूनही सक्रिय आहे. तुम्ही ओनलाइन आहात आणि खरेदीसाठी वापरलेल्या Google खात्याने साइन इन केले आहे याची खात्री करा, नंतर पुनर्संचयित करण्याचा प्रयत्न करा.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ini ialah pembelian berasingan — ia tidak membatalkan atau memulangkan wang langganan anda. Gunakan akaun Google yang sama.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Langganan anda masih ditetapkan untuk diperbaharui. Batalkannya di Google Play terlebih dahulu, kemudian tukar kepada pembelian sekali sahaja. Baru sahaja membatalkan? Beri Google Play sedikit masa dan cuba lagi.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Semakan langganan gagal</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tidak dapat menyemak status langganan anda dengan Google Play. Untuk mengelakkan pembelian berganda, cuba lagi sebentar lagi.</string>
     <string name="upgrade_screen_grace_title">Mengesahkan pembelian anda</string>
     <string name="upgrade_screen_grace_body_short">Google Play belum mengesahkan pembelian anda lagi. Pro masih aktif — tiada tindakan diperlukan.</string>
     <string name="upgrade_screen_grace_body">Google Play belum mengesahkan pembelian anda buat seketika. Pro masih aktif. Pastikan anda dalam talian dan log masuk dengan akaun Google yang digunakan untuk pembelian, kemudian cuba pulihkan.</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ဤသည်မှာ သီးခြားဝယ်ယူမှုတစ်ခုဖြစ်သည် — ၎င်းသည် သင့်စာရင်းသွင်းမှုကို မပယ်ဖျက်ပါ၊ ငွေပြန်အမ်းမှုလည်း မပြုလုပ်ပါ။ တူညီသော Google အကောင့်ကို အသုံးပြုပါ။</string>
     <string name="upgrade_screen_sub_still_renewing_title">စာရင်းသွင်းမှု ဆက်လက်အသက်ဝင်နေဆဲ</string>
     <string name="upgrade_screen_sub_still_renewing_message">သင့်စာရင်းသွင်းမှုသည် ပြန်လည်သက်တမ်းတိုးရန် ဆက်လက်သတ်မှတ်ထားဆဲဖြစ်သည်။ ဦးစွာ Google Play တွင် ၎င်းကို ပယ်ဖျက်ပြီးမှ တစ်ကြိမ်တည်း ဝယ်ယူမှုသို့ ပြောင်းလဲပါ။ ယခုပဲ ပယ်ဖျက်လိုက်ပါသလား။ Google Play ကို အချိန်အနည်းငယ်ပေးပြီး ထပ်စမ်းကြည့်ပါ။</string>
-    <string name="upgrade_screen_sub_check_failed_title">စာရင်းသွင်းမှု စစ်ဆေးမှု မအောင်မြင်ပါ</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play ဖြင့် သင့်စာရင်းသွင်းမှုအခြေအနေကို စစ်ဆေး၍မရပါ။ နှစ်ကြိမ် ဝယ်ယူမိမှုကို ရှောင်ရှားရန် အချိန်အနည်းငယ်ကြာပြီးမှ ထပ်စမ်းကြည့်ပါ။</string>
     <string name="upgrade_screen_grace_title">သင့်ဝယ်ယူမှုကို အတည်ပြုနေသည်</string>
     <string name="upgrade_screen_grace_body_short">Google Play က သင့်ဝယ်ယူမှုကို အတည်မပြုရသေးပါ။ Pro မှာ ဆက်လက်အသက်ဝင်နေဆဲဖြစ်သည် — မည်သည့်အရာမှ လုပ်ဆောင်ရန် မလိုအပ်ပါ။</string>
     <string name="upgrade_screen_grace_body">Google Play သည် သင့်ဝယ်ယူမှုကို အတန်ကြာအောင် အတည်မပြုနိုင်သေးပါ။ Pro မှာ ဆက်လက်အသက်ဝင်နေဆဲဖြစ်သည်။ အွန်လိုင်းနှင့် ချိတ်ဆက်ထားပြီး ဝယ်ယူမှုတွင် အသုံးပြုခဲ့သည့် Google အကောင့်ဖြင့် လက်မှတ်ရေးထိုးဝင်ထားကြောင်း သေချာစေပြီးမှ ပြန်လည်ရယူရန် စမ်းကြည့်ပါ။</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dette er et separat kjøp — det kansellerer eller refunderer ikke abonnementet ditt. Bruk samme Google-konto.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnementet er fortsatt aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt satt til å fornyes. Kanseller det i Google Play først, og bytt deretter til engangskjøpet. Nettopp kansellert? Gi Google Play litt tid og prøv igjen.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontroll av abonnement mislyktes</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke kontrollere abonnementsstatusen din med Google Play. For å unngå et dobbelt kjøp, prøv igjen om litt.</string>
     <string name="upgrade_screen_grace_title">Bekrefter kjøpet ditt</string>
     <string name="upgrade_screen_grace_body_short">Google Play har ikke bekreftet kjøpet ditt ennå. Pro er fortsatt aktivt — ingen handling nødvendig.</string>
     <string name="upgrade_screen_grace_body">Google Play har ikke bekreftet kjøpet ditt på en stund. Pro er fortsatt aktivt. Sørg for at du er tilkoblet internett og logget inn med Google-kontoen som ble brukt til kjøpet, og prøv deretter å gjenopprette.</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">यो एउटा छुट्टै खरिद हो — यसले तपाईंको सदस्यता रद्द वा फिर्ता गर्दैन। उही Google खाता प्रयोग गर्नुहोस्।</string>
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अझै सक्रिय छ</string>
     <string name="upgrade_screen_sub_still_renewing_message">तपाईंको सदस्यता अझै नवीकरण हुने गरी सेट गरिएको छ। पहिले Google Play मा यसलाई रद्द गर्नुहोस्, त्यसपछि एक-पटक खरिदमा स्विच गर्नुहोस्। भर्खरै रद्द गर्नुभयो? Google Play लाई केही समय दिनुहोस् र फेरि प्रयास गर्नुहोस्।</string>
-    <string name="upgrade_screen_sub_check_failed_title">सदस्यता जाँच असफल भयो</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play सँग तपाईंको सदस्यता स्थिति जाँच गर्न सकिएन। दोहोरो खरिदबाट बच्न, केही क्षणमा फेरि प्रयास गर्नुहोस्।</string>
     <string name="upgrade_screen_grace_title">तपाईंको खरिद पुष्टि गर्दै</string>
     <string name="upgrade_screen_grace_body_short">Google Play ले तपाईंको खरिद अझै पुष्टि गरेको छैन। Pro अझै सक्रिय छ — कुनै कार्य आवश्यक छैन।</string>
     <string name="upgrade_screen_grace_body">Google Play ले तपाईंको खरिद धेरै समयदेखि पुष्टि गरेको छैन। Pro अझै सक्रिय छ। तपाईं अनलाइन हुनुहुन्छ र खरिदको लागि प्रयोग गरिएको Google खातामा साइन इन गर्नुभएको सुनिश्चित गर्नुहोस्, त्यसपछि पुनर्स्थापना गर्ने प्रयास गर्नुहोस्।</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Dit is een aparte aankoop - je abonnement wordt hiermee niet geannuleerd en het aankoopbedrag wordt niet terugbetaald. Gebruik hetzelfde Google-account.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog steeds actief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Je abonnement wordt automatisch verlengd. Annuleer het eerst in Google Play en schakel daarna over naar de eenmalige aankoop. Net geannuleerd? Geef Google Play even de tijd en probeer het opnieuw.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Controle van abonnement mislukt</string>
-    <string name="upgrade_screen_sub_check_failed_message">Je abonnementsstatus kon niet worden gecontroleerd bij Google Play. Om een ​​dubbele aankoop te voorkomen, probeer het over een moment opnieuw.</string>
     <string name="upgrade_screen_grace_title">Je aankoop wordt bevestigd</string>
     <string name="upgrade_screen_grace_body_short">Google Play heeft je aankoop nog niet bevestigd. Pro is nog steeds actief — geen actie nodig.</string>
     <string name="upgrade_screen_grace_body">Google Play heeft je aankoop al een tijdje niet bevestigd. Pro is nog steeds actief. Zorg ervoor dat je online bent en bent ingelogd met het Google-account dat je voor de aankoop hebt gebruikt, en probeer het dan opnieuw te herstellen.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">To osobny zakup — nie anuluje ani nie zwraca kosztów Twojej subskrypcji. Użyj tego samego konta Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subskrypcja nadal aktywna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja nadal jest ustawiona na odnawianie. Najpierw anuluj ją w Sklepie Google Play, a następnie przejdź na jednorazowy zakup. Właśnie anulowałeś? Daj Sklepowi Google Play chwilę i spróbuj ponownie.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Sprawdzenie subskrypcji nie powiodło się</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nie udało się sprawdzić stanu twojej subskrypcji w Sklepie Google Play. Aby uniknąć podwójnego zakupu, spróbuj ponownie za chwilę.</string>
     <string name="upgrade_screen_grace_title">Potwierdzanie twojego zakupu</string>
     <string name="upgrade_screen_grace_body_short">Sklep Google Play nie potwierdził jeszcze twojego zakupu. Pro nadal jest aktywne — nie musisz nic robić.</string>
     <string name="upgrade_screen_grace_body">Sklep Google Play od jakiegoś czasu nie potwierdził twojego zakupu. Pro nadal jest aktywne. Upewnij się, że jesteś online i zalogowany na konto Google użyte do zakupu, a następnie spróbuj przywrócić zakup.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta é uma compra separada — ela não cancela nem reembolsa sua assinatura. Use a mesma conta Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Assinatura ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está configurada para renovar. Cancele-a primeiro no Google Play e depois mude para a compra única. Acabou de cancelar? Dê um tempo ao Google Play e tente novamente.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Falha ao verificar a assinatura</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar o status da sua assinatura com o Google Play. Para evitar uma compra duplicada, tente novamente em instantes.</string>
     <string name="upgrade_screen_grace_title">Confirmando sua compra</string>
     <string name="upgrade_screen_grace_body_short">O Google Play ainda não confirmou sua compra. O Pro continua ativo — nenhuma ação necessária.</string>
     <string name="upgrade_screen_grace_body">O Google Play não confirma sua compra há um tempo. O Pro continua ativo. Verifique se você está online e conectado com a conta Google usada na compra, depois tente restaurar.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Esta é uma compra separada — não cancela nem reembolsa a tua subscrição. Utiliza a mesma conta Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscrição ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">A tua subscrição ainda está configurada para renovar. Cancela-a primeiro no Google Play e depois muda para a compra única. Acabaste de cancelar? Dá um momento ao Google Play e tenta novamente.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Falha ao verificar a subscrição</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar o estado da tua subscrição com o Google Play. Para evitar uma compra duplicada, tenta novamente dentro de momentos.</string>
     <string name="upgrade_screen_grace_title">A confirmar a tua compra</string>
     <string name="upgrade_screen_grace_body_short">O Google Play ainda não confirmou a tua compra. O Pro continua ativo — não é necessária qualquer ação.</string>
     <string name="upgrade_screen_grace_body">O Google Play não confirma a tua compra há algum tempo. O Pro continua ativo. Certifica-te de que estás online e com sessão iniciada com a conta Google utilizada na compra e, em seguida, tenta restaurar.</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Quai è ina cumpra separada — ella n\'annulescha e n\'rimborsa betg tes abunament. Utilisescha il medem conto Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abunament anc activ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tes abunament è anc configurà per sa renovar. Annullescha el en Google Play l\'emprim, e midescha lura a la cumpra unica. Già annullà? Dai in mument a Google Play ed emprova anc ina giada.</string>
-    <string name="upgrade_screen_sub_check_failed_title">La controlla da l\'abunament n\'ha betg reussi</string>
-    <string name="upgrade_screen_sub_check_failed_message">Impussibel da controllar tes status d\'abunament tar Google Play. Per evitar ina cumpra dubla, emprova anc ina giada en in mument.</string>
     <string name="upgrade_screen_grace_title">Confirmaziun da tia cumpra</string>
     <string name="upgrade_screen_grace_body_short">Google Play n\'ha anc betg confirmà tia cumpra. Pro resta activ — nagina acziun necessaria.</string>
     <string name="upgrade_screen_grace_body">Google Play n\'ha betg confirmà tia cumpra dapi in tschert temp. Pro resta activ. Controllescha che ti sajas online e annunzià cun il conto Google duvrà per la cumpra, ed emprova lura da restaurar.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Aceasta este o achiziție separată — nu anulează și nu rambursează abonamentul tău. Folosește același cont Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonamentul este încă activ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă setat să se reînnoiască. Anulează-l mai întâi din Google Play, apoi treci la achiziția unică. Tocmai l-ai anulat? Acordă-i lui Google Play un moment și încearcă din nou.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Verificarea abonamentului a eșuat</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nu s-a putut verifica starea abonamentului tău cu Google Play. Pentru a evita o achiziție dublă, încearcă din nou peste puțin timp.</string>
     <string name="upgrade_screen_grace_title">Se confirmă achiziția ta</string>
     <string name="upgrade_screen_grace_body_short">Google Play nu ți-a confirmat încă achiziția. Pro este încă activ — nu este nevoie de nicio acțiune.</string>
     <string name="upgrade_screen_grace_body">Google Play nu a confirmat achiziția ta de ceva vreme. Pro este încă activ. Asigură-te că ești conectat la internet și autentificat cu contul Google folosit pentru achiziție, apoi încearcă să restaurezi.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Это отдельная покупка — она не отменяет и не возвращает средства за подписку. Используйте тот же аккаунт Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка всё ещё будет продлена. Сначала отмените её в Google Play, а затем перейдите на разовую покупку. Только что отменили? Дайте Google Play немного времени и попробуйте снова.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Не удалось проверить подписку</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить статус подписки в Google Play. Чтобы избежать двойной покупки, попробуйте снова через некоторое время.</string>
     <string name="upgrade_screen_grace_title">Подтверждение покупки</string>
     <string name="upgrade_screen_grace_body_short">Google Play ещё не подтвердил вашу покупку. Pro всё ещё активен — никаких действий не требуется.</string>
     <string name="upgrade_screen_grace_body">Google Play уже некоторое время не подтверждает вашу покупку. Pro всё ещё активен. Убедитесь, что вы в сети и вошли в тот аккаунт Google, с которого была совершена покупка, а затем попробуйте восстановить покупку.</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Custu est unu cùmperu separadu — non cantzellat nen rimbursat s\'abbonamentu tuo. Impreu su matessi contu Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">S\'abbonamentu est galu atívu</string>
     <string name="upgrade_screen_sub_still_renewing_message">S\'abbonamentu tuo est galu programadu pro si rennovare. Cantzella·lu innantis in Google Play, e a pustis passa a su cùmperu de una borta. Cantzelladu como como? Dae unu momentu a Google Play e torra a proare.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Verífica de s\'abbonamentu fallida</string>
-    <string name="upgrade_screen_sub_check_failed_message">No at pòtidu verificare s\'istadu de s\'abbonamentu tuo cun Google Play. Pro non fàghere unu cùmperu dobbiu, torra a proare intre pagu tempus.</string>
     <string name="upgrade_screen_grace_title">Cunfirmande su cùmperu tuo</string>
     <string name="upgrade_screen_grace_body_short">Google Play no at ancora cunfirmadu su cùmperu tuo. Pro est galu atívu — no b\'at bisòngiu de fàghere nudda.</string>
     <string name="upgrade_screen_grace_body">Google Play no at cunfirmadu su cùmperu tuo dae unu pagu de tempus. Pro est galu atívu. Assegura·ti de èssere in lìnia e de àere fatu s\'aciesu cun su contu Google impreadu pro su cùmperu, e a pustis proa a ripristinare.</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">මෙය වෙනම මිලදී ගැනීමකි — එය ඔබේ දායකත්වය අවලංගු කිරීමක් හෝ මුදල් ආපසු ගෙවීමක් සිදු නොකරයි. එකම Google ගිණුම භාවිත කරන්න.</string>
     <string name="upgrade_screen_sub_still_renewing_title">දායකත්වය තවමත් සක්‍රියයි</string>
     <string name="upgrade_screen_sub_still_renewing_message">ඔබේ දායකත්වය තවමත් අළුත් කිරීමට සකසා ඇත. පළමුව Google Play හි එය අවලංගු කර, පසුව එක් වරක් මිලදී ගැනීමට මාරු වන්න. දැන් අවලංගු කළාද? Google Play ට මොහොතක් ලබා දී නැවත උත්සාහ කරන්න.</string>
-    <string name="upgrade_screen_sub_check_failed_title">දායකත්ව පරීක්ෂාව අසාර්ථක විය</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play සමඟ ඔබේ දායකත්ව තත්ත්වය පරීක්ෂා කළ නොහැකි විය. ද්විත්ව මිලදී ගැනීමක් වළක්වා ගැනීමට, මොහොතකින් නැවත උත්සාහ කරන්න.</string>
     <string name="upgrade_screen_grace_title">ඔබේ මිලදී ගැනීම තහවුරු කරමින්</string>
     <string name="upgrade_screen_grace_body_short">Google Play තවම ඔබේ මිලදී ගැනීම තහවුරු කර නැත. Pro තවමත් සක්‍රියයි — කිසිදු ක්‍රියාමාර්ගයක් අවශ්‍ය නොවේ.</string>
     <string name="upgrade_screen_grace_body">Google Play ටික කලක් තිස්සේ ඔබේ මිලදී ගැනීම තහවුරු කර නැත. Pro තවමත් සක්‍රියයි. ඔබ අන්තර්ජාලයට සම්බන්ධව සිටින බවත්, මිලදී ගැනීම සඳහා භාවිත කළ Google ගිණුමෙන් පුරන්ව ඇති බවත් තහවුරු කරගෙන, පසුව ප්‍රතිසාධනය කිරීමට උත්සාහ කරන්න.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Toto je samostatný nákup — nezruší ani nevráti platbu za vaše predplatné. Použite rovnaký účet Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Predplatné je stále aktívne</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše predplatné je stále nastavené na obnovenie. Najprv ho zrušte v Google Play a potom prejdite na jednorazový nákup. Práve ste ho zrušili? Dajte Google Play chvíľu čas a skúste to znova.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontrola predplatného zlyhala</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepodarilo sa skontrolovať stav vášho predplatného v Google Play. Aby ste predišli dvojitému nákupu, skúste to o chvíľu znova.</string>
     <string name="upgrade_screen_grace_title">Potvrdzujeme váš nákup</string>
     <string name="upgrade_screen_grace_body_short">Google Play zatiaľ nepotvrdil váš nákup. Pro je stále aktívne — nie je potrebná žiadna akcia.</string>
     <string name="upgrade_screen_grace_body">Google Play už dlhšie nepotvrdil váš nákup. Pro je stále aktívne. Uistite sa, že ste online a prihlásení s účtom Google, ktorý ste použili pri nákupe, a potom skúste nákup obnoviť.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">To je ločen nakup — ne prekliče ali povrne stroškov vaše naročnine. Uporabite isti Google račun.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Naročnina je še vedno aktivna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaša naročnina je še vedno nastavljena na samodejno podaljšanje. Najprej jo prekličite v Google Play, nato preklopite na enkratni nakup. Ste jo pravkar preklicali? Počakajte trenutek, da se Google Play posodobi, in poskusite znova.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Preverjanje naročnine ni uspelo</string>
-    <string name="upgrade_screen_sub_check_failed_message">Stanja vaše naročnine pri Google Play ni bilo mogoče preveriti. Da se izognete dvojnemu nakupu, poskusite znova čez trenutek.</string>
     <string name="upgrade_screen_grace_title">Potrjevanje vašega nakupa</string>
     <string name="upgrade_screen_grace_body_short">Google Play še ni potrdil vašega nakupa. Pro je še vedno aktiven — ni potreben noben ukrep.</string>
     <string name="upgrade_screen_grace_body">Google Play že nekaj časa ni potrdil vašega nakupa. Pro je še vedno aktiven. Prepričajte se, da ste povezani v splet in prijavljeni z Google računom, uporabljenim za nakup, nato poskusite obnoviti nakup.</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Kjo është një blerje e veçantë — nuk e anulon dhe nuk e rimburson abonimin tuaj. Përdorni të njëjtën llogari Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonimi ende aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonimi juaj është ende i caktuar për t\'u rinovuar. Anulojeni fillimisht në Google Play, pastaj kaloni në blerjen një herë. Sapo e keni anuluar? Jepini Google Play pak kohë dhe provoni përsëri.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontrolli i abonimit dështoi</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nuk u arrit të kontrollohej statusi i abonimit tuaj me Google Play. Për të shmangur një blerje të dyfishtë, provoni përsëri pas pak.</string>
     <string name="upgrade_screen_grace_title">Duke konfirmuar blerjen tuaj</string>
     <string name="upgrade_screen_grace_body_short">Google Play ende nuk e ka konfirmuar blerjen tuaj. Pro është ende aktiv — nuk kërkohet asnjë veprim.</string>
     <string name="upgrade_screen_grace_body">Google Play nuk e ka konfirmuar blerjen tuaj prej njëfarë kohe. Pro është ende aktiv. Sigurohuni që jeni online dhe të kyçur me llogarinë Google të përdorur për blerjen, pastaj provoni ta rikthyeni.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Ово је посебна куповина — не отказује нити рефундира вашу претплату. Користите исти Google налог.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Претплата је и даље активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је и даље подешена да се обнавља. Прво је откажите у Google Play-у, а затим пређите на једнократну куповину. Управо сте је отказали? Сачекајте тренутак да Google Play обради промену и покушајте поново.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Провера претплате није успела</string>
-    <string name="upgrade_screen_sub_check_failed_message">Није било могуће проверити статус претплате код Google Play-а. Да бисте избегли двоструку куповину, покушајте поново за тренутак.</string>
     <string name="upgrade_screen_grace_title">Потврђивање ваше куповине</string>
     <string name="upgrade_screen_grace_body_short">Google Play још увек није потврдио вашу куповину. Pro је и даље активан — није потребна никаква радња.</string>
     <string name="upgrade_screen_grace_body">Google Play већ извесно време није потврдио вашу куповину. Pro је и даље активан. Проверите да ли сте на мрежи и пријављени на Google налог који сте користили за куповину, а затим покушајте да обновите куповину.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Detta är ett separat köp — det avbryter eller återbetalar inte din prenumeration. Använd samma Google-konto.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Prenumerationen är fortfarande aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande inställd på att förnyas. Avbryt den i Google Play först och byt sedan till engångsköpet. Precis avbrutit? Ge Google Play en stund och försök igen.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kontroll av prenumeration misslyckades</string>
-    <string name="upgrade_screen_sub_check_failed_message">Det gick inte att kontrollera din prenumerationsstatus med Google Play. Försök igen om en stund för att undvika ett dubbelt köp.</string>
     <string name="upgrade_screen_grace_title">Bekräftar ditt köp</string>
     <string name="upgrade_screen_grace_body_short">Google Play har inte bekräftat ditt köp än. Pro är fortfarande aktivt — ingen åtgärd behövs.</string>
     <string name="upgrade_screen_grace_body">Google Play har inte bekräftat ditt köp på ett tag. Pro är fortfarande aktivt. Kontrollera att du är online och inloggad med det Google-konto som användes för köpet, och försök sedan återställa.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Huu ni ununuzi tofauti — hauighairi wala kurejesha fedha za usajili wako. Tumia akaunti ile ile ya Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Usajili bado unatumika</string>
     <string name="upgrade_screen_sub_still_renewing_message">Usajili wako bado umewekwa kujiongeza upya. Ughairi kwanza katika Google Play, kisha ubadilishe hadi ununuzi wa mara moja. Umeghairi hivi punde? Mpe Google Play muda kidogo kisha ujaribu tena.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Ukaguzi wa usajili umeshindwa</string>
-    <string name="upgrade_screen_sub_check_failed_message">Imeshindwa kuangalia hali ya usajili wako na Google Play. Ili kuepuka ununuzi mara mbili, jaribu tena baada ya muda kidogo.</string>
     <string name="upgrade_screen_grace_title">Inathibitisha ununuzi wako</string>
     <string name="upgrade_screen_grace_body_short">Google Play bado haijathibitisha ununuzi wako. Pro bado inatumika — hakuna hatua inayohitajika.</string>
     <string name="upgrade_screen_grace_body">Google Play haijathibitisha ununuzi wako kwa muda. Pro bado inatumika. Hakikisha uko mtandaoni na umeingia na akaunti ya Google iliyotumika kununua, kisha jaribu kurejesha.</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">இது ஒரு தனி கொள்முதல் — இது உங்கள் சந்தாவை ரத்து செய்யாது அல்லது பணத்தைத் திரும்பச் செலுத்தாது. அதே Google கணக்கைப் பயன்படுத்தவும்.</string>
     <string name="upgrade_screen_sub_still_renewing_title">சந்தா இன்னும் செயலில் உள்ளது</string>
     <string name="upgrade_screen_sub_still_renewing_message">உங்கள் சந்தா இன்னும் புதுப்பிக்க அமைக்கப்பட்டுள்ளது. முதலில் Google Play-இல் அதை ரத்து செய்யவும், பின்னர் ஒரு முறை வாங்குதலுக்கு மாறவும். இப்போதுதான் ரத்து செய்தீர்களா? Google Play-க்கு சிறிது நேரம் கொடுத்து மீண்டும் முயற்சிக்கவும்.</string>
-    <string name="upgrade_screen_sub_check_failed_title">சந்தா சரிபார்ப்பு தோல்வியடைந்தது</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play உடன் உங்கள் சந்தா நிலையைச் சரிபார்க்க முடியவில்லை. இரட்டை கொள்முதலைத் தவிர்க்க, சிறிது நேரத்தில் மீண்டும் முயற்சிக்கவும்.</string>
     <string name="upgrade_screen_grace_title">உங்கள் கொள்முதலை உறுதிப்படுத்துகிறது</string>
     <string name="upgrade_screen_grace_body_short">Google Play இன்னும் உங்கள் கொள்முதலை உறுதிப்படுத்தவில்லை. Pro இன்னும் செயலில் உள்ளது — எந்த நடவடிக்கையும் தேவையில்லை.</string>
     <string name="upgrade_screen_grace_body">Google Play சிறிது காலமாக உங்கள் கொள்முதலை உறுதிப்படுத்தவில்லை. Pro இன்னும் செயலில் உள்ளது. நீங்கள் ஆன்லைனில் இருப்பதையும், கொள்முதலுக்குப் பயன்படுத்திய Google கணக்கில் உள்நுழைந்திருப்பதையும் உறுதிப்படுத்திக் கொண்டு, பின்னர் மீட்டெடுக்க முயற்சிக்கவும்.</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">ఇది ఒక ప్రత్యేక కొనుగోలు — ఇది మీ సబ్‌స్క్రిప్షన్‌ను రద్దు చేయదు లేదా రీఫండ్ చేయదు. అదే Google ఖాతాను ఉపయోగించండి.</string>
     <string name="upgrade_screen_sub_still_renewing_title">సబ్‌స్క్రిప్షన్ ఇప్పటికీ యాక్టివ్‌గా ఉంది</string>
     <string name="upgrade_screen_sub_still_renewing_message">మీ సబ్‌స్క్రిప్షన్ ఇప్పటికీ రెన్యూ అయ్యేలా సెట్ చేయబడి ఉంది. ముందుగా Google Playలో దాన్ని రద్దు చేసి, తర్వాత ఒకేసారి కొనుగోలుకు మారండి. ఇప్పుడే రద్దు చేశారా? Google Playకి కొంత సమయం ఇచ్చి మళ్ళీ ప్రయత్నించండి.</string>
-    <string name="upgrade_screen_sub_check_failed_title">సబ్‌స్క్రిప్షన్ తనిఖీ విఫలమైంది</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Playతో మీ సబ్‌స్క్రిప్షన్ స్థితిని తనిఖీ చేయడం సాధ్యం కాలేదు. రెండుసార్లు కొనుగోలు చేయకుండా ఉండటానికి, కొంత సేపటి తర్వాత మళ్ళీ ప్రయత్నించండి.</string>
     <string name="upgrade_screen_grace_title">మీ కొనుగోలును నిర్ధారిస్తోంది</string>
     <string name="upgrade_screen_grace_body_short">Google Play ఇంకా మీ కొనుగోలును నిర్ధారించలేదు. Pro ఇప్పటికీ యాక్టివ్‌గా ఉంది — ఎలాంటి చర్య అవసరం లేదు.</string>
     <string name="upgrade_screen_grace_body">కొంత సమయంగా Google Play మీ కొనుగోలును నిర్ధారించలేదు. Pro ఇప్పటికీ యాక్టివ్‌గా ఉంది. మీరు ఆన్‌లైన్‌లో ఉన్నారని మరియు కొనుగోలు కోసం ఉపయోగించిన Google ఖాతాతో సైన్ ఇన్ అయ్యి ఉన్నారని నిర్ధారించుకుని, తర్వాత పునరుద్ధరించడానికి ప్రయత్నించండి.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">นี่เป็นการซื้อแยกต่างหาก — จะไม่ยกเลิกหรือคืนเงินการสมัครสมาชิกของคุณ ใช้บัญชี Google เดียวกัน</string>
     <string name="upgrade_screen_sub_still_renewing_title">การสมัครสมาชิกยังคงใช้งานอยู่</string>
     <string name="upgrade_screen_sub_still_renewing_message">การสมัครสมาชิกของคุณยังคงตั้งค่าให้ต่ออายุ ให้ยกเลิกใน Google Play ก่อน แล้วจึงเปลี่ยนไปใช้การซื้อครั้งเดียว เพิ่งยกเลิกใช่ไหม รอสักครู่ให้ Google Play อัปเดตแล้วลองอีกครั้ง</string>
-    <string name="upgrade_screen_sub_check_failed_title">ตรวจสอบการสมัครสมาชิกล้มเหลว</string>
-    <string name="upgrade_screen_sub_check_failed_message">ไม่สามารถตรวจสอบสถานะการสมัครสมาชิกของคุณกับ Google Play ได้ เพื่อหลีกเลี่ยงการซื้อซ้ำซ้อน ลองอีกครั้งในอีกสักครู่</string>
     <string name="upgrade_screen_grace_title">กำลังยืนยันการซื้อของคุณ</string>
     <string name="upgrade_screen_grace_body_short">Google Play ยังไม่ได้ยืนยันการซื้อของคุณ Pro ยังคงใช้งานได้อยู่ — ไม่ต้องดำเนินการใด ๆ</string>
     <string name="upgrade_screen_grace_body">Google Play ยังไม่ได้ยืนยันการซื้อของคุณมาสักระยะแล้ว Pro ยังคงใช้งานได้อยู่ ตรวจสอบให้แน่ใจว่าคุณออนไลน์อยู่และลงชื่อเข้าใช้ด้วยบัญชี Google ที่ใช้ซื้อ จากนั้นลองกู้คืน</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bu ayrı bir satın almadır — aboneliğini iptal etmez veya geri ödemez. Aynı Google hesabını kullan.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonelik hâlâ aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Aboneliğin hâlâ yenilenecek şekilde ayarlı. Önce Google Play\'de iptal et, ardından tek seferlik satın alıma geç. Az önce mi iptal ettin? Google Play\'e biraz zaman tanı ve tekrar dene.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Abonelik kontrolü başarısız oldu</string>
-    <string name="upgrade_screen_sub_check_failed_message">Abonelik durumun Google Play ile kontrol edilemedi. Çift satın almayı önlemek için biraz sonra tekrar dene.</string>
     <string name="upgrade_screen_grace_title">Satın alman onaylanıyor</string>
     <string name="upgrade_screen_grace_body_short">Google Play satın almanı henüz onaylamadı. Pro hâlâ aktif — herhangi bir işlem yapmana gerek yok.</string>
     <string name="upgrade_screen_grace_body">Google Play satın almanı bir süredir onaylamadı. Pro hâlâ aktif. Çevrimiçi olduğundan ve satın alma için kullanılan Google hesabıyla oturum açtığından emin ol, ardından geri yüklemeyi dene.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Це окрема покупка — вона не скасовує підписку та не повертає за неї кошти. Використовуйте той самий обліковий запис Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Підписка досі активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка досі налаштована на автоматичне продовження. Спочатку скасуйте її в Google Play, а потім перейдіть на одноразову покупку. Щойно скасували? Дайте Google Play трохи часу та спробуйте ще раз.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Не вдалося перевірити підписку</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити статус вашої підписки в Google Play. Щоб уникнути подвійної покупки, спробуйте ще раз за мить.</string>
     <string name="upgrade_screen_grace_title">Підтвердження вашої покупки</string>
     <string name="upgrade_screen_grace_body_short">Google Play ще не підтвердив вашу покупку. Pro все ще активний — жодних дій не потрібно.</string>
     <string name="upgrade_screen_grace_body">Google Play вже деякий час не підтверджує вашу покупку. Pro все ще активний. Переконайтеся, що ви в мережі та ввійшли в обліковий запис Google, який використовували для покупки, а потім спробуйте відновити.</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">یہ ایک الگ خریداری ہے — یہ آپ کے سبسکرپشن کو منسوخ یا ریفنڈ نہیں کرتی۔ وہی گوگل اکاؤنٹ استعمال کریں۔</string>
     <string name="upgrade_screen_sub_still_renewing_title">سبسکرپشن اب بھی فعال ہے</string>
     <string name="upgrade_screen_sub_still_renewing_message">آپ کا سبسکرپشن اب بھی تجدید ہونے کے لیے طے ہے۔ پہلے اسے گوگل پلے میں منسوخ کریں، پھر ایک بار کی خریداری پر منتقل ہوں۔ ابھی منسوخ کیا؟ گوگل پلے کو تھوڑا وقت دیں اور دوبارہ کوشش کریں۔</string>
-    <string name="upgrade_screen_sub_check_failed_title">سبسکرپشن کی جانچ ناکام ہو گئی</string>
-    <string name="upgrade_screen_sub_check_failed_message">گوگل پلے کے ساتھ آپ کے سبسکرپشن کی حیثیت چیک نہیں کی جا سکی۔ دوہری خریداری سے بچنے کے لیے، تھوڑی دیر میں دوبارہ کوشش کریں۔</string>
     <string name="upgrade_screen_grace_title">آپ کی خریداری کی تصدیق ہو رہی ہے</string>
     <string name="upgrade_screen_grace_body_short">گوگل پلے نے ابھی تک آپ کی خریداری کی تصدیق نہیں کی۔ Pro اب بھی فعال ہے — کسی اقدام کی ضرورت نہیں۔</string>
     <string name="upgrade_screen_grace_body">گوگل پلے نے کافی عرصے سے آپ کی خریداری کی تصدیق نہیں کی۔ Pro اب بھی فعال ہے۔ یقینی بنائیں کہ آپ آن لائن ہیں اور وہی گوگل اکاؤنٹ سے سائن ان ہیں جو خریداری کے لیے استعمال ہوا تھا، پھر بحال کرنے کی کوشش کریں۔</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Bu alohida xarid — u obunangizni bekor qilmaydi yoki pulini qaytarmaydi. Bir xil Google hisobidan foydalaning.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Obuna hali ham faol</string>
     <string name="upgrade_screen_sub_still_renewing_message">Obunangiz hali ham yangilanishga sozlangan. Avval uni Google Play\'da bekor qiling, so\'ngra bir martalik xaridga o\'ting. Hozirgina bekor qildingizmi? Google Play\'ga biroz vaqt bering va qayta urinib ko\'ring.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Obunani tekshirish amalga oshmadi</string>
-    <string name="upgrade_screen_sub_check_failed_message">Obuna holatingizni Google Play bilan tekshirib bo\'lmadi. Ikki marta xarid qilmaslik uchun birozdan so\'ng qayta urinib ko\'ring.</string>
     <string name="upgrade_screen_grace_title">Xaridingiz tasdiqlanmoqda</string>
     <string name="upgrade_screen_grace_body_short">Google Play hali xaridingizni tasdiqlamadi. Pro hali ham faol — hech qanday amal talab qilinmaydi.</string>
     <string name="upgrade_screen_grace_body">Google Play xaridingizni ancha vaqtdan beri tasdiqlamadi. Pro hali ham faol. Onlayn ekanligingizga va xarid uchun ishlatilgan Google hisobi bilan tizimga kirganingizga ishonch hosil qiling, so\'ngra tiklashga urinib ko\'ring.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Đây là một giao dịch mua riêng biệt — không hủy hoặc hoàn tiền gói đăng ký của bạn. Hãy sử dụng cùng tài khoản Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Gói đăng ký vẫn đang hoạt động</string>
     <string name="upgrade_screen_sub_still_renewing_message">Gói đăng ký của bạn vẫn được đặt để gia hạn. Hãy hủy gói đăng ký trong Google Play trước, sau đó chuyển sang mua một lần. Vừa mới hủy? Hãy chờ Google Play một chút rồi thử lại.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Kiểm tra gói đăng ký thất bại</string>
-    <string name="upgrade_screen_sub_check_failed_message">Không thể kiểm tra trạng thái gói đăng ký của bạn với Google Play. Để tránh mua trùng, hãy thử lại sau một lát.</string>
     <string name="upgrade_screen_grace_title">Đang xác nhận giao dịch mua của bạn</string>
     <string name="upgrade_screen_grace_body_short">Google Play chưa xác nhận giao dịch mua của bạn. Pro vẫn đang hoạt động — không cần thực hiện gì thêm.</string>
     <string name="upgrade_screen_grace_body">Google Play đã một thời gian chưa xác nhận giao dịch mua của bạn. Pro vẫn đang hoạt động. Hãy đảm bảo bạn đang trực tuyến và đã đăng nhập bằng tài khoản Google đã dùng để mua, sau đó thử khôi phục.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">这是一笔独立的购买——不会取消或退款您的订阅。请使用相同的 Google 账号。</string>
     <string name="upgrade_screen_sub_still_renewing_title">订阅仍然有效</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍设置为自动续订。请先在 Google Play 中取消订阅,再切换为一次性购买。刚取消?请稍等片刻,让 Google Play 同步后再试。</string>
-    <string name="upgrade_screen_sub_check_failed_title">订阅检查失败</string>
-    <string name="upgrade_screen_sub_check_failed_message">无法通过 Google Play 检查您的订阅状态。为避免重复购买,请稍后再试。</string>
     <string name="upgrade_screen_grace_title">正在确认您的购买</string>
     <string name="upgrade_screen_grace_body_short">Google Play 尚未确认您的购买。Pro 功能仍然有效——无需任何操作。</string>
     <string name="upgrade_screen_grace_body">Google Play 已有一段时间未确认您的购买。Pro 功能仍然有效。请确保您已联网,并使用购买时的 Google 账号登录,然后尝试恢复购买。</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">這是一項獨立的購買——不會取消或退還你的訂閱款項。請使用同一個 Google 帳戶。</string>
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
     <string name="upgrade_screen_sub_still_renewing_message">你的訂閱仍設定為自動續訂。請先在 Google Play 取消訂閱，然後再切換至一次性購買。剛剛才取消？請給 Google Play 一點時間，然後再試一次。</string>
-    <string name="upgrade_screen_sub_check_failed_title">訂閱檢查失敗</string>
-    <string name="upgrade_screen_sub_check_failed_message">無法透過 Google Play 檢查你的訂閱狀態。為避免重複付款，請稍後再試。</string>
     <string name="upgrade_screen_grace_title">正在確認你的購買</string>
     <string name="upgrade_screen_grace_body_short">Google Play 尚未確認你的購買。Pro 仍然有效——無需任何操作。</string>
     <string name="upgrade_screen_grace_body">Google Play 已有一段時間未有確認你的購買。Pro 仍然有效。請確保你已連接網絡，並使用購買時所用的 Google 帳戶登入，然後嘗試還原。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">這是一項獨立的購買，不會取消或退還您的訂閱費用。請使用相同的 Google 帳戶。</string>
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍在生效中</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍設定為自動續訂。請先在 Google Play 中取消訂閱，再切換至一次性購買。剛取消嗎？請稍候片刻讓 Google Play 更新後再試一次。</string>
-    <string name="upgrade_screen_sub_check_failed_title">訂閱檢查失敗</string>
-    <string name="upgrade_screen_sub_check_failed_message">無法向 Google Play 查詢您的訂閱狀態。為避免重複購買，請稍後再試一次。</string>
     <string name="upgrade_screen_grace_title">正在確認您的購買</string>
     <string name="upgrade_screen_grace_body_short">Google Play 尚未確認您的購買。Pro 仍處於啟用狀態 — 無需採取任何動作。</string>
     <string name="upgrade_screen_grace_body">Google Play 已有一段時間尚未確認您的購買。Pro 仍處於啟用狀態。請確認您已連上網路，並登入購買時所用的 Google 帳戶，然後嘗試還原購買項目。</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -46,8 +46,6 @@
     <string name="upgrade_screen_owned_iap_purchase_note">Lokhu kuwukuthenga okuhlukile — akukhanseli noma akubuyiseli imali yokubhalisa kwakho. Sebenzisa i-akhawunti ye-Google efanayo.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Ukubhalisa kusasebenza</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ukubhalisa kwakho kusahlelelwe ukuvuselelwa. Kuqale ukhansele ku-Google Play, bese ushintshela ekuthengeni okwenziwa kanye. Usanda kukhansela? Nika i-Google Play isikhashana bese uzama futhi.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Ukuhlolwa kokubhalisa kuhlulekile</string>
-    <string name="upgrade_screen_sub_check_failed_message">Akukwazanga ukuhlola isimo sokubhalisa kwakho ku-Google Play. Ukuze ugweme ukuthenga kabili, zama futhi ngesikhashana.</string>
     <string name="upgrade_screen_grace_title">Kuqinisekiswa ukuthenga kwakho</string>
     <string name="upgrade_screen_grace_body_short">I-Google Play ayikaqinisekisi ukuthenga kwakho. I-Pro isasebenza — akudingeki sinyathelo.</string>
     <string name="upgrade_screen_grace_body">I-Google Play ayikaqinisekisi ukuthenga kwakho isikhathi eside. I-Pro isasebenza. Qinisekisa ukuthi ukuxhunyiwe ku-inthanethi futhi ungenile nge-akhawunti ye-Google eyasetshenziswa ekutheneni, bese uzama ukubuyisela.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -46,8 +46,10 @@
     <string name="upgrade_screen_owned_iap_purchase_note">This is a separate purchase — it does not cancel or refund your subscription. Use the same Google account.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
     <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still set to renew. Cancel it in Google Play first, then switch to the one-time purchase. Just cancelled? Give Google Play a moment and try again.</string>
-    <string name="upgrade_screen_sub_check_failed_title">Subscription check failed</string>
-    <string name="upgrade_screen_sub_check_failed_message">Couldn\'t check your subscription status with Google Play. To avoid a double purchase, try again in a moment.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Couldn\'t check your purchases with Google Play. To avoid a double purchase, try again in a moment.</string>
+    <string name="upgrade_screen_pending_card_title">Payment pending</string>
+    <string name="upgrade_screen_pending_card_body">Google Play is still processing your payment. Pro unlocks automatically once the payment goes through. Some payment methods can take a while. There is nothing else you need to do.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play found a purchase with a pending payment and is still processing it. Pro unlocks automatically once the payment goes through.</string>
     <string name="upgrade_screen_grace_title">Confirming your purchase</string>
     <string name="upgrade_screen_grace_body_short">Google Play hasn\'t confirmed your purchase yet. Pro is still active — no action needed.</string>
     <string name="upgrade_screen_grace_body">Google Play hasn\'t confirmed your purchase for a while. Pro is still active. Make sure you\'re online and signed in with the Google account used for the purchase, then try restoring.</string>

--- a/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/capod/common/upgrade/ui/UpgradeContent.kt
@@ -86,6 +86,7 @@ internal object UpgradeScreenTags {
     const val GPLAY_OWNED_IAP = "upgrade_gplay_owned_iap"
     const val GPLAY_OWNED_SUB = "upgrade_gplay_owned_sub"
     const val GPLAY_MANAGE_SUB = "upgrade_gplay_manage_sub"
+    const val GPLAY_PENDING = "upgrade_gplay_pending"
     const val GPLAY_GRACE = "upgrade_gplay_grace"
     const val GPLAY_GRACE_SPINNER = "upgrade_gplay_grace_spinner"
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"

--- a/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/capod/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -192,6 +192,35 @@ class FossUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `forced route lands on the upgraded status when the sponsor flow completes`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Forced routes (Pro-locked settings entry) deliberately don't auto-close, so the screen is
+        // still up when the unlock lands — it must flip to the supporter status instead of keeping
+        // the sales pitch, which reads as "sponsoring didn't work".
+        val info = MutableStateFlow(UpgradeRepoFoss.Info())
+        val vm = buildVm(repo = mockRepo(info))
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { navEvents.add(it) } }
+
+        val pitchView = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(forced = true))
+        advanceUntilIdle()
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+
+        val upgradedView = async { vm.state.first { it?.view == FossUpgradeView.STATUS_UPGRADED }!! }
+        info.value = upgradedInfo()
+        advanceUntilIdle()
+
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+        // The don't-auto-close semantics of forced routes are unchanged — status, not navigation,
+        // is what acknowledges the upgrade here.
+        navEvents.shouldBeEmpty()
+        collector.cancel()
+    }
+
+    @Test
     fun `default route bounces an upgraded user out of the screen`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
 

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -10,6 +10,7 @@ import eu.darken.capod.common.upgrade.core.billing.BillingData
 import eu.darken.capod.common.upgrade.core.billing.BillingManager
 import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.capod.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.capod.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.capod.common.upgrade.core.billing.PurchasedSku
 import eu.darken.capod.common.upgrade.core.billing.UserCanceledBillingException
 import eu.darken.capod.main.core.CurriculumVitae
@@ -118,6 +119,13 @@ class UpgradeRepoGplayTest : BaseTest() {
         every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
     }
 
+    // A payment Play is still processing. Lands in BillingData.pendingPurchases, never in
+    // purchases — the split happens at the billing layer, this is what the repo receives.
+    private fun pendingPurchase(productId: String = OurSku.Iap.PRO_UPGRADE.id) = mockk<Purchase>().apply {
+        every { products } returns listOf(productId)
+        every { purchaseTime } returns 1_000L
+    }
+
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoGplay.Info(
             gracePeriod = false,
@@ -147,6 +155,108 @@ class UpgradeRepoGplayTest : BaseTest() {
         info.upgradedAt shouldBe Instant.parse("2023-12-10T00:00:00Z")
         info.type
     }
+
+    // region pending payments
+
+    @Test fun `a pending payment is mapped but grants nothing`() {
+        val info = UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(purchases = emptySet(), pendingPurchases = setOf(pendingPurchase())),
+        )
+
+        info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+        // The whole point of the split: visible, never an entitlement.
+        info.upgrades shouldBe emptyList()
+        info.isPro shouldBe false
+        info.upgradedAt shouldBe null
+    }
+
+    @Test fun `a pending payment for an unknown product is dropped`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(
+                purchases = emptySet(),
+                pendingPurchases = setOf(pendingPurchase("some.unknown.product")),
+            ),
+        ).pendingSkus shouldBe emptyList()
+    }
+
+    @Test fun `the grace-substituted info keeps the pending payment visible`() = runTest2 {
+        // The audience that needs the explanation most: Pro is running on grace while Play is still
+        // processing the payment that will renew it. Dropping the data here (as the grace branch
+        // used to) left them with a silent screen.
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        outcome.info.isPro shouldBe true
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a restore that only finds a pending payment reports it without pro`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = 0L).restorePurchaseNow()
+
+        outcome.shouldBeInstanceOf<UpgradeRepoGplay.RestoreOutcome.Checked>()
+        outcome.info.isPro shouldBe false
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a manual restore over a partial refresh still advances the unconfirmed episode`() = runTest2 {
+        // The restore itself succeeds (a pending payment IS an answer), so nothing on this path
+        // throws — the episode clock is fed by the manager's reconciliation signal instead, which
+        // carries the refresh's commit time.
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis() - 1_000
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+        val repo = repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        repo.restorePurchaseNow().info.isPro shouldBe true
+        failures.emit(confirmedAt + 500)
+        advanceUntilIdle()
+
+        coVerify { proUnconfirmedMock.update(any()) }
+    }
+
+    @Test fun `verifyPurchaseStateNow fails closed instead of substituting grace`() = runTest2 {
+        val boom = GplayServiceUnavailableException(RuntimeException("one product type failed"))
+        coEvery { billingManager.refreshStrict() } throws boom
+
+        // Even a recent owner gets the error: a gate that can't verify must not let a purchase
+        // through on the strength of a grace window.
+        shouldThrow<GplayServiceUnavailableException> {
+            repo(lastProAt = System.currentTimeMillis() - 1_000).verifyPurchaseStateNow()
+        }
+    }
+
+    @Test fun `verifyPurchaseStateNow reports the fresh split state`() = runTest2 {
+        coEvery { billingManager.refreshStrict() } returns BillingData(
+            purchases = setOf(proPurchase()),
+            pendingPurchases = setOf(pendingPurchase(OurSku.Sub.PRO_UPGRADE.id)),
+        )
+
+        val info = repo(lastProAt = 0L).verifyPurchaseStateNow()
+
+        info.upgrades.map { it.sku } shouldBe OurSku.PRO_SKUS.toList()
+        info.pendingSkus shouldBe listOf(OurSku.Sub.PRO_UPGRADE)
+        info.isSettled shouldBe true
+    }
+
+    @Test fun `already-owned recovery reports a pending payment instead of restore tips`() = runTest2 {
+        // Play refuses to re-sell a product whose payment it is still processing. The already-owned
+        // dialog would tell the user to restore, which cannot help.
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<PendingPurchaseBillingException>()
+    }
+
+    // endregion
 
     @Test fun `grace period is 7 days`() {
         // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManagerTest.kt
@@ -14,6 +14,7 @@ import eu.darken.capod.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.capod.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.capod.common.upgrade.core.billing.client.BillingConnectionProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -728,6 +729,54 @@ class BillingManagerTest : BaseTest() {
         runCurrent()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a strict gate failure on a dead connection still tears the connection down`() = runTest2 {
+        // The gate's throw happens after useConnection already returned, so its dead-binder
+        // detection can't fire — without the explicit invalidation connection 1 stays installed and
+        // every later purchase check runs against the corpse. Feeding the episode clock still stays
+        // off this path.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(
+                    occurredAt = 4242L,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+        runCurrent() // connection 1 established
+
+        shouldThrow<Exception> { manager.refreshStrict() }
+        // Teardown takes several dispatches and runs on backgroundScope — runCurrent, never
+        // advanceUntilIdle, which would leave the connect loop untouched.
+        runCurrent()
+
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+
+        runCurrent()
+        // The torn-down connection is a failed loop iteration (wall-clock stamped), but the gate's
+        // own partial refresh must never reach the feed with its commit time.
+        failures.isNotEmpty() shouldBe true
+        failures shouldNotContain 4242L
     }
 
     @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/billing/BillingManagerTest.kt
@@ -71,6 +71,15 @@ class BillingManagerTest : BaseTest() {
         every { isAcknowledged } returns true
     }
 
+    // A payment Play is still processing: carried by the state, but never owned and never ackable.
+    private fun pendingPurchase(token: String = "pending-token") = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PENDING
+        every { purchaseTime } returns 2_000L
+        every { purchaseToken } returns token
+        every { isAcknowledged } returns false
+        every { products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+    }
+
     // An unacknowledged purchase with its own token: the ack bookkeeping (log level, permanent
     // failure reports) is keyed per token, so tests need distinguishable ones.
     private fun unackedPurchase(
@@ -89,16 +98,53 @@ class BillingManagerTest : BaseTest() {
     private fun connection(
         refreshResults: List<Collection<Purchase>> = listOf(emptyList()),
         refreshComplete: Boolean = true,
+        // Full refresh outcomes for the tests that care about provenance (confirmed set, commit
+        // time, partial error); overrides the plain refreshResults shorthand.
+        refreshes: List<BillingConnection.PurchaseRefresh>? = null,
         purchasesFlow: Flow<Collection<Purchase>> = flowOf(emptyList()),
         freshUpdatesFlow: Flow<BillingConnection.FreshUpdate> = emptyFlow(),
         failures: Flow<BillingResult> = emptyFlow(),
     ) = mockk<BillingConnection>().apply {
-        coEvery { refreshPurchases() } returnsMany
-            refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
+        coEvery { refreshPurchases() } returnsMany (
+            refreshes ?: refreshResults.map {
+                BillingConnection.PurchaseRefresh(
+                    purchases = it,
+                    confirmed = it,
+                    hasConfirmedProPurchase = it.isNotEmpty(),
+                    isComplete = refreshComplete,
+                )
+            }
+            )
         every { purchases } returns purchasesFlow
         every { freshUpdates } returns freshUpdatesFlow
         every { purchaseFailures } returns failures
     }
+
+    // An incomplete reconciliation: it committed what it found, but one product type couldn't be
+    // checked. The default cause is NON-invalidating — the dead-binder codes are opted into.
+    private fun partialRefresh(
+        purchases: Collection<Purchase> = emptyList(),
+        confirmed: Collection<Purchase> = emptyList(),
+        hasConfirmedPro: Boolean = false,
+        occurredAt: Long = 4242L,
+        error: Throwable = GplayServiceUnavailableException(
+            BillingClientException(result(BillingResponseCode.ERROR))
+        ),
+    ) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = confirmed,
+        hasConfirmedProPurchase = hasConfirmedPro,
+        isComplete = false,
+        occurredAt = occurredAt,
+        partialError = error,
+    )
+
+    private fun completeRefresh(purchases: Collection<Purchase> = emptyList()) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = purchases,
+        hasConfirmedProPurchase = purchases.isNotEmpty(),
+        isComplete = true,
+    )
 
     // The real provider flow emits one connection and stays open for its lifetime -- flowOf() would
     // complete immediately, which the connect loop rightly treats as a connection failure.
@@ -540,6 +586,10 @@ class BillingManagerTest : BaseTest() {
 
     // Drains the manager's connectionFailures (occurrence timestamps) into a list. Launched on
     // backgroundScope so it lives for the whole test.
+    //
+    // Drive it with runCurrent() (or a suspension of the test body), NEVER with advanceUntilIdle():
+    // that one stops as soon as no FOREGROUND event is left and never runs backgroundScope work, so
+    // a signal sent from the test body would sit unconsumed and the list would read empty.
     private fun TestScope.collectFailures(manager: BillingManager): List<Long> = mutableListOf<Long>().also { out ->
         backgroundScope.launch { manager.connectionFailures.collect { out.add(it) } }
     }
@@ -665,20 +715,199 @@ class BillingManagerTest : BaseTest() {
         failures.isNotEmpty() shouldBe true
     }
 
-    @Test fun `a non-invalidating action error does not emit`() = runTest2 {
-        // A strict querySubscriptions failure whose code is NOT invalidating leaves the connection
-        // installed, so no connect-loop iteration fails and nothing feeds the episode clock.
-        val conn = connection().apply {
-            coEvery { querySubscriptions() } throws BillingClientException(result(BillingResponseCode.ERROR))
-        }
+    @Test fun `a strict gate failure does not feed the episode clock`() = runTest2 {
+        // The gate surfaces its own failure to the user (fail-closed) and leaves the connection
+        // installed. The episode clock is fed by the connect loop and by refresh() — a gate that
+        // the user aborted mid-purchase is not a reconciliation outcome.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh()))
         val manager = manager(conn)
         val failures = collectFailures(manager)
         runCurrent() // connection established
 
-        shouldThrow<Exception> { manager.querySubscriptions() }
-        advanceUntilIdle()
+        shouldThrow<Exception> { manager.refreshStrict() }
+        runCurrent()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {
+        // The pending-only cold start: Play answered for one type with a payment in progress, the
+        // other failed. Nothing confirms Pro, so the grace episode clock must advance — stamped
+        // with the refresh's COMMIT time, so a confirmation landing in between stays newer.
+        val pending = pendingPurchase()
+        val conn = connection(
+            refreshes = listOf(partialRefresh(purchases = listOf(pending), occurredAt = 4242L)),
+            purchasesFlow = flowOf(listOf(pending)),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+
+        runCurrent()
+
+        // Still published: a partial refresh is a usable connection, and starving billingData would
+        // leave the screen at Loading forever.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = emptyList(),
+            pendingPurchases = listOf(pending),
+        )
+        failures shouldBe listOf(4242L)
+    }
+
+    @Test fun `a partial manual refresh signals too`() = runTest2 {
+        // Manual Restore runs the same reconciliation as the connect loop — before this it was the
+        // only path whose partial outcome silently vanished.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh(occurredAt = 7_777L)))
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        runCurrent() // the collector lives on backgroundScope, which advanceUntilIdle would skip
+
+        failures shouldBe listOf(7_777L)
+    }
+
+    @Test fun `a partial refresh that confirmed pro does not signal`() = runTest2 {
+        val owned = purchase()
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(owned), confirmed = listOf(owned), hasConfirmedPro = true),
+            ),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        runCurrent()
+
+        // Pro WAS confirmed by this round-trip; the failed sibling type proves nothing against it.
+        failures shouldBe emptyList()
+    }
+
+    @Test fun `an invalidating partial refresh tears the connection down`() = runTest2 {
+        // The dead-binder teardown used to ride refreshPurchases' throw path through useConnection.
+        // A partial refresh returns instead of throwing, so without the explicit invalidation the
+        // dead connection would stay installed for every later caller.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                partialRefresh(
+                    purchases = listOf(owned),
+                    confirmed = listOf(owned),
+                    hasConfirmedPro = true,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        runCurrent() // connection 1 established; its partial refresh signals the invalidation
+
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        // await() is what drives the connect loop here — it runs on backgroundScope, which
+        // advanceUntilIdle() alone would never touch.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+    }
+
+    // endregion
+
+    // region pending purchases
+
+    @Test fun `billing data splits owned purchases from pending payments`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val manager = manager(connection(purchasesFlow = flowOf(listOf(owned, pending))))
+
+        // The split is what keeps a payment in progress out of every entitlement decision while
+        // still letting the UI show it.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `a pending purchase is never acknowledged`() = runTest2 {
+        val pending = pendingPurchase()
+        val purchases = purchasesFlow()
+        val conn = connection(purchasesFlow = purchases)
+        val acks = conn.scriptAck { _, _ -> result(BillingResponseCode.OK) }
+        manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        advanceTimeBy(400_000)
+        runCurrent()
+
+        // Play rejects acking a pending purchase permanently: an unfiltered pass would fire a bug
+        // report on every pass, forever, for a purchase that has nothing to acknowledge yet.
+        acks shouldBe emptyList()
+        verify(exactly = 0) { Bugs.report(any(), any(), any()) }
+    }
+
+    @Test fun `a follow-up refresh after a partial publish recovers the full state`() = runTest2 {
+        val pending = pendingPurchase()
+        val owned = purchase()
+        val purchases = purchasesFlow()
+        val conn = connection(
+            refreshes = listOf(
+                partialRefresh(purchases = listOf(pending)),
+                completeRefresh(listOf(owned)),
+            ),
+            purchasesFlow = purchases,
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        manager.billingData.first().pendingPurchases shouldBe listOf(pending)
+
+        // The payment completed: the next reconciliation returns the owned purchase, no reconnect
+        // needed (the partial one left a working connection installed).
+        manager.refresh() shouldBe BillingData(listOf(owned))
+    }
+
+    @Test fun `refreshStrict fails closed on an incomplete refresh`() = runTest2 {
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(purchase()), confirmed = listOf(purchase())),
+            ),
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        // A gate must not treat "one product type couldn't be checked" as "nothing else is owned":
+        // that is exactly how a double purchase gets through.
+        shouldThrow<GplayServiceUnavailableException> { manager.refreshStrict() }
+    }
+
+    @Test fun `refreshStrict returns the split data on a complete refresh`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val conn = connection(refreshes = listOf(completeRefresh(), completeRefresh(listOf(owned, pending))))
+        val manager = manager(conn)
+        runCurrent()
+
+        manager.refreshStrict() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -25,7 +25,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -69,13 +68,20 @@ class BillingConnectionTest : BaseTest() {
         token: String = "token-$time",
         products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
         acknowledged: Boolean = false,
+        state: Int = PurchaseState.PURCHASED,
     ) = mockk<Purchase>().apply {
         every { purchaseTime } returns time
         every { purchaseToken } returns token
         every { this@apply.products } returns products
-        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseState } returns state
         every { isAcknowledged } returns acknowledged
     }
+
+    private fun pendingPurchase(
+        time: Long,
+        token: String = "pending-$time",
+        products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
+    ) = purchase(time = time, token = token, products = products, state = PurchaseState.PENDING)
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
@@ -121,6 +127,42 @@ class BillingConnectionTest : BaseTest() {
                 sub = Result.failure(RuntimeException("SUBS query failed")),
             )
         }
+    }
+
+    @Test fun `a known pending purchase suppresses the couldn't-verify error`() {
+        // The user's payment is being processed: that IS a usable answer about this account, so a
+        // failing sibling query must not turn the screen into "can't reach Play".
+        val pending = pendingPurchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(pending)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(pending)
+    }
+
+    @Test fun `an unknown pending purchase does not suppress the couldn't-verify error`() {
+        // A pending payment for a product this app doesn't sell says nothing about the type whose
+        // query failed — counting it as a find would swallow a real "couldn't verify".
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iap = Result.success(listOf(pendingPurchase(1_000, products = listOf("some.unknown.product")))),
+                sub = Result.failure(RuntimeException("SUBS query failed")),
+                typeOf = typeOf,
+            )
+        }
+    }
+
+    @Test fun `an unknown PURCHASED product still suppresses the error`() {
+        // Ownership of anything is authoritative: every product this app sells is a Pro SKU, so an
+        // unrecognized owned product means our own SKU list is stale, not that Play failed.
+        val owned = purchase(1_000, products = listOf("some.unknown.product"))
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(owned)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(owned)
     }
 
     // endregion
@@ -423,13 +465,8 @@ class BillingConnectionTest : BaseTest() {
         connection.purchaseFailures.first().responseCode shouldBe BillingResponseCode.USER_CANCELED
     }
 
-    @Test fun `a pending purchase never surfaces as owned or as fresh data`() = runTest2 {
-        val pending = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending"
-            every { this@apply.products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
-        }
+    @Test fun `a pending purchase event enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
         val connection = BillingConnection(
             client = clientReturning(
                 result(BillingResponseCode.OK) to emptyList(),
@@ -437,14 +474,169 @@ class BillingConnectionTest : BaseTest() {
             ),
         )
 
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
-        connection.refreshPurchases()
+        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            connection.freshUpdates.collect { freshUpdates.add(it) }
+        }
+        connection.refreshPurchases() // settles the state; predates the event
 
-        connection.purchases.first() shouldBe emptyList()
-        // Only the refresh's own emission — the PENDING event never produced one.
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        runCurrent()
+
+        // Visible as state (the UI must be able to show a payment in progress)...
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
+        // ...but the fresh stream feeds the entitlement and grace bookkeeping, so only the
+        // refresh's own emission is on it — a pending payment confirms nothing.
+        freshUpdates.size shouldBe 1
+        freshUpdates.single().purchases shouldBe emptyList()
+    }
+
+    @Test fun `a pending query result enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(pending),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.purchases.map { it.purchaseToken } shouldBe listOf("pending")
+        refresh.confirmed shouldBe emptyList()
+        refresh.hasConfirmedProPurchase shouldBe false
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
         val update = connection.freshUpdates.first()
         update.purchases shouldBe emptyList()
         update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a completing payment supersedes its own pending entry`() = runTest2 {
+        // Play delivers the same purchaseToken again once the payment cleared: the dedup must let
+        // the PURCHASED instance win instead of leaving the user with two records.
+        val pending = pendingPurchase(1_000, token = "same")
+        val purchased = purchase(1_000, token = "same")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        connection.refreshPurchases() // settles the state; predates both events
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(purchased))
+
+        val merged = connection.purchases.first()
+        merged.size shouldBe 1
+        merged.single().purchaseState shouldBe PurchaseState.PURCHASED
+        // The completion is fresh Play data: it must reach the grace bookkeeping, unlike the
+        // pending event before it.
+        val updates = connection.freshUpdates.take(2).toList()
+        updates[0].purchases shouldBe emptyList()
+        updates[1].purchases shouldBe listOf(purchased)
+    }
+
+    @Test fun `an unspecified-state purchase is dropped everywhere`() = runTest2 {
+        val unspecified = purchase(1_000, token = "unspecified", state = PurchaseState.UNSPECIFIED_STATE)
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(unspecified),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unspecified))
+
+        val refresh = connection.refreshPurchases()
+
+        // Neither owned nor a payment in progress: it must not reach state, refresh or UI.
+        refresh.purchases shouldBe emptyList()
+        connection.purchases.first() shouldBe emptyList()
+    }
+
+    @Test fun `a pending-only overlay survivor does not suppress absence bookkeeping`() = runTest2 {
+        // A pending payment arrives while a refresh is in flight: the queries verified empty, and
+        // the surviving PENDING overlay proves no ownership — the snapshot still proves absence,
+        // unlike the PURCHASED case (which must not start a false unconfirmed-grace episode).
+        val pendingListeners = mutableListOf<PurchasesResponseListener>()
+        val client = mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                pendingListeners.add(secondArg())
+            }
+        }
+        val connection = BillingConnection(client = client)
+
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        runCurrent()
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pendingPurchase(1_000)))
+        pendingListeners.forEach { it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf()) }
+        runCurrent()
+        refresh.await()
+
+        val update = connection.freshUpdates.first()
+        update.purchases shouldBe emptyList()
+        update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a refresh reports only what its own queries confirmed`() = runTest2 {
+        val iapOwned = purchase(1_000, token = "iap")
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: both succeed, IAP owned.
+                result(BillingResponseCode.OK) to listOf(iapOwned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP fails (stale snapshot retained), SUB confirms a pending payment.
+                result(BillingResponseCode.ERROR) to emptyList(),
+                result(BillingResponseCode.OK) to listOf(
+                    pendingPurchase(2_000, token = "pending-sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+                ),
+            ),
+        )
+        connection.refreshPurchases()
+
+        val second = connection.refreshPurchases()
+
+        // The retained IAP purchase is in the committed view, but it is NOT something these
+        // queries confirmed — reporting it as confirmed Pro would keep the grace clock frozen
+        // through an indefinite outage.
+        second.purchases.map { it.purchaseToken } shouldContainExactly listOf("pending-sub", "iap")
+        second.confirmed shouldBe emptyList()
+        second.hasConfirmedProPurchase shouldBe false
+        second.isComplete shouldBe false
+        second.partialError.shouldNotBeNull()
+    }
+
+    @Test fun `a confirmed known purchase is reported as confirmed pro`() = runTest2 {
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(purchase(1_000, token = "iap")),
+                result(BillingResponseCode.ERROR) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.confirmed.map { it.purchaseToken } shouldBe listOf("iap")
+        refresh.hasConfirmedProPurchase shouldBe true
+        refresh.isComplete shouldBe false
+    }
+
+    @Test fun `a refresh is stamped with its commit time`() = runTest2 {
+        val before = System.currentTimeMillis()
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+        val after = System.currentTimeMillis()
+
+        (refresh.occurredAt in before..after) shouldBe true
+        // The same instant travels on the fresh update, so a confirmation and a later failure
+        // signal can be ordered against each other.
+        refresh.occurredAt shouldBe connection.freshUpdates.first().occurredAt
     }
 
     @Test fun `fresh updates arrive in commit order`() = runTest2 {
@@ -803,146 +995,6 @@ class BillingConnectionTest : BaseTest() {
         shouldThrow<BillingClientException> {
             connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
         }
-    }
-
-    // endregion
-
-    // region querySubscriptions (pre-purchase gate)
-
-    @Test fun `querySubscriptions returns fresh subs and keeps the iap snapshot intact`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val client = clientReturning(
-            // Refresh: IAP owned, no subs yet.
-            result(BillingResponseCode.OK) to listOf(iapOwned),
-            result(BillingResponseCode.OK) to emptyList(),
-            // SUBS-only gate query: sub found.
-            result(BillingResponseCode.OK) to listOf(subOwned),
-        )
-        val connection = BillingConnection(client = client)
-        connection.refreshPurchases()
-
-        val gateView = connection.querySubscriptions()
-
-        gateView shouldBe listOf(subOwned)
-        // The gate must have queried SUBS, not INAPP (clientReturning ignores the params, so this
-        // would otherwise go unnoticed). zza() is the params' only product-type accessor — a
-        // billing library upgrade renaming it breaks this line loudly at compile time.
-        verify(exactly = 2) {
-            client.queryPurchasesAsync(match<QueryPurchasesParams> { it.zza() == BillingClient.ProductType.SUBS }, any())
-        }
-        // The SUBS-only commit updates the reactive view WITHOUT disturbing the IAP snapshot —
-        // wiping it would briefly un-Pro a one-time-purchase owner.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        val updates = connection.freshUpdates.take(2).toList()
-        // Partial by definition: it proves what the SUBS query found, never absence of the rest.
-        updates[1].purchases shouldBe listOf(subOwned)
-        updates[1].isFullSnapshot shouldBe false
-    }
-
-    @Test fun `a failed querySubscriptions propagates and commits nothing`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(
-                result(BillingResponseCode.OK) to listOf(iapOwned),
-                result(BillingResponseCode.OK) to listOf(subOwned),
-                result(BillingResponseCode.ERROR) to emptyList(),
-            ),
-        )
-        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            connection.freshUpdates.collect { freshUpdates.add(it) }
-        }
-        connection.refreshPurchases()
-
-        // Fail-closed contract: the gate must see the error, not an empty "no subscriptions".
-        shouldThrow<BillingClientException> { connection.querySubscriptions() }
-        runCurrent()
-
-        // No commit and no fresh emission from the failed query — only the refresh's own. Both
-        // snapshots survive, including the SUB one the failed query was about.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        freshUpdates.size shouldBe 1
-    }
-
-    @Test fun `querySubscriptions clears an older sub overlay it could have seen`() = runTest2 {
-        // The sub arrived via purchase event, then the user refunded/cancelled it away: the gate
-        // query verifies empty and must supersede the stale event — otherwise the ghost sub keeps
-        // blocking the one-time purchase.
-        val subEvent = purchase(1_000, token = "sub-event", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(subEvent))
-
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
-    }
-
-    @Test fun `querySubscriptions prefers a racing event's renewal state for the same token`() = runTest2 {
-        // The stale query result says the sub no longer renews, but a purchase event that landed
-        // while the query was in flight says it does (user just re-subscribed): the gate must see
-        // the overlay version, or the fail-closed double-billing check lets the buy through.
-        val queried = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns false
-        }
-        val raced = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns true
-        }
-        val pendingListeners = mutableListOf<PurchasesResponseListener>()
-        val client = mockk<BillingClient>().apply {
-            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
-                pendingListeners.add(secondArg())
-            }
-        }
-        val connection = BillingConnection(client = client)
-
-        val gate = async(start = CoroutineStart.UNDISPATCHED) { connection.querySubscriptions() }
-        runCurrent()
-        pendingListeners.size shouldBe 1
-
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(raced))
-        pendingListeners.single().onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf(queried))
-        runCurrent()
-
-        val gateView = gate.await()
-        gateView.single().isAutoRenewing shouldBe true
-    }
-
-    @Test fun `querySubscriptions excludes iap overlay entries but keeps untyped ones`() = runTest2 {
-        val iapEvent = purchase(1_000, token = "iap-event")
-        val unknownEvent = purchase(2_000, token = "unknown", products = listOf("some.unknown.product"))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(iapEvent))
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unknownEvent))
-
-        val gateView = connection.querySubscriptions()
-
-        // An IAP can't be the blocking subscription; an unknown product might be, so it stays in
-        // on the safe side.
-        gateView.map { it.purchaseToken } shouldBe listOf("unknown")
-        // Excluded from the gate view only — the reducer still owns both entries.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("unknown", "iap-event")
-    }
-
-    @Test fun `querySubscriptions filters pending subscription results`() = runTest2 {
-        val pendingSub = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending-sub"
-            every { this@apply.products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
-        }
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to listOf(pendingSub)),
-        )
-
-        // A PENDING subscription is not an active one — it must neither block the gate nor
-        // surface as owned.
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeOwnershipTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeOwnershipTest.kt
@@ -89,4 +89,38 @@ class GplayUpgradeOwnershipTest : BaseTest() {
 
         ownership.ownsAnything shouldBe false
     }
+
+    private fun pendingInfo(vararg pending: Purchase) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = pending.toList()),
+        null,
+    )
+
+    @Test
+    fun `a pending payment sets the pending flag`() {
+        pendingInfo(mockPurchase("eu.darken.capod.iap.upgrade.pro")).toPendingFlag().shouldBeTrue()
+        pendingInfo(mockPurchase("upgrade.pro")).toPendingFlag().shouldBeTrue()
+    }
+
+    @Test
+    fun `no pending payment leaves the flag off`() {
+        info(mockPurchase("eu.darken.capod.iap.upgrade.pro")).toPendingFlag().shouldBeFalse()
+        pendingInfo().toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `an unknown pending product does not set the flag`() {
+        // Nothing to explain and nothing to lock: a product this app doesn't sell isn't the Pro
+        // upgrade the user is waiting for.
+        pendingInfo(mockPurchase("some.unknown.sku")).toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `a pending payment is not ownership`() {
+        val ownership = pendingInfo(mockPurchase("eu.darken.capod.iap.upgrade.pro")).toOwnership()
+
+        ownership.hasIap.shouldBeFalse()
+        ownership.subscription.shouldBeNull()
+        ownership.ownsAnything.shouldBeFalse()
+    }
 }

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -2,8 +2,10 @@ package eu.darken.capod.common.upgrade.ui
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import eu.darken.capod.R
 import eu.darken.capod.common.compose.PreviewWrapper
 import eu.darken.capod.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
@@ -39,6 +41,34 @@ class GplayUpgradeScreenHostTest : BaseTest() {
         every { proUnconfirmedSince } returns MutableStateFlow(0L)
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `a pending-purchase event puts the informational dialog on screen`() {
+        // Host-level wiring: the ViewModel tests prove the event is emitted, only a real
+        // composition proves it reaches a dialog (and survives as a rememberSaveable flag).
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(mapOf("forced" to false)),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.events.tryEmit(UpgradeEvents.PurchasePending)
+
+        val message = composeRule.activity.getString(R.string.upgrade_screen_pending_dialog_message)
+        composeRule.waitUntil {
+            composeRule.onAllNodesWithText(message, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -356,6 +357,88 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         )
         check(idle.iapEnabled) { "IAP buy should be enabled when idle" }
         check(idle.subscriptionEnabled) { "Subscription buy should be enabled when idle" }
+
+        // A pending payment locks BOTH, whichever product it belongs to: Play rejects a second
+        // purchase of the pending product, and the alternative would charge twice for Pro.
+        val pending = toLoadedState(
+            iap = SkuDetails(OurSku.Iap.PRO_UPGRADE, iapDetails),
+            sub = SkuDetails(OurSku.Sub.PRO_UPGRADE, subDetails),
+            ownership = Ownership(),
+            hasPendingPurchase = true,
+        )
+        check(!pending.iapEnabled) { "IAP buy must be disabled while a payment is pending" }
+        check(!pending.subscriptionEnabled) { "Subscription buy must be disabled while a payment is pending" }
+    }
+
+    @Test
+    fun `a pending payment shows the card and locks the offers for acquisition`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = false,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = false,
+                    iapPrice = "$24.99",
+                    hasPendingPurchase = true,
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_pending_card_body))
+            .assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertIsNotEnabled()
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+        // Restore stays available: re-checking with Play is exactly the right move for someone who
+        // believes the payment already went through.
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card on the ownership screen and locks the switch`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = ownedState(Ownership(subscription = SubscriptionOwnership(isAutoRenewing = false)))
+                    .copy(hasPendingPurchase = true),
+            )
+        }
+
+        // The subscriber switching to the one-time purchase: the switch offer is unlocked by the
+        // non-renewing subscription, but a payment in progress must still hold it.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card during a young grace episode`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = graceState(showDiagnostics = false).copy(hasPendingPurchase = true))
+        }
+
+        // The young grace stage hides the offers box entirely, so a card rendered inside it would
+        // never reach this audience — which is precisely the one waiting for a renewal payment.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the pending dialog is informational only`() {
+        var dismissals = 0
+        composeRule.setUpgradeContent { PurchasePendingDialog(onDismiss = { dismissals++ }) }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_pending_dialog_message),
+            substring = true,
+        ).assertExists()
+        // No support escalation and no restore tips: there is nothing for the user to do.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_contact_support_action))
+            .assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_restore_multiaccount_hint))
+            .assertCountEquals(0)
+
+        composeRule.onNodeWithText(context.getString(R.string.general_close_action)).performClick()
+        composeRule.runOnIdle { dismissals shouldBe 1 }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/capod/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -11,6 +11,7 @@ import eu.darken.capod.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.capod.common.upgrade.core.billing.BillingData
 import eu.darken.capod.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.capod.common.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.capod.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.capod.common.upgrade.core.billing.Sku
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -22,6 +23,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -296,6 +298,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+        // Both purchase paths run the pre-purchase gate: the default is a clean account (nothing
+        // owned, nothing pending), so tests only stub it when the gate IS the subject.
+        coEvery { verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
     }
 
     private fun buildVm(
@@ -319,6 +324,15 @@ class GplayUpgradeViewModelTest : BaseTest() {
         BillingData(purchases = purchases.toList()),
         null,
         // Ownership data implies a committed reconciliation -> always settled.
+        isSettled = true,
+    )
+
+    // Play is still processing a payment: nothing owned, nothing granted, but the purchase paths
+    // must treat it as a blocking answer.
+    private fun pendingInfo(skuId: String = OurSku.Iap.PRO_UPGRADE.id) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = listOf(mockPurchase(skuId))),
+        null,
         isSettled = true,
     )
 
@@ -371,6 +385,22 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `restore that finds a pending payment emits PurchasePending`() = runTest2(context = testDispatcher) {
+        // Play answered and DID find the purchase — it just isn't paid for yet. RestoreFailed would
+        // send this user through account troubleshooting and support for something that resolves
+        // itself.
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns checked(pendingInfo())
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
@@ -526,7 +556,28 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase is blocked while the subscription is still set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = true))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `iap purchase is blocked by a renewing subscription with an unknown product`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The gate reads the RAW purchases, never the mapped upgrades: a subscription whose product
+        // ID this build doesn't know (legacy SKU, renamed product) still renews and still bills, so
+        // letting the one-time purchase through here charges the user for Pro twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
@@ -540,7 +591,8 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds when the subscription is not set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = false))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = false))
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -552,7 +604,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds without any subscription`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        coEvery { repo.verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -562,12 +614,12 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `failing subscription verification blocks the purchase and forwards the error`() = runTest2(
+    fun `failing purchase verification blocks the purchase and forwards the error`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
         val boom = IllegalStateException("Play unavailable")
-        coEvery { repo.queryCurrentSubscriptions() } throws boom
+        coEvery { repo.verifyPurchaseStateNow() } throws boom
         val vm = buildVm(repo)
 
         val forwardedError = async { vm.errorEvents.first() }
@@ -579,13 +631,13 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `subscription verification timeout blocks the purchase with a check-failed event`() = runTest2(
+    fun `purchase verification timeout blocks the purchase with a check-failed event`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(30_000) // longer than the 10s verification timeout
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -593,16 +645,126 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription gate timeout blocks that purchase too`() = runTest2(context = testDispatcher) {
+        // The subscription path used to launch unverified: a slow Play means we don't know whether
+        // a payment is already pending, so it must fail closed like the one-time path.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
+            delay(30_000)
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the one-time purchase`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the subscription purchase`() = runTest2(context = testDispatcher) {
+        // SKU-agnostic on purpose: the two products are alternatives, so a pending payment for
+        // either one must block both — completing both charges the user twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscriptionTrial(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription purchase is blocked when the fresh check finds an owned upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The screen can be stale (the one-time purchase was made on another device) and Play sells
+        // the subscription right next to an owned IAP — launching here charges the user for Pro a
+        // second time.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns proInfo(mockPurchase(OurSku.Iap.PRO_UPGRADE.id))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreSucceeded
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription purchase is blocked when an unknown renewing subscription exists`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Unknown product ID => zero mapped upgrades, so the ownership block above lets it through.
+        // It still renews and still bills, and a second subscription for the same features is the
+        // same double charge.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
+        // Play can only report this at launch time (the gate saw a clean state moments earlier):
+        // the already-owned error dialog with its restore tips would be the wrong advice.
+        // The callback is captured and invoked from the test body rather than from inside the
+        // answer: on a suspend function the argument list carries the continuation, so grabbing the
+        // callback positionally there is a coin flip — and a wrong cast would surface as a hang.
+        val repo = mockRepo()
+        val onError = slot<(Throwable) -> Unit>()
+        coEvery { repo.launchBillingFlowNow(any(), any(), any(), capture(onError)) } returns Unit
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        onError.captured(PendingPurchaseBillingException())
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
     fun `iap taps are single-flight while a verification is running`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(5_000)
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -611,7 +773,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), eq(OurSku.Iap.PRO_UPGRADE), isNull(), any()) }
     }
 
@@ -648,8 +810,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         // One arbiter for all three: the purchase and the restore would otherwise run concurrent
-        // Play operations against the same account state.
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        // Play operations against the same account state. Exactly one gate ran — the subscription's
+        // own; the blocked IAP tap never got to verify anything.
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 0) { repo.restorePurchaseNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
     }
@@ -672,7 +835,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         coVerify(exactly = 1) { repo.restorePurchaseNow() }
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 0) { repo.verifyPurchaseStateNow() }
     }
 
     @Test
@@ -968,6 +1131,43 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `a pending payment renders while the price queries are still running`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Price-independent like owners and grace users: the pending card is this user's answer and
+        // both offers are locked anyway, so waiting on prices would hide it behind Loading.
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(60_000) // effectively never within this test
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        testScheduler.advanceTimeBy(1_000)
+
+        val loaded = vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        loaded.hasPendingPurchase shouldBe true
+        collector.cancel()
+    }
+
+    @Test
+    fun `a pending payment keeps its card when both price queries fail`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val loaded = async { awaitLoaded(vm) }
+        advanceUntilIdle()
+
+        // Not the acquisition-style Unavailable card: the pending explanation must survive a price
+        // outage, exactly like the grace card does.
+        loaded.await().hasPendingPurchase shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## What changed

When Google Play is still processing a payment (cash, carrier billing, bank transfer), the app previously had no idea the user had bought anything: the upgrade screen kept selling, and a retry was rejected by Play as "already owned". Pending payments now travel through the billing stack: a "Payment pending" card explains the wait, both purchase buttons lock (buying the alternative product would double-charge), a restore that finds the unpaid purchase says so instead of suggesting account troubleshooting, and retrying the pending product gets the same explanation instead of a misleading "already owned" error.

Both purchase buttons also verify the account state with Play at tap time before opening the checkout: a pending payment, an existing Pro purchase made on another device, or a subscription still set to renew stops the launch instead of charging twice. If the check cannot complete, the purchase does not start.

## Technical Context

- Port of the canonical sdmaid-se implementation (d4rken-org/sdmaid-se#2653 plus its two follow-up gate corrections, sdmaid-se PR #2662); billing-core files are byte-parity with the donor modulo package rename, verified by a normalized diff in review.
- Pending purchases never touch entitlement: `BillingData` splits PURCHASED-only `purchases` from `pendingPurchases` at every exit, so granting Pro, stamping the grace cache, and the acknowledgement pass (which Play rejects permanently for pending purchases) stay PURCHASED-only by construction.
- The pre-purchase gate fails closed on anything short of a complete Play round-trip (`refreshStrict`), and invalidates a connection that died mid-check so later checks reconnect instead of reusing it.
- The renewal guard reads RAW purchases, not mapped SKUs, so a renewing subscription with a legacy or unknown product ID still blocks a double purchase.
