### PR TITLE
Fix: Prevent crash for Amharic users when showing battery time

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -283,7 +283,7 @@
     <string name="last_seen_x">ለመጨረሻ ጊዜ የታየው: %s</string>
     <string name="first_seen_x">ለመጀመሪያ ጊዜ የታየው: %s</string>
     <string name="battery_cached_label">የመጨረሻ ታወቀ · %s</string>
-    <string name="battery_time_remaining_format_hm">%1$dሰ %2$ደ</string>
+    <string name="battery_time_remaining_format_hm">%1$dሰ %2$dደ</string>
     <string name="battery_time_remaining_format_h">%1$dሰ</string>
     <string name="battery_time_remaining_format_m">%1$dደ</string>
     <string name="permission_post_notifications_label">ማሳወቂያዎችን አሳይ</string>


### PR DESCRIPTION
## What changed

Amharic users crashed whenever the app displayed a battery time estimate that had both hours and minutes — so any remaining time between 1h1m and 23h59m, which is most of the time. It hit the pod cards on the dashboard, the home screen widget, and the ongoing notification.

The Amharic translation of the "hours and minutes" battery format had lost part of one of its number placeholders, so Android could not build the text and threw instead. Corrected, and no other language is affected.

## Technical Context

- Root cause: `battery_time_remaining_format_hm` in `values-am` read `%1$dሰ %2$ደ`. The translator localized the unit letters (`h`/`m` → `ሰ`/`ደ`) but dropped the `d` conversion character from the second placeholder, so Java's formatter parsed `%2$` followed by `ደ` as an unknown conversion and threw `UnknownFormatConversionException`. The `_h` and `_m` variants are correct; only the combined form was broken.
- Found via the Play Store rejecting the Amharic screenshot upload with "Dimensions out of range". `WidgetConfiguration` had rendered as a 1×1 PNG because layoutlib aborted the render on the same exception — the crash was visible as a broken image long before anyone reported it as a crash.
- Fixed at source first: the Crowdin translation was corrected and CAPod's translation memory updated. The TM still mapped the English source to the broken string at 100% match, so a repo-only fix would have been undone by the next pre-translate run. That TM is shared across all five projects on this Crowdin account.
- All 76 locale files were scanned for malformed positional format specifiers; this was the only one, and none remain.
- CI did not catch this. `StringFormatInvalid` is ERROR severity, and the pipeline gates `lintVital*`, which runs fatal-severity checks only — so the check that would flag this never runs on PRs.
