### PR TITLE
General: Explain the compatibility settings in plain language

### DIFF
--- a/app/src/main/java/eu/darken/capod/common/settings/SettingsCategoryHeader.kt
+++ b/app/src/main/java/eu/darken/capod/common/settings/SettingsCategoryHeader.kt
@@ -1,5 +1,6 @@
 package eu.darken.capod.common.settings
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -13,19 +14,40 @@ import eu.darken.capod.common.compose.PreviewWrapper
 @Composable
 fun SettingsCategoryHeader(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
 ) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
-        fontWeight = FontWeight.Medium,
+    Column(
         modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp)
-    )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Medium,
+        )
+        subtitle?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+        }
+    }
 }
 
 @Preview2
 @Composable
 private fun SettingsCategoryHeaderPreview() = PreviewWrapper {
     SettingsCategoryHeader(text = "Other")
+}
+
+@Preview2
+@Composable
+private fun SettingsCategoryHeaderWithSubtitlePreview() = PreviewWrapper {
+    SettingsCategoryHeader(
+        text = "Compatibility options",
+        subtitle = "Don't touch if everything works ;)",
+    )
 }

--- a/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -220,7 +220,10 @@ fun GeneralSettingsScreen(
                 )
             }
             item {
-                SettingsCategoryHeader(text = stringResource(R.string.settings_category_compatibility_options_title))
+                SettingsCategoryHeader(
+                    text = stringResource(R.string.settings_category_compatibility_options_title),
+                    subtitle = stringResource(R.string.settings_category_compatibility_options_description),
+                )
             }
             item {
                 SettingsBaseItem(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
 
 
     <string name="settings_monitor_connected_notification_label">Extra notification</string>
-    <string name="settings_monitor_connected_notification_description">Shows an extra notification when a device is connected. This lets you hide the permanent \"No devices\" notification by disabling the \"Device status\" channel.</string>
+    <string name="settings_monitor_connected_notification_description">Shows a second notification that only appears while a device is connected. With this on, you can hide the permanent \"No devices\" notification: turn off the \"Device status\" category in Android\'s notification settings for CAPod.</string>
     <string name="settings_keep_notification_after_disconnect_label">Keep notification after disconnect</string>
     <string name="settings_keep_notification_after_disconnect_description">Continue showing the last known battery levels even after your AirPods disconnect</string>
     <string name="settings_autopause_label">Auto pause</string>
@@ -61,9 +61,9 @@
     <string name="settings_category_compatibility_options_title">Compatibility options</string>
     <string name="settings_category_compatibility_options_description">Don\'t touch if everything works ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Disable hardware filtering</string>
-    <string name="settings_compat_offloaded_filtering_disabled_summary">Don\'t delegate data filtering to the system, instead get all data and filter within the app.</string>
+    <string name="settings_compat_offloaded_filtering_disabled_summary">Try this if your AirPods are never detected. The app will look through all nearby Bluetooth signals itself, instead of letting your phone pre-select them.</string>
     <string name="settings_compat_offloaded_batching_disabled_title">Disable hardware batching</string>
-    <string name="settings_compat_offloaded_batching_disabled_summary">Don\'t let the system group collected BLE data before forwarding it to us.</string>
+    <string name="settings_compat_offloaded_batching_disabled_summary">Try this if battery levels only update late or in bursts. Your phone will pass on each Bluetooth signal right away, instead of collecting them first.</string>
 
     <string name="settings_onepod_mode_label">One pod mode</string>
     <string name="settings_onepod_mode_description">Auto play/pause and auto-connect react to a single pod instead of requiring both.</string>
@@ -183,7 +183,7 @@
     <string name="widget_config_preset_green">Green</string>
     <string name="widget_config_preset_red">Red</string>
     <string name="settings_compat_indirectcallback_title">Indirect data delivery</string>
-    <string name="settings_compat_indirectcallback_summary">Use an alternative method to receive BLE data from the system (broadcast instead of callback).</string>
+    <string name="settings_compat_indirectcallback_summary">Try this if the other compatibility options didn\'t help. Android will hand Bluetooth signals to the app in the background, instead of the app listening for them directly.</string>
 
     <string name="troubleshooter_title">Troubleshooter</string>
     <string name="troubleshooter_summary">Diagnose and fix Bluetooth connectivity issues.</string>


### PR DESCRIPTION
## What changed

The settings under "Compatibility options" now say what problem they solve instead of describing how they work internally. Each one starts with the symptom it's for ("Try this if your AirPods are never detected"), so you can tell at a glance whether a row applies to you.

The "Don't touch if everything works ;)" hint above that section is visible again. It has been missing since the app moved to Compose, which left users reading three technical toggles with nothing telling them the section is optional.

The "Extra notification" setting now says where to turn off the permanent notification, rather than just naming the notification category.

## Technical Context

- Reported through a Play Store review (Vietnamese, 4 stars, 5.2.3-rc0): the user understood everything above the "Other" header and nothing below it. The Vietnamese translations were faithful, so this is a source-text problem, not a localization one.
- `settings_category_compatibility_options_description` stopped rendering in 63692595 (Fragments to Compose), which dropped the `res/xml` preference screens. `SettingsCategoryHeader` only accepted a title, so the string and its ~75 translations sat unused in the repo. Fixed by adding an optional `subtitle` param; the padding moved from the `Text` to the wrapping `Column`, so the nine call sites that pass only `text` render unchanged.
- The three rewritten summaries were checked against `BleScanner.kt` rather than paraphrased from the old copy: filtering maps to `isOffloadedFilteringSupported` plus software `ScanFilter.matches`, batching to `setReportDelay(0)` instead of 500-2000 ms, indirect delivery to `startScan(…, PendingIntent)` instead of a `ScanCallback`.
- Toggle titles are deliberately unchanged. They name the mechanism and get referenced verbatim when pointing users at them in issues; renaming would break that.
- The four changed source strings leave existing translations stale until the next Crowdin round. They aren't wrong, just as jargon-heavy as the old English was, so no locale files were touched.
