### PR TITLE
General: Correct the outdated auto connect description

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="settings_signal_minimum_label">Minimum signal quality</string>
     <string name="settings_signal_minimum_description">The minimum signal quality that a device needs to have to be considered yours.</string>
     <string name="settings_autoconnect_label">Auto connect</string>
-    <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This will set the monitor mode setting to \'Always\'.</string>
+    <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This keeps CAPod monitoring in the background at all times.</string>
     <string name="settings_autoconnect_info_android12">Auto connect relies on a system feature that Android 12 and newer restricts. It may not work on your device.</string>
     <string name="settings_autoconnect_condition_label">Auto connect condition</string>
     <string name="settings_autoconnect_condition_description">When should we try to connect to your device?</string>


### PR DESCRIPTION
## What changed

The auto connect setting's description told users that turning it on would set the "monitor mode" setting to "Always". That setting was removed a few versions ago, so the sentence pointed at something users can't find in the app. It now says what actually happens: auto connect keeps CAPod monitoring in the background at all times.

## Technical Context

- The monitor mode setting was removed in 5.1.6 (`a4ba3022`), and the scanner mode setting in 5.1.2 (`c8f5ceda`). Both are derived automatically now, monitor mode via `MonitorModeResolver` from profile state. The behaviour the old sentence described is unchanged: an addressed profile with auto-connect enabled still resolves to `ALWAYS`, so only the reference to a settings entry was wrong.
- Base string only. The 75 locale files are left alone so Crowdin flags them as outdated on the next push, matching how `8f0ec5a3` handled a base-string reword.
- The string renders in `ReactionsCard` on the device settings screen, which backs the `DeviceSettingsReactions` `@PreviewTest`. No screenshot regeneration: it falls below the fold in the committed `7_device_settings_reactions.png` (which cuts off at the "Auto connect" title), and being the last item in a vertical column, its length change can't reflow anything visible above it.
- Prompted by a support mail from a user on 5.2.3 who went looking for the monitor and scanning mode settings after reading the FAQ. The wiki FAQ has been corrected separately; this was the last user-facing text in the app still naming the removed setting.
