### PR TITLE
General: Tidy up the captions under the battery levels

### DIFF
--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.darken.capod.R
@@ -493,8 +494,7 @@ private fun CaseRow(
         if (charges != null) {
             CaseChargesLine(
                 charges = charges,
-                // Aligned under the percentage, past the case icon and its spacer.
-                modifier = Modifier.padding(start = 36.dp, top = 2.dp),
+                modifier = Modifier.padding(top = 2.dp),
             )
         }
     }
@@ -542,7 +542,10 @@ private fun CaseChargesLine(
         text = text,
         style = MaterialTheme.typography.bodySmall,
         color = color,
-        modifier = modifier.semantics { stateDescription = state },
+        textAlign = TextAlign.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics { stateDescription = state },
     )
 }
 

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/DualPodsCard.kt
@@ -288,7 +288,7 @@ private fun ColumnScope.DualPodsCardExpanded(
 
     // Cached battery indicator
     if (device.isBatteryCached && !device.isLive) {
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = stringResource(R.string.battery_cached_label, device.cachedBatteryFormatted(now)),
             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/eu/darken/capod/main/ui/overview/cards/SinglePodsCard.kt
+++ b/app/src/main/java/eu/darken/capod/main/ui/overview/cards/SinglePodsCard.kt
@@ -322,7 +322,7 @@ private fun ColumnScope.SinglePodsCardExpanded(
 
     // Cached battery indicator
     if (device.isBatteryCached && !device.isLive) {
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = stringResource(R.string.battery_cached_label, device.cachedBatteryFormatted(now)),
             style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
## What changed

The line telling you how many more charges the case holds ("~1 more full charge for both earbuds") is now centred under the battery card instead of sitting at a fixed left indent, where it read as misaligned against everything around it. The "Last known · …" caption that shows when a device is out of range also gets a little more space above it, so it no longer crowds the bottom edge of the card.

## Technical Context

- The old 36.dp start indent was deliberate (28.dp case icon plus 8.dp spacer), putting the caption's left edge under the case percentage label, per the M3 "supporting text aligns with the item's text column" convention. The case row isn't a list item though, and the sentence runs nearly full width, so the lone left gutter read as an accident rather than an alignment.
- Centring on the battery capsule was the other candidate, and it isn't reachable with static padding: the capsule is `weight(1f)` between the percentage label and the status-chip `FlowRow`, so its offset and width are runtime values that shift with locale and font scale. It would need `onGloballyPositioned` or a custom `Layout`. Centring within the surface is stable and needs neither.
- Accepted trade-off: at large font scales, or in locales with long plural forms, the caption wraps, and centred wrapped text reads worse than start-aligned. At normal scale it stays a single line.
- `DashboardLight` / `DashboardDark` in `PlayStoreScreenshots.kt` reach this caption through `OverviewScreen`, so the committed en-US PNGs under `fastlane/metadata/` no longer match the app. Regenerating them was deliberately left out of this PR; it needs `generate_screenshots.sh --smoke` plus `copy_screenshots.sh --clean` before the next store upload.
