### PR TITLE
General: Stop asking translators for strings the app no longer uses

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Skenk</string>
-    <string name="foss_upgrade_alreadydonated_label">Ek het reeds geskenk</string>
-    <string name="foss_upgrade_no_money_label">Ek spandeer al my geld op AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS is gratis en oopbron. As u dit nuttig vind, oorweeg dit om ontwikkeling te befonds om die projek aan die gang te hou.</string>
     <string name="upgrade_foss_sponsor_action">Borg ontwikkeling</string>
     <string name="upgrade_foss_sponsor_subtitle">Geen advertensies. Geen opsporing. Geen Google Play-binding.</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">ልገሳ</string>
-    <string name="foss_upgrade_alreadydonated_label">አስቀድሜ ልገሳ ፈጽሜአለሁ</string>
-    <string name="foss_upgrade_no_money_label">ገንዘቤን በሙሉ በAirPods ላይ አውጥቻለሁ</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ነፃ እና ክፍት ምንጭ ነው። ግኾሚ ሆኖ ካግኝት፣ ፕሮጀክቱ ቀጥሎ እንደይይድ ለመርዳት ላማቱን ማስደገፏ ያስቡ።</string>
     <string name="upgrade_foss_sponsor_action">ልማትን ይደግፉ</string>
     <string name="upgrade_foss_sponsor_subtitle">ምንም ማስታወቂያ የሉም። ምንም ክትትል የሉም። ምንም Google Play ቆለፋ የሉም።</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">تبرَّع</string>
-    <string name="foss_upgrade_alreadydonated_label">لقد تبرّعتُ فعلًا</string>
-    <string name="foss_upgrade_no_money_label">أنفق كلّ أموالي على سمّاعات أيربودز</string>
     <string name="upgrade_foss_preamble">برنامج كابود FOSS مجّاني ومفتوح المصدر. إذا وجدته مفيدًا، ففكّر في دعم تطويره للمساعدة في استمرار المشروع.</string>
     <string name="upgrade_foss_sponsor_action">ادعم التطوير</string>
     <string name="upgrade_foss_sponsor_subtitle">لا إعلانات. لا تتبّع. لا قيود من جوجل بلاي.</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">İanə ver</string>
-    <string name="foss_upgrade_alreadydonated_label">Artıq ianə vermişəm</string>
-    <string name="foss_upgrade_no_money_label">Bütün pulumu AirPods-lara xərcləyirəm</string>
     <string name="upgrade_foss_preamble">CAPod FOSS pulsuzdur və açıq mənbəlidir. Faydalı tapırsınızsa, layihənin davamına kömək etmək üçün inkişafı maliyyələşdirməyi düşünün.</string>
     <string name="upgrade_foss_sponsor_action">İnkişafı sponsor edin</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklam yoxdur. İzləmə yoxdur. Google Play bağlılığı yoxdur.</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Ахвяраваць</string>
-    <string name="foss_upgrade_alreadydonated_label">Я ўжо ахвяраваў</string>
-    <string name="foss_upgrade_no_money_label">Я патраціў усе грошы на AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS бясплатны і з адкрытым зыходным кодам. Калі вы лічыце яго карысным, разгледзьце магчымасць спансіравання распрацоўкі, каб дапамагчы трымаць праект ў жывых.</string>
     <string name="upgrade_foss_sponsor_action">Падтрымаць распрацоўку</string>
     <string name="upgrade_foss_sponsor_subtitle">Ніякай рэкламы. Ніякай адсочкі. Ніякай залежнасці ад Google Play.</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Дарение</string>
-    <string name="foss_upgrade_alreadydonated_label">Вече съм дарил</string>
-    <string name="foss_upgrade_no_money_label">Харча всичките си пари за AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS е безплатен и с отворен код. Ако ви е полезен, размислете да подкрепите разработката, за да помогнете проектът да продължи.</string>
     <string name="upgrade_foss_sponsor_action">Спонсорирайте разработката</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклами. Без следене. Без заключване в Google Play.</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">দান করুন</string>
-    <string name="foss_upgrade_alreadydonated_label">আমি ইতিমধ্যে দান করেছি</string>
-    <string name="foss_upgrade_no_money_label">আমি আমার সব টাকা AirPods এর জন্য খরচ করি</string>
     <string name="upgrade_foss_preamble">CAPod FOSS বিনামূল্যে এবং মুক্ত উৎস। আপনি যদি এটি উপযোগী মনে করেন, প্রকল্পটি চালু রাখতে সাহায্য করতে ডেভেলপমেন্ট স্পনসর করার কথা বিবেচনা করুন।</string>
     <string name="upgrade_foss_sponsor_action">স্পনসর ডেভলপমেন্ট</string>
     <string name="upgrade_foss_sponsor_subtitle">কোনো বিজ্ঞাপন নেই। কোনো ট্র্যাকিং নেই। Google Play-এর সাথে বাঁধানো নেই।</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donacions</string>
-    <string name="foss_upgrade_alreadydonated_label">Ja he donat</string>
-    <string name="foss_upgrade_no_money_label">Gasto tots els meus diners en AirPods</string>
     <string name="upgrade_foss_preamble">El CAPod FOSS és gratuït i de codi obert. Si el trobeu útil, considereu patrocinar el desenvolupament per ajudar a mantenir el projecte en marxa.</string>
     <string name="upgrade_foss_sponsor_action">Patrocina el desenvolupament</string>
     <string name="upgrade_foss_sponsor_subtitle">Sense anuncis. Sense seguiment. Sense dependència del Google Play.</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Přispět</string>
-    <string name="foss_upgrade_alreadydonated_label">Již jsem přispěl/a</string>
-    <string name="foss_upgrade_no_money_label">Všechny peníze jsem utratil/a za AirPods</string>
     <string name="upgrade_foss_preamble">Aplikace CAPod FOSS je zdarma a open source. Pokud vám přijde užitečná, zvažte sponzorování vývoje, abyste pomohli udržet projekt v chodu.</string>
     <string name="upgrade_foss_sponsor_action">Sponzorovat vývoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Žádné reklamy. Žádné sledování. Žádná závislost na Google Play.</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doner</string>
-    <string name="foss_upgrade_alreadydonated_label">Jeg har allerede doneret</string>
-    <string name="foss_upgrade_no_money_label">Jeg bruger alle mine penge på AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS er gratis og open source. Hvis du finder det nüttigt, kan du overveje at sponsorere udviklingen for at hjælpe projektet med at fortsætte.</string>
     <string name="upgrade_foss_sponsor_action">Sponsorudvikling</string>
     <string name="upgrade_foss_sponsor_subtitle">Ingen annoncer. Ingen sporing. Ingen Google Play-lås.</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Spenden</string>
-    <string name="foss_upgrade_alreadydonated_label">Ich habe schon gespendet</string>
-    <string name="foss_upgrade_no_money_label">Hab alles für AirPods ausgegeben</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ist kostenlos und Open Source. Wenn du es nützlich findest, erwäge, die Entwicklung zu sponsern, um das Projekt am Laufen zu halten.</string>
     <string name="upgrade_foss_sponsor_action">Fördere Entwicklung</string>
     <string name="upgrade_foss_sponsor_subtitle">Keine Werbung. Kein Tracking. Keine Google-Play-Bindung.</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Δωρεά</string>
-    <string name="foss_upgrade_alreadydonated_label">Ήδη δώρισα</string>
-    <string name="foss_upgrade_no_money_label">Ξόδεψα όλα τα χρήματά μου στα AirPods</string>
     <string name="upgrade_foss_preamble">Το CAPod FOSS είναι δωρεάν και ανοιχτού κώδικα. Αν το βρίσκετε χρήσιμο, εξετάστε το ενδεχόμενο να χρηματοδοτήσετε την ανάπτυξη για να συνεχίσει το έργο.</string>
     <string name="upgrade_foss_sponsor_action">Χορηγήστε την ανάπτυξη</string>
     <string name="upgrade_foss_sponsor_subtitle">Χωρίς διαφημίσεις. Χωρίς παρακολούθηση. Χωρίς δέσμευση στο Google Play.</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donar</string>
-    <string name="foss_upgrade_alreadydonated_label">Ya doné</string>
-    <string name="foss_upgrade_no_money_label">Gasto todo mi dinero en AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS es gratuito y de código abierto. Si lo encontrás útil, considerá patrocinar el desarrollo para ayudar a mantener el proyecto en marcha.</string>
     <string name="upgrade_foss_sponsor_action">Sponsorear el desarrollo</string>
     <string name="upgrade_foss_sponsor_subtitle">Sin publicidad. Sin rastreo. Sin dependencia de Google Play.</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donar</string>
-    <string name="foss_upgrade_alreadydonated_label">Ya doné</string>
-    <string name="foss_upgrade_no_money_label">Gasto todo mi dinero en AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS es gratuito y de código abierto. Si lo encuentras útil, considera patrocinar el desarrollo para ayudar a mantener el proyecto.</string>
     <string name="upgrade_foss_sponsor_action">Patrocinar el desarrollo</string>
     <string name="upgrade_foss_sponsor_subtitle">Sin anuncios. Sin rastreo. Sin dependencia de Google Play.</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donar</string>
-    <string name="foss_upgrade_alreadydonated_label">Ya he donado</string>
-    <string name="foss_upgrade_no_money_label">Gasto todo mi dinero en AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS es gratuito y de código abierto. Si lo encuentras útil, considera patrocinar el desarrollo para ayudar a mantener el proyecto en marcha.</string>
     <string name="upgrade_foss_sponsor_action">Patrocinadores</string>
     <string name="upgrade_foss_sponsor_subtitle">Sin anuncios. Sin rastreo. Sin dependencia de Google Play.</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Anneta</string>
-    <string name="foss_upgrade_alreadydonated_label">Juba annetasin</string>
-    <string name="foss_upgrade_no_money_label">Kulutasin kogu raha AirPodsidele</string>
     <string name="upgrade_foss_preamble">CAPod FOSS on tasuta ja avatud lähtekoodiga. Kui sellest on sulle kasu, kaalu arenduse rahastamist, et aidata projekti arendada.</string>
     <string name="upgrade_foss_sponsor_action">Rahasta arendamist</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklaami pole. Jälgimist pole. Google Play lukustust pole.</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Eman dohaintza</string>
-    <string name="foss_upgrade_alreadydonated_label">Dagoeneko eman dut dohaintza</string>
-    <string name="foss_upgrade_no_money_label">Nire diru guztia AirPods-etan gastatzen dut</string>
     <string name="upgrade_foss_preamble">CAPod FOSS doakoa eta kode irekikoa da. Erabilgarria iruditzen bazaizu, kontuan hartu garapena babestu proiektua aurrera jarraitzeko.</string>
     <string name="upgrade_foss_sponsor_action">Garapena babestu</string>
     <string name="upgrade_foss_sponsor_subtitle">Iragarkirik ez. Jarraipenik ez. Google Play-ren lotura ez.</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">کمک مالی</string>
-    <string name="foss_upgrade_alreadydonated_label">کمک مالی کرده‌ام</string>
-    <string name="foss_upgrade_no_money_label">من تمام پولم را خرج ایرپاد می‌کنم</string>
     <string name="upgrade_foss_preamble">CAPod FOSS رایگان و متن-باز است. اگر آن را مفید یافتید، حمایت مالی از توسعه را در نظر بگیرید تا پروژه ادامه یابد.</string>
     <string name="upgrade_foss_sponsor_action">حامی توسعه دهنده</string>
     <string name="upgrade_foss_sponsor_subtitle">بدون تبلیغ. بدون ردیابی. بدون وابستگی به Google Play.</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Lahjoita</string>
-    <string name="foss_upgrade_alreadydonated_label">Olen jo lahjoittanut</string>
-    <string name="foss_upgrade_no_money_label">Käytän kaikki rahani AirPodeihin</string>
     <string name="upgrade_foss_preamble">CAPod FOSS on ilmainen ja avoimen lähdekoodin ohjelma. Jos löydät sen hyödylliseksi, harkitse kehityksen tukemista projektin elässä pitämiseksi.</string>
     <string name="upgrade_foss_sponsor_action">Sponsoroi kehitystä</string>
     <string name="upgrade_foss_sponsor_subtitle">Ei mainoksia. Ei seurantaa. Ei Google Play -riippuvuutta.</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Mag-donate</string>
-    <string name="foss_upgrade_alreadydonated_label">Nakapag-donate na ako</string>
-    <string name="foss_upgrade_no_money_label">Ginagastos ko lahat ng pera ko sa AirPods</string>
     <string name="upgrade_foss_preamble">Ang CAPod FOSS ay libre at open source. Kung nakita mong kapaki-pakinabang ito, isaalang-alang ang pag-sponsor ng development para mapanatiling aktibo ang proyekto.</string>
     <string name="upgrade_foss_sponsor_action">Mag-sponsor ng development</string>
     <string name="upgrade_foss_sponsor_subtitle">Walang ads. Walang tracking. Walang Google Play lock-in.</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Faire un don</string>
-    <string name="foss_upgrade_alreadydonated_label">J’ai déjà fait un don</string>
-    <string name="foss_upgrade_no_money_label">J’ai dépensé tout mon argent sur des AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS est gratuite et à code source ouvert. Si vous la trouvez utile, pensez à soutenir le développement pour contribuer à la pérennité du projet.</string>
     <string name="upgrade_foss_sponsor_action">Soutenir le développement</string>
     <string name="upgrade_foss_sponsor_subtitle">Pas de publicités. Pas de suivi à la trace. Pas de dépendance à Google Play.</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doar</string>
-    <string name="foss_upgrade_alreadydonated_label">Xa doei</string>
-    <string name="foss_upgrade_no_money_label">Gasto todos os meus cartos en AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS é gratuito e de código aberto. Se o atopas útil, considera patrocinar o desenvolvemento para axudar a manter o proxecto en marcha.</string>
     <string name="upgrade_foss_sponsor_action">Patrocinar desenvolvemento</string>
     <string name="upgrade_foss_sponsor_subtitle">Sen anuncios. Sen rastrexo. Sen dependencia de Google Play.</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">दान करें</string>
-    <string name="foss_upgrade_alreadydonated_label">मैंने पहले ही दान कर दिया है</string>
-    <string name="foss_upgrade_no_money_label">मैं अपना सारा पैसा AirPods पर खर्च करता हूं</string>
     <string name="upgrade_foss_preamble">CAPod FOSS मुफ्त और ओपन सोर्स है। यदि आपको यह उपयोगी लगता है, तो प्रोजेक्ट को जारी रखने में मदद के लिए विकास को प्रायोजित करने पर विचार करें।</string>
     <string name="upgrade_foss_sponsor_action">विकास को प्रायोजक करें</string>
     <string name="upgrade_foss_sponsor_subtitle">कोई विज्ञापन नहीं। कोई ट्रैकिंग नहीं। Google Play पर निर्भरता नहीं।</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donirajte</string>
-    <string name="foss_upgrade_alreadydonated_label">Već sam donirao</string>
-    <string name="foss_upgrade_no_money_label">Sav svoj novac trošim na AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS je besplatan i otvorenog koda. Ako vam je koristan, razmislite o sponzoriranju razvoja kako bi projekt ostao živ.</string>
     <string name="upgrade_foss_sponsor_action">Podržite razvoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Bez oglasa. Bez praćenja. Bez zaključanosti na Google Play.</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Adományoz</string>
-    <string name="foss_upgrade_alreadydonated_label">Már adományoztam</string>
-    <string name="foss_upgrade_no_money_label">Minden pénzemet az AirPods-ra költöttem</string>
     <string name="upgrade_foss_preamble">A CAPod FOSS ingyenes és nyílt forráskódú. Ha hasznosnak találod, fontold meg a fejlesztés támogatását, hogy a projekt tovább élhessen.</string>
     <string name="upgrade_foss_sponsor_action">Szponzori fejlesztés</string>
     <string name="upgrade_foss_sponsor_subtitle">Nincs hirdetés. Nincs nyomkövetés. Nincs Google Play-függőség.</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Նվիրաբերել</string>
-    <string name="foss_upgrade_alreadydonated_label">Ես արդեն նվիրաբերել եմ</string>
-    <string name="foss_upgrade_no_money_label">Ես իմ ամբողջ գումարը ծախսում եմ AirPods-ի վրա</string>
     <string name="upgrade_foss_preamble">CAPod FOSS անվճար և բաց կոդով: Այն ոգտակար էք, խնդրում զարգացությունը կենդանի պահելու համար:</string>
     <string name="upgrade_foss_sponsor_action">Հովանավորել զարգացումը</string>
     <string name="upgrade_foss_sponsor_subtitle">Լրատնություն չկա: հետքխկություն չկա: Google Play-ի կապվածություն չկա:</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Menyumbang</string>
-    <string name="foss_upgrade_alreadydonated_label">Saya telah berdonasi</string>
-    <string name="foss_upgrade_no_money_label">Saya menghabiskan semua uang saya untuk AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS gratis dan sumber terbuka. Jika Anda merasa bermanfaat, pertimbangkan untuk mensponsori pengembangan guna menjaga proyek ini berjalan.</string>
     <string name="upgrade_foss_sponsor_action">Pengembangan sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Tanpa iklan. Tanpa pelacakan. Tanpa ketergantungan Google Play.</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Gefa</string>
-    <string name="foss_upgrade_alreadydonated_label">Ég hef þegar gefið</string>
-    <string name="foss_upgrade_no_money_label">Ég eyði öllum peningunum mínum í AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS er ókeypis og opinn kóði. Ef þú finnur það gagnlegt, þakkaðu þér fyrir að stuðla að þróun til að hjálpa til við að halda verkefninu gangandi.</string>
     <string name="upgrade_foss_sponsor_action">Styrkja þróun</string>
     <string name="upgrade_foss_sponsor_subtitle">Engar auglysíngar. Engin rakning. Ekkert Google Play-lás.</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Dona</string>
-    <string name="foss_upgrade_alreadydonated_label">Ho già donato</string>
-    <string name="foss_upgrade_no_money_label">Spendo tutti i miei soldi per gli AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS è gratuito e open source. Se lo trovi utile, considera di sponsorizzare lo sviluppo per contribuire a mantenere il progetto in vita.</string>
     <string name="upgrade_foss_sponsor_action">Finanzia lo sviluppo</string>
     <string name="upgrade_foss_sponsor_subtitle">Nessuna pubblicità. Nessun tracciamento. Nessun vincolo con Google Play.</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">תרומה</string>
-    <string name="foss_upgrade_alreadydonated_label">כבר תרמתי</string>
-    <string name="foss_upgrade_no_money_label">מיטב כספי מושקע ב-AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS הוא חינם וקוד פתוח. אם הוא שימושי לך, שקול לשקול על חסוי הפיתוח כדי לעזור להמשיך את הפרויקט.</string>
     <string name="upgrade_foss_sponsor_action">פיתוח חסות</string>
     <string name="upgrade_foss_sponsor_subtitle">אין פרסומות. אין מעקב. אין תלות ב-Google Play.</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">寄付</string>
-    <string name="foss_upgrade_alreadydonated_label">すでに寄付しました</string>
-    <string name="foss_upgrade_no_money_label">AirPodsに全財産をつぎ込んでいます</string>
     <string name="upgrade_foss_preamble">CAPod FOSSは無料かつオープンソースです。便利だと思ったら、プロジェクトの継続に向けて開発をスポンサーすることをご検討ください。</string>
     <string name="upgrade_foss_sponsor_action">開発支援者</string>
     <string name="upgrade_foss_sponsor_subtitle">広告なし。追跡なし。Google Play依存なし。</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">შემოწირულობა</string>
-    <string name="foss_upgrade_alreadydonated_label">მე უკვე შემოწირული მაქვს</string>
-    <string name="foss_upgrade_no_money_label">მთელ ჩემს ფულს AirPods-ებზე ვხარჯავ</string>
     <string name="upgrade_foss_preamble">CAPod FOSS უფასოა და ღია წყაროა. თუ გსარგებლია, გაანაბრეთ განვითარება პროექტის გადასაგრელად.</string>
     <string name="upgrade_foss_sponsor_action">სპონსორის განვითარება</string>
     <string name="upgrade_foss_sponsor_subtitle">რეკლამა არა. თვალთვალება არა. Google Play-ზე დამოკიდება არა.</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">បរិច្ចាគ</string>
-    <string name="foss_upgrade_alreadydonated_label">ខ្ញុំបានបរិច្ចាគរួចហើយ</string>
-    <string name="foss_upgrade_no_money_label">ខ្ញុំចំណាយលុយទាំងអស់របស់ខ្ញុំលើ AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ជាកម្មវិធីឥតគិតថ្លៃ និងប្រភពបើកចំហ។ ប្រសិនបើអ្នករកហើញថ្លៃវាមានប្រយោជន៍ សូមពិចារណាឧបត្ថម្ភការអភិវឌ្ឍន៍ ដើម្បីជួយឥ្សរិយគម្រោងបន្តដំណើរការ។</string>
     <string name="upgrade_foss_sponsor_action">ឧបត្ថម្ភការអភិវឌ្ឍន៍</string>
     <string name="upgrade_foss_sponsor_subtitle">គ្មានការផ្សាយពាណិជ្ជកម្ម។ គ្មានការតាមដាន។ គ្មានការចាក់សោ Google Play។</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Beşdar bike</string>
-    <string name="foss_upgrade_alreadydonated_label">Min berê bexş kir</string>
-    <string name="foss_upgrade_no_money_label">Ez hemû pereyê xwe li AirPods xerc dikim</string>
     <string name="upgrade_foss_preamble">CAPod FOSS belaş û çavkaniya vekirî ye. Ger hûn wê kêrhastî dibînin, fikir bikin ku perkirezan bike da ku alîkariya berdewamî projeya bide.</string>
     <string name="upgrade_foss_sponsor_action">Pêşdebiriyê teref bike</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklam tune. Śopandin tune. Girêdana Google Play tune.</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">ದಾನ ಮಾಡಿ</string>
-    <string name="foss_upgrade_alreadydonated_label">ನಾನು ಈಗಾಗಲೇ ದಾನ ಮಾಡಿದ್ದೇನೆ</string>
-    <string name="foss_upgrade_no_money_label">ನಾನು ನನ್ನ ಎಲ್ಲಾ ಹಣವನ್ನು AirPods ಗಾಗಿ ಖರ್ಚು ಮಾಡುತ್ತೇನೆ</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ಉಚಿತ ಮತ್ತು ತೆರೆದ ಮೂಲದ್ದಾಗಿದೆ. ನಿಮಗೆ ಉಪಯುಕ್ತವಾಗಿ ತೋರಿದರೆ, ಯೋಜನೆಯನ್ನು ಮುಂದುವರಿಸಲು ಅಭಿವೃದ್ಧಿಗೆ ಪ್ರಾಯೋಜಕತ್ವ ನೀಡಲು ಪರಿಗಣಿಸಿ.</string>
     <string name="upgrade_foss_sponsor_action">ಅಭಿವೃದ್ಧಿಗೆ ಪ್ರಾಯೋಜಕತ್ವ ನೀಡಿ</string>
     <string name="upgrade_foss_sponsor_subtitle">ಜಾಹೀರಾತುಗಳಿಲ್ಲ. ಭಕ್ಷಣೆ ಇಲ್ಲ. Google Play ಲಾಕ್-ಇನ್ ಇಲ್ಲ.</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">후원하기</string>
-    <string name="foss_upgrade_alreadydonated_label">이미 후원했어요</string>
-    <string name="foss_upgrade_no_money_label">AirPods에 돈을 다 썼어요</string>
     <string name="upgrade_foss_preamble">CAPod FOSS는 무료 오픈소스입니다. 유용하게 사용하고 계신다면 프로젝트 유지에 도움이 되도록 후원을 고려해 주세요.</string>
     <string name="upgrade_foss_sponsor_action">개발 후원하기</string>
     <string name="upgrade_foss_sponsor_subtitle">광고 없음. 추적 없음. Google Play 의존 없음.</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Демөөрчүлүк кылуу</string>
-    <string name="foss_upgrade_alreadydonated_label">Мен буга чейин демөөрчүлүк кылгам</string>
-    <string name="foss_upgrade_no_money_label">Мен бүт акчамды AirPods үчүн короттум</string>
     <string name="upgrade_foss_preamble">CAPod FOSS беплатан жана ачык каттулууда. Егер пайдалуу таапсаңыз, жобаны улантырууга колдоо көрсөтүңүз.</string>
     <string name="upgrade_foss_sponsor_action">Иштелеп чыгууну колдоо</string>
     <string name="upgrade_foss_sponsor_subtitle">Жарнама. Кадалоолоо жок. Google Playга байланма.</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">ບໍລິຈາກ</string>
-    <string name="foss_upgrade_alreadydonated_label">ຂ້ອຍໄດ້ບໍລິຈາກແລ້ວ</string>
-    <string name="foss_upgrade_no_money_label">ຂ້ອຍໃຊ້ເງິນທັງໝົດຂອງຂ້ອຍໃສ່ AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ແມ່ນຟຣີ ແລະ ໂອເພນຊອດ. ຖ້າທ່ານເຫັນວ່າມີປະໂຫຍດ, ພິຈາລະນາສະໜັບສະໜູນການພັດທະນາເພື່ອຊ່ວຍໃຫ້ໂຄງການດຳເນີນຕໍ່ໄປ.</string>
     <string name="upgrade_foss_sponsor_action">ສະໜັບສະໜູນການພັດທະນາ</string>
     <string name="upgrade_foss_sponsor_subtitle">ບໍ່ມີໂຄສະນາ. ບໍ່ມີການຕິດຕາມ. ບໍ່ຕິດ Google Play.</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Aukoti</string>
-    <string name="foss_upgrade_alreadydonated_label">Aš jau paaukojau</string>
-    <string name="foss_upgrade_no_money_label">Visus savo pinigus išleidžiu „AirPods“ ausinėms</string>
     <string name="upgrade_foss_preamble">CAPod FOSS yra nemokama ir atviro kodo programa. Jei ji jums naudinga, pagalvokite apie rėmimą, kad projektą būtų galima tęsti.</string>
     <string name="upgrade_foss_sponsor_action">Remti plėtrą</string>
     <string name="upgrade_foss_sponsor_subtitle">Jokių reklamų. Jokio sekimo. Jokio „Google Play“ priklausomybės.</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Ziedot</string>
-    <string name="foss_upgrade_alreadydonated_label">Es jau ziedoju</string>
-    <string name="foss_upgrade_no_money_label">Es iztērēju visu savu naudu AirPods austiņām</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ir bezmaksas un atkļējkoda. Ja tā ir noderba, apsveriet attīstības sponsēšanu, lai palīdzētu turpināt projektu.</string>
     <string name="upgrade_foss_sponsor_action">Sponsorēt attīstību</string>
     <string name="upgrade_foss_sponsor_subtitle">Bez reklamām. Bez izsekošanas. Bez Google Play saistībām.</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Донирај</string>
-    <string name="foss_upgrade_alreadydonated_label">Веќе донирав</string>
-    <string name="foss_upgrade_no_money_label">Ги трошам сите пари на AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS е бесплатен и отворен код. Ако ви е корисен, размислете да го спонзорирате развојот за да помогнете проектот да продолжи.</string>
     <string name="upgrade_foss_sponsor_action">Спонзорирај развој</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклами. Без пратење. Без зависност од Google Play.</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">സംഭാവന ചെയ്യുക</string>
-    <string name="foss_upgrade_alreadydonated_label">ഞാൻ ഇതിനകം സംഭാവന ചെയ്തു</string>
-    <string name="foss_upgrade_no_money_label">ഞാൻ എൻ്റെ എല്ലാ പണവും AirPods-നായി ചെലവഴിക്കുന്നു</string>
     <string name="upgrade_foss_preamble">CAPod FOSS സൗജന്യവും ഓപ്പൻ സോഴ്സുമാണ്. നിങ്ങൾക്ക് ഇത് ഉപകാരപ്രദമാണെങ്കിൽ, പ്രോജെക്ട് തുടരാൻ സഹായിക്കുന്നതിന് ഡെവലപ്പ്മെന്റ് സ്പോൺസർ ചെയ്യുന്നത് പരിഗണിക്കുക.</string>
     <string name="upgrade_foss_sponsor_action">വികസനം സ്പോൺസർ ചെയ്യുക</string>
     <string name="upgrade_foss_sponsor_subtitle">പരസ്യങ്ങൾ ഇല്ല. ട്രാക്കിംഗ് ഇല്ല. Google Play ലോക്ക്-ഇൻ ഇല്ല.</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Хандивлах</string>
-    <string name="foss_upgrade_alreadydonated_label">Би аль хэдийн хандивласан</string>
-    <string name="foss_upgrade_no_money_label">Би бүх мөнгөө AirPods-д зарцуулдаг</string>
     <string name="upgrade_foss_preamble">CAPod FOSS нь үнэгүй, нээлтэй эхийн програм. Хэрэв танд хэрэгтэй бол төслийг үргэлжүүлэхэд туслахын тулд хөгжүүлэлтийг дэмжих талаар бодоорой.</string>
     <string name="upgrade_foss_sponsor_action">Хөгжлийг дэмжих</string>
     <string name="upgrade_foss_sponsor_subtitle">Реклам байхгүй. Хяналт байхгүй. Google Play-д хамааралгүй.</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">दान करा</string>
-    <string name="foss_upgrade_alreadydonated_label">मी आधीच दान केले आहे</string>
-    <string name="foss_upgrade_no_money_label">मी माझे सर्व पैसे AirPods वर खर्च करतो</string>
     <string name="upgrade_foss_preamble">CAPod FOSS विनामूल्य आणि ओपन सोर्स आहे. जर तुम्हाला ते उपयुक्त वाटत असेल, तर प्रकल्प सुरू ठेवण्यासाठी विकासास प्रायोजित करण्याचा विचार करा.</string>
     <string name="upgrade_foss_sponsor_action">विकासास प्रायोजित करा</string>
     <string name="upgrade_foss_sponsor_subtitle">कोणत्याही जाहिराती नाहीत. कोणतेही ट्रॅकिंग नाही. Google Play चे बंधन नाही.</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Sumbang</string>
-    <string name="foss_upgrade_alreadydonated_label">Saya telah menyumbang</string>
-    <string name="foss_upgrade_no_money_label">Saya belanjakan semua wang saya untuk AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS adalah percuma dan sumber terbuka. Jika anda mendapatinya berguna, pertimbangkan untuk menaja pembangunannya bagi membantu projek ini terus berjalan.</string>
     <string name="upgrade_foss_sponsor_action">Pembangunan penaja</string>
     <string name="upgrade_foss_sponsor_subtitle">Tiada iklan. Tiada penjejakan. Tiada ikatan Google Play.</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">လှူဒါန်းပါ</string>
-    <string name="foss_upgrade_alreadydonated_label">ကျွန်တော် လှူပြီးပါပြီ</string>
-    <string name="foss_upgrade_no_money_label">ကျွန်တော် ပိုက်ဆံအားလုံးကို AirPods မှာ သုံးတယ်</string>
     <string name="upgrade_foss_preamble">CAPod FOSS သည် အခမဲ့နှင့် open source ဖြစ်သည်။ အသုံးပြုခုပ်ဆည်းနိုင် အသားဖြစ်ပါက ပရာဗက်ဆက်လက်ရန် ဖွဲ့ဖြီးရေးကို ပံ့ပိုးပေးသည်။</string>
     <string name="upgrade_foss_sponsor_action">ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးရန်</string>
     <string name="upgrade_foss_sponsor_subtitle">ကြောင်ညာမရှိ။ ခြေရာမခံ။ Google Play ချုပ်ချယ်မြုမရှိ။</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doner</string>
-    <string name="foss_upgrade_alreadydonated_label">Jeg har allerede donert</string>
-    <string name="foss_upgrade_no_money_label">Jeg bruker alle pengene mine på AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS er gratis og åpen kildekode. Hvis du synes den er nyttig, kan du vurdere å sponse utviklingen for å bidra til at prosjektet går videre.</string>
     <string name="upgrade_foss_sponsor_action">Støtt utviklingen</string>
     <string name="upgrade_foss_sponsor_subtitle">Ingen reklame. Ingen sporing. Ingen Google Play-avhengighet.</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">दान गर्नुहोस्</string>
-    <string name="foss_upgrade_alreadydonated_label">मैले पहिले नै दान गरिसकेको छु</string>
-    <string name="foss_upgrade_no_money_label">म आफ्नो सबै पैसा AirPods मा खर्च गर्छु</string>
     <string name="upgrade_foss_preamble">CAPod FOSS निःशुल्क र खुला स्रोत छ। यदि तपाईंले उपयोगी पाउनुभएको छ भने, प्राजेक्ट चलाउन राख्न विकासमा प्रायोजन गर्न विचार गर्नुहोस्।</string>
     <string name="upgrade_foss_sponsor_action">विकासलाई प्रायोजन गर्नुहोस्</string>
     <string name="upgrade_foss_sponsor_subtitle">कुनै विज्ञापन छैन। कुनै ट्रैकिङ छैन। Google Playमा बाँधिएको छैन।</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doneren</string>
-    <string name="foss_upgrade_alreadydonated_label">Ik heb al gedoneerd</string>
-    <string name="foss_upgrade_no_money_label">Ik besteed al mijn geld aan AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS is gratis en open source. Als je het nuttig vindt, overweeg dan om de ontwikkeling te sponsoren om het project gaande te houden.</string>
     <string name="upgrade_foss_sponsor_action">Sponsor ontwikkeling</string>
     <string name="upgrade_foss_sponsor_subtitle">Geen advertenties. Geen tracking. Geen Google Play-vergrendeling.</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Wesprzyj</string>
-    <string name="foss_upgrade_alreadydonated_label">Już wsparłem</string>
-    <string name="foss_upgrade_no_money_label">Wydałem wszystkie pieniądze na AirPods</string>
     <string name="upgrade_foss_preamble">CAPod Foss jest bezpłatny i otwarto-źródłowy. Jeśli uważasz go za użyteczny, rozważ sponsorowanie rozwoju, aby pomóc kontynuować projekt.</string>
     <string name="upgrade_foss_sponsor_action">Wesprzyj rozwój</string>
     <string name="upgrade_foss_sponsor_subtitle">Bez reklam. Bez śledzenia. Bez uzależnienia od Google Play.</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doar</string>
-    <string name="foss_upgrade_alreadydonated_label">Eu já doei</string>
-    <string name="foss_upgrade_no_money_label">Eu gasto todo o meu dinheiro em AirPods</string>
     <string name="upgrade_foss_preamble">O CAPod FOSS é gratuito e de código aberto. Se você o achar útil, considere patrocinar o desenvolvimento para ajudar a manter o projeto ativo.</string>
     <string name="upgrade_foss_sponsor_action">Patrocinador do desenvolvimento</string>
     <string name="upgrade_foss_sponsor_subtitle">Sem anúncios. Sem rastreamento. Sem dependência do Google Play.</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doar</string>
-    <string name="foss_upgrade_alreadydonated_label">Já doei</string>
-    <string name="foss_upgrade_no_money_label">Gastei todo o meu dinheiro em AirPods</string>
     <string name="upgrade_foss_preamble">O CAPod FOSS é gratuito e de código aberto. Se o achar útil, considere patrocinar o desenvolvimento para ajudar a manter o projeto ativo.</string>
     <string name="upgrade_foss_sponsor_action">Patrocine o desenvolvimento</string>
     <string name="upgrade_foss_sponsor_subtitle">Sem anúncios. Sem rastreamento. Sem dependência do Google Play.</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donar</string>
-    <string name="foss_upgrade_alreadydonated_label">Hai gia donat</string>
-    <string name="foss_upgrade_no_money_label">Mett tut mes daners en AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS è gratuit ed open source. Sche ti chattast ch\'el è util, considerescha da sponsurisar il sviluppament per agidà a mantegnair il project.</string>
     <string name="upgrade_foss_sponsor_action">Sponsurisar il sviluppament</string>
     <string name="upgrade_foss_sponsor_subtitle">Nagins annunzis. Nagin tracking. Nagin blocadi da Google Play.</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donează</string>
-    <string name="foss_upgrade_alreadydonated_label">Am donat deja</string>
-    <string name="foss_upgrade_no_money_label">Mi-am cheltuit toți banii pe AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS este gratuit si open source. Daca il gasiti util, luati in considerare sponsorizarea dezvoltarii pentru a ajuta la continuarea proiectului.</string>
     <string name="upgrade_foss_sponsor_action">Sponsorizează dezvoltarea</string>
     <string name="upgrade_foss_sponsor_subtitle">Fara reclame. Fara urmarire. Fara dependenta de Google Play.</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Пожертвовать</string>
-    <string name="foss_upgrade_alreadydonated_label">Я уже пожертвовал</string>
-    <string name="foss_upgrade_no_money_label">Я потратил все свои деньги на AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS бесплатный и с открытым исходным кодом. Если Вам полезно приложение, рассмотрите возможность спонсировать разработку, чтобы помочь проекту продолжать развиваться.</string>
     <string name="upgrade_foss_sponsor_action">Поддержать разработку</string>
     <string name="upgrade_foss_sponsor_subtitle">Без рекламы. Без слежки. Без привязки к Google Play.</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Dona</string>
-    <string name="foss_upgrade_alreadydonated_label">Apo giai donadu</string>
-    <string name="foss_upgrade_no_money_label">Apo spèndidu totu is soddos meos pro is AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS est gratis e fonte aberta. Si t’est de agiudu, considera de patrotzinare su isviluppu pro agiudare a mantennere su progetu.</string>
     <string name="upgrade_foss_sponsor_action">Sponsoriza s\'isvilupu</string>
     <string name="upgrade_foss_sponsor_subtitle">Peroe publicidade. Peroe trachiamentu. Peroe dipendentzia de Google Play.</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">පරිත්‍යාග</string>
-    <string name="foss_upgrade_alreadydonated_label">මම දැනටමත් පරිත්‍යාග කර ඇත</string>
-    <string name="foss_upgrade_no_money_label">මම මගේ මුදල් සියල්ල AirPods සඳහා වියදම් කරමි</string>
     <string name="upgrade_foss_preamble">CAPod FOSS නියමිත සහ විවෘත මූලාශ්‍රයි. ඔබට ඉත උපකාරී නම්, ආයෝජනය ගිණුම්‍ සහය ගෙවිපීම කිරීමට අර්වමයක් ගෙවිපීම් ප්‍රස්තා කරන්නට සංවර්ධන කරන්න.</string>
     <string name="upgrade_foss_sponsor_action">සංවර්ධනයට අනුග්‍රහය දෙන්න</string>
     <string name="upgrade_foss_sponsor_subtitle">අළු නැත. ට්‍රැකිං නැත. Google Play සලක඾ත්වය නැත.</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Prispieť</string>
-    <string name="foss_upgrade_alreadydonated_label">Už som prispel/a</string>
-    <string name="foss_upgrade_no_money_label">Všetky peniaze som minul na AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS je zadarmo a open source. Ak ho nájdete užitočným, zvažte sponzorovanie vývoja, aby ste pomohli udržiavať projekt v chode.</string>
     <string name="upgrade_foss_sponsor_action">Sponzorovaný vývoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Žiadne reklamy. Žiadne sledovanie. Žiadna závislosť od Google Play.</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Doniraj</string>
-    <string name="foss_upgrade_alreadydonated_label">Sem že doniral</string>
-    <string name="foss_upgrade_no_money_label">Ves svoj denar porabim za AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS je brezplačen in odprtokoden. Če se vam zdi koristen, razmislite o sponzoriranju razvoja, da pomagate ohranjati projekt.</string>
     <string name="upgrade_foss_sponsor_action">Podpri razvoj</string>
     <string name="upgrade_foss_sponsor_subtitle">Brez oglasov. Brez sledenja. Brez vezave na Google Play.</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Dhuro</string>
-    <string name="foss_upgrade_alreadydonated_label">Unë tashmë kam dhuruar</string>
-    <string name="foss_upgrade_no_money_label">Unë i shpenzoj të gjitha paratë e mia për AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS është falas dhe me burim të hapur. Nëse e gjeni të dobishmëm, konsideroni sponsorizimin e zhvillimit për ta mbajtur projektin gjallë.</string>
     <string name="upgrade_foss_sponsor_action">Zhvillimi i sponsorëve</string>
     <string name="upgrade_foss_sponsor_subtitle">Pa reklama. Pa gjurmim. Pa varësi nga Google Play.</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Донације</string>
-    <string name="foss_upgrade_alreadydonated_label">Већ сам донирао/ла</string>
-    <string name="foss_upgrade_no_money_label">Сав новац трошим на АирПодс</string>
     <string name="upgrade_foss_preamble">CAPod FOSS је бесплатан и отвореног кода. Ако вам је користан, размотрите спонзорисање развоја да би пројекат остао жив.</string>
     <string name="upgrade_foss_sponsor_action">Спонзориши развој</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклама. Без праћења. Без зависности од Google Play.</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donera</string>
-    <string name="foss_upgrade_alreadydonated_label">Jag har redan donerat</string>
-    <string name="foss_upgrade_no_money_label">Jag spenderar alla mina pengar på AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS är gratis och öppen källkod. Om du tycker att det är användbart kan du överväga att sponsra utvecklingen för att hjälpa till att hålla projektet vid liv.</string>
     <string name="upgrade_foss_sponsor_action">Sponsra utvecklingen</string>
     <string name="upgrade_foss_sponsor_subtitle">Inga annonser. Ingen spårning. Ingen bindning till Google Play.</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Changia</string>
-    <string name="foss_upgrade_alreadydonated_label">Nimeshachangia tayari</string>
-    <string name="foss_upgrade_no_money_label">Natumia pesa zangu zote kwenye AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ni bure na chanzo huria. Ikiwa unaikuta ni muhimu, fikiria kuchangia maendeleo ili kusaidia mradi kuendelea.</string>
     <string name="upgrade_foss_sponsor_action">Faidhi maendeleo</string>
     <string name="upgrade_foss_sponsor_subtitle">Hakuna matangazo. Hakuna ufuatiliaji. Hakuna kufungwa kwa Google Play.</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">நன்கொடை</string>
-    <string name="foss_upgrade_alreadydonated_label">நான் ஏற்கனவே நன்கொடை அளித்துவிட்டேன்</string>
-    <string name="foss_upgrade_no_money_label">எனது பணத்தை எல்லாம் ஏர்பாட்களில் செலவிடுகிறேன்</string>
     <string name="upgrade_foss_preamble">CAPod FOSS இலவசமாகவும் திறழ் மூலக்கோடும் உள்ளது. இது பயனுள்ளதாக கணித்தால், தொடர்பு பொறுத்துக்க அம்சத்தை நிச்சயிக்கவும்.</string>
     <string name="upgrade_foss_sponsor_action">மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்</string>
     <string name="upgrade_foss_sponsor_subtitle">ஐவிளம்பரம் இல்லை. கண்காணிப்பு இல்லை. Google Play கட்டுப்பாட்டு இல்லை.</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">విరాళం ఇవ్వండి</string>
-    <string name="foss_upgrade_alreadydonated_label">నేను ఇప్పటికే విరాళం ఇచ్చాను</string>
-    <string name="foss_upgrade_no_money_label">నా డబ్బు అంతా ఎయిర్‌పాడ్స్‌కే ఖర్చు చేస్తాను</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ఉచిత మరియు ముక్త మూలం. ఇది ఉపయోగకరంగా అనిపిస్తే, ప్రాజెక్ట్ కొనసాగించడానికి అభివృద్ధిని స్పాన్సర్ చేయబక్తా పరిగణించండి.</string>
     <string name="upgrade_foss_sponsor_action">అభివృద్ధిని స్పాన్సర్ చేయండి</string>
     <string name="upgrade_foss_sponsor_subtitle">జాహీరాతులు లేవు. ట్రాకింగ్ లేదు. Google Play ఒక్కటికి పరిమితం కాదు.</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">บริจาค</string>
-    <string name="foss_upgrade_alreadydonated_label">ฉันบริจาคแล้ว</string>
-    <string name="foss_upgrade_no_money_label">ฉันใช้เงินทั้งหมดไปกับ AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS เป็นฟรีและโอเพนซอร์ส หากคุณเห็นว่ามีประโยชน์ ลองสนับสนุนการพัฒนาเพื่อช่วยให้โครงการดำเนินต่อไป</string>
     <string name="upgrade_foss_sponsor_action">สปอนเซอร์การพัฒนา</string>
     <string name="upgrade_foss_sponsor_subtitle">ไม่มีโฆษณา ไม่ติดตาม ไม่ผูกขาด Google Play</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Bağış yap</string>
-    <string name="foss_upgrade_alreadydonated_label">Zaten bağış yaptım</string>
-    <string name="foss_upgrade_no_money_label">Tüm paramı AirPods\'a harcıyorum</string>
     <string name="upgrade_foss_preamble">CAPod FOSS ücretsiz ve açık kaynaklıdır. Eğer faydalı bulduysan, projenin devam edebilmesi için lütfen geliştirmeye destek olmayı düşün.</string>
     <string name="upgrade_foss_sponsor_action">Geliştirmeyi destekleyin</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklam yok. Takip yok. Google Play sınırlaması yok.</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Пожертва</string>
-    <string name="foss_upgrade_alreadydonated_label">Вже пожертвував</string>
-    <string name="foss_upgrade_no_money_label">Витратив усі гроші на AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS є безкоштовним та відкритим програмним забезпеченням. Якщо він вам корисний, розгляньте можливість спонсорування розробки, щоб допомогти проєкту продовжувати роботу.</string>
     <string name="upgrade_foss_sponsor_action">Розвиток спонсорів</string>
     <string name="upgrade_foss_sponsor_subtitle">Без реклами. Без стеження. Без прив\'язки до Google Play.</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">عطیہ کریں۔</string>
-    <string name="foss_upgrade_alreadydonated_label">میں نے پہلے ہی عطیہ کر دیا ہے۔</string>
-    <string name="foss_upgrade_no_money_label">میں اپنی تمام رقم ایئر پوڈز پر خرچ کرتا ہوں۔</string>
     <string name="upgrade_foss_preamble">CAPod FOSS مفت اور اوپن سورس ہے۔ اگر آپ اسے مفید پاتے ہیں، تو منصوبے کو سپانسر کرنے کا خیال کریں تاکہ پراجیکٹ جاری رہے۔</string>
     <string name="upgrade_foss_sponsor_action">ترقی کو اسپانسر کریں</string>
     <string name="upgrade_foss_sponsor_subtitle">کوئی اشتہار نہیں۔ کوئی ٹریکنگ نہیں۔ کوئی Google Play کی قید نہیں۔</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Xayriya qilish</string>
-    <string name="foss_upgrade_alreadydonated_label">Men allaqachon xayriya qildim</string>
-    <string name="foss_upgrade_no_money_label">Men butun pulimni AirPods uchun sarflayman</string>
     <string name="upgrade_foss_preamble">CAPod FOSS bepul va ochiq manbali. Agar foydali deb topsangiz, loyihani davom ettirishga yordam berish uchun rivojlantiruvchini qo\'llab-quvvatlashni ko\'rib chiqing.</string>
     <string name="upgrade_foss_sponsor_action">Rivojlanishni sponsorlik qilish</string>
     <string name="upgrade_foss_sponsor_subtitle">Reklamasiz. Kuzatishsiz. Google Play cheklovlarisiz.</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Quyên tặng</string>
-    <string name="foss_upgrade_alreadydonated_label">Tôi đã quyên góp</string>
-    <string name="foss_upgrade_no_money_label">Tôi tiêu hết tiền cho AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS miễn phí và mã nguồn mở. Nếu bạn thấy nó hữu ích, hãy cân nhắc tài trợ cho việc phát triển để giúp duy trì dự án.</string>
     <string name="upgrade_foss_sponsor_action">Tài trợ nhà phát triển</string>
     <string name="upgrade_foss_sponsor_subtitle">Không quảng cáo. Không theo dõi. Không phụ thuộc Google Play.</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">捐赠</string>
-    <string name="foss_upgrade_alreadydonated_label">已捐赠过了</string>
-    <string name="foss_upgrade_no_money_label">钱都用来买 AirPods 了</string>
     <string name="upgrade_foss_preamble">CAPod FOSS 是免费开源的。如果您觉得它有用，请考虑赞助开发以帮助项目持续下去。</string>
     <string name="upgrade_foss_sponsor_action">赞助开发</string>
     <string name="upgrade_foss_sponsor_subtitle">无广告。无追踪。无 Google Play 绑定。</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">資助</string>
-    <string name="foss_upgrade_alreadydonated_label">我已經資助了</string>
-    <string name="foss_upgrade_no_money_label">我已經為 AirPods 傾家蕩產了</string>
     <string name="upgrade_foss_preamble">CAPod FOSS 是免費且開源的。如果您覺得它對您有幫助，請考慮贊助開發以支持項目繼續運行。</string>
     <string name="upgrade_foss_sponsor_action">贊助開發</string>
     <string name="upgrade_foss_sponsor_subtitle">沒有廣告。沒有追蹤。沒有 Google Play 鎖定。</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">抖內</string>
-    <string name="foss_upgrade_alreadydonated_label">我已經抖內了</string>
-    <string name="foss_upgrade_no_money_label">我已經為 AirPods 傾家蕩產了</string>
     <string name="upgrade_foss_preamble">CAPod FOSS 是免費且開源的。如果您覺得它對您有幫助，請考慮贊助開發以支持專案繼續運行。</string>
     <string name="upgrade_foss_sponsor_action">贊助開發</string>
     <string name="upgrade_foss_sponsor_subtitle">無廣告。無追蹤。無 Google Play 鎖定。</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Nikela</string>
-    <string name="foss_upgrade_alreadydonated_label">Senginikele kakade</string>
-    <string name="foss_upgrade_no_money_label">Ngisebenzisa yonke imali yami kuma-AirPods</string>
     <string name="upgrade_foss_preamble">I-CAPod FOSS imahhala futhi ivulelwe umphakathi. Uma uyithola iyasiza, cabanga ngokuxhasa ukuthuthukiswa ukuze usizo kugcina iphrojekthi iqhubeka.</string>
     <string name="upgrade_foss_sponsor_action">Xhasa ukuthuthukiswa</string>
     <string name="upgrade_foss_sponsor_subtitle">Azikho izibhangeli. Akunakulandelelwa. Ayikho ukuvinjwa kwe-Google Play.</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="foss_upgrade_donate_label">Donate</string>
-    <string name="foss_upgrade_alreadydonated_label">I already donated</string>
-    <string name="foss_upgrade_no_money_label">I spend all my money on AirPods</string>
     <string name="upgrade_foss_preamble">CAPod FOSS is free and open source. If you find it useful, consider sponsoring development to help keep the project going.</string>
     <string name="upgrade_foss_sponsor_action">Sponsor development</string>
     <string name="upgrade_foss_sponsor_subtitle">No ads. No tracking. No Google Play lock-in.</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-dienste is nie beskikbaar nie.</string>
-    <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-fout</string>
     <string name="upgrades_gplay_billing_error_description">Daar was \'n fout in Google Play. Probeer asseblief later weer of herbegin jou foon.\n\nFout: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play-faktureringsfout</string>
-    <string name="upgrades_gplay_billing_result_error_description">Daar was \'n fout toe Google Play om jou aankoopbesonderhede gevra is. Maak die Google Play-kas skoon en herbegin jou foon.\n\nFout %s</string>
     <string name="upgrades_gplay_already_owned_label">Reeds gekoop?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play meld dat jy reeds hierdie opgradering besit, maar dit kon nie herstel word nie. Maak seker jy gebruik die Google-rekening waarmee jy gekoop het. Play Store-sinkronisasie kan tyd neem — probeer herbegin, maak die Google Play-kas skoon, of wag eenvoudig \'n rukkie.</string>
-    <string name="upgrade_restore_action">Herstel aankoop</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Kry %1$s</string>
     <string name="upgrade_preamble">CAPod word deur een persoon ontwikkel. Opgradering ontsluit ekstra kenmerke en help om die toepassing lewend te hou.</string>
-    <string name="upgrade_screen_options_description">Dieselfde kenmerke, verskillende pryse. Die intekening sluit \'n gratis proeftydperk in en kan te eniger tyd gekanselleer word.</string>
-    <string name="upgrade_screen_options_description_no_trial">Dieselfde kenmerke, verskillende pryse. Die intekening kan te eniger tyd gekanselleer word.</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis proeftydperk</string>
     <string name="upgrade_screen_subscription_action">Teken jaarliks in</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/jaar</string>
     <string name="upgrade_screen_iap_action">Koop eenmalig</string>
-    <string name="upgrade_screen_iap_action_hint">Eenmalige aankoop: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Herstel aankoop</string>
-    <string name="upgrade_screen_restore_purchase_message">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">As jy onlangs gekoop het, kan dit \'n rukkie neem vir Google Play om te sinkroniseer.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Probeer weer oor \'n paar minute as jou aankoop nie verskyn nie.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Maak seker jy is aangemeld met dieselfde Google-rekening wat vir die aankoop gebruik is.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Veelvuldige rekeninge kan Google Play verwar. Deur die toepassing via die Google Play-webwerf te installeer, word die assosiasie met \'n spesifieke rekening afgedwing.</string>
     <string name="upgrade_screen_restore_banner_title">Reeds Pro gekoop?</string>
     <string name="upgrade_screen_restore_banner_body">Dit lyk asof jy voorheen op hierdie toestel na Pro opgegradeer het. Herstel jou aankoop om dit weer te ontsluit.</string>
     <string name="upgrade_screen_restore_success_message">Aankoop herstel.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Jy het CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ontsluit deur jou intekening. Dankie dat jy CAPod ondersteun!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ontsluit deur jou eenmalige aankoop. Dankie dat jy CAPod ondersteun!</string>
-    <string name="upgrade_screen_owned_sub_title">Jaarlikse intekening</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Jou intekening is aktief en gestel om te hernu. Fakturering word deur Google Play bestuur.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Jou intekening is aktief, maar nie gestel om te hernu nie. Pro bly beskikbaar totdat die huidige tydperk eindig.</string>
     <string name="upgrade_screen_owned_iap_title">Eenmalige aankoop</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">የGoogle Play አገልግሎቶች አይገኙም።</string>
-    <string name="upgrades_no_purchases_found_check_account">ምንም ግዢዎች አልተገኙም። ትክክለኛውን መለያ እየተጠቀሙ ነው?</string>
     <string name="upgrades_gplay_billing_error_label">የGoogle Play ስህተት</string>
     <string name="upgrades_gplay_billing_error_description">በGoogle Play ላይ ስህተት ነበር። እባክዎ ቆይተው ይሞክሩ ወይም ስልክዎን እንደገና ያስጀምሩ።\n\nስህተት: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">የGoogle Play ክፍያ ስህተት</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play የግዢ ዝርዝሮችዎን ሲጠይቅ ስህተት ነበር። የGoogle Play መሸጎጫውን ያጽዱ እና ስልክዎን እንደገና ያስጀምሩ።\n\nስህተት %s</string>
     <string name="upgrades_gplay_already_owned_label">አስቀድመው ገዝተዋል?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play ይህን ማሻሻያ አስቀድመው እንደያዙ ዘግቧል፣ ነገር ግን መመለስ አልተቻለም። በገዙበት የGoogle መለያ እየተጠቀሙ መሆኑን ያረጋግጡ። የPlay Store ማመሳሰል ጊዜ ሊወስድ ይችላል — እንደገና ለማስጀመር፣ የGoogle Play መሸጎጫን ለማጽዳት ወይም በቀላሉ ለመጠበቅ ይሞክሩ።</string>
-    <string name="upgrade_restore_action">ግዢን ወደነበረበት መልስ</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ያግኑ</string>
     <string name="upgrade_preamble">CAPod የሚዘጋጀው በአንድ ሰው ብቻ ነው። ማሻሻል ተጨማሪ ባህሪያትን ይከፍታል እንዲሁም መተግበሪያውን ሕያው ለማድረግ ይረዳል።</string>
-    <string name="upgrade_screen_options_description">ተመሳሳይ ባህሪያት፣ የተለያየ ዋጋ አሰጣጥ። ምዝገባው ነጻ የሙከራ ጊዜ ያካትታል እና በማንኛውም ጊዜ ሊሰረዝ ይችላል።</string>
-    <string name="upgrade_screen_options_description_no_trial">ተመሳሳይ ባህሪያት፣ የተለያየ ዋጋ አሰጣጥ። ምዝገባው በማንኛውም ጊዜ ሊሰረዝ ይችላል።</string>
     <string name="upgrade_screen_subscription_trial_action">ነጻ ሙከራ ጀምር</string>
     <string name="upgrade_screen_subscription_action">በዓመት ይመዝገቡ</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ዓመት</string>
     <string name="upgrade_screen_iap_action">አንዴ ይግዙ</string>
-    <string name="upgrade_screen_iap_action_hint">የአንድ ጊዜ ግዢ፦ %s</string>
     <string name="upgrade_screen_restore_purchase_action">ግዢን ወደነበረበት መልስ</string>
-    <string name="upgrade_screen_restore_purchase_message">ምንም ግዢዎች አልተገኙም። ትክክለኛውን መለያ እየተጠቀሙ ነው?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">በቅርቡ ገዝተው ከሆነ፣ Google Play ለማመሳሰል ትንሽ ጊዜ ሊወስድ ይችላል።</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ግዢዎ ካልታየ በጥቂት ደቂቃዎች ውስጥ እንደገና ይሞክሩ።</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ለግዢው ጥቅም ላይ በዋለው ተመሳሳይ የGoogle መለያ መግባትዎን ያረጋግጡ።</string>
-    <string name="upgrade_screen_restore_webinstall_hint">ብዙ መለያዎች Google Playን ማምታታት ይችላሉ። መተግበሪያውን በGoogle Play ድርጣቢያ በኩል መጫን ከተወሰነ መለያ ጋር ግንኙነትን ያስገድዳል።</string>
     <string name="upgrade_screen_restore_banner_title">Pro አስቀድመው ገዝተዋል?</string>
     <string name="upgrade_screen_restore_banner_body">ቀደም ሲል በዚህ መሣሪያ ወደ Pro እንዳሻሻሉ ይመስላል። እንደገና ለመክፈት ግዢዎን ይመልሱ።</string>
     <string name="upgrade_screen_restore_success_message">ግዢ ተመልሷል።</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">CAPod Pro አለዎት!</string>
     <string name="upgrade_screen_owned_hero_sub_body">በምዝገባዎ ተከፍቷል። CAPod ን ስለደገፉ እናመሰግናለን!</string>
     <string name="upgrade_screen_owned_hero_iap_body">በአንድ ጊዜ ግዢዎ ተከፍቷል። CAPod ን ስለደገፉ እናመሰግናለን!</string>
-    <string name="upgrade_screen_owned_sub_title">ዓመታዊ ምዝገባ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ምዝገባዎ ንቁ ነው እና ለማደስ ተዘጋጅቶል። ክፍያ በGoogle Play ይተዳደራል።</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ምዝገባዎ ንቁ ነው፣ ነገር ግን ለማደስ አልተዘጋጀም። አሑን ያለው ጊዜ እስክያለቅ ድረስ Pro ይገኛል።</string>
     <string name="upgrade_screen_owned_iap_title">አንድ ጊዜ ግዢ</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">خدمات جوجل بلاي غير متوفّرة.</string>
-    <string name="upgrades_no_purchases_found_check_account">لم يُعثَر على أيّ مشتريات. هل تستخدم الحساب الصحيح؟</string>
     <string name="upgrades_gplay_billing_error_label">خطأٌ في جوجل بلاي</string>
     <string name="upgrades_gplay_billing_error_description">حدث خطأٌ في جوجل بلاي. يُرجى المحاولة لاحقًا أو إعادة تشغيل هاتفك.\n\nالخطأ: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">خطأٌ في فوترة جوجل بلاي</string>
-    <string name="upgrades_gplay_billing_result_error_description">حدث خطأٌ في أثناء طلب تفاصيل عملية الاشتراء من جوجل بلاي. يُرجى مسح ذاكرة التخزين المؤقّت لجوجل بلاي وإعادة تشغيل هاتفك.\n\nالخطأ %s</string>
     <string name="upgrades_gplay_already_owned_label">هل اشتريت فعلًا؟</string>
     <string name="upgrades_gplay_already_owned_description">أفاد جوجل بلاي بأنّك تمتلك هذه الترقية فعلًا، ولكنْ تعذّرت استعادتها. تأكّد استخدام حساب جوجل الذي اشتريت به الترقية. قد تستغرق مزامنة سوق بلاي بعض الوقت — حاول إعادة تشغيل الجهاز، أو مسح ذاكرة التخزين المؤقّت لجوجل بلاي، أو الانتظار ببساطة.</string>
-    <string name="upgrade_restore_action">استعادة المشتريات</string>
     <string name="upgrade_badge_label">النسخة الاحترافية</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">احصل على %1$s</string>
     <string name="upgrade_preamble">تمّ تطوير كابود بواسطة شخصٍ واحد. تتيح الترقية مزايا إضافية وتساعد في استمرار عمل التطبيق.</string>
-    <string name="upgrade_screen_options_description">نفس المزايا، بتسعيرٍ مختلف. يشمل الاشتراك مدّةً تجريبيةً مجّانيةً ويمكن إلغاؤه في أيّ وقت.</string>
-    <string name="upgrade_screen_options_description_no_trial">نفس المزايا، بتسعيرٍ مختلف. يمكن إلغاء الاشتراك في أيّ وقت.</string>
     <string name="upgrade_screen_subscription_trial_action">بدء المدّة التجريبية المجّانية</string>
     <string name="upgrade_screen_subscription_action">الاشتراك سنويًّا</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/سنويًّا</string>
     <string name="upgrade_screen_iap_action">الاشتراء لمرّةٍ واحدة</string>
-    <string name="upgrade_screen_iap_action_hint">اشتراء لمرّةٍ واحدة: %s</string>
     <string name="upgrade_screen_restore_purchase_action">استعادة المشتريات</string>
-    <string name="upgrade_screen_restore_purchase_message">لم يُعثَر على أيّ مشتريات. هل تستخدم الحساب الصحيح؟</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">إذا اشتريت مؤخّرًا، فقد يستغرق الأمر بعض الوقت حتى تتمّ مزامنة حسابك على جوجل بلاي.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">حاول مرّةً أخرى بعد بضع دقائق إذا لم يظهر طلبك.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">تأكّد تسجيل دخولك باستخدام حساب جوجل نفسه المُستخدَم في عملية الاشتراء.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">قد يؤدّي تعدّد الحسابات إلى إرباك جوجل بلاي. لذا، فإنّ تثبيت التطبيق عبر موقع جوجل بلاي الإلكتروني يُجبِر التطبيق على الارتباط بحسابٍ مُحدَّد.</string>
     <string name="upgrade_screen_restore_banner_title">هل اشتريت النسخة الاحترافية فعلًا؟</string>
     <string name="upgrade_screen_restore_banner_body">يبدو أنّك رقّيت إلى النسخة الاحترافية على هذا الجهاز سابقًا. استعِدْ عملية الاشتراء لفتحه مرّةً أخرى.</string>
     <string name="upgrade_screen_restore_success_message">تمّت استعادة عملية الاشتراء.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">لديك النسخة الاحترافية من كابود!</string>
     <string name="upgrade_screen_owned_hero_sub_body">تمّ فتحها باشتراكك. شكرًا لدعمك لكابود!</string>
     <string name="upgrade_screen_owned_hero_iap_body">تمّ فتحها باختيارك خيار الاشتراء لمرّةٍ واحدة. شكرًا لدعمك لكابود!</string>
-    <string name="upgrade_screen_owned_sub_title">اشتراك سنوي</string>
     <string name="upgrade_screen_owned_sub_renewing_body">اشتراكك فعّالٌ ومُعَدٌّ للتجديد. تتمّ إدارة الفواتير بواسطة جوجل بلاي.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">اشتراكك فعّالٌ، لكنّه غير مُعَدٍّ للتجديد. ستظلّ النسخة الاحترافية متاحةً حتّى نهاية المدّة الحالية.</string>
     <string name="upgrade_screen_owned_iap_title">اشتراء لمرّةٍ واحدة</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play xidmətləri əlçatmazdır.</string>
-    <string name="upgrades_no_purchases_found_check_account">Heç bir satın alma tapılmadı. Doğru hesabı istifadə edirsiniz?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play xətası</string>
     <string name="upgrades_gplay_billing_error_description">Google Play-də xəta baş verdi. Zəhmət olmasa daha sonra yenidən cəhd edin və ya telefonunuzu yenidən başladın.\n\nXəta: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play faktura xətası</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play-dən satınalma təfərrüatlarınızı soruşarkən xəta baş verdi. Google Play keşini təmizləyin və telefonunuzu yenidən başladın.\n\nXəta %s</string>
     <string name="upgrades_gplay_already_owned_label">Artıq satın almısınız?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play bu yüksəltməyə artıq sahib olduğunuzu bildirir, lakin bərpa edilə bilmədi. Satın aldığınız Google hesabından istifadə etdiyinizə əmin olun. Play Store sinxronizasiyası bir qədər vaxt apara bilər — yenidən başlatmağı, Google Play keşini təmizləməyi və ya sadəcə gözləməyi sınayın.</string>
-    <string name="upgrade_restore_action">Alışı bərpa et</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s əldə edin</string>
     <string name="upgrade_preamble">CAPod tək bir şəxs tərəfindən hazırlanır. Yüksəltmə əlavə funksiyaların kilidini açır və tətbiqin yaşamasına kömək edir.</string>
-    <string name="upgrade_screen_options_description">Eyni funksiyalar, fərqli qiymətləndirmə. Abunəliyə pulsuz sınaq müddəti daxildir və istənilən vaxt ləğv edilə bilər.</string>
-    <string name="upgrade_screen_options_description_no_trial">Eyni funksiyalar, fərqli qiymətləndirmə. Abunəlik istənilən vaxt ləğv edilə bilər.</string>
     <string name="upgrade_screen_subscription_trial_action">Pulsuz sınağı başlat</string>
     <string name="upgrade_screen_subscription_action">İllik abunə ol</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/il</string>
     <string name="upgrade_screen_iap_action">Bir dəfə satın al</string>
-    <string name="upgrade_screen_iap_action_hint">Birdəfəlik satınalma: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Alışı bərpa et</string>
-    <string name="upgrade_screen_restore_purchase_message">Heç bir satın alma tapılmadı. Doğru hesabı istifadə edirsiniz?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Yaxınlarda satın almısınızsa, Google Play-in sinxronlaşması bir qədər vaxt apara bilər.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Satınalmanız görünmürsə, bir neçə dəqiqədən sonra yenidən cəhd edin.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Satınalma üçün istifadə edilən eyni Google hesabı ilə daxil olduğunuzdan əmin olun.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Birdən çox hesab Google Play-i çaşdıra bilər. Tətbiqi Google Play saytı vasitəsilə quraşdırmaq müəyyən bir hesabla əlaqələndirməyi məcburi edir.</string>
     <string name="upgrade_screen_restore_banner_title">Artıq Pro almısınız?</string>
     <string name="upgrade_screen_restore_banner_body">Görünür ki, bu cihazda əvvəllər Pro-ya yüksəltmisiniz. Onu yenidən kiliddan çıxarmaq üçün satınalmanızı bərpa edin.</string>
     <string name="upgrade_screen_restore_success_message">Satınalma bərpa edildi.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Sizdə CAPod Pro var!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abunəliyiniz vasitəsilə kiliddan çıxarıldı. CAPod-u dəstəklədiyiniz üçün təşəkkürlər!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Birdəfəlik satınalmanız vasitəsilə kiliddan çıxarıldı. CAPod-u dəstəklədiyiniz üçün təşəkkürlər!</string>
-    <string name="upgrade_screen_owned_sub_title">İllik abunə</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Abunəliyiniz aktivdir və yenilənməyə təyin edilib. Ödəniş Google Play tərəfindən idarə olunur.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Abunəliyiniz aktivdir, lakin yenilənməyə təyin edilməyib. Pro cari dövr bitənə qədər əlçatan qalır.</string>
     <string name="upgrade_screen_owned_iap_title">Birdəfəlik alış</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Службы Google Play недаступныя.</string>
-    <string name="upgrades_no_purchases_found_check_account">Пакупак не знойдзена. Вы выкарыстоўваеце правільны ўліковы запіс?</string>
     <string name="upgrades_gplay_billing_error_label">Памылка Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Адбылася памылка ў Google Play. Калі ласка, паспрабуйце пазней або перазагрузіце тэлефон.\n\nПамылка: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Памылка выстаўлення рахункаў Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Адбылася памылка пры запыце дэталяў пакупкі ў Google Play. Ачысціце кэш Google Play і перазагрузіце тэлефон.\n\nПамылка %s</string>
     <string name="upgrades_gplay_already_owned_label">Ужо купілі?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play паведамляе, што вы ўжо валодаеце гэтым абнаўленнем, але яго не ўдалося аднавіць. Пераканайцеся, што вы выкарыстоўваеце той акаунт Google, з якім рабілі пакупку. Сінхранізацыя Play Store можа заняць час — паспрабуйце перазагрузіць прыладу, ачысціць кэш Google Play або проста пачакаць.</string>
-    <string name="upgrade_restore_action">Аднавіць пакупку</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Атрымаць %1$s</string>
     <string name="upgrade_preamble">CAPod распрацоўвае адзін чалавек. Абнаўленне да Pro адкрывае дадатковыя функцыі і дапамагае падтрымліваць праграму жывой.</string>
-    <string name="upgrade_screen_options_description">Тыя ж функцыі, розныя цэны. Падпіска ўключае бясплатны пробны перыяд і можа быць скасавана ў любы момант.</string>
-    <string name="upgrade_screen_options_description_no_trial">Тыя ж функцыі, розныя цэны. Падпіску можна скасаваць у любы момант.</string>
     <string name="upgrade_screen_subscription_trial_action">Пачаць бясплатны пробны перыяд</string>
     <string name="upgrade_screen_subscription_action">Падпісацца на год</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/год</string>
     <string name="upgrade_screen_iap_action">Купіць адзін раз</string>
-    <string name="upgrade_screen_iap_action_hint">Аднаразовая пакупка: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Аднавіць пакупку</string>
-    <string name="upgrade_screen_restore_purchase_message">Пакупак не знойдзена. Вы выкарыстоўваеце правільны ўліковы запіс?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Калі вы нядаўна зрабілі пакупку, Google Play можа спатрэбіцца час на сінхранізацыю.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Паспрабуйце яшчэ раз праз некалькі хвілін, калі ваша пакупка не з\'явілася.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Пераканайцеся, што вы ўвайшлі ў той жа акаунт Google, які выкарыстоўваўся для пакупкі.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Некалькі акаунтаў могуць заблытаць Google Play. Усталяванне праграмы праз сайт Google Play прымусова прывязвае яе да канкрэтнага акаунта.</string>
     <string name="upgrade_screen_restore_banner_title">Ужо купілі Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Падобна, што вы раней абнаўляліся да Pro на гэтай прыладзе. Аднавіце пакупку, каб зноў яе разблакаваць.</string>
     <string name="upgrade_screen_restore_success_message">Пакупка адноўлена.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">У вас ёсць CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Разблакавана вашай падпіскай. Дзякуй за падтрымку CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Разблакавана вашай аднаразовай пакупкай. Дзякуй за падтрымку CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Гадавая падпіска</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша падпіска актыўная і будзе аўтаматычна прадоўжана. Аплатай кіруе Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша падпіска актыўная, але не будзе аўтаматычна прадоўжана. Pro застанецца даступным да канца бягучага перыяду.</string>
     <string name="upgrade_screen_owned_iap_title">Аднаразовая пакупка</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Услугите на Google Play не са налични.</string>
-    <string name="upgrades_no_purchases_found_check_account">Няма намерени покупки. Правилния акаунт ли използвате?</string>
     <string name="upgrades_gplay_billing_error_label">Грешка в Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Възникна грешка в Google Play. Моля, опитайте отново по-късно или рестартирайте телефона си.\n\nГрешка: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Грешка при фактуриране в Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Възникна грешка при заявката за данни за покупката ви от Google Play. Изчистете кеша на Google Play и рестартирайте телефона си.\n\nГрешка %s</string>
     <string name="upgrades_gplay_already_owned_label">Вече сте закупили?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play съобщава, че вече притежавате тази надстройка, но тя не можа да бъде възстановена. Уверете се, че използвате акаунта в Google, с който сте направили покупката. Синхронизирането с Play Store може да отнеме време — опитайте да рестартирате устройството, да изчистите кеша на Google Play или просто изчакайте.</string>
-    <string name="upgrade_restore_action">Възстановете покупката</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Получете %1$s</string>
     <string name="upgrade_preamble">CAPod се разработва от един-единствен човек. Надстройката отключва допълнителни функции и помага приложението да продължи да съществува.</string>
-    <string name="upgrade_screen_options_description">Едни и същи функции, различно ценообразуване. Абонаментът включва безплатен пробен период и може да бъде отказан по всяко време.</string>
-    <string name="upgrade_screen_options_description_no_trial">Едни и същи функции, различно ценообразуване. Абонаментът може да бъде отказан по всяко време.</string>
     <string name="upgrade_screen_subscription_trial_action">Стартирай безплатен пробен период</string>
     <string name="upgrade_screen_subscription_action">Абонирай се годишно</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/година</string>
     <string name="upgrade_screen_iap_action">Купи еднократно</string>
-    <string name="upgrade_screen_iap_action_hint">Еднократна покупка: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Възстановете покупката</string>
-    <string name="upgrade_screen_restore_purchase_message">Няма намерени покупки. Правилния акаунт ли използвате?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ако наскоро сте направили покупка, може да отнеме известно време на Google Play да се синхронизира.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Опитайте отново след няколко минути, ако покупката ви не се появи.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Уверете се, че сте влезли със същия акаунт в Google, използван за покупката.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Няколко акаунта могат да объркат Google Play. Инсталирането на приложението през уебсайта на Google Play налага асоциирането с конкретен акаунт.</string>
     <string name="upgrade_screen_restore_banner_title">Вече сте закупили Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Изглежда, че преди сте надстроили до Pro на това устройство. Възстановете покупката си, за да го отключите отново.</string>
     <string name="upgrade_screen_restore_success_message">Покупката е възстановена.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Имате CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Отключено благодарение на вашия абонамент. Благодарим ви, че подкрепяте CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Отключено благодарение на еднократната ви покупка. Благодарим ви, че подкрепяте CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Годишен абонамент</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Абонаментът ви е активен и е настроен да се подновява. Таксуването се управлява от Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Абонаментът ви е активен, но не е настроен да се подновява. Pro остава достъпен до края на текущия период.</string>
     <string name="upgrade_screen_owned_iap_title">Еднократна покупка</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play পরিষেবাগুলি উপলব্ধ নেই৷</string>
-    <string name="upgrades_no_purchases_found_check_account">কোনও কেনাকাটা খুঁজে পাওয়া যায়নি। আপনি কি সঠিক অ্যাকাউন্ট ব্যবহার করছেন?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play ত্রুটি</string>
     <string name="upgrades_gplay_billing_error_description">Google Play-তে একটি ত্রুটি হয়েছে। অনুগ্রহ করে পরে আবার চেষ্টা করুন অথবা আপনার ফোন রিবুট করুন।\n\nত্রুটি: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play বিলিং ত্রুটি</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play-তে আপনার কেনাকাটার বিবরণ জানতে চাইলে একটি ত্রুটি হয়েছে। Google Play ক্যাশে সাফ করুন এবং আপনার ফোন রিবুট করুন।\n\nত্রুটি %s</string>
     <string name="upgrades_gplay_already_owned_label">ইতিমধ্যে কেনা হয়ে গেছে?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play রিপোর্ট করছে যে আপনি ইতিমধ্যে এই আপগ্রেডের মালিক, কিন্তু এটি পুনরুদ্ধার করা যায়নি। আপনি যে Google অ্যাকাউন্ট দিয়ে কিনেছিলেন সেটিই ব্যবহার করছেন কিনা তা নিশ্চিত করুন। Play Store সিঙ্ক্রোনাইজেশনে সময় লাগতে পারে — রিবুট করা, Google Play ক্যাশে সাফ করা বা কিছুক্ষণ অপেক্ষা করার চেষ্টা করুন।</string>
-    <string name="upgrade_restore_action">ক্রয় পুনরুদ্ধার</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s পান</string>
     <string name="upgrade_preamble">CAPod একজন মাত্র ব্যক্তি দ্বারা তৈরি। আপগ্রেড করলে অতিরিক্ত ফিচার আনলক হয় এবং অ্যাপটি সচল রাখতে সাহায্য করে।</string>
-    <string name="upgrade_screen_options_description">একই ফিচার, ভিন্ন মূল্য। সাবস্ক্রিপশনে একটি বিনামূল্যে ট্রায়াল রয়েছে এবং যেকোনো সময় বাতিল করা যায়।</string>
-    <string name="upgrade_screen_options_description_no_trial">একই ফিচার, ভিন্ন মূল্য। সাবস্ক্রিপশন যেকোনো সময় বাতিল করা যায়।</string>
     <string name="upgrade_screen_subscription_trial_action">বিনামূল্যের ট্রায়াল শুরু করুন</string>
     <string name="upgrade_screen_subscription_action">বার্ষিক সাবস্ক্রাইব করুন</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/বছর</string>
     <string name="upgrade_screen_iap_action">একবার ক্রয় করুন</string>
-    <string name="upgrade_screen_iap_action_hint">এককালীন ক্রয়: %s</string>
     <string name="upgrade_screen_restore_purchase_action">ক্রয় পুনরুদ্ধার</string>
-    <string name="upgrade_screen_restore_purchase_message">কোনও কেনাকাটা খুঁজে পাওয়া যায়নি। আপনি কি সঠিক অ্যাকাউন্ট ব্যবহার করছেন?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">আপনি যদি সম্প্রতি কিনে থাকেন, তাহলে Google Play সিঙ্ক করতে কিছুটা সময় নিতে পারে।</string>
     <string name="upgrade_screen_restore_sync_patience_hint">আপনার কেনাকাটা দেখা না গেলে কয়েক মিনিট পর আবার চেষ্টা করুন।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">কেনাকাটার জন্য ব্যবহৃত একই Google অ্যাকাউন্ট দিয়ে সাইন ইন করা আছে কিনা তা নিশ্চিত করুন।</string>
-    <string name="upgrade_screen_restore_webinstall_hint">একাধিক অ্যাকাউন্ট Google Play কে বিভ্রান্ত করতে পারে। Google Play ওয়েবসাইটের মাধ্যমে অ্যাপটি ইনস্টল করলে তা একটি নির্দিষ্ট অ্যাকাউন্টের সাথে যুক্ত হতে বাধ্য করে।</string>
     <string name="upgrade_screen_restore_banner_title">ইতিমধ্যে Pro কিনেছেন?</string>
     <string name="upgrade_screen_restore_banner_body">মনে হচ্ছে আপনি আগে এই ডিভাইসে Pro-তে আপগ্রেড করেছিলেন। এটি পুনরায় আনলক করতে আপনার কেনাকাটা পুনরুদ্ধার করুন।</string>
     <string name="upgrade_screen_restore_success_message">কেনাকাটা পুনরুদ্ধার করা হয়েছে।</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">আপনার কাছে CAPod Pro আছে!</string>
     <string name="upgrade_screen_owned_hero_sub_body">আপনার সাবস্ক্রিপশন দ্বারা আনলক করা হয়েছে। CAPod-কে সমর্থন করার জন্য ধন্যবাদ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">আপনার এককালীন ক্রয় দ্বারা আনলক করা হয়েছে। CAPod-কে সমর্থন করার জন্য ধন্যবাদ!</string>
-    <string name="upgrade_screen_owned_sub_title">বার্ষিক সাবস্ক্রিপশন</string>
     <string name="upgrade_screen_owned_sub_renewing_body">আপনার সাবস্ক্রিপশন সক্রিয় এবং নবায়ন হওয়ার জন্য সেট করা আছে। বিলিং Google Play দ্বারা পরিচালিত হয়।</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">আপনার সাবস্ক্রিপশন সক্রিয়, কিন্তু নবায়ন হওয়ার জন্য সেট করা নেই। বর্তমান মেয়াদ শেষ না হওয়া পর্যন্ত Pro উপলব্ধ থাকবে।</string>
     <string name="upgrade_screen_owned_iap_title">এককালীন ক্রয়</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Els serveis de Google Play no estan disponibles.</string>
-    <string name="upgrades_no_purchases_found_check_account">No s\'ha trobat cap compra. Esteu utilitzant el compte correcte?</string>
     <string name="upgrades_gplay_billing_error_label">Error del Google Play</string>
     <string name="upgrades_gplay_billing_error_description">S\'ha produït un error al Google Play. Torneu-ho a provar més tard o reinicieu el telèfon.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Error de facturació del Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">S\'ha produït un error en demanar al Google Play els detalls de la vostra compra. Netegeu la memòria cau del Google Play i reinicieu el telèfon.\n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">Ja ho heu comprat?</string>
     <string name="upgrades_gplay_already_owned_description">El Google Play informa que ja teniu aquesta actualització, però no s\'ha pogut restaurar. Assegureu-vos que feu servir el compte de Google amb què vau comprar-la. La sincronització del Play Store pot trigar una mica: proveu de reiniciar, esborreu la memòria cau del Google Play o simplement espereu.</string>
-    <string name="upgrade_restore_action">Restaura la compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtingueu %1$s</string>
     <string name="upgrade_preamble">El CAPod està desenvolupat per una sola persona. La millora desbloqueja funcions addicionals i ajuda a mantenir l\'aplicació activa.</string>
-    <string name="upgrade_screen_options_description">Les mateixes funcions, preus diferents. La subscripció inclou una prova gratuïta i es pot cancel·lar en qualsevol moment.</string>
-    <string name="upgrade_screen_options_description_no_trial">Les mateixes funcions, preus diferents. La subscripció es pot cancel·lar en qualsevol moment.</string>
     <string name="upgrade_screen_subscription_trial_action">Inicia la prova gratuïta</string>
     <string name="upgrade_screen_subscription_action">Subscripció anual</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/any</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaura la compra</string>
-    <string name="upgrade_screen_restore_purchase_message">No s\'ha trobat cap compra. Esteu utilitzant el compte correcte?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Si heu comprat alguna cosa recentment, és possible que el Google Play trigui una estona a sincronitzar-se.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Torneu-ho a provar en uns minuts si la vostra compra no apareix.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Assegureu-vos d\'haver iniciat la sessió amb el mateix compte de Google que heu utilitzat per a la compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Tenir diversos comptes pot generar confusió al Google Play. La instal·lació de l\'aplicació a través del lloc web del Google Play obliga a associar-lo amb un compte específic.</string>
     <string name="upgrade_screen_restore_banner_title">Ja heu comprat Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Sembla que ja vau actualitzar al Pro en aquest dispositiu abans. Restaureu la vostra compra per tornar-la a desbloquejar.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Teniu el CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloquejat per la vostra subscripció. Gràcies per donar suport al CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloquejat per la vostra compra única. Gràcies per donar suport al CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Subscripció anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">La vostra subscripció està activa i configurada per renovar-se. La facturació la gestiona el Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">La vostra subscripció està activa, però no configurada per renovar-se. El Pro seguirà disponible fins que acabi el període actual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Služby Google Play nejsou k dispozici.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>
     <string name="upgrades_gplay_billing_error_label">Chyba Google Play</string>
     <string name="upgrades_gplay_billing_error_description">V Google Play došlo k chybě. Zkuste to prosím znovu později nebo restartujte telefon.\n\nChyba: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Chyba fakturacie Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Při dotazování Google Play na podrobnosti o nákupu došlo k chybě. Smažte mezipaměť Google Play a restartujte telefon.\n\nChyba %s</string>
     <string name="upgrades_gplay_already_owned_label">Již zakoupeno?</string>
     <string name="upgrades_gplay_already_owned_description">Služba Google Play hlásí, že tento upgrade již vlastníte, ale nepodařilo se ho obnovit. Ujistěte se, že používáte účet Google, se kterým jste nákup provedli. Synchronizace Obchodu Play může nějakou dobu trvat — zkuste restartovat zařízení, vymazat mezipaměť Obchodu Google Play nebo prostě počkat.</string>
-    <string name="upgrade_restore_action">Obnovit nákup</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Získat %1$s</string>
     <string name="upgrade_preamble">CAPod vyvíjí jediná osoba. Upgrade odemkne další funkce a pomůže udržet aplikaci naživu.</string>
-    <string name="upgrade_screen_options_description">Stejné funkce, různé ceny. Předplatné zahrnuje bezplatnou zkušební dobu a lze jej kdykoli zrušit.</string>
-    <string name="upgrade_screen_options_description_no_trial">Stejné funkce, jiná cena. Předplatné lze kdykoli zrušit.</string>
     <string name="upgrade_screen_subscription_trial_action">Spustit zkušební verzi</string>
     <string name="upgrade_screen_subscription_action">Předplatit na rok</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/rok</string>
     <string name="upgrade_screen_iap_action">Koupit jednou</string>
-    <string name="upgrade_screen_iap_action_hint">Jednorázový nákup: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovit nákup</string>
-    <string name="upgrade_screen_restore_purchase_message">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Pokud jste produkt zakoupili nedávno, synchronizace Google Play může chvíli trvat.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Pokud se váš nákup nezobrazí, zkuste to znovu za několik minut.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ujistěte se, že jste přihlášeni ke stejnému účtu Google, který jste použili při nákupu.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Více účtů může zmást Google Play. Instalace aplikace přes web Obchodu Google Play vynutí přiřazení ke konkrétnímu účtu.</string>
     <string name="upgrade_screen_restore_banner_title">Už jste si koupili Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Vypadá to, že jste na tomto zařízení už dříve upgradovali na Pro. Obnovte svůj nákup a odemkněte ho znovu.</string>
     <string name="upgrade_screen_restore_success_message">Nákup obnoven.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Máte CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Odemčeno vaším předplatným. Děkujeme za podporu CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Odemčeno vaším jednorázovým nákupem. Děkujeme za podporu CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Roční předplatné</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaše předplatné je aktivní a nastavené na obnovování. Fakturaci spravuje Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše předplatné je aktivní, ale není nastaveno na obnovování. Pro zůstane dostupné až do konce aktuálního období.</string>
     <string name="upgrade_screen_owned_iap_title">Jednorázový nákup</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-tjenester er ikke tilgængelige.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-fejl</string>
     <string name="upgrades_gplay_billing_error_description">Der opstod en fejl i Google Play. Prøv venligst igen senere, eller genstart din telefon.\n\nFejl: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play-faktureringsfejl</string>
-    <string name="upgrades_gplay_billing_result_error_description">Der opstod en fejl under forespørgsel af dine købsoplysninger fra Google Play. Ryd Google Play-cachen, og genstart din telefon.\n\nFejl %s</string>
     <string name="upgrades_gplay_already_owned_label">Allerede købt?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterer, at du allerede ejer denne opgradering, men den kunne ikke gendannes. Sørg for, at du bruger den Google-konto, du købte med. Synkronisering med Play Store kan tage tid — prøv at genstarte, ryd Google Play-cachen, eller vent blot.</string>
-    <string name="upgrade_restore_action">Gendan køb</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Få %1$s</string>
     <string name="upgrade_preamble">CAPod udvikles af én person. En opgradering låser ekstra funktioner op og hjælper med at holde appen i live.</string>
-    <string name="upgrade_screen_options_description">Samme funktioner, forskellig prisfastsættelse. Abonnementet inkluderer en gratis prøveperiode og kan opsiges når som helst.</string>
-    <string name="upgrade_screen_options_description_no_trial">Samme funktioner, forskellig prisfastsættelse. Abonnementet kan opsiges når som helst.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner årligt</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/år</string>
     <string name="upgrade_screen_iap_action">Køb én gang</string>
-    <string name="upgrade_screen_iap_action_hint">Engangskøb: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Gendan køb</string>
-    <string name="upgrade_screen_restore_purchase_message">Ingen køb fundet. Bruger du den rigtige konto?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Hvis du for nylig har foretaget et køb, kan det tage et øjeblik, før Google Play synkroniserer.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Prøv igen om et par minutter, hvis dit køb ikke vises.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Sørg for, at du er logget ind med den samme Google-konto, som blev brugt til købet.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Flere konti kan forvirre Google Play. Installation af appen via Google Play-webstedet gennemtvinger tilknytningen til en bestemt konto.</string>
     <string name="upgrade_screen_restore_banner_title">Allerede købt Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Det ser ud til, at du tidligere har opgraderet til Pro på denne enhed. Gendan dit køb for at låse det op igen.</string>
     <string name="upgrade_screen_restore_success_message">Køb gendannet.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Du har CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Låst op af dit abonnement. Tak fordi du støtter CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Låst op af dit engangskøb. Tak fordi du støtter CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Årligt abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Dit abonnement er aktivt og indstillet til at blive fornyet. Fakturering håndteres af Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Dit abonnement er aktivt, men ikke indstillet til at blive fornyet. Pro forbliver tilgængeligt, indtil den nuværende periode udløber.</string>
     <string name="upgrade_screen_owned_iap_title">Engangskøb</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-Dienste sind nicht verfügbar.</string>
-    <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest Du das richtige Konto?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Fehler</string>
     <string name="upgrades_gplay_billing_error_description">Es gab einen Fehler in Google Play. Bitte versuche es später erneut oder starte Dein Telefon neu.\n\nFehler: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Abrechnungsfehler</string>
-    <string name="upgrades_gplay_billing_result_error_description">Es trat ein Fehler auf, als Google Play nach Kaufdetails gefragt wurde. Lösch deinen Google Play-Cache und starte dein Gerät neu.\n\nFehler %s</string>
     <string name="upgrades_gplay_already_owned_label">Bereits gekauft?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play meldet, dass du dieses Upgrade bereits besitzt, es konnte jedoch nicht wiederhergestellt werden. Stelle sicher, dass du das Google-Konto verwendest, mit dem du es gekauft hast. Die Synchronisierung des Play Stores kann etwas dauern – versuche dein Gerät neu zu starten, den Cache von Google Play zu leeren oder einfach abzuwarten.</string>
-    <string name="upgrade_restore_action">Auswahl wiederherstellen</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Hol dir %1$s</string>
     <string name="upgrade_preamble">CAPod wird von einer einzelnen Person entwickelt. Ein Upgrade schaltet zusätzliche Funktionen frei und hilft, die App am Leben zu erhalten.</string>
-    <string name="upgrade_screen_options_description">Gleiche Funktionen, unterschiedliche Preise. Das Abonnement enthält eine kostenlose Testphase und kann jederzeit gekündigt werden.</string>
-    <string name="upgrade_screen_options_description_no_trial">Gleiche Funktionen, unterschiedliche Preise. Das Abonnement kann jederzeit gekündigt werden.</string>
     <string name="upgrade_screen_subscription_trial_action">Kostenlos testen</string>
     <string name="upgrade_screen_subscription_action">Jährlich abonnieren</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/Jahr</string>
     <string name="upgrade_screen_iap_action">Einmalig kaufen</string>
-    <string name="upgrade_screen_iap_action_hint">Einmaliger Kauf: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Kauf wiederherstellen</string>
-    <string name="upgrade_screen_restore_purchase_message">Keine Käufe gefunden. Verwendest Du das richtige Konto?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Wenn du kürzlich gekauft hast, kann es einen Moment dauern, bis Google Play synchronisiert.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Versuche es in wenigen Minuten erneut, falls dein Kauf nicht erscheint.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Stelle sicher, dass du mit demselben Google-Konto angemeldet bist, das für den Kauf verwendet wurde.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Mehrere Konten können Google Play durcheinanderbringen. Die Installation der App über die Google Play-Website erzwingt die Zuordnung zu einem bestimmten Konto.</string>
     <string name="upgrade_screen_restore_banner_title">Pro bereits gekauft?</string>
     <string name="upgrade_screen_restore_banner_body">Es sieht so aus, als hättest du auf diesem Gerät bereits ein Upgrade auf Pro erworben. Stell deinen Kauf wieder her, um es erneut freizuschalten.</string>
     <string name="upgrade_screen_restore_success_message">Kauf wiederhergestellt.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Du hast CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Freigeschaltet durch dein Abonnement. Danke, dass du CAPod unterstützt!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Freigeschaltet durch deinen einmaligen Kauf. Danke, dass du CAPod unterstützt!</string>
-    <string name="upgrade_screen_owned_sub_title">Jährliches Abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Dein Abonnement ist aktiv und wird verlängert. Die Abrechnung erfolgt über Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Dein Abonnement ist aktiv, wird aber nicht verlängert. Pro bleibt bis zum Ende des aktuellen Zeitraums verfügbar.</string>
     <string name="upgrade_screen_owned_iap_title">Einmaliger Kauf</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Οι υπηρεσίες Google Play δεν είναι διαθέσιμες.</string>
-    <string name="upgrades_no_purchases_found_check_account">Δε βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>
     <string name="upgrades_gplay_billing_error_label">Σφάλμα Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Παρουσιάστηκε σφάλμα στο Google Play. Παρακαλώ προσπαθήστε ξανά αργότερα ή επανεκκινήστε το τηλέφωνό σας.\n\nΣφάλμα: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Σφάλμα χρέωσης Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Παρουσιάστηκε σφάλμα κατά την αίτηση των στοιχείων αγοράς σας από το Google Play. Εκκαθαρίστε την προσωρινή μνήμη του Google Play και επανεκκινήστε το τηλέφωνό σας.\n\nΣφάλμα %s</string>
     <string name="upgrades_gplay_already_owned_label">Ήδη αγορασμένο?</string>
     <string name="upgrades_gplay_already_owned_description">Το Google Play αναφέρει ότι έχετε ήδη αυτήν την αναβάθμιση, αλλά δεν ήταν δυνατή η επαναφορά της. Βεβαιωθείτε ότι χρησιμοποιείτε τον λογαριασμό Google με τον οποίο κάνατε την αγορά. Ο συγχρονισμός του Play Store ενδέχεται να χρειαστεί χρόνο — δοκιμάστε να επανεκκινήσετε, να διαγράψετε την κρυφή μνήμη του Google Play ή απλώς να περιμένετε.</string>
-    <string name="upgrade_restore_action">Επαναφορά αγοράς</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Αποκτήστε %1$s</string>
     <string name="upgrade_preamble">Το CAPod αναπτύσσεται από ένα μόνο άτομο. Η αναβάθμιση ξεκλειδώνει επιπλέον λειτουργίες και βοηθά να διατηρείται η εφαρμογή ζωντανή.</string>
-    <string name="upgrade_screen_options_description">Ίδιες λειτουργίες, διαφορετική τιμολόγηση. Η συνδρομή περιλαμβάνει δωρεάν δοκιμή και μπορεί να ακυρωθεί ανά πάσα στιγμή.</string>
-    <string name="upgrade_screen_options_description_no_trial">Ίδιες λειτουργίες, διαφορετική τιμολόγηση. Η συνδρομή μπορεί να ακυρωθεί ανά πάσα στιγμή.</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής</string>
     <string name="upgrade_screen_subscription_action">Ετήσια συνδρομή</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/έτος</string>
     <string name="upgrade_screen_iap_action">Αγορά εφάπαξ</string>
-    <string name="upgrade_screen_iap_action_hint">Εφάπαξ αγορά: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Επαναφορά αγοράς</string>
-    <string name="upgrade_screen_restore_purchase_message">Δε βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Αν κάνατε πρόσφατα την αγορά, ενδέχεται να χρειαστεί λίγος χρόνος για να συγχρονιστεί το Google Play.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Δοκιμάστε ξανά σε λίγα λεπτά αν η αγορά σας δεν εμφανίζεται.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Βεβαιωθείτε ότι έχετε συνδεθεί με τον ίδιο λογαριασμό Google που χρησιμοποιήσατε για την αγορά.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Πολλαπλοί λογαριασμοί μπορεί να μπερδέψουν το Google Play. Η εγκατάσταση της εφαρμογής μέσω του ιστοτόπου Google Play επιβάλλει τη συσχέτιση με έναν συγκεκριμένο λογαριασμό.</string>
     <string name="upgrade_screen_restore_banner_title">Έχετε ήδη αγοράσει το Pro;</string>
     <string name="upgrade_screen_restore_banner_body">Φαίνεται ότι έχετε αναβαθμίσει σε Pro σε αυτήν τη συσκευή στο παρελθόν. Επαναφέρετε την αγορά σας για να το ξεκλειδώσετε ξανά.</string>
     <string name="upgrade_screen_restore_success_message">Η αγορά επαναφέρθηκε.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Έχετε το CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ξεκλειδώθηκε από τη συνδρομή σας. Ευχαριστούμε που υποστηρίζετε το CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ξεκλειδώθηκε από την εφάπαξ αγορά σας. Ευχαριστούμε που υποστηρίζετε το CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Ετήσια συνδρομή</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Η συνδρομή σας είναι ενεργή και έχει οριστεί να ανανεωθεί. Η χρέωση διαχειρίζεται από το Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Η συνδρομή σας είναι ενεργή, αλλά δεν έχει οριστεί να ανανεωθεί. Το Pro παραμένει διαθέσιμο μέχρι να λήξει η τρέχουσα περίοδος.</string>
     <string name="upgrade_screen_owned_iap_title">Εφάπαξ αγορά</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Los servicios de Google Play no están disponibles.</string>
-    <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Está usando la cuenta correcta?</string>
     <string name="upgrades_gplay_billing_error_label">Error en la Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Se ha producido un error en la Google Play. Vuelve a intentarlo más tarde o reinicia tu teléfono.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Error en el cobro en la Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Se ha producido un error al solicitar a Google Play los detalles de tu compra. Borra la caché de Google Play y reinicia tu teléfono.\n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">¿Ya lo compraste?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play informa que ya tenés esta mejora, pero no se pudo restaurar. Asegurate de usar la cuenta de Google con la que la compraste. La sincronización de Play Store puede demorar — probá reiniciar, borrar la caché de Google Play o simplemente esperar.</string>
-    <string name="upgrade_restore_action">Restaurar la compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtener %1$s</string>
     <string name="upgrade_preamble">CAPod es desarrollado por una sola persona. Actualizar desbloquea funciones adicionales y ayuda a mantener viva la app.</string>
-    <string name="upgrade_screen_options_description">Las mismas funciones, distintos precios. La suscripción incluye una prueba gratuita y se puede cancelar en cualquier momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">Las mismas funciones, distintos precios. La suscripción se puede cancelar en cualquier momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Empezá la prueba gratuita</string>
     <string name="upgrade_screen_subscription_action">Suscribite por año</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/año</string>
     <string name="upgrade_screen_iap_action">Comprá una vez</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar la compra</string>
-    <string name="upgrade_screen_restore_purchase_message">No se encontraron compras. ¿Está usando la cuenta correcta?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Si compraste recientemente, es posible que Google Play tarde un momento en sincronizar.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Probá de nuevo en unos minutos si tu compra no aparece.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Asegurate de haber iniciado sesión con la misma cuenta de Google que usaste para la compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Varias cuentas pueden confundir a Google Play. Instalar la app a través del sitio web de Google Play fuerza la asociación con una cuenta específica.</string>
     <string name="upgrade_screen_restore_banner_title">¿Ya compraste Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste a Pro en este dispositivo antes. Restaurá tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">¡Tenés CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloqueado por tu suscripción. ¡Gracias por apoyar a CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloqueado por tu compra única. ¡Gracias por apoyar a CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Suscripción anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción está activa y configurada para renovarse. La facturación la gestiona Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción está activa, pero no configurada para renovarse. Pro sigue disponible hasta que termine el período actual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Los servicios de Google Play no están disponibles.</string>
-    <string name="upgrades_no_purchases_found_check_account">No se han encontrado compras. ¿Estás usando la cuenta correcta?</string>
     <string name="upgrades_gplay_billing_error_label">Error en la Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Se ha producido un error en la Google Play. Vuelve a intentarlo más tarde o reinicia tu teléfono.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Error en el cobro en la Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Se ha producido un error al solicitar a Google Play los detalles de tu compra. Borra la caché de Google Play y reinicia tu teléfono.\n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">¿Ya lo compraste?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play indica que ya tienes esta actualización, pero no se pudo restaurar. Asegúrate de estar usando la cuenta de Google con la que la compraste. La sincronización de Play Store puede tardar: intenta reiniciar, borrar la caché de Google Play o simplemente esperar.</string>
-    <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtener %1$s</string>
     <string name="upgrade_preamble">CAPod es desarrollado por una sola persona. Actualizar desbloquea funciones adicionales y ayuda a mantener viva la aplicación.</string>
-    <string name="upgrade_screen_options_description">Las mismas funciones, con precios diferentes. La suscripción incluye una prueba gratuita y se puede cancelar en cualquier momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">Las mismas funciones, con precios diferentes. La suscripción se puede cancelar en cualquier momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar prueba gratuita</string>
     <string name="upgrade_screen_subscription_action">Suscríbete anualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s al año</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
-    <string name="upgrade_screen_restore_purchase_message">No se han encontrado compras. ¿Estás usando la cuenta correcta?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Si compraste recientemente, Google Play puede tardar un momento en sincronizar.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Inténtalo de nuevo en unos minutos si tu compra no aparece.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Asegúrate de haber iniciado sesión con la misma cuenta de Google que usaste para la compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Varias cuentas pueden confundir a Google Play. Instalar la aplicación a través del sitio web de Google Play fuerza la asociación con una cuenta específica.</string>
     <string name="upgrade_screen_restore_banner_title">¿Ya compraste Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste a Pro en este dispositivo anteriormente. Restaura tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">¡Tienes CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloqueado por tu suscripción. ¡Gracias por apoyar a CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloqueado por tu compra única. ¡Gracias por apoyar a CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Suscripción anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción está activa y configurada para renovarse. La facturación la administra Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción está activa, pero no configurada para renovarse. Pro seguirá disponible hasta que termine el período actual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Los servicios de Google Play no están disponibles.</string>
-    <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Está usando la cuenta correcta?</string>
     <string name="upgrades_gplay_billing_error_label">Error en la Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Se ha producido un error en la Google Play. Vuelve a intentarlo más tarde o reinicia tu teléfono.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Error en el cobro en la Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Se ha producido un error al solicitar a Google Play los detalles de tu compra. Borra la caché de Google Play y reinicia tu teléfono.\n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">¿Ya lo compraste?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play indica que ya tienes esta mejora, pero no se pudo restaurar. Asegúrate de usar la cuenta de Google con la que la compraste. La sincronización de Play Store puede tardar: prueba a reiniciar, borrar la caché de Google Play o simplemente esperar.</string>
-    <string name="upgrade_restore_action">Restaurar la compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtén %1$s</string>
     <string name="upgrade_preamble">CAPod lo desarrolla una sola persona. Mejorar a Pro desbloquea funciones adicionales y ayuda a mantener la aplicación viva.</string>
-    <string name="upgrade_screen_options_description">Las mismas funciones, precios diferentes. La suscripción incluye una prueba gratuita y se puede cancelar en cualquier momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">Las mismas funciones, precios diferentes. La suscripción se puede cancelar en cualquier momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar el período de prueba gratuita</string>
     <string name="upgrade_screen_subscription_action">Suscríbete anualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/año</string>
     <string name="upgrade_screen_iap_action">Comprar una vez</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar la compra</string>
-    <string name="upgrade_screen_restore_purchase_message">No se encontraron compras. ¿Está usando la cuenta correcta?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Si has comprado recientemente, es posible que Google Play tarde un momento en sincronizarse.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Inténtalo de nuevo en unos minutos si tu compra no aparece.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Asegúrate de haber iniciado sesión con la misma cuenta de Google que usaste para la compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Varias cuentas pueden confundir a Google Play. Instalar la aplicación a través del sitio web de Google Play obliga la asociación con una cuenta específica.</string>
     <string name="upgrade_screen_restore_banner_title">¿Ya compraste Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parece que ya mejoraste a Pro en este dispositivo anteriormente. Restaura tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">¡Tienes CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloqueado por tu suscripción. ¡Gracias por apoyar a CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloqueado por tu compra única. ¡Gracias por apoyar a CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Suscripción anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción está activa y configurada para renovarse. Google Play gestiona la facturación.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción está activa, pero no está configurada para renovarse. Pro seguirá disponible hasta que finalice el periodo actual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play teenused pole saadaval.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ühtki ostu ei leitud. Kasutate õiget kontot?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play viga</string>
     <string name="upgrades_gplay_billing_error_description">Google Play viga. Üritage hiljem uuesti või taaskäivitage oma telefon.\n\nViga: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play makse viga</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Playl ilmnes teie ostuandmete pärimisel viga. Tühjendage Google Play vahemälu ja taaskäivitage oma telefon.\n\nViga %s</string>
     <string name="upgrades_gplay_already_owned_label">Juba ostetud?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play andmetel on see uuendus sul juba olemas, kuid seda ei õnnestunud taastada. Veendu, et kasutad sama Google\'i kontot, millega ostu tegid. Play poe sünkroonimine võib aega võtta — proovi taaskäivitada, tühjendada Google Play vahemälu või lihtsalt oodata.</string>
-    <string name="upgrade_restore_action">Taasta ost</string>
     <string name="upgrade_badge_label">Tasuline</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Hangi %1$s</string>
     <string name="upgrade_preamble">CAPodi arendab üks inimene. Uuendamine avab lisavõimalused ja aitab rakendust arendada.</string>
-    <string name="upgrade_screen_options_description">Samad võimalused, erinev hind. Tellimus sisaldab tasuta katseaega ja selle saab igal ajal tühistada.</string>
-    <string name="upgrade_screen_options_description_no_trial">Samad võimalused, erinev hind. Tellimuse saab igal ajal tühistada.</string>
     <string name="upgrade_screen_subscription_trial_action">Proovi</string>
     <string name="upgrade_screen_subscription_action">Telli aastaks</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/aastas</string>
     <string name="upgrade_screen_iap_action">Osta korra</string>
-    <string name="upgrade_screen_iap_action_hint">Ühekordne ost: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Taasta ost</string>
-    <string name="upgrade_screen_restore_purchase_message">Ühtki ostu ei leitud. Kasutate õiget kontot?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Kui olete hiljuti ostnud, võib Google Playl kuluda ajakohastamiseks hetk.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Proovige mõne minuti pärast uuesti, kui teie ost ei ilmu.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Veenduge, et olete sisse logitud sama Google\'i kontoga, mida kasutasite ostu sooritamiseks.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Mitu kontot võivad Google Playd segadusse ajada. Rakenduse paigaldamine Google Play veebilehe kaudu sunnib seose kindla kontoga.</string>
     <string name="upgrade_screen_restore_banner_title">Oled juba Pro versiooni ostnud?</string>
     <string name="upgrade_screen_restore_banner_body">Tundub, et oled selles seadmes varem Pro versioonile uuendanud. Taasta oma ost, et see uuesti avada.</string>
     <string name="upgrade_screen_restore_success_message">Ost taastatud.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Sul on CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Avatud sinu tellimusega. Täname, et toetad CAPodi!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Avatud sinu ühekordse ostuga. Täname, et toetad CAPodi!</string>
-    <string name="upgrade_screen_owned_sub_title">Aastane tellimus</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Teie Pro tellimus on kasutatav ja seadistatud uuendamiseks. Google Play tegeleb arveldusega.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Teie tellimus on kasutatav, kuid pole seadistatud uuendamiseks. Pro on saadaval kuni praeguse perioodi lõpuni.</string>
     <string name="upgrade_screen_owned_iap_title">Ühekordne ost</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play zerbitzuak ez daude erabilgarri.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ez da erosketarik aurkitu. Kontu egokia erabiltzen ari zara?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play errorea</string>
     <string name="upgrades_gplay_billing_error_description">Errore bat gertatu da Google Play-n. Mesedez, saiatu berriro geroago edo berrabiarazi telefonoa.\n\nErrorea: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play fakturazio errorea</string>
-    <string name="upgrades_gplay_billing_result_error_description">Errore bat gertatu da Google Play-ri zure erosketa xehetasunak eskatzean. Garbitu Google Play-ren cachea eta berrabiarazi telefonoa.\n\nErrorea %s</string>
     <string name="upgrades_gplay_already_owned_label">Dagoeneko erosi duzu?</string>
     <string name="upgrades_gplay_already_owned_description">Google Playk dio dagoeneko eguneratze hau baduzula, baina ezin izan da leheneratu. Ziurtatu erosketa egiteko erabili zenuen Google kontua erabiltzen ari zarela. Play Storeren sinkronizazioak denbora har dezake — saiatu berrabiarazten, Google Play-ren katxea garbitzen edo, besterik gabe, itxaroten.</string>
-    <string name="upgrade_restore_action">Berreskuratu erosketa</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Lortu %1$s</string>
     <string name="upgrade_preamble">CAPod pertsona bakar batek garatzen du. Eguneratzeak eginbide gehigarriak desblokeatzen ditu eta aplikazioa bizirik mantentzen laguntzen du.</string>
-    <string name="upgrade_screen_options_description">Eginbide berdinak, prezio ezberdinak. Harpidetzak doako probaldi bat dakar eta edonoiz utz daiteke.</string>
-    <string name="upgrade_screen_options_description_no_trial">Eginbide berdinak, prezio ezberdinak. Harpidetza edonoiz utz daiteke.</string>
     <string name="upgrade_screen_subscription_trial_action">Hasi doako probaldia</string>
     <string name="upgrade_screen_subscription_action">Harpidetu urtero</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/urte</string>
     <string name="upgrade_screen_iap_action">Erosi behin</string>
-    <string name="upgrade_screen_iap_action_hint">Erosketa bakarra: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Berreskuratu erosketa</string>
-    <string name="upgrade_screen_restore_purchase_message">Ez da erosketarik aurkitu. Kontu egokia erabiltzen ari zara?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Duela gutxi erosi baduzu, litekeena da Google Playk sinkronizatzeko denbora behar izatea.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Saiatu berriro minutu batzuk barru zure erosketa agertzen ez bada.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ziurtatu erosketa egiteko erabilitako Google kontu berarekin saioa hasita duzula.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Kontu anitzek Google Play nahas dezakete. Aplikazioa Google Play webgunearen bidez instalatzeak kontu jakin batekin lotzea behartzen du.</string>
     <string name="upgrade_screen_restore_banner_title">Dagoeneko Pro erosi duzu?</string>
     <string name="upgrade_screen_restore_banner_body">Badirudi lehenago gailu honetan Pro bertsiora eguneratu zenuela. Leheneratu zure erosketa berriro desblokeatzeko.</string>
     <string name="upgrade_screen_restore_success_message">Erosketa leheneratu da.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">CAPod Pro daukazu!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Zure harpidetzak desblokeatu du. Eskerrik asko CAPod babesteagatik!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Zure aldi bateko erosketak desblokeatu du. Eskerrik asko CAPod babesteagatik!</string>
-    <string name="upgrade_screen_owned_sub_title">Urteko harpidetza</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Zure harpidetza aktibo dago eta berritzeko ezarrita. Fakturazioa Google Playk kudeatzen du.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Zure harpidetza aktibo dago, baina ez dago berritzeko ezarrita. Pro eskuragarri egongo da uneko epea amaitu arte.</string>
     <string name="upgrade_screen_owned_iap_title">Erosketa bakarra</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">سرویس‌های Google Play در دسترس نیستند.</string>
-    <string name="upgrades_no_purchases_found_check_account">خریدی یافت نشد. آیا از حساب درستی استفاده می‌کنید؟</string>
     <string name="upgrades_gplay_billing_error_label">خطای Google Play</string>
     <string name="upgrades_gplay_billing_error_description">خطایی در Google Play رخ داد. لطفاً بعداً دوباره امتحان کنید یا گوشی خود را مجدداً راه‌اندازی کنید.\n\nخطا: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">خطای صورت‌حساب Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">هنگام درخواست جزئیات خرید از Google Play خطایی رخ داد. حافظه پنهان Google Play را پاک کنید و گوشی خود را مجدداً راه‌اندازی کنید.\n\nخطا %s</string>
     <string name="upgrades_gplay_already_owned_label">قبلاً خریداری کرده‌اید؟</string>
     <string name="upgrades_gplay_already_owned_description">گوگل پلی گزارش می‌دهد که شما قبلاً این ارتقا را خریداری کرده‌اید، اما بازیابی آن ممکن نشد. مطمئن شوید که از همان حساب گوگلی که با آن خرید کرده‌اید استفاده می‌کنید. همگام‌سازی Play Store ممکن است زمان‌بر باشد — راه‌اندازی مجدد دستگاه، پاک کردن حافظه پنهان گوگل پلی یا کمی صبر کردن را امتحان کنید.</string>
-    <string name="upgrade_restore_action">بازیابی خرید</string>
     <string name="upgrade_badge_label">حرفه‌ای</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">دریافت %1$s</string>
     <string name="upgrade_preamble">CAPod توسط یک نفر توسعه داده می‌شود. ارتقا امکانات اضافی را باز می‌کند و به زنده نگه داشتن این برنامه کمک می‌کند.</string>
-    <string name="upgrade_screen_options_description">امکانات یکسان، قیمت‌گذاری متفاوت. اشتراک شامل یک دوره آزمایشی رایگان است و در هر زمان قابل لغو است.</string>
-    <string name="upgrade_screen_options_description_no_trial">امکانات یکسان، قیمت‌گذاری متفاوت. اشتراک در هر زمان قابل لغو است.</string>
     <string name="upgrade_screen_subscription_trial_action">شروع دوره آزمایشی</string>
     <string name="upgrade_screen_subscription_action">اشتراک سالانه</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/سال</string>
     <string name="upgrade_screen_iap_action">خرید یک‌باره</string>
-    <string name="upgrade_screen_iap_action_hint">خرید یک‌باره: %s</string>
     <string name="upgrade_screen_restore_purchase_action">بازیابی خرید</string>
-    <string name="upgrade_screen_restore_purchase_message">خریدی یافت نشد. آیا از حساب درستی استفاده می‌کنید؟</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">اگر اخیراً خرید کرده‌اید، ممکن است همگام‌سازی گوگل پلی کمی زمان ببرد.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">اگر خرید شما نمایش داده نشد، چند دقیقه دیگر دوباره امتحان کنید.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">مطمئن شوید که با همان حساب گوگلی که خرید را با آن انجام داده‌اید وارد شده‌اید.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">چندین حساب کاربری می‌تواند گوگل پلی را دچار سردرگمی کند. نصب برنامه از طریق وب‌سایت گوگل پلی، ارتباط با یک حساب خاص را اجباری می‌کند.</string>
     <string name="upgrade_screen_restore_banner_title">قبلاً Pro را خریده‌اید؟</string>
     <string name="upgrade_screen_restore_banner_body">به نظر می‌رسد قبلاً در این دستگاه به Pro ارتقا داده‌اید. برای باز کردن دوباره آن، خرید خود را بازیابی کنید.</string>
     <string name="upgrade_screen_restore_success_message">خرید بازیابی شد.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">شما CAPod Pro را دارید!</string>
     <string name="upgrade_screen_owned_hero_sub_body">با اشتراک شما باز شده است. از حمایت شما از CAPod سپاسگزاریم!</string>
     <string name="upgrade_screen_owned_hero_iap_body">با خرید یک‌باره شما باز شده است. از حمایت شما از CAPod سپاسگزاریم!</string>
-    <string name="upgrade_screen_owned_sub_title">اشتراک سالانه</string>
     <string name="upgrade_screen_owned_sub_renewing_body">اشتراک شما فعال است و برای تمدید تنظیم شده. صورت‌حساب توسط گوگل پلی مدیریت می‌شود.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">اشتراک شما فعال است، اما برای تمدید تنظیم نشده. Pro تا پایان دوره فعلی در دسترس باقی می‌ماند.</string>
     <string name="upgrade_screen_owned_iap_title">خرید یکباره</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play -palvelut eivät ole käytettävissä.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ostoksia ei löytynyt. Käytätkö oikeaa tiliä?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play -virhe</string>
     <string name="upgrades_gplay_billing_error_description">Google Playssa tapahtui virhe. Yritä myöhemmin uudelleen tai käynnistä puhelimesi uudelleen.\n\nVirhe: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play -laskutusvirhe</string>
-    <string name="upgrades_gplay_billing_result_error_description">Ostotietojen hakemisessa Google Playsta tapahtui virhe. Tyhjennä Google Playn välimuisti ja käynnistä puhelimesi uudelleen.\n\nVirhe %s</string>
     <string name="upgrades_gplay_already_owned_label">Ostettu jo?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play ilmoittaa, että omistat jo tämän päivityksen, mutta sitä ei voitu palauttaa. Varmista, että käytät samaa Google-tiliä, jolla ostit sen. Play Kaupan synkronointi voi kestää hetken — kokeile laitteen uudelleenkäynnistystä, Google Play -välimuistin tyhjentämistä tai odota hetki.</string>
-    <string name="upgrade_restore_action">Palauta ostos</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Hanki %1$s</string>
     <string name="upgrade_preamble">CAPodia kehittää yksi henkilö. Päivittäminen avaa lisäominaisuuksia ja auttaa pitämään sovelluksen elossa.</string>
-    <string name="upgrade_screen_options_description">Samat ominaisuudet, eri hinnoittelu. Tilaukseen sisältyy maksuton kokeilujakso, ja sen voi peruuttaa milloin tahansa.</string>
-    <string name="upgrade_screen_options_description_no_trial">Samat ominaisuudet, eri hinnoittelu. Tilauksen voi peruuttaa milloin tahansa.</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita maksuton kokeilu</string>
     <string name="upgrade_screen_subscription_action">Tilaa vuosittain</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/vuosi</string>
     <string name="upgrade_screen_iap_action">Osta kertaostoksena</string>
-    <string name="upgrade_screen_iap_action_hint">Kertaostos: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Palauta ostos</string>
-    <string name="upgrade_screen_restore_purchase_message">Ostoksia ei löytynyt. Käytätkö oikeaa tiliä?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Jos teit ostoksen äskettäin, Google Playn synkronointi voi kestää hetken.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Yritä uudelleen muutaman minuutin kuluttua, jos ostoksesi ei näy.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Varmista, että olet kirjautunut samalla Google-tilillä, jolla teit ostoksen.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Useat tilit voivat sekoittaa Google Playn. Sovelluksen asentaminen Google Play -verkkosivuston kautta pakottaa yhdistämisen tiettyyn tiliin.</string>
     <string name="upgrade_screen_restore_banner_title">Ostitko jo Pro-version?</string>
     <string name="upgrade_screen_restore_banner_body">Näyttää siltä, että olet päivittänyt Pro-versioon tällä laitteella aiemmin. Palauta ostoksesi avataksesi sen uudelleen.</string>
     <string name="upgrade_screen_restore_success_message">Ostos palautettu.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Sinulla on CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Avattu tilauksesi ansiosta. Kiitos, että tuet CAPodia!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Avattu kertaostoksesi ansiosta. Kiitos, että tuet CAPodia!</string>
-    <string name="upgrade_screen_owned_sub_title">Vuositilaus</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tilauksesi on aktiivinen ja uusiutuu automaattisesti. Laskutusta hallinnoi Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tilauksesi on aktiivinen, mutta ei uusiudu automaattisesti. Pro pysyy käytettävissä nykyisen jakson loppuun asti.</string>
     <string name="upgrade_screen_owned_iap_title">Kertaostos</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Hindi available ang mga serbisyo ng Google Play.</string>
-    <string name="upgrades_no_purchases_found_check_account">Walang nakitang binili. Tamang account ba ang gamit mo?</string>
     <string name="upgrades_gplay_billing_error_label">Error sa Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Nagkaroon ng error sa Google Play. Pakisubukan ulit mamaya o i-reboot ang iyong telepono.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Error sa Google Play Billing</string>
-    <string name="upgrades_gplay_billing_result_error_description">Nagkaroon ng error sa paghingi ng detalye ng iyong pagbili sa Google Play. I-clear ang Google Play cache at i-reboot ang iyong telepono.\n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">Nabili na?</string>
     <string name="upgrades_gplay_already_owned_description">Iniuulat ng Google Play na nasa iyo na ang upgrade na ito, ngunit hindi ito ma-restore. Siguraduhing ginagamit mo ang Google account na ginamit mo sa pagbili. Maaaring magtagal ang pag-sync ng Play Store — subukang i-restart ang device, i-clear ang cache ng Google Play, o maghintay lang.</string>
-    <string name="upgrade_restore_action">I-restore ang pagbili</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Kumuha ng %1$s</string>
     <string name="upgrade_preamble">Ginawa ang CAPod ng isang tao lang. Ang pag-upgrade ay nagbubukas ng karagdagang mga feature at tumutulong na mapanatiling buhay ang app.</string>
-    <string name="upgrade_screen_options_description">Pareho ang mga feature, magkaiba ang presyo. Kasama sa subscription ang libreng trial at maaari itong kanselahin anumang oras.</string>
-    <string name="upgrade_screen_options_description_no_trial">Pareho ang mga feature, magkaiba ang presyo. Maaaring kanselahin ang subscription anumang oras.</string>
     <string name="upgrade_screen_subscription_trial_action">Simulan ang libreng trial</string>
     <string name="upgrade_screen_subscription_action">Mag-subscribe taun-taon</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/taon</string>
     <string name="upgrade_screen_iap_action">Bilhin nang minsan</string>
-    <string name="upgrade_screen_iap_action_hint">One-time na pagbili: %s</string>
     <string name="upgrade_screen_restore_purchase_action">I-restore ang pagbili</string>
-    <string name="upgrade_screen_restore_purchase_message">Walang nakitang binili. Tamang account ba ang gamit mo?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Kung kararaan mo lang bumili, maaaring magtagal nang kaunti bago mag-sync ang Google Play.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Subukan muli sa loob ng ilang minuto kung hindi lumitaw ang iyong pagbili.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Siguraduhing naka-sign in ka sa parehong Google account na ginamit sa pagbili.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Maaaring makalito sa Google Play ang maraming account. Ang pag-install ng app sa pamamagitan ng Google Play website ay nagpipilit ng kaugnayan sa isang partikular na account.</string>
     <string name="upgrade_screen_restore_banner_title">Nabili mo na ang Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Mukhang nag-upgrade ka na sa Pro sa device na ito noon. I-restore ang iyong pagbili para ma-unlock ulit ito.</string>
     <string name="upgrade_screen_restore_success_message">Naibalik na ang pagbili.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Mayroon kang CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Na-unlock ng iyong subscription. Salamat sa pagsuporta sa CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Na-unlock ng iyong one-time na pagbili. Salamat sa pagsuporta sa CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Taunang subscription</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Aktibo ang iyong subscription at nakatakdang mag-renew. Ang billing ay pinamamahalaan ng Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Aktibo ang iyong subscription, ngunit hindi ito nakatakdang mag-renew. Mananatiling available ang Pro hanggang sa matapos ang kasalukuyang panahon.</string>
     <string name="upgrade_screen_owned_iap_title">One-time na pagbili</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Les services Google Play sont inaccessibles.</string>
-    <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>
     <string name="upgrades_gplay_billing_error_label">Erreur Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Une erreur est survenue dans Google Play. Réessayez plus tard ou redémarrez votre téléphone.\n\nErreur : %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Erreur de facturation Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Une erreur est survenue lors de la demande des détails de votre achat à Google Play. Videz le cache de Google Play et redémarrez votre téléphone.\n\nErreur %s</string>
     <string name="upgrades_gplay_already_owned_label">Déjà acheté?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play indique que vous possédez déjà cette mise à niveau, mais elle n’a pas pu être restaurée. Assurez-vous d’utiliser le compte Google avec lequel vous avez effectué l’achat. La synchronisation du Play Store peut prendre du temps — essayez de redémarrer, de vider le cache du Google Play ou simplement d’attendre.</string>
-    <string name="upgrade_restore_action">Rétablir l’achat</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtenir %1$s</string>
     <string name="upgrade_preamble">CAPod est développée par une seule personne. Passer à la version Pro déverrouille des fonctions supplémentaires et contribue à la pérennité de l’appli.</string>
-    <string name="upgrade_screen_options_description">Mêmes fonctions, tarification différente. L’abonnement comprend un essai gratuit et peut être annulé n’importe quand.</string>
-    <string name="upgrade_screen_options_description_no_trial">Mêmes fonctions, tarification différente. L’abonnement peut être annulé n’importe quand.</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit</string>
     <string name="upgrade_screen_subscription_action">Abonnement annuel</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/an</string>
     <string name="upgrade_screen_iap_action">Acheter une fois</string>
-    <string name="upgrade_screen_iap_action_hint">Achat unique : %s</string>
     <string name="upgrade_screen_restore_purchase_action">Rétablir l’achat</string>
-    <string name="upgrade_screen_restore_purchase_message">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Si l’achat est récent, Google Play peut mettre du temps à synchroniser.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Si votre achat n’apparaît pas, réessayez dans quelques minutes.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Le même compte Google doit être utilisé pour l’achat et la connexion.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Plusieurs comptes peuvent perturber Google Play. Installer l’appli via le site Web de Google Play force l’association avec un compte précis.</string>
     <string name="upgrade_screen_restore_banner_title">Vous avez déjà acheté Pro ?</string>
     <string name="upgrade_screen_restore_banner_body">Il semble que vous ayez déjà mis à niveau vers Pro sur cet appareil. Restaurez votre achat pour le débloquer à nouveau.</string>
     <string name="upgrade_screen_restore_success_message">Achat restauré.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Vous avez CAPod Pro !</string>
     <string name="upgrade_screen_owned_hero_sub_body">Débloqué par votre abonnement. Merci de soutenir CAPod !</string>
     <string name="upgrade_screen_owned_hero_iap_body">Débloqué par votre achat unique. Merci de soutenir CAPod !</string>
-    <string name="upgrade_screen_owned_sub_title">Abonnement annuel</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Votre abonnement est actif et sera renouvelé. La facturation est gérée par Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Votre abonnement est actif, mais ne sera pas renouvelé. Pro reste disponible jusqu’à la fin de la période en cours.</string>
     <string name="upgrade_screen_owned_iap_title">Achat unique</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Os servizos de Google Play non están dispoñibles.</string>
-    <string name="upgrades_no_purchases_found_check_account">Non se atoparon compras. Estás a usar a conta correcta?</string>
     <string name="upgrades_gplay_billing_error_label">Erro de Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Houbo un erro en Google Play. Téntao de novo máis tarde ou reinicia o teu teléfono.\n\nErro: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Erro de facturación de Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Houbo un erro ao solicitar os detalles da túa compra a Google Play. Limpa a caché de Google Play e reinicia o teu teléfono.\n\nErro %s</string>
     <string name="upgrades_gplay_already_owned_label">Xa o mercaches?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play indica que xa tes esta mellora, pero non se puido restaurar. Asegúrate de usar a conta de Google coa que a mercaches. A sincronización coa Play Store pode levar tempo — proba a reiniciar, borrar a caché de Google Play ou simplemente esperar.</string>
-    <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">CAPod está desenvolvido por unha soa persoa. Mellorar desbloquea funcións adicionais e axuda a manter viva a aplicación.</string>
-    <string name="upgrade_screen_options_description">As mesmas funcións, prezos diferentes. A subscrición inclúe unha proba gratuíta e pódese cancelar en calquera momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">As mesmas funcións, prezos diferentes. A subscrición pódese cancelar en calquera momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar proba gratuíta</string>
     <string name="upgrade_screen_subscription_action">Subscribirse anualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ano</string>
     <string name="upgrade_screen_iap_action">Mercar unha vez</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
-    <string name="upgrade_screen_restore_purchase_message">Non se atoparon compras. Estás a usar a conta correcta?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Se mercaches recentemente, Google Play pode tardar un anaco en sincronizar.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Téntao de novo nuns minutos se a túa compra non aparece.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Asegúrate de ter a sesión iniciada coa mesma conta de Google usada para a compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Múltiples contas poden confundir a Google Play. Instalar a aplicación a través do sitio web de Google Play forza a asociación cunha conta específica.</string>
     <string name="upgrade_screen_restore_banner_title">Xa mercaches Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parece que xa mercaches Pro neste dispositivo antes. Restaura a túa compra para desbloquealo de novo.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Tes CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloqueado pola túa subscrición. Grazas por apoiar a CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloqueado pola túa compra única. Grazas por apoiar a CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Subscrición anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">A túa subscrición está activa e configurada para renovarse. A facturación xestiónaa Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">A túa subscrición está activa, pero non está configurada para renovarse. Pro seguirá dispoñible ata que remate o período actual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play सेवाएं अनुपलब्ध हैं।</string>
-    <string name="upgrades_no_purchases_found_check_account">कोई खरीदारी नहीं मिली, क्या आप सही खाते का उपयोग कर रहे हैं?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play त्रुटि</string>
     <string name="upgrades_gplay_billing_error_description">Google Play में एक त्रुटि हुई। कृपया बाद में पुनः प्रयास करें या अपना फ़ोन रीबूट करें।\n\nत्रुटि: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play बिलिंग त्रुटि</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play से आपकी खरीदारी का विवरण प्राप्त करते समय एक त्रुटि हुई। Google Play कैश साफ़ करें और अपना फ़ोन रीबूट करें।\n\nत्रुटि %s</string>
     <string name="upgrades_gplay_already_owned_label">पहले से खरीदा हुआ है?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play की रिपोर्ट है कि आपके पास पहले से यह अपग्रेड है, लेकिन इसे पुनर्स्थापित नहीं किया जा सका। सुनिश्चित करें कि आप उसी Google खाते का उपयोग कर रहे हैं जिससे आपने खरीदारी की थी। Play Store सिंक होने में समय लग सकता है — रीबूट करने, Google Play कैश साफ़ करने या बस थोड़ा इंतज़ार करने का प्रयास करें।</string>
-    <string name="upgrade_restore_action">खरीदारी पुनर्स्थापित करें</string>
     <string name="upgrade_badge_label">प्रो</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s प्राप्त करें</string>
     <string name="upgrade_preamble">CAPod को एक ही व्यक्ति द्वारा विकसित किया गया है। अपग्रेड करने से अतिरिक्त सुविधाएँ अनलॉक होती हैं और ऐप को जीवित रखने में मदद मिलती है।</string>
-    <string name="upgrade_screen_options_description">सुविधाएँ समान हैं, कीमत अलग है। सदस्यता में एक मुफ़्त ट्रायल शामिल है और इसे किसी भी समय रद्द किया जा सकता है।</string>
-    <string name="upgrade_screen_options_description_no_trial">सुविधाएँ समान हैं, कीमत अलग है। सदस्यता को किसी भी समय रद्द किया जा सकता है।</string>
     <string name="upgrade_screen_subscription_trial_action">निशुल्क प्रयोग प्रारंभ करें</string>
     <string name="upgrade_screen_subscription_action">सालाना सदस्यता लें</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/वर्ष</string>
     <string name="upgrade_screen_iap_action">एक बार खरीदें</string>
-    <string name="upgrade_screen_iap_action_hint">एकमुश्त खरीद: %s</string>
     <string name="upgrade_screen_restore_purchase_action">खरीदारी पुनर्स्थापित करें</string>
-    <string name="upgrade_screen_restore_purchase_message">कोई खरीदारी नहीं मिली, क्या आप सही खाते का उपयोग कर रहे हैं?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">अगर आपने हाल ही में खरीदा है, तो Google Play को सिंक होने में कुछ समय लग सकता है।</string>
     <string name="upgrade_screen_restore_sync_patience_hint">अगर आपकी खरीदारी दिखाई नहीं देती, तो कुछ मिनट बाद फिर से कोशिश करें।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">सुनिश्चित करें कि आप उसी Google खाते से साइन इन हैं जिससे खरीदारी की गई थी।</string>
-    <string name="upgrade_screen_restore_webinstall_hint">कई खाते Google Play को भ्रमित कर सकते हैं। Google Play वेबसाइट के जरिए ऐप इंस्टॉल करने से विशेष खाते के साथ संबंध सुनिश्चित हो जाता है।</string>
     <string name="upgrade_screen_restore_banner_title">पहले से Pro खरीदा हुआ है?</string>
     <string name="upgrade_screen_restore_banner_body">ऐसा लगता है कि आपने पहले इस डिवाइस पर Pro में अपग्रेड किया था। इसे दोबारा अनलॉक करने के लिए अपनी खरीदारी पुनर्स्थापित करें।</string>
     <string name="upgrade_screen_restore_success_message">खरीदारी पुनर्स्थापित हो गई।</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">आपके पास CAPod Pro है!</string>
     <string name="upgrade_screen_owned_hero_sub_body">आपकी सदस्यता द्वारा अनलॉक किया गया। CAPod का समर्थन करने के लिए धन्यवाद!</string>
     <string name="upgrade_screen_owned_hero_iap_body">आपकी एकमुश्त खरीद द्वारा अनलॉक किया गया। CAPod का समर्थन करने के लिए धन्यवाद!</string>
-    <string name="upgrade_screen_owned_sub_title">सालाना सदस्यता</string>
     <string name="upgrade_screen_owned_sub_renewing_body">आपकी सदस्यता सक्रिय है और नवीनीकरण होने के लिए सेट है। बिलिंग का प्रबंधन Google Play द्वारा किया जाता है।</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">आपकी सदस्यता सक्रिय है, लेकिन नवीनीकरण के लिए सेट नहीं है। मौजूदा अवधि समाप्त होने तक Pro उपलब्ध रहेगा।</string>
     <string name="upgrade_screen_owned_iap_title">एक-बार खरीदे</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Usluge Google Playa nisu dostupne.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nisu pronađene kupnje. Koristite li pravi račun?</string>
     <string name="upgrades_gplay_billing_error_label">Greška Google Playa</string>
     <string name="upgrades_gplay_billing_error_description">Došlo je do greške u Google Playu. Pokušajte ponovo kasnije ili ponovo pokrenite telefon.\n\nGreška: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Greška naplate Google Playa</string>
-    <string name="upgrades_gplay_billing_result_error_description">Došlo je do greške prilikom dohvaćanja podataka o kupnji iz Google Playa. Očistite predmemoriju Google Playa i ponovo pokrenite telefon.\n\nGreška %s</string>
     <string name="upgrades_gplay_already_owned_label">Već ste kupili?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play javlja da već posjedujete ovu nadogradnju, ali nije ju bilo moguće vratiti. Provjerite koristite li Google račun kojim ste izvršili kupnju. Sinkronizacija Play trgovine može potrajati — pokušajte ponovno pokrenuti uređaj, izbrisati predmemoriju Google Playa ili jednostavno pričekati.</string>
-    <string name="upgrade_restore_action">Obnovi kupnju</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Nabavite %1$s</string>
     <string name="upgrade_preamble">CAPod razvija jedna osoba. Nadogradnja otključava dodatne značajke i pomaže održati aplikaciju živom.</string>
-    <string name="upgrade_screen_options_description">Iste značajke, različite cijene. Pretplata uključuje besplatno probno razdoblje i može se otkazati u bilo kojem trenutku.</string>
-    <string name="upgrade_screen_options_description_no_trial">Iste značajke, različite cijene. Pretplata se može otkazati u bilo kojem trenutku.</string>
     <string name="upgrade_screen_subscription_trial_action">Započnite besplatnu probu</string>
     <string name="upgrade_screen_subscription_action">Pretplati se godišnje</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/godišnje</string>
     <string name="upgrade_screen_iap_action">Kupi jednom</string>
-    <string name="upgrade_screen_iap_action_hint">Jednokratna kupnja: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovi kupnju</string>
-    <string name="upgrade_screen_restore_purchase_message">Nisu pronađene kupnje. Koristite li pravi račun?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ako ste nedavno izvršili kupnju, Google Playu može zatrebati trenutak za sinkronizaciju.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Pokušajte ponovno za nekoliko minuta ako se vaša kupnja ne pojavi.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Provjerite jeste li prijavljeni s istim Google računom koji ste koristili za kupnju.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Više računa može zbuniti Google Play. Instaliranje aplikacije putem web-stranice Google Playa prisiljava povezivanje s određenim računom.</string>
     <string name="upgrade_screen_restore_banner_title">Već ste kupili Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Izgleda da ste prije nadogradili na Pro na ovom uređaju. Vratite svoju kupnju kako biste ga ponovno otključali.</string>
     <string name="upgrade_screen_restore_success_message">Kupnja vraćena.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Imate CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Otključano vašom pretplatom. Hvala vam što podržavate CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Otključano vašom jednokratnom kupnjom. Hvala vam što podržavate CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Godišnja pretplata</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaša pretplata je aktivna i postavljena je za obnavljanje. Naplatom upravlja Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaša pretplata je aktivna, ali nije postavljena za obnavljanje. Pro ostaje dostupan do kraja trenutnog razdoblja.</string>
     <string name="upgrade_screen_owned_iap_title">Jednokratna kupnja</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">A Google Play szolgáltatások nem érhetők el.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nem található vásárlás. A megfelelő fiókot használja?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play hiba</string>
     <string name="upgrades_gplay_billing_error_description">Hiba történt a Google Playben. Kérjük, próbálja újra később, vagy indítsa újra a telefonját.\n\nHiba: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play számlázási hiba</string>
-    <string name="upgrades_gplay_billing_result_error_description">Hiba történt a vásárlási adatok lekérésekor a Google Playből. Törölje a Google Play gyorsítótárát, és indítsa újra a telefonját.\n\nHiba %s</string>
     <string name="upgrades_gplay_already_owned_label">Már megvásároltad?</string>
     <string name="upgrades_gplay_already_owned_description">A Google Play szerint már megvásároltad ezt a frissítést, de nem sikerült visszaállítani. Győződj meg róla, hogy azzal a Google-fiókkal vagy bejelentkezve, amellyel a vásárlást végezted. A Play Store szinkronizálása eltarthat egy ideig – próbáld meg újraindítani a készüléket, törölni a Google Play gyorsítótárát, vagy egyszerűen várj egy kicsit.</string>
-    <string name="upgrade_restore_action">Vásárlás visszaállítása</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Szerezd meg a %1$s-t</string>
     <string name="upgrade_preamble">A CAPod-ot egyetlen ember fejleszti. A frissítés extra funkciókat old fel, és segít életben tartani az alkalmazást.</string>
-    <string name="upgrade_screen_options_description">Ugyanazok a funkciók, eltérő árazás. Az előfizetés ingyenes próbaidőszakot tartalmaz, és bármikor lemondható.</string>
-    <string name="upgrade_screen_options_description_no_trial">Ugyanazok a funkciók, eltérő árazás. Az előfizetés bármikor lemondható.</string>
     <string name="upgrade_screen_subscription_trial_action">Ingyenes próba indítása</string>
     <string name="upgrade_screen_subscription_action">Éves előfizetés</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/év</string>
     <string name="upgrade_screen_iap_action">Egyszeri vásárlás</string>
-    <string name="upgrade_screen_iap_action_hint">Egyszeri vásárlás: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Vásárlás visszaállítása</string>
-    <string name="upgrade_screen_restore_purchase_message">Nem található vásárlás. A megfelelő fiókot használja?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ha nemrég vásároltál, eltarthat egy ideig, amíg a Google Play szinkronizál.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Próbáld újra néhány perc múlva, ha a vásárlásod nem jelenik meg.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Győződj meg róla, hogy ugyanazzal a Google-fiókkal vagy bejelentkezve, amellyel a vásárlást végezted.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">A több fiók összezavarhatja a Google Playt. Az alkalmazás Google Play weboldalán keresztüli telepítése kikényszeríti a társulást egy adott fiókkal.</string>
     <string name="upgrade_screen_restore_banner_title">Már megvásároltad a Pro-t?</string>
     <string name="upgrade_screen_restore_banner_body">Úgy tűnik, korábban már frissítettél Pro-ra ezen az eszközön. Állítsd vissza a vásárlásod, hogy újra feloldd.</string>
     <string name="upgrade_screen_restore_success_message">A vásárlás visszaállítva.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Megvan a CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Az előfizetésed oldotta fel. Köszönjük, hogy támogatod a CAPod-ot!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Az egyszeri vásárlásod oldotta fel. Köszönjük, hogy támogatod a CAPod-ot!</string>
-    <string name="upgrade_screen_owned_sub_title">Éves előfizetés</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Az előfizetésed aktív, és megújulásra van állítva. A számlázást a Google Play kezeli.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Az előfizetésed aktív, de nincs megújulásra állítva. A Pro a jelenlegi időszak végéig elérhető marad.</string>
     <string name="upgrade_screen_owned_iap_title">Egyszeri vásárlás</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play ծառայությունները հասանելի չեն:</string>
-    <string name="upgrades_no_purchases_found_check_account">Գնումներ չեն գտնվել: Արդյո՞ք ճիշտ հաշիվն եք օգտագործում:</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-ի սխալ</string>
     <string name="upgrades_gplay_billing_error_description">Google Play-ում սխալ է տեղի ունեցել: Խնդրում ենք փորձել ավելի ուշ կամ վերագործարկել ձեր հեռախոսը.\n\nՍխալ: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Billing-ի սխալ</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play-ից ձեր գնումների տվյալները հարցնելիս սխալ է տեղի ունեցել: Մաքրեք Google Play-ի քեշը և վերագործարկեք ձեր հեռախոսը.\n\nՍխալ %s</string>
     <string name="upgrades_gplay_already_owned_label">Արդեն գնե՞լ եք:</string>
     <string name="upgrades_gplay_already_owned_description">Google Play-ը հայտնում է, որ դուք արդեն ունեք այս արդիացումը, բայց այն չհաջողվեց վերականգնել: Համոզվեք, որ օգտագործում եք այն Google հաշիվը, որով կատարել եք գնումը: Play Store-ի համաժամացումը կարող է ժամանակ պահանջել․ փորձեք վերագործարկել սարքը, մաքրել Google Play-ի քեշը կամ պարզապես սպասել:</string>
-    <string name="upgrade_restore_action">Վերականգնել գնումը</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Ստացեք %1$s</string>
     <string name="upgrade_preamble">CAPod-ը մշակվում է մեկ մարդու կողմից: Արդիացումը բացում է լրացուցիչ գործառույթներ և օգնում է հավելվածին մնալ ակտիվ:</string>
-    <string name="upgrade_screen_options_description">Նույն գործառույթները, տարբեր գնագոյացում: Բաժանորդագրությունը ներառում է անվճար փորձաշրջան և կարող է չեղարկվել ցանկացած պահի:</string>
-    <string name="upgrade_screen_options_description_no_trial">Նույն գործառույթները, տարբեր գնագոյացում: Բաժանորդագրությունը կարող է չեղարկվել ցանկացած պահի:</string>
     <string name="upgrade_screen_subscription_trial_action">Սկսել անվճար փորձաշրջանը</string>
     <string name="upgrade_screen_subscription_action">Բաժանորդագրվել տարեկան</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/տարի</string>
     <string name="upgrade_screen_iap_action">Գնել մեկ անգամ</string>
-    <string name="upgrade_screen_iap_action_hint">Միանգամյա գնում՝ %s</string>
     <string name="upgrade_screen_restore_purchase_action">Վերականգնել գնումը</string>
-    <string name="upgrade_screen_restore_purchase_message">Գնումներ չեն գտնվել: Արդյո՞ք ճիշտ հաշիվն եք օգտագործում:</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Եթե վերջերս եք գնում կատարել, Google Play-ին կարող է որոշ ժամանակ պահանջվել համաժամացնելու համար:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Փորձեք կրկին մի քանի րոպեից, եթե ձեր գնումը չի հայտնվում:</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Համոզվեք, որ մուտք եք գործել այն նույն Google հաշվով, որով կատարվել է գնումը:</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Բազմաթիվ հաշիվները կարող են շփոթեցնել Google Play-ին: Հավելվածը Google Play կայքի միջոցով տեղադրելը ստիպում է կապ հաստատել կոնկրետ հաշվի հետ:</string>
     <string name="upgrade_screen_restore_banner_title">Արդեն գնե՞լ եք Pro-ն:</string>
     <string name="upgrade_screen_restore_banner_body">Կարծես դուք նախկինում արդիացրել եք Pro այս սարքում: Վերականգնեք ձեր գնումը՝ այն կրկին բացելու համար:</string>
     <string name="upgrade_screen_restore_success_message">Գնումը վերականգնվեց:</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Դուք ունեք CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Բացված է ձեր բաժանորդագրության միջոցով: Շնորհակալություն CAPod-ին աջակցելու համար!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Բացված է ձեր միանգամյա գնման միջոցով: Շնորհակալություն CAPod-ին աջակցելու համար!</string>
-    <string name="upgrade_screen_owned_sub_title">Տարեկան բաժանորդագրություն</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ձեր բաժանորդագրությունը ակտիվ է և կնորոգվի: Վճարումները կառավարվում են Google Play-ի կողմից:</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ձեր բաժանորդագրությունը ակտիվ է, բայց չի նորոգվելու: Pro-ն մատչելի կմնա մինչև ընթացիկ շրջանի ավարտը:</string>
     <string name="upgrade_screen_owned_iap_title">Միանգամյա գնում</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Layanan Google Play tidak tersedia.</string>
-    <string name="upgrades_no_purchases_found_check_account">Tidak ada pembelian yang ditemukan. Apakah Anda menggunakan akun yang benar?</string>
     <string name="upgrades_gplay_billing_error_label">Kesalahan Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Terjadi kesalahan di Google Play. Silakan coba lagi nanti atau mulai ulang ponsel Anda.\n\nKesalahan: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Kesalahan Penagihan Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Terjadi kesalahan saat meminta detail pembelian Anda dari Google Play. Hapus cache Google Play dan mulai ulang ponsel Anda.\n\nKesalahan %s</string>
     <string name="upgrades_gplay_already_owned_label">Sudah membeli?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play melaporkan bahwa Anda sudah memiliki peningkatan ini, tetapi tidak dapat dipulihkan. Pastikan Anda menggunakan akun Google yang sama dengan yang digunakan untuk membeli. Sinkronisasi Play Store mungkin memerlukan waktu — coba mulai ulang perangkat, hapus cache Google Play, atau tunggu sebentar.</string>
-    <string name="upgrade_restore_action">Pulihkan pembelian</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Dapatkan %1$s</string>
     <string name="upgrade_preamble">CAPod dikembangkan oleh satu orang. Melakukan peningkatan membuka fitur tambahan dan membantu menjaga aplikasi ini tetap ada.</string>
-    <string name="upgrade_screen_options_description">Fitur yang sama, harga yang berbeda. Langganan ini mencakup masa uji coba gratis dan dapat dibatalkan kapan saja.</string>
-    <string name="upgrade_screen_options_description_no_trial">Fitur yang sama, harga yang berbeda. Langganan dapat dibatalkan kapan saja.</string>
     <string name="upgrade_screen_subscription_trial_action">Mulai coba gratis</string>
     <string name="upgrade_screen_subscription_action">Berlangganan tahunan</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/tahun</string>
     <string name="upgrade_screen_iap_action">Beli sekali</string>
-    <string name="upgrade_screen_iap_action_hint">Sekali bayar: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Pulihkan pembelian</string>
-    <string name="upgrade_screen_restore_purchase_message">Tidak ada pembelian yang ditemukan. Apakah Anda menggunakan akun yang benar?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Jika Anda baru saja membeli, mungkin perlu waktu sebentar agar Google Play tersinkronisasi.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Coba lagi dalam beberapa menit jika pembelian Anda tidak muncul.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Pastikan Anda masuk dengan akun Google yang sama seperti yang digunakan untuk pembelian.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Beberapa akun dapat membingungkan Google Play. Memasang aplikasi melalui situs web Google Play memaksa penghubungan dengan akun tertentu.</string>
     <string name="upgrade_screen_restore_banner_title">Sudah membeli Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Sepertinya Anda pernah meningkatkan ke Pro di perangkat ini sebelumnya. Pulihkan pembelian Anda untuk membukanya kembali.</string>
     <string name="upgrade_screen_restore_success_message">Pembelian dipulihkan.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Anda memiliki CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dibuka oleh langganan Anda. Terima kasih karena telah mendukung CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dibuka oleh sekali bayar Anda. Terima kasih karena telah mendukung CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Langganan tahunan</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Langganan Anda aktif dan diatur untuk diperpanjang. Penagihan dikelola oleh Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Langganan Anda aktif, tetapi tidak diatur untuk diperpanjang. Pro akan tetap tersedia hingga periode saat ini berakhir.</string>
     <string name="upgrade_screen_owned_iap_title">Sekali bayar</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play þjónustur eru ekki tiltækar.</string>
-    <string name="upgrades_no_purchases_found_check_account">Engin kaup fundust. Ertu að nota réttan aðgang?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play villa</string>
     <string name="upgrades_gplay_billing_error_description">Villa kom upp í Google Play. Vinsamlegast reyndu aftur síðar eða endurræstu símann þinn.\n\nVilla: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play innheimtuvilla</string>
-    <string name="upgrades_gplay_billing_result_error_description">Villa kom upp við að sækja upplýsingar um kaupin þín frá Google Play. Hreinsaðu skyndiminni Google Play og endurræstu símann þinn.\n\nVilla %s</string>
     <string name="upgrades_gplay_already_owned_label">Þegar keypt?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play greinir frá því að þú eigir þegar þessa uppfærslu, en ekki tókst að endurheimta hana. Gakktu úr skugga um að þú sért að nota sama Google reikning og þú keyptir með. Samstilling Play Store getur tekið tíma — reyndu að endurræsa, hreinsa skyndiminni Google Play eða bíða einfaldlega.</string>
-    <string name="upgrade_restore_action">Endurheimta kaup</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Fáðu %1$s</string>
     <string name="upgrade_preamble">CAPod er þróað af einum einstaklingi. Uppfærsla opnar aukamöguleika og hjálpar til við að halda forritinu á lífi.</string>
-    <string name="upgrade_screen_options_description">Sömu eiginleikar, mismunandi verðlagning. Áskriftin inniheldur ókeypis prufutíma og hægt er að segja henni upp hvenær sem er.</string>
-    <string name="upgrade_screen_options_description_no_trial">Sömu eiginleikar, mismunandi verðlagning. Hægt er að segja upp áskriftinni hvenær sem er.</string>
     <string name="upgrade_screen_subscription_trial_action">Byrja ókeypis prufutíma</string>
     <string name="upgrade_screen_subscription_action">Gerast áskrifandi árlega</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ár</string>
     <string name="upgrade_screen_iap_action">Kaupa einu sinni</string>
-    <string name="upgrade_screen_iap_action_hint">Einskiptiskaup: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Endurheimta kaup</string>
-    <string name="upgrade_screen_restore_purchase_message">Engin kaup fundust. Ertu að nota réttan aðgang?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ef þú keyptir nýlega getur tekið smástund fyrir Google Play að samstilla.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Reyndu aftur eftir nokkrar mínútur ef kaupin birtast ekki.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Gakktu úr skugga um að þú sért skráð(ur) inn með sama Google reikningi og notaður var við kaupin.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Margir reikningar geta ruglað Google Play. Uppsetning forritsins í gegnum Google Play vefsíðuna neyðir fram tengingu við ákveðinn reikning.</string>
     <string name="upgrade_screen_restore_banner_title">Þegar keypt Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Það lítur út fyrir að þú hafir áður uppfært í Pro á þessu tæki. Endurheimtu kaupin til að opna það aftur.</string>
     <string name="upgrade_screen_restore_success_message">Kaup endurheimt.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Þú ert með CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Opnað með áskrift þínni. Takk fyrir að styðja CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Opnað með einskiptiskaupum þínum. Takk fyrir að styðja CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Árleg áskrift</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Áskrift þín er virk og stillt á að endurnýjast. Greiðslur eru í umsjón Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Áskrift þín er virk, en ekki stillt á að endurnýjast. Pro er áfram aðgengilegt til loka núverandi tímabils.</string>
     <string name="upgrade_screen_owned_iap_title">Einskiptiskaup</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">I servizi di Google Play non sono disponibili.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai usando l\'account giusto?</string>
     <string name="upgrades_gplay_billing_error_label">Errore di Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Si è verificato un errore in Google Play. Riprova più tardi o riavvia il telefono.\n\nErrore: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Errore di fatturazione Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Si è verificato un errore durante la richiesta dei dettagli di acquisto a Google Play. Svuota la cache di Google Play e riavvia il telefono.\n\nErrore %s</string>
     <string name="upgrades_gplay_already_owned_label">Hai già acquistato?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play segnala che possiedi già questo aggiornamento, ma non è stato possibile ripristinarlo. Assicurati di utilizzare l’account Google con cui hai effettuato l’acquisto. La sincronizzazione del Play Store potrebbe richiedere tempo: prova a riavviare, cancellare la cache di Google Play o semplicemente attendere.</string>
-    <string name="upgrade_restore_action">Ripristina acquisto</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Ottieni %1$s</string>
     <string name="upgrade_preamble">CAPod è sviluppato da una sola persona. L’aggiornamento sblocca funzionalità extra e aiuta a mantenere viva l’app.</string>
-    <string name="upgrade_screen_options_description">Stesse funzionalità, prezzi diversi. L’abbonamento include una prova gratuita e può essere annullato in qualsiasi momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">Stesse funzionalità, prezzi diversi. L’abbonamento può essere annullato in qualsiasi momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita</string>
     <string name="upgrade_screen_subscription_action">Abbonati annualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/anno</string>
     <string name="upgrade_screen_iap_action">Acquista una tantum</string>
-    <string name="upgrade_screen_iap_action_hint">Acquisto una tantum: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Ripristina acquisto</string>
-    <string name="upgrade_screen_restore_purchase_message">Nessun acquisto trovato. Stai usando l\'account giusto?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Se hai effettuato l’acquisto di recente, Google Play potrebbe impiegare del tempo per sincronizzarsi.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Riprova tra qualche minuto se il tuo acquisto non appare.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Assicurati di aver effettuato l’accesso con lo stesso account Google utilizzato per l’acquisto.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Più account possono confondere Google Play. Installare l’app tramite il sito web di Google Play forza l’associazione con un account specifico.</string>
     <string name="upgrade_screen_restore_banner_title">Hai già acquistato Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Sembra che tu abbia già effettuato l’aggiornamento a Pro su questo dispositivo. Ripristina il tuo acquisto per sbloccarlo di nuovo.</string>
     <string name="upgrade_screen_restore_success_message">Acquisto ripristinato.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Hai CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sbloccato dal tuo abbonamento. Grazie per il supporto a CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Sbloccato dal tuo acquisto una tantum. Grazie per il supporto a CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Abbonamento annuale</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Il tuo abbonamento è attivo e impostato per il rinnovo. La fatturazione è gestita da Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Il tuo abbonamento è attivo, ma non è impostato per il rinnovo. Pro rimane disponibile fino alla fine del periodo attuale.</string>
     <string name="upgrade_screen_owned_iap_title">Acquisto una tantum</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">שירותי Google Play אינם זמינים.</string>
-    <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>
     <string name="upgrades_gplay_billing_error_label">שגיאת Google Play</string>
     <string name="upgrades_gplay_billing_error_description">אירעה שגיאה ב-Google Play. נסה שוב מאוחר יותר או הפעל מחדש את הטלפון.\n\nשגיאה: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">שגיאת חיוב Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">אירעה שגיאה בעת בקשת פרטי הרכישה מ-Google Play. נקה את המטמון של Google Play והפעל מחדש את הטלפון.\n\nשגיאה %s</string>
     <string name="upgrades_gplay_already_owned_label">כבר רכשת?</string>
     <string name="upgrades_gplay_already_owned_description">לפי Google Play, כבר רכשת את השדרוג הזה, אך לא ניתן היה לשחזר אותו. ודא שאתה משתמש בחשבון Google שאיתו ביצעת את הרכישה. סנכרון Play Store עשוי לקחת זמן — נסה להפעיל מחדש את המכשיר, לנקות את מטמון Google Play או פשוט להמתין.</string>
-    <string name="upgrade_restore_action">שחזור רכישה</string>
     <string name="upgrade_badge_label">פרו</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">קבל %1$s</string>
     <string name="upgrade_preamble">CAPod מפותחת על ידי אדם אחד בלבד. שדרוג פותח תכונות נוספות ועוזר לשמור על האפליקציה בחיים.</string>
-    <string name="upgrade_screen_options_description">אותן תכונות, תמחור שונה. המינוי כולל ניסיון חינם וניתן לבטל אותו בכל עת.</string>
-    <string name="upgrade_screen_options_description_no_trial">אותן תכונות, תמחור שונה. ניתן לבטל את המינוי בכל עת.</string>
     <string name="upgrade_screen_subscription_trial_action">התחל ניסיון חינם</string>
     <string name="upgrade_screen_subscription_action">הירשם למינוי שנתי</string>
-    <string name="upgrade_screen_subscription_action_hint">%s לשנה</string>
     <string name="upgrade_screen_iap_action">רכישה חד-פעמית</string>
-    <string name="upgrade_screen_iap_action_hint">רכישה חד-פעמית: %s</string>
     <string name="upgrade_screen_restore_purchase_action">שחזור רכישה</string>
-    <string name="upgrade_screen_restore_purchase_message">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">אם רכשת לאחרונה, ייתכן שיחלוף רגע עד ש-Google Play יסתנכרן.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">נסה שוב בעוד כמה דקות אם הרכישה שלך לא מופיעה.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ודא שאתה מחובר עם אותו חשבון Google שבו בוצעה הרכישה.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">מספר חשבונות עלולים לבלבל את Google Play. התקנת האפליקציה דרך אתר Google Play מכריחה שיוך לחשבון ספציפי.</string>
     <string name="upgrade_screen_restore_banner_title">כבר רכשת את Pro?</string>
     <string name="upgrade_screen_restore_banner_body">נראה ששדרגת ל-Pro במכשיר הזה בעבר. שחזר את הרכישה כדי לפתוח אותו מחדש.</string>
     <string name="upgrade_screen_restore_success_message">הרכישה שוחזרה.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">יש לך CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">נפתח בזכות המינוי שלך. תודה שאתה תומך ב-CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">נפתח בזכות הרכישה החד-פעמית שלך. תודה שאתה תומך ב-CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">מינוי שנתי</string>
     <string name="upgrade_screen_owned_sub_renewing_body">המינוי שלך פעיל ומוגדר להתחדש. החיוב מנוהל על ידי Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">המינוי שלך פעיל, אך לא מוגדר להתחדש. Pro יישאר זמין עד לסיום התקופה הנוכחית.</string>
     <string name="upgrade_screen_owned_iap_title">רכישה חד-פעמית</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Playサービスが利用できません。</string>
-    <string name="upgrades_no_purchases_found_check_account">購入履歴がありません。正しいアカウントを使用していますか？</string>
     <string name="upgrades_gplay_billing_error_label">Google Playエラー</string>
     <string name="upgrades_gplay_billing_error_description">Google Playでエラーが発生しました。後でもう一度お試しいただくか、スマートフォンを再起動してください。\n\nエラー: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play請求エラー</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Playに購入情報を問い合わせる際にエラーが発生しました。Google Playのキャッシュをクリアし、スマートフォンを再起動してください。\n\nエラー %s</string>
     <string name="upgrades_gplay_already_owned_label">購入済みですか?</string>
     <string name="upgrades_gplay_already_owned_description">Google Playによると、このアップグレードはすでに購入済みですが、復元できませんでした。購入時に使用したGoogleアカウントを使用していることを確認してください。Playストアの同期には時間がかかる場合があります。再起動する、Google Playのキャッシュを削除する、またはしばらく待ってみてください。</string>
-    <string name="upgrade_restore_action">購入を復元</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s を入手</string>
     <string name="upgrade_preamble">CAPodは一人の個人開発者によって開発されています。アップグレードすると追加機能が使えるようになり、アプリの継続的な開発を支えることができます。</string>
-    <string name="upgrade_screen_options_description">機能は同じで、料金プランが異なります。サブスクリプションには無料トライアルが含まれており、いつでも解約できます。</string>
-    <string name="upgrade_screen_options_description_no_trial">機能は同じで、料金プランが異なります。サブスクリプションはいつでも解約できます。</string>
     <string name="upgrade_screen_subscription_trial_action">試用を開始する</string>
     <string name="upgrade_screen_subscription_action">年間プランを購入</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/年</string>
     <string name="upgrade_screen_iap_action">1回のみ購入</string>
-    <string name="upgrade_screen_iap_action_hint">1回限りの購入: %s</string>
     <string name="upgrade_screen_restore_purchase_action">購入を復元</string>
-    <string name="upgrade_screen_restore_purchase_message">購入履歴がありません。正しいアカウントを使用していますか？</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">最近購入した場合、Google Playの同期に時間がかかることがあります。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">購入が反映されない場合は、数分後にもう一度お試しください。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">購入時に使用したものと同じGoogleアカウントでサインインしていることを確認してください。</string>
-    <string name="upgrade_screen_restore_webinstall_hint">複数のアカウントがあると、Google Playが混乱する場合があります。Google Playのウェブサイトからアプリをインストールすると、特定のアカウントとの関連付けが強制されます。</string>
     <string name="upgrade_screen_restore_banner_title">すでにProを購入済みですか?</string>
     <string name="upgrade_screen_restore_banner_body">このデバイスで以前Proにアップグレードしたようです。購入を復元すると再利用できるようになります。</string>
     <string name="upgrade_screen_restore_success_message">購入を復元しました。</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">CAPod Proをご利用中です!</string>
     <string name="upgrade_screen_owned_hero_sub_body">サブスクリプションにより解除されています。CAPodをサポートいただきありがとうございます!</string>
     <string name="upgrade_screen_owned_hero_iap_body">1回限りの購入により解除されています。CAPodをサポートいただきありがとうございます!</string>
-    <string name="upgrade_screen_owned_sub_title">年間サブスクリプション</string>
     <string name="upgrade_screen_owned_sub_renewing_body">サブスクリプションは有効で、更新するように設定されています。請求はGoogle Playによって管理されます。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">サブスクリプションは有効ですが、更新しないように設定されています。Proは現在の期間が終了するまで利用できます。</string>
     <string name="upgrade_screen_owned_iap_title">1 回限りの購入</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play სერვისები მიუწვდომელია.</string>
-    <string name="upgrades_no_purchases_found_check_account">შენაძენები ვერ მოიძებნა. იყენებთ სწორ ანგარიშს?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-ის შეცდომა</string>
     <string name="upgrades_gplay_billing_error_description">Google Play-ში მოხდა შეცდომა. სცადეთ მოგვიანებით ან გადატვირთეთ ტელეფონი.\n\nშეცდომა: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play ბილინგის შეცდომა</string>
-    <string name="upgrades_gplay_billing_result_error_description">შეცდომა მოხდა Google Play-დან შენაძენის დეტალების მოთხოვნისას. გაასუფთავეთ Google Play-ის ქეში და გადატვირთეთ ტელეფონი.\n\nშეცდომა %s</string>
     <string name="upgrades_gplay_already_owned_label">უკვე შეძენილია?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play იტყობინება, რომ ეს განახლება უკვე შეძენილი გაქვთ, მაგრამ მისი აღდგენა ვერ მოხერხდა. დარწმუნდით, რომ იყენებთ იმ Google ანგარიშს, რომლითაც შეიძინეთ. Play Store-ის სინქრონიზაციას შეიძლება დრო დასჭირდეს — სცადეთ გადატვირთვა, Google Play-ის ქეშის გასუფთავება ან უბრალოდ დაელოდეთ.</string>
-    <string name="upgrade_restore_action">შეძენის აღდგენა</string>
     <string name="upgrade_badge_label">პრო</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">მიიღეთ %1$s</string>
     <string name="upgrade_preamble">CAPod-ს ერთი ადამიანი ავითარებს. განახლება ხსნის დამატებით ფუნქციებს და ეხმარება აპლიკაციის ცოცხლად შენარჩუნებაში.</string>
-    <string name="upgrade_screen_options_description">იგივე ფუნქციები, განსხვავებული ფასი. გამოწერა მოიცავს უფასო საცდელ პერიოდს და მისი გაუქმება შესაძლებელია ნებისმიერ დროს.</string>
-    <string name="upgrade_screen_options_description_no_trial">იგივე ფუნქციები, განსხვავებული ფასი. გამოწერის გაუქმება შესაძლებელია ნებისმიერ დროს.</string>
     <string name="upgrade_screen_subscription_trial_action">დაიწყეთ უფასო საცდელი ვერსიით</string>
     <string name="upgrade_screen_subscription_action">გამოიწერეთ წლიურად</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/წელი</string>
     <string name="upgrade_screen_iap_action">ერთჯერადი შეძენა</string>
-    <string name="upgrade_screen_iap_action_hint">ერთჯერადი შესყიდვა: %s</string>
     <string name="upgrade_screen_restore_purchase_action">შეძენის აღდგენა</string>
-    <string name="upgrade_screen_restore_purchase_message">შენაძენები ვერ მოიძებნა. იყენებთ სწორ ანგარიშს?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">თუ ახლახან შეიძინეთ, Google Play-ს სინქრონიზაციისთვის შეიძლება გარკვეული დრო დასჭირდეს.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">თუ თქვენი შესყიდვა არ გამოჩნდა, სცადეთ ხელახლა რამდენიმე წუთში.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">დარწმუნდით, რომ შესული ხართ იმავე Google ანგარიშით, რომლითაც შესყიდვა განახორციელეთ.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">რამდენიმე ანგარიშმა შეიძლება Google Play დააბნიოს. აპლიკაციის Google Play-ის ვებგვერდის საშუალებით დაყენება აიძულებს კონკრეტულ ანგარიშთან დაკავშირებას.</string>
     <string name="upgrade_screen_restore_banner_title">უკვე შეიძინეთ Pro?</string>
     <string name="upgrade_screen_restore_banner_body">როგორც ჩანს, ამ მოწყობილობაზე ადრე უკვე განაახლეთ Pro-მდე. აღადგინეთ თქვენი შესყიდვა მის ხელახლა გასახსნელად.</string>
     <string name="upgrade_screen_restore_success_message">შესყიდვა აღდგენილია.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">თქვენ გაქვთ CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">გახსნილია თქვენი გამოწერით. მადლობა CAPod-ის მხარდაჭერისთვის!</string>
     <string name="upgrade_screen_owned_hero_iap_body">გახსნილია თქვენი ერთჯერადი შესყიდვით. მადლობა CAPod-ის მხარდაჭერისთვის!</string>
-    <string name="upgrade_screen_owned_sub_title">წლიური გამოწერა</string>
     <string name="upgrade_screen_owned_sub_renewing_body">თქვენი გამოწერა აქტიურია და განახლდება ავტომატურად. ბილინგს მართავს Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">თქვენი გამოწერა აქტიურია, მაგრამ არ არის დაყენებული განახლებაზე. Pro ხელმისაწვდომი დარჩება მიმდინარე პერიოდის დასრულებამდე.</string>
     <string name="upgrade_screen_owned_iap_title">ერთჯერადი შეძენა</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">សេវាកម្ម Google Play មិនអាចប្រើបានទេ</string>
-    <string name="upgrades_no_purchases_found_check_account">រកមិនឃើញការទិញទេ។ តើអ្នកកំពុងប្រើគណនីត្រឹមត្រូវទេ?</string>
     <string name="upgrades_gplay_billing_error_label">កំហុស Google Play</string>
     <string name="upgrades_gplay_billing_error_description">មានកំហុសនៅក្នុង Google Play។ សូមព្យាយាមម្តងទៀតនៅពេលក្រោយ ឬចាប់ផ្តើមទូរសព្ទឡើងវិញ។\n\nកំហុស: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">កំហុសការចេញវិក្កយបត្រ Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">មានកំហុសពេលស្នើសុំព័ត៌មានការទិញពី Google Play។ សូមសម្អាតឃ្លាំងសម្ងាត់ Google Play និងចាប់ផ្តើមទូរសព្ទឡើងវិញ។\n\nកំហុស %s</string>
     <string name="upgrades_gplay_already_owned_label">បានទិញរួចហើយ?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play រាយការណ៍ថាអ្នកបានទទួលកម្មសិទ្ធិការដំឡើងកម្រិតនេះរួចហើយ ប៉ុន្តែមិនអាចស្ដារវាឡើងវិញបានទេ។ សូមប្រាកដថាអ្នកកំពុងប្រើគណនី Google ដែលអ្នកបានទិញជាមួយ។ ការធ្វើសមកាលកម្ម Play Store អាចត្រូវការពេលវេលា — សូមសាកល្បងចាប់ផ្ដើមឧបករណ៍ឡើងវិញ សម្អាតឃ្លាំងសម្ងាត់ Google Play ឬគ្រាន់តែរង់ចាំ។</string>
-    <string name="upgrade_restore_action">ស្តារការជាវមកវិញ</string>
     <string name="upgrade_badge_label">ប្រូ</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">ទទួលបាន %1$s</string>
     <string name="upgrade_preamble">CAPod ត្រូវបានបង្កើតឡើងដោយមនុស្សតែម្នាក់។ ការដំឡើងកម្រិតដោះសោលក្ខណៈពិសេសបន្ថែម និងជួយរក្សាកម្មវិធីនេះឲ្យបន្តដំណើរការ។</string>
-    <string name="upgrade_screen_options_description">លក្ខណៈពិសេសដូចគ្នា តម្លៃខុសគ្នា។ ការជាវរួមមានការសាកល្បងឥតគិតថ្លៃ ហើយអាចលុបចោលបានគ្រប់ពេល។</string>
-    <string name="upgrade_screen_options_description_no_trial">លក្ខណៈពិសេសដូចគ្នា តម្លៃខុសគ្នា។ ការជាវអាចលុបចោលបានគ្រប់ពេល។</string>
     <string name="upgrade_screen_subscription_trial_action">ចាប់ផ្ដើមការសាកល្បងឥតគិតថ្លៃ</string>
     <string name="upgrade_screen_subscription_action">ជាវប្រចាំឆ្នាំ</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ឆ្នាំ</string>
     <string name="upgrade_screen_iap_action">ទិញតែម្តង</string>
-    <string name="upgrade_screen_iap_action_hint">ការទិញតែម្ដង៖ %s</string>
     <string name="upgrade_screen_restore_purchase_action">ស្តារការជាវមកវិញ</string>
-    <string name="upgrade_screen_restore_purchase_message">រកមិនឃើញការទិញទេ។ តើអ្នកកំពុងប្រើគណនីត្រឹមត្រូវទេ?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">ប្រសិនបើអ្នកទើបតែបានទិញថ្មីៗ វាអាចត្រូវការពេលបន្តិចដើម្បីឱ្យ Google Play ធ្វើសមកាលកម្ម។</string>
     <string name="upgrade_screen_restore_sync_patience_hint">សូមព្យាយាមម្តងទៀតក្នុងរយៈពេលពីរបីនាទី ប្រសិនបើការទិញរបស់អ្នកមិនបង្ហាញ។</string>
     <string name="upgrade_screen_restore_multiaccount_hint">សូមប្រាកដថាអ្នកបានចូលគណនីជាមួយគណនី Google ដូចគ្នានឹងគណនីដែលបានប្រើសម្រាប់ការទិញ។</string>
-    <string name="upgrade_screen_restore_webinstall_hint">គណនីច្រើនអាចធ្វើឱ្យ Google Play ច្រឡំ។ ការដំឡើងកម្មវិធីតាមរយៈគេហទំព័រ Google Play នឹងបង្ខំការភ្ជាប់ជាមួយគណនីជាក់លាក់មួយ។</string>
     <string name="upgrade_screen_restore_banner_title">បានទិញ Pro រួចហើយ?</string>
     <string name="upgrade_screen_restore_banner_body">ហាក់ដូចជាអ្នកបានដំឡើងកម្រិតទៅ Pro នៅលើឧបករណ៍នេះពីមុនមកហើយ។ សូមស្ដារការទិញរបស់អ្នកឡើងវិញដើម្បីដោះសោវាម្ដងទៀត។</string>
     <string name="upgrade_screen_restore_success_message">ការទិញត្រូវបានស្ដារឡើងវិញ។</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">អ្នកមាន CAPod Pro ហើយ!</string>
     <string name="upgrade_screen_owned_hero_sub_body">បានដោះសោដោយការជាវរបស់អ្នក។ សូមអរគុណចំពោះការគាំទ្រ CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">បានដោះសោដោយការទិញតែម្ដងរបស់អ្នក។ សូមអរគុណចំពោះការគាំទ្រ CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">ការជាវប្រចាំឆ្នាំ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ការជាវរបស់អ្នកកំពុងសកម្ម និងត្រូវបានកំណត់ឲ្យបន្ត។ ការគិតប្រាក់ត្រូវបានគ្រប់គ្រងដោយ Google Play។</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ការជាវរបស់អ្នកកំពុងសកម្ម ប៉ុន្តែមិនត្រូវបានកំណត់ឲ្យបន្តទេ។ Pro នៅតែអាចប្រើបានរហូតដល់ចុងបញ្ចប់នៃរយៈពេលបច្ចុប្បន្ន។</string>
     <string name="upgrade_screen_owned_iap_title">ការជាវតែម្ដងរួច</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Xizmetên Google Play ne berdest in.</string>
-    <string name="upgrades_no_purchases_found_check_account">Kirîn nehatin dîtin. Hûn hesabê rast bikar tînin?</string>
     <string name="upgrades_gplay_billing_error_label">Çewtiya Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Di Google Play de çewtiyek çêbû. Ji kerema xwe paşê dîsa biceribîne an jî têlefona xwe ji nû ve bide destpêkirin.\n\nÇewtî: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Çewtiya Fatûrekirina Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Dema ku ji Google Play agahdariyên kirîna we hat xwestin çewtiyek çêbû. Pêşbîra Google Play paqij bikin û têlefona xwe ji nû ve bide destpêkirin.\n\nÇewtî %s</string>
     <string name="upgrades_gplay_already_owned_label">Jixwe kirriye?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play radigihîne ku vê nûvekirinê jixwe di destê te de ye, lê ew nehat vegerandin. Piştrast bike ku tu bi hesabê Google yê ku pê kirriye têkevî. Senkronîzasyona Play Store dibe ku demê bigire — biceribîne ku cîhazê ji nû ve bidî destpêkirin, cache\'ya Google Play paqij bike an tenê bisekine.</string>
-    <string name="upgrade_restore_action">Kirînê vegerîne</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Wergir %1$s</string>
     <string name="upgrade_preamble">CAPod ji aliyê kesekî yekane ve tê pêşxistin. Nûvekirin taybetmendiyên zêde vedike û dibe alîkar ku sepan berdewam bimîne.</string>
-    <string name="upgrade_screen_options_description">Heman taybetmendî, buhayên cuda. Abonetî ceribandineke belaş vedihewîne û her dem dikare bê betalkirin.</string>
-    <string name="upgrade_screen_options_description_no_trial">Heman taybetmendî, buhayên cuda. Abonetî her dem dikare bê betalkirin.</string>
     <string name="upgrade_screen_subscription_trial_action">Ceribandina belaş dest pê bike</string>
     <string name="upgrade_screen_subscription_action">Bi salane bibe abone</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/sal</string>
     <string name="upgrade_screen_iap_action">Carekê bikire</string>
-    <string name="upgrade_screen_iap_action_hint">Kirîna carekî: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Kirînê vegerîne</string>
-    <string name="upgrade_screen_restore_purchase_message">Kirîn nehatin dîtin. Hûn hesabê rast bikar tînin?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Heke te vê dawiyê kirriye, dibe ku demek bigire ku Google Play were senkronîzekirin.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Heke kirîna te xuya nabe, piştî çend deqeyan dîsa biceribîne.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Piştrast bike ku tu bi heman hesabê Google yê ku pê kirî, têkevî.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Gelek hesab dikarin Google Play tevlihîv bikin. Sazkirina sepanê bi rêya malpera Google Play, girêdana bi hesabekî diyarkirî re mecbûrî dike.</string>
     <string name="upgrade_screen_restore_banner_title">Jixwe Pro kirriye?</string>
     <string name="upgrade_screen_restore_banner_body">Xuya ye ku te berê li ser vê cîhazê xwe Pro kiriye. Kirîna xwe vegerîne da ku dîsa were vekirin.</string>
     <string name="upgrade_screen_restore_success_message">Kirîn hate vegerandin.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">CAPod Pro li ba te ye!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Bi aboneya te hat vekirin. Spas ji bo piştgiriya te ya CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bi kirîna te ya carekî hat vekirin. Spas ji bo piştgiriya te ya CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Aboneya salane</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Aboneya te çalak e û hatiye mêhengkirin ku were nûkirin. Faturekirin ji aliyê Google Play ve tê rêvebirin.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Aboneya te çalak e, lê ji bo nûkirinê nehatiye mêhengkirin. Pro heta dawiya dema heyî berdest dimîne.</string>
     <string name="upgrade_screen_owned_iap_title">Kirîna carekî</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play ಸೇವೆಗಳು ಲಭ್ಯವಿಲ್ಲ.</string>
-    <string name="upgrades_no_purchases_found_check_account">ಯಾವುದೇ ಖರೀದಿಗಳು ಕಂಡುಬಂದಿಲ್ಲ. ನೀವು ಸರಿಯಾದ ಖಾತೆಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಾ?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play ದೋಷ</string>
     <string name="upgrades_gplay_billing_error_description">Google Play ನಲ್ಲಿ ದೋಷ ಸಂಭವಿಸಿದೆ. ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ನಿಮ್ಮ ಫೋನ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.\n\nದೋಷ: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play ಬಿಲ್ಲಿಂಗ್ ದೋಷ</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play ನಿಂದ ನಿಮ್ಮ ಖರೀದಿ ವಿವರಗಳನ್ನು ಕೇಳುವಾಗ ದೋಷ ಸಂಭವಿಸಿದೆ. Google Play ಕ್ಯಾಶ್ ಅನ್ನು ತೆರವುಗೊಳಿಸಿ ಮತ್ತು ನಿಮ್ಮ ಫೋನ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.\n\nದೋಷ %s</string>
     <string name="upgrades_gplay_already_owned_label">ಈಗಾಗಲೇ ಖರೀದಿಸಿದ್ದೀರಾ?</string>
     <string name="upgrades_gplay_already_owned_description">ನೀವು ಈ ಅಪ್‌ಗ್ರೇಡ್ ಅನ್ನು ಈಗಾಗಲೇ ಹೊಂದಿದ್ದೀರಿ ಎಂದು Google Play ವರದಿ ಮಾಡುತ್ತದೆ, ಆದರೆ ಅದನ್ನು ಮರುಸ್ಥಾಪಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ನೀವು ಖರೀದಿಸಿದ Google ಖಾತೆಯನ್ನೇ ಬಳಸುತ್ತಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ. Play Store ಸಿಂಕ್ರೊನೈಸೇಶನ್‌ಗೆ ಸಮಯ ತೆಗೆದುಕೊಳ್ಳಬಹುದು — ಮರುಪ್ರಾರಂಭಿಸಲು, Google Play ಕ್ಯಾಶ್ ಅನ್ನು ತೆರವುಗೊಳಿಸಲು ಅಥವಾ ಸ್ವಲ್ಪ ಕಾಯಲು ಪ್ರಯತ್ನಿಸಿ.</string>
-    <string name="upgrade_restore_action">ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಿ</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ಪಡೆಯಿರಿ</string>
     <string name="upgrade_preamble">CAPod ಅನ್ನು ಒಬ್ಬ ವ್ಯಕ್ತಿ ಅಭಿವೃದ್ಧಿಪಡಿಸುತ್ತಾರೆ. ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡುವುದರಿಂದ ಹೆಚ್ಚುವರಿ ವೈಶಿಷ್ಟ್ಯಗಳು ಅನ್‌ಲಾಕ್ ಆಗುತ್ತವೆ ಮತ್ತು ಅಪ್ಲಿಕೇಶನ್ ಜೀವಂತವಾಗಿರಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.</string>
-    <string name="upgrade_screen_options_description">ಅದೇ ವೈಶಿಷ್ಟ್ಯಗಳು, ವಿಭಿನ್ನ ಬೆಲೆ. ಚಂದಾದಾರಿಕೆಯು ಉಚಿತ ಪ್ರಯೋಗವನ್ನು ಒಳಗೊಂಡಿದೆ ಮತ್ತು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ರದ್ದುಗೊಳಿಸಬಹುದು.</string>
-    <string name="upgrade_screen_options_description_no_trial">ಅದೇ ವೈಶಿಷ್ಟ್ಯಗಳು, ವಿಭಿನ್ನ ಬೆಲೆ. ಚಂದಾದಾರಿಕೆಯನ್ನು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ರದ್ದುಗೊಳಿಸಬಹುದು.</string>
     <string name="upgrade_screen_subscription_trial_action">ಉಚಿತ ಪ್ರಯೋಗ ಪ್ರಾರಂಭಿಸಿ</string>
     <string name="upgrade_screen_subscription_action">ವಾರ್ಷಿಕವಾಗಿ ಚಂದಾದಾರರಾಗಿ</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ವರ್ಷ</string>
     <string name="upgrade_screen_iap_action">ಒಮ್ಮೆ ಖರೀದಿಸಿ</string>
-    <string name="upgrade_screen_iap_action_hint">ಒಂದು ಬಾರಿಯ ಖರೀದಿ: %s</string>
     <string name="upgrade_screen_restore_purchase_action">ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಿ</string>
-    <string name="upgrade_screen_restore_purchase_message">ಯಾವುದೇ ಖರೀದಿಗಳು ಕಂಡುಬಂದಿಲ್ಲ. ನೀವು ಸರಿಯಾದ ಖಾತೆಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಾ?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">ನೀವು ಇತ್ತೀಚೆಗೆ ಖರೀದಿಸಿದ್ದರೆ, Google Play ಸಿಂಕ್ ಆಗಲು ಸ್ವಲ್ಪ ಸಮಯ ತೆಗೆದುಕೊಳ್ಳಬಹುದು.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ನಿಮ್ಮ ಖರೀದಿ ಕಾಣಿಸದಿದ್ದರೆ ಕೆಲವು ನಿಮಿಷಗಳಲ್ಲಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ಖರೀದಿಗೆ ಬಳಸಿದ ಅದೇ Google ಖಾತೆಯೊಂದಿಗೆ ನೀವು ಸೈನ್ ಇನ್ ಆಗಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">ಬಹು ಖಾತೆಗಳು Google Play ಅನ್ನು ಗೊಂದಲಗೊಳಿಸಬಹುದು. Google Play ವೆಬ್‌ಸೈಟ್ ಮೂಲಕ ಅಪ್ಲಿಕೇಶನ್ ಅನ್ನು ಸ್ಥಾಪಿಸುವುದರಿಂದ ನಿರ್ದಿಷ್ಟ ಖಾತೆಯೊಂದಿಗೆ ಸಂಬಂಧವನ್ನು ಬಲವಂತಪಡಿಸುತ್ತದೆ.</string>
     <string name="upgrade_screen_restore_banner_title">ಈಗಾಗಲೇ Pro ಖರೀದಿಸಿದ್ದೀರಾ?</string>
     <string name="upgrade_screen_restore_banner_body">ನೀವು ಈ ಹಿಂದೆ ಈ ಸಾಧನದಲ್ಲಿ Pro ಗೆ ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿದಂತೆ ಕಾಣುತ್ತದೆ. ಅದನ್ನು ಮತ್ತೆ ಅನ್‌ಲಾಕ್ ಮಾಡಲು ನಿಮ್ಮ ಖರೀದಿಯನ್ನು ಮರುಸ್ಥಾಪಿಸಿ.</string>
     <string name="upgrade_screen_restore_success_message">ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಲಾಗಿದೆ.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">ನಿಮ್ಮಲ್ಲಿ CAPod Pro ಇದೆ!</string>
     <string name="upgrade_screen_owned_hero_sub_body">ನಿಮ್ಮ ಚಂದಾದಾರಿಕೆಯಿಂದ ಅನ್‌ಲಾಕ್ ಮಾಡಲಾಗಿದೆ. CAPod ಅನ್ನು ಬೆಂಬಲಿಸಿದ್ದಕ್ಕಾಗಿ ಧನ್ಯವಾದಗಳು!</string>
     <string name="upgrade_screen_owned_hero_iap_body">ನಿಮ್ಮ ಒಂದು ಬಾರಿಯ ಖರೀದಿಯಿಂದ ಅನ್‌ಲಾಕ್ ಮಾಡಲಾಗಿದೆ. CAPod ಅನ್ನು ಬೆಂಬಲಿಸಿದ್ದಕ್ಕಾಗಿ ಧನ್ಯವಾದಗಳು!</string>
-    <string name="upgrade_screen_owned_sub_title">ವಾರ್ಷಿಕ ಚಂದಾದಾರಿಕೆ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ನಿಮ್ಮ ಚಂದಾದಾರಿಕೆ ಸಕ್ರಿಯವಾಗಿದೆ ಮತ್ತು ನವೀಕರಿಸಲು ಹೊಂದಿಸಲಾಗಿದೆ. ಬಿಲ್ಲಿಂಗ್ ಅನ್ನು Google Play ನಿರ್ವಹಿಸುತ್ತದೆ.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ನಿಮ್ಮ ಚಂದಾದಾರಿಕೆ ಸಕ್ರಿಯವಾಗಿದೆ, ಆದರೆ ನವೀಕರಿಸಲು ಹೊಂದಿಸಿಲ್ಲ. ಪ್ರಸ್ತುತ ಅವಧಿ ಮುಗಿಯುವವರೆಗೆ Pro ಲಭ್ಯವಿರುತ್ತದೆ.</string>
     <string name="upgrade_screen_owned_iap_title">ಒಂದು ಬಾರಿಯ ಖರೀದಿ</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play 서비스를 사용할 수 없습니다.</string>
-    <string name="upgrades_no_purchases_found_check_account">구매 내역을 찾지 못했습니다. 결제했던 계정이 맞나요?</string>
     <string name="upgrades_gplay_billing_error_label">구글 플레이 오류</string>
     <string name="upgrades_gplay_billing_error_description">구글 플레이에 오류가 발생했습니다. 나중에 다시 시도하거나 휴대전화를 재시작하세요.\n\n오류:%s</string>
-    <string name="upgrades_gplay_billing_result_error_label">구글 플레이 결제 오류</string>
-    <string name="upgrades_gplay_billing_result_error_description">구글 플레이에서 귀하의 구매 세부 사항을 불러오는데 문제가 발생했습니다. 구글 플레이 캐시를 지우고 휴대전화를 재시작해주세요.\n\n오류%s</string>
     <string name="upgrades_gplay_already_owned_label">이미 구매하셨나요?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play에서 이미 이 업그레이드를 보유하고 있다고 알렸지만 복원할 수 없었습니다. 구매할 때 사용한 Google 계정을 사용 중인지 확인하세요. Play 스토어 동기화에는 시간이 걸릴 수 있습니다. 기기를 재부팅하거나 Google Play 캐시를 지우거나 잠시 기다려 보세요.</string>
-    <string name="upgrade_restore_action">구매 복원</string>
     <string name="upgrade_badge_label">프로</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s 받기</string>
     <string name="upgrade_preamble">CAPod는 한 사람이 개발하고 있습니다. 업그레이드하면 추가 기능이 열리고 앱을 계속 운영하는 데 도움이 됩니다.</string>
-    <string name="upgrade_screen_options_description">기능은 동일하고 가격만 다릅니다. 구독에는 무료 체험이 포함되어 있으며 언제든지 취소할 수 있습니다.</string>
-    <string name="upgrade_screen_options_description_no_trial">기능은 동일하고 가격만 다릅니다. 구독은 언제든지 취소할 수 있습니다.</string>
     <string name="upgrade_screen_subscription_trial_action">무료 체험 시작</string>
     <string name="upgrade_screen_subscription_action">연간 구독하기</string>
-    <string name="upgrade_screen_subscription_action_hint">연 %s</string>
     <string name="upgrade_screen_iap_action">한 번만 구매하기</string>
-    <string name="upgrade_screen_iap_action_hint">일회성 구매: %s</string>
     <string name="upgrade_screen_restore_purchase_action">구매 복원</string>
-    <string name="upgrade_screen_restore_purchase_message">구매 내역을 찾지 못했습니다. 결제했던 계정이 맞나요?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">최근에 구매하셨다면 Google Play가 동기화되는 데 잠시 시간이 걸릴 수 있습니다.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">구매 내역이 표시되지 않으면 몇 분 후 다시 시도해 보세요.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">구매에 사용한 Google 계정으로 로그인되어 있는지 확인하세요.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">계정이 여러 개면 Google Play가 혼동할 수 있습니다. Google Play 웹사이트를 통해 앱을 설치하면 특정 계정과의 연결이 강제로 지정됩니다.</string>
     <string name="upgrade_screen_restore_banner_title">이미 Pro를 구매하셨나요?</string>
     <string name="upgrade_screen_restore_banner_body">이 기기에서 이전에 Pro로 업그레이드하셨던 것 같습니다. 구매를 복원하여 다시 잠금을 해제하세요.</string>
     <string name="upgrade_screen_restore_success_message">구매가 복원되었습니다.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">CAPod Pro를 이용 중입니다!</string>
     <string name="upgrade_screen_owned_hero_sub_body">구독으로 잠금이 해제되었습니다. CAPod를 후원해 주셔서 감사합니다!</string>
     <string name="upgrade_screen_owned_hero_iap_body">일회성 구매로 잠금이 해제되었습니다. CAPod를 후원해 주셔서 감사합니다!</string>
-    <string name="upgrade_screen_owned_sub_title">연간 구독</string>
     <string name="upgrade_screen_owned_sub_renewing_body">구독이 활성화되어 있으며 갱신되도록 설정되어 있습니다. 결제는 Google Play가 관리합니다.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">구독이 활성화되어 있지만 갱신되지 않도록 설정되어 있습니다. 현재 기간이 끝날 때까지 Pro를 계속 이용할 수 있습니다.</string>
     <string name="upgrade_screen_owned_iap_title">영구적 구매</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play кызматтары жеткиликсиз.</string>
-    <string name="upgrades_no_purchases_found_check_account">Эч кандай сатып алуулар табылган жок. Туура каттоо эсебин колдонуп жатасызбы?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play катасы</string>
     <string name="upgrades_gplay_billing_error_description">Google Play\'де ката кетти. Кийинчерээк кайра аракет кылыңыз же телефонуңузду өчүрүп күйгүзүңүз.\n\nКата: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play төлөм катасы</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play\'ден сатып алуу маалыматын сурап жатканда ката кетти. Google Play кэшин тазалаңыз жана телефонуңузду өчүрүп күйгүзүңүз.\n\nКата %s</string>
     <string name="upgrades_gplay_already_owned_label">Мурунтан эле сатып алгансызбы?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play бул жаңыртууну мурунтан эле сатып алганыңызды билдирет, бирок аны калыбына келтирүү мүмкүн болбоду. Сатып алган Google каттоо эсебиңизди колдонуп жатканыңызды текшериңиз. Play Store синхрондоштуруусу убакытты талап кылышы мүмкүн — түзмөктү өчүрүп-күйгүзүп көрүңүз, Google Play кэшин тазалаңыз же жөн эле күтө туруңуз.</string>
-    <string name="upgrade_restore_action">Сатып алууну калыбына келтирүү</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s алыңыз</string>
     <string name="upgrade_preamble">CAPod бир адам тарабынан иштелип чыгууда. Жаңыртуу кошумча мүмкүнчүлүктөрдү ачат жана колдонмонун иштешин колдоого жардам берет.</string>
-    <string name="upgrade_screen_options_description">Бирдей мүмкүнчүлүктөр, ар кандай баа. Жазылууга акысыз сыноо мөөнөтү кирет жана каалаган убакытта жокко чыгарууга болот.</string>
-    <string name="upgrade_screen_options_description_no_trial">Бирдей мүмкүнчүлүктөр, ар кандай баа. Жазылууну каалаган убакытта жокко чыгарууга болот.</string>
     <string name="upgrade_screen_subscription_trial_action">Акысыз сыноону баштоо</string>
     <string name="upgrade_screen_subscription_action">Жылдык жазылуу</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/жыл</string>
     <string name="upgrade_screen_iap_action">Бир жолу сатып алуу</string>
-    <string name="upgrade_screen_iap_action_hint">Бир жолку сатып алуу: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Сатып алууну калыбына келтирүү</string>
-    <string name="upgrade_screen_restore_purchase_message">Эч кандай сатып алуулар табылган жок. Туура каттоо эсебин колдонуп жатасызбы?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Эгер жакында сатып алган болсоңуз, Google Play синхрондошуу үчүн бир аз убакыт талап кылышы мүмкүн.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Сатып алууңуз көрүнбөсө, бир нече мүнөттөн кийин кайра аракет кылыңыз.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Сатып алуу үчүн колдонулган Google каттоо эсебиңиз менен кирип турганыңызды текшериңиз.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Бир нече каттоо эсеби Google Play\'ди адаштырышы мүмкүн. Колдонмону Google Play веб-сайты аркылуу орнотуу аны белгилүү бир каттоо эсеби менен байланыштырууга мажбурлайт.</string>
     <string name="upgrade_screen_restore_banner_title">Pro\'ну мурунтан сатып алгансызбы?</string>
     <string name="upgrade_screen_restore_banner_body">Бул түзмөктө мурун Pro\'го жаңырткан окшойсуз. Аны кайра ачуу үчүн сатып алууңузду калыбына келтириңиз.</string>
     <string name="upgrade_screen_restore_success_message">Сатып алуу калыбына келтирилди.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Сизде CAPod Pro бар!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Жазылууңуз аркылуу ачылды. CAPod\'ду колдогонуңуз үчүн рахмат!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Бир жолку сатып алууңуз аркылуу ачылды. CAPod\'ду колдогонуңуз үчүн рахмат!</string>
-    <string name="upgrade_screen_owned_sub_title">Жылдык жазылуу</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Жазылууңуз активдүү жана жаңылануучу кылып койулган. Төлөмдөрдү Google Play башкарат.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Жазылууңуз активдүү, бирок жаңылануучу кылып койулган эмес. Pro учурдагы мезгил бүткөнгө чейин жеткиликтүү бойдн калат.</string>
     <string name="upgrade_screen_owned_iap_title">Бир жолку сатып алуу</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">ບໍລິການ Google Play ບໍ່ສາມາດໃຊ້ໄດ້.</string>
-    <string name="upgrades_no_purchases_found_check_account">ບໍ່ພົບການຊື້. ທ່ານກຳລັງໃຊ້ບັນຊີທີ່ຖືກຕ້ອງບໍ?</string>
     <string name="upgrades_gplay_billing_error_label">ຂໍ້ຜິດພາດ Google Play</string>
     <string name="upgrades_gplay_billing_error_description">ເກີດຂໍ້ຜິດພາດໃນ Google Play. ກະລຸນາລອງໃໝ່ພາຍຫຼັງ ຫຼືປິດເປີດໂທລະສັບຂອງທ່ານໃໝ່.\n\nຂໍ້ຜິດພາດ: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">ຂໍ້ຜິດພາດການຮຽກເກັບເງິນ Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">ເກີດຂໍ້ຜິດພາດໃນການຂໍລາຍລະອຽດການຊື້ຈາກ Google Play. ລຶບແຄສ Google Play ແລະປິດເປີດໂທລະສັບຂອງທ່ານໃໝ່.\n\nຂໍ້ຜິດພາດ %s</string>
     <string name="upgrades_gplay_already_owned_label">ຊື້ໄປແລ້ວບໍ?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play ລາຍງານວ່າທ່ານເປັນເຈົ້າຂອງການອັບເກຣດນີ້ແລ້ວ, ແຕ່ບໍ່ສາມາດກູ້ຄືນໄດ້. ກະລຸນາກວດສອບໃຫ້ແນ່ໃຈວ່າທ່ານກຳລັງໃຊ້ບັນຊີ Google ດຽວກັນກັບທີ່ໃຊ້ຊື້. ການຊິງຄ໌ຂໍ້ມູນຂອງ Play Store ອາດຈະໃຊ້ເວລາ — ລອງຣີສະຕາດເຄື່ອງ, ລ້າງແຄດຊ໌ຂອງ Google Play ຫຼືພຽງແຕ່ລໍຖ້າ.</string>
-    <string name="upgrade_restore_action">ກູ້ຄືນການຊື້</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">ຮັບ %1$s</string>
     <string name="upgrade_preamble">CAPod ຖືກພັດທະນາໂດຍຄົນຄົນດຽວ. ການອັບເກຣດຈະປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ຊ່ວຍໃຫ້ແອັບຄົງຢູ່ຕໍ່ໄປ.</string>
-    <string name="upgrade_screen_options_description">ຄຸນສົມບັດຄືກັນ, ລາຄາຕ່າງກັນ. ການສະໝັກສະມາຊິກມີການທົດລອງໃຊ້ຟຣີ ແລະ ສາມາດຍົກເລີກໄດ້ທຸກເວລາ.</string>
-    <string name="upgrade_screen_options_description_no_trial">ຄຸນສົມບັດຄືກັນ, ລາຄາຕ່າງກັນ. ການສະໝັກສະມາຊິກສາມາດຍົກເລີກໄດ້ທຸກເວລາ.</string>
     <string name="upgrade_screen_subscription_trial_action">ເລິ່ມທົດລອງໃຊ້ຟຣີ</string>
     <string name="upgrade_screen_subscription_action">ສະໝັກສະມາຊິກລາຍປີ</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ປີ</string>
     <string name="upgrade_screen_iap_action">ຊື້ຄັ້ງດຽວ</string>
-    <string name="upgrade_screen_iap_action_hint">ການຊື້ຄັ້ງດຽວ: %s</string>
     <string name="upgrade_screen_restore_purchase_action">ກູ້ຄືນການຊື້</string>
-    <string name="upgrade_screen_restore_purchase_message">ບໍ່ພົບການຊື້. ທ່ານກຳລັງໃຊ້ບັນຊີທີ່ຖືກຕ້ອງບໍ?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">ຖ້າທ່ານຫາກໍ່ຊື້ໄປບໍ່ດົນມານີ້, ອາດຈະໃຊ້ເວລາຊັກໝ້ອຍໃຫ້ Google Play ຊິງຄ໌ຂໍ້ມູນ.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ລອງໃໝ່ອີກຄັ້ງພາຍໃນສອງສາມນາທີ ຖ້າການຊື້ຂອງທ່ານບໍ່ປາກົດ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ກະລຸນາກວດສອບໃຫ້ແນ່ໃຈວ່າທ່ານເຂົ້າສູ່ລະບົບດ້ວຍບັນຊີ Google ດຽວກັນກັບທີ່ໃຊ້ຊື້.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">ບັນຊີໜຼາຍບັນຊີສາມາດເຮັດໃຫ້ Google Play ສັບສົນ. ການຕິດຕັ້ງແອັບຜ່ານເວັບໄຊ Google Play ຈະບັງຄັບການເຊື່ອມໂຍງກັບບັນຊີສະເພາະ.</string>
     <string name="upgrade_screen_restore_banner_title">ຊື້ Pro ໄປແລ້ວບໍ?</string>
     <string name="upgrade_screen_restore_banner_body">ເບິ່ງຄືວ່າທ່ານເຄີຍອັບເກຣດເປັນ Pro ຍູ່ອຸປະກອນນີ້ມາກ່ອນ. ກູ້ຄືນການຊື້ຂອງທ່ານເພື່ອປົດລັອກມັນອີກຄັ້ງ.</string>
     <string name="upgrade_screen_restore_success_message">ກູ້ຄືນການຊື້ແລ້ວ.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">ທ່ານມີ CAPod Pro ແລ້ວ!</string>
     <string name="upgrade_screen_owned_hero_sub_body">ປົດລັອກໂດຍການສະໝັກສະມາຊິກຂອງທ່ານ. ຂອບໃຈທີ່ສະໜັບສະໜູນ CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">ປົດລັອກໂດຍການຊື້ຄັ້ງດຽວຂອງທ່ານ. ຂອບໃຈທີ່ສະໜັບສະໜູນ CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">ການສະໝັກສະມາຊິກລາຍປີ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ການສະໝັກສະມາຊິກຂອງທ່ານກຳລັງໃຊ້ງານ ແລະ ຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸ. ການເອີ້ນເກັບເງິນຖືກຈັດການໂດຍ Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ການສະໝັກສະມາຊິກຂອງທ່ານກຳລັງໃຊ້ງານ, ແຕ່ບໍ່ໄດ້ຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸ. Pro ຈະຍັງໃຊ້ໄດ້ຈົນກວ່າໄລຍະປັດຈຸບັນຈະສິ້ນສຸດ.</string>
     <string name="upgrade_screen_owned_iap_title">ການຊື້ຄັ້ງດຽວ</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">„Google Play“ paslaugos nepasiekiamos.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nerasta jokių pirkinių. Ar naudojate tinkamą paskyrą?</string>
     <string name="upgrades_gplay_billing_error_label">„Google Play\" klaida</string>
     <string name="upgrades_gplay_billing_error_description">„Google Play\" įvyko klaida. Bandykite dar kartą vėliau arba paleiskite telefoną iš naujo.\n\nKlaida: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">„Google Play\" atsiskaitymo klaida</string>
-    <string name="upgrades_gplay_billing_result_error_description">Įvyko klaida gaunant pirkinių informaciją iš „Google Play\". Išvalykite „Google Play\" talpyklą ir paleiskite telefoną iš naujo.\n\nKlaida %s</string>
     <string name="upgrades_gplay_already_owned_label">Jau nusipirkote?</string>
     <string name="upgrades_gplay_already_owned_description">„Google Play“ praneša, kad jau turite šį atnaujinimą, tačiau jo nepavyko atkurti. Įsitikinkite, kad naudojate tą pačią „Google“ paskyrą, su kuria atlikote pirkimą. „Play Store“ sinchronizavimas gali užtrukti — pabandykite paleisti įrenginį iš naujo, išvalyti „Google Play“ talpyklą arba tiesiog palaukite.</string>
-    <string name="upgrade_restore_action">Atkurti pirkimą</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Gauti %1$s</string>
     <string name="upgrade_preamble">CAPod kuria vienas žmogus. Atnaujinimas atrakina papildomas funkcijas ir padeda išlaikyti programą gyvą.</string>
-    <string name="upgrade_screen_options_description">Tos pačios funkcijos, skirtingos kainos. Prenumerata apima nemokamą bandomąjį laikotarpį ir bet kada gali būti atšaukta.</string>
-    <string name="upgrade_screen_options_description_no_trial">Tos pačios funkcijos, skirtingos kainos. Prenumerata bet kada gali būti atšaukta.</string>
     <string name="upgrade_screen_subscription_trial_action">Pradėti nemokamą bandomąjį laikotarpį</string>
     <string name="upgrade_screen_subscription_action">Prenumeruoti metams</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/metus</string>
     <string name="upgrade_screen_iap_action">Pirkti vieną kartą</string>
-    <string name="upgrade_screen_iap_action_hint">Vienkartinis pirkimas: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Atkurti pirkimą</string>
-    <string name="upgrade_screen_restore_purchase_message">Nerasta jokių pirkinių. Ar naudojate tinkamą paskyrą?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Jei nesenai atlikote pirkimą, „Google Play“ sinchronizavimas gali užtrukti.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Jei jūsų pirkimas nerodomas, pabandykite dar kartą po kelių minučių.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Įsitikinkite, kad esate prisijungę ta pačia „Google“ paskyra, kuria atlikote pirkimą.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Kelios paskyros gali supainioti „Google Play“. Įdiegus programą per „Google Play“ svetainę, ji priverstinai susiejama su konkrečia paskyra.</string>
     <string name="upgrade_screen_restore_banner_title">Jau nusipirkote „Pro“?</string>
     <string name="upgrade_screen_restore_banner_body">Panašu, kad anksčiau šiame įrenginyje jau atnaujinote iki „Pro“. Atkurkite savo pirkimą, kad jį vėl atrakintumėte.</string>
     <string name="upgrade_screen_restore_success_message">Pirkimas atkurtas.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Turite CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Atrakinta jūsų prenumeratos dėka. Dėkojame, kad remiate CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Atrakinta jūsų vienkartinio pirkimo dėka. Dėkojame, kad remiate CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Metinė prenumerata</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Jūsų prenumerata aktyvi ir bus atnaujinta. Atsiskaitymą tvarko „Google Play“.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Jūsų prenumerata aktyvi, tačiau nebus atnaujinta. „Pro“ liks pasiekiama iki dabartinio laikotarpio pabaigos.</string>
     <string name="upgrade_screen_owned_iap_title">Vienkartinis pirkimas</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play pakalpojumi nav pieejami.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nav atrasts neviens pirkums. Vai izmanto pareizo kontu?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play kļūda</string>
     <string name="upgrades_gplay_billing_error_description">Google Play radās kļūda. Lūgums mēģināt vēlreiz vēlāk vai pārsāknēt tālruni.\n\nKļūda: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play norēķinu kļūda</string>
-    <string name="upgrades_gplay_billing_result_error_description">Radās kļūda, pieprasot no Google Play pirkuma informāciju. Jāiztīra Google Play kešatmiņa un jāpārsāknē tālrunis.\n\nKļūda %s</string>
     <string name="upgrades_gplay_already_owned_label">Jau iegādājies?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play ziņo, ka tev jau ir šis jauninājums, taču to neizdevās atjaunot. Pārliecinies, ka izmanto to pašu Google kontu, ar kuru veici pirkumu. Play veikala sinhronizācija var aizņemt laiku — mēģini restartēt ierīci, notīrīt Google Play kešatmiņu vai vienkārši uzgaidi.</string>
-    <string name="upgrade_restore_action">Atjaunot pirkumu</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Iegūstiet %1$s</string>
     <string name="upgrade_preamble">CAPod izstrādā viens cilvēks. Jaunināšana atbloķē papildu funkcijas un palīdz uzturēt lietotni dzīvu.</string>
-    <string name="upgrade_screen_options_description">Vienādas funkcijas, atšķirīga cenu noteikšana. Abonements ietver bezmaksas izmēģinājuma periodu, un to var atcelt jebkurā laikā.</string>
-    <string name="upgrade_screen_options_description_no_trial">Vienādas funkcijas, atšķirīga cenu noteikšana. Abonementu var atcelt jebkurā laikā.</string>
     <string name="upgrade_screen_subscription_trial_action">Sākt bezmaksas izmēģinājumu</string>
     <string name="upgrade_screen_subscription_action">Abonēt uz gadu</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/gadā</string>
     <string name="upgrade_screen_iap_action">Pirkt vienreiz</string>
-    <string name="upgrade_screen_iap_action_hint">Vienreizējs pirkums: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Atjaunot pirkumu</string>
-    <string name="upgrade_screen_restore_purchase_message">Nav atrasts neviens pirkums. Vai izmantojat pareizo kontu?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ja tu nesen veici pirkumu, Google Play sinhronizācijai var būt nepieciešams brīdis.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ja tavs pirkums neparādās, mēģini vēlreiz pēc dažām minūtēm.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Pārliecinies, ka esi pieteicies ar to pašu Google kontu, kas izmantots pirkumam.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Vairāki konti var mulsināt Google Play. Lietotnes instalēšana caur Google Play tīmekļa vietni piespiedu kārtā piesaista to konkrētam kontam.</string>
     <string name="upgrade_screen_restore_banner_title">Jau iegādājies Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Izskatās, ka tu jau iepriekš esi jauninājis uz Pro šajā ierīcē. Atjauno pirkumu, lai to atbloķētu vēlreiz.</string>
     <string name="upgrade_screen_restore_success_message">Pirkums atjaunots.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Tev ir CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Atbloķēts ar tavu abonementu. Paldies, ka atbalsti CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Atbloķēts ar tavu vienreizējo pirkumu. Paldies, ka atbalsti CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Gada abonements</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tavs abonements ir aktīvs un iestatīts atjaunoties. Norēķinus pārvalda Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tavs abonements ir aktīvs, taču nav iestatīts atjaunoties. Pro paliks pieejams līdz pašreizējā perioda beigām.</string>
     <string name="upgrade_screen_owned_iap_title">Vienreizējs pirkums</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Услугите на Google Play не се достапни.</string>
-    <string name="upgrades_no_purchases_found_check_account">Не се пронајдени купувања. Дали ја користите вистинската сметка?</string>
     <string name="upgrades_gplay_billing_error_label">Грешка во Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Настана грешка во Google Play. Обидете се повторно подоцна или рестартирајте го телефонот.\n\nГрешка: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Грешка при наплата на Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Настана грешка при барање на деталите за вашата купувања од Google Play. Исчистете го кешот на Google Play и рестартирајте го телефонот.\n\nГрешка %s</string>
     <string name="upgrades_gplay_already_owned_label">Веќе купено?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play пријавува дека веќе ја поседуваш оваа надградба, но не можеше да се врати. Провери дали го користиш истиот Google профил со кој си купил/а. Синхронизацијата со Play Store може да потрае — обиди се со рестартирање, бришење на кешот на Google Play или едноставно почекај.</string>
-    <string name="upgrade_restore_action">Обнови купувачка</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Земи %1$s</string>
     <string name="upgrade_preamble">CAPod е развиен од едно лице. Надградбата отклучува дополнителни функции и помага апликацијата да остане жива.</string>
-    <string name="upgrade_screen_options_description">Исти функции, различни цени. Претплатата вклучува бесплатен пробен период и може да се откаже во секое време.</string>
-    <string name="upgrade_screen_options_description_no_trial">Исти функции, различни цени. Претплатата може да се откаже во секое време.</string>
     <string name="upgrade_screen_subscription_trial_action">Започни бесплатен пробен период</string>
     <string name="upgrade_screen_subscription_action">Претплати се годишно</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/годишно</string>
     <string name="upgrade_screen_iap_action">Купи еднаш</string>
-    <string name="upgrade_screen_iap_action_hint">Еднократно купување: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Обнови купувачка</string>
-    <string name="upgrade_screen_restore_purchase_message">Не се пронајдени купувања. Дали ја користите вистинската сметка?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ако неодамна купил/а, може да помине малку време додека Google Play се синхронизира.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Обиди повторно за неколку минути ако куповката не се појави.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Провери дали си најавен/а со истиот Google профил што беше користен за куповката.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Повеќе профили можат да го збунат Google Play. Инсталирањето на апликацијата преку веб сајтот на Google Play го присилува поврзувањето со одреден профил.</string>
     <string name="upgrade_screen_restore_banner_title">Веќе го купи Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Изгледа дека порано си надградил/а на Pro на овој уред. Врати ја куповката за да го отклучиш повторно.</string>
     <string name="upgrade_screen_restore_success_message">Куповката е вратена.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Го имаш CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Отклучено од твојата претплата. Благодариме што го поддржуваш CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Отклучено од твојата еднократна куповка. Благодариме што го поддржуваш CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Годишна претплата</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Твојата претплата е активна и поставена да се обновува. Наплатата ја управува Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Твојата претплата е активна, но не е поставена да се обновува. Pro останува достапен се до крајот на тековниот период.</string>
     <string name="upgrade_screen_owned_iap_title">Еднократна купувачка</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play സേവനങ്ങൾ ലഭ്യമല്ല.</string>
-    <string name="upgrades_no_purchases_found_check_account">വാങ്ങലുകളൊന്നും കണ്ടെത്തിയില്ല. നിങ്ങൾ ശരിയായ അക്കൗണ്ട് ആണോ ഉപയോഗിക്കുന്നത്?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play പിശക്</string>
     <string name="upgrades_gplay_billing_error_description">Google Play-ൽ ഒരു പിശക് സംഭവിച്ചു. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക അല്ലെങ്കിൽ നിങ്ങളുടെ ഫോൺ റീബൂട്ട് ചെയ്യുക.\n\nപിശക്: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play ബില്ലിംഗ് പിശക്</string>
-    <string name="upgrades_gplay_billing_result_error_description">നിങ്ങളുടെ വാങ്ങൽ വിശദാംശങ്ങൾക്കായി Google Play-യോട് അഭ്യർത്ഥിക്കുമ്പോൾ ഒരു പിശക് സംഭവിച്ചു. Google Play കാഷെ മായ്‌ച്ച് നിങ്ങളുടെ ഫോൺ റീബൂട്ട് ചെയ്യുക.\n\nപിശക് %s</string>
     <string name="upgrades_gplay_already_owned_label">ഇതിനകം വാങ്ങിയോ?</string>
     <string name="upgrades_gplay_already_owned_description">നിങ്ങൾ ഇതിനകം ഈ അപ്ഗ്രേഡ് സ്വന്തമാക്കിയിട്ടുണ്ടെന്ന് Google Play റിപ്പോർട്ട് ചെയ്യുന്നു, പക്ഷേ അത് പുനഃസ്ഥാപിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾ വാങ്ങിയ Google അക്കൗണ്ട് ഉപയോഗിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കുക. Play Store സമന്വയത്തിന് സമയമെടുത്തേക്കാം — റീബൂട്ട് ചെയ്യാൻ ശ്രമിക്കുക, Google Play കാഷെ ക്ലിയർ ചെയ്യുക അല്ലെങ്കിൽ അൽപ്പം കാത്തിരിക്കുക.</string>
-    <string name="upgrade_restore_action">വാങ്ങൽ പുനഃസ്ഥാപിക്കുക</string>
     <string name="upgrade_badge_label">പ്രോ</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s നേടുക</string>
     <string name="upgrade_preamble">CAPod ഒരൊറ്റ വ്യക്തിയാണ് വികസിപ്പിക്കുന്നത്. അപ്ഗ്രേഡ് ചെയ്യുന്നത് അധിക ഫീച്ചറുകൾ അൺലോക്ക് ചെയ്യുകയും ആപ്പ് സജീവമായി നിലനിർത്താൻ സഹായിക്കുകയും ചെയ്യുന്നു.</string>
-    <string name="upgrade_screen_options_description">അതേ ഫീച്ചറുകൾ, വ്യത്യസ്ത വിലനിർണ്ണയം. സബ്സ്ക്രിപ്ഷനിൽ ഒരു സൗജന്യ ട്രയൽ ഉൾപ്പെടുന്നു, എപ്പോൾ വേണമെങ്കിലും റദ്ദാക്കാവുന്നതുമാണ്.</string>
-    <string name="upgrade_screen_options_description_no_trial">അതേ ഫീച്ചറുകൾ, വ്യത്യസ്ത വിലനിർണ്ണയം. സബ്സ്ക്രിപ്ഷൻ എപ്പോൾ വേണമെങ്കിലും റദ്ദാക്കാവുന്നതാണ്.</string>
     <string name="upgrade_screen_subscription_trial_action">സൗജന്യ ട്രയൽ ആരംഭിക്കുക</string>
     <string name="upgrade_screen_subscription_action">വാർഷികമായി സബ്സ്ക്രൈബ് ചെയ്യുക</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/വർഷം</string>
     <string name="upgrade_screen_iap_action">ഒറ്റത്തവണ വാങ്ങുക</string>
-    <string name="upgrade_screen_iap_action_hint">ഒറ്റത്തവണ വാങ്ങൽ: %s</string>
     <string name="upgrade_screen_restore_purchase_action">വാങ്ങൽ പുനഃസ്ഥാപിക്കുക</string>
-    <string name="upgrade_screen_restore_purchase_message">വാങ്ങലുകളൊന്നും കണ്ടെത്തിയില്ല. നിങ്ങൾ ശരിയായ അക്കൗണ്ട് ആണോ ഉപയോഗിക്കുന്നത്?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">നിങ്ങൾ അടുത്തിടെ വാങ്ങിയതാണെങ്കിൽ, Google Play സമന്വയിപ്പിക്കാൻ കുറച്ച് സമയമെടുത്തേക്കാം.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">നിങ്ങളുടെ വാങ്ങൽ കാണിക്കുന്നില്ലെങ്കിൽ കുറച്ച് മിനിറ്റുകൾക്ക് ശേഷം വീണ്ടും ശ്രമിക്കുക.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">വാങ്ങലിനായി ഉപയോഗിച്ച അതേ Google അക്കൗണ്ട് ഉപയോഗിച്ച് സൈൻ ഇൻ ചെയ്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">ഒന്നിലധികം അക്കൗണ്ടുകൾ Google Play-യെ ആശയക്കുഴത്തത്തിലാക്കാം. Google Play വെബ്‌സൈറ്റ് വഴി ആപ്പ് ഇൻസ്റ്റാൽ ചെയ്യുന്നത് ഒരു നിർദ്ദിഷ്ട അക്കൗണ്ടുമായുള്ള ബന്ധം നിർബന്ധമാക്കുന്നു.</string>
     <string name="upgrade_screen_restore_banner_title">ഇതിനകം Pro വാങ്ങിയോ?</string>
     <string name="upgrade_screen_restore_banner_body">നിങ്ങൾ മുമ്പ് ഈ ഉപകരണത്തിൽ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്തതായി തോന്നുന്നു. വീണ്ടും അൺലോക്ക് ചെയ്യാൻ നിങ്ങളുടെ വാങ്ങൽ പുനഃസ്ഥാപിക്കുക.</string>
     <string name="upgrade_screen_restore_success_message">വാങ്ങൽ പുനഃസ്ഥാപിച്ചു.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">നിങ്ങൾക്ക് CAPod Pro ഉണ്ട്!</string>
     <string name="upgrade_screen_owned_hero_sub_body">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വഴി അൺലോക്ക് ചെയ്തു. CAPod-നെ പിന്തുണച്ചതിന് നന്ദി!</string>
     <string name="upgrade_screen_owned_hero_iap_body">നിങ്ങളുടെ ഒറ്റത്തവണ വാങ്ങൽ വഴി അൺലോക്ക് ചെയ്തു. CAPod-നെ പിന്തുണച്ചതിന് നന്ദി!</string>
-    <string name="upgrade_screen_owned_sub_title">വാർഷിക സബ്സ്ക്രിപ്ഷൻ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാണ്, പുതുക്കാൻ സജ്ജീകരിച്ചിരിക്കുന്നു. ബിൽലിംഗ് Google Play നിയന്ത്രിക്കുന്നു.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാണ്, പക്ഷേ പുതുക്കാൻ സജ്ജീകരിച്ചിട്ടില്ല. നിലവിലെ കാലയളവ് അവസാനിക്കുന്നത് വരെ Pro ലഭ്യമായി തുടരും.</string>
     <string name="upgrade_screen_owned_iap_title">ഒറ്റത്തവണ വാങ്ങൽ</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play үйлчилгээ боломжгүй байна.</string>
-    <string name="upgrades_no_purchases_found_check_account">Худалдан авалт олдсонгүй. Та зөв бүртгэл ашиглаж байна уу?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play алдаа</string>
     <string name="upgrades_gplay_billing_error_description">Google Play-д алдаа гарлаа. Дараа дахин оролдоно уу эсвэл утсаа дахин асаана уу.\n\nАлдаа: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play төлбөрийн алдаа</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play-с таны худалдан авалтын мэдээллийг авахад алдаа гарлаа. Google Play кэшийг цэвэрлээд утсаа дахин асаана уу.\n\nАлдаа %s</string>
     <string name="upgrades_gplay_already_owned_label">Аль хэдийн худалдаж авсан уу?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play нь та энэ шинэчлэлтийг аль хэдийн эзэмшиж байгааг мэдээлж байгаа ч сэргээх боломжгүй байна. Худалдан авахдаа ашигласан Google бүртгэлээ ашиглаж байгаа эсэхээ шалгана уу. Play Store-ын синхрончлол хугацаа шаардаж болзошгүй тул дахин асаах, Google Play-ийн кэшийг цэвэрлэх эсвэл хэсэг хугацаа хүлээж үзнэ үү.</string>
-    <string name="upgrade_restore_action">Худалдан авалтыг сэргээх</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s авах</string>
     <string name="upgrade_preamble">CAPod-ыг ганц хүн хөгжүүлдэг. Шинэчлэл хийснээр нэмэлт боломжууд нээгдэж, аппликейшнийг тогтвортой ажиллуулахад тусална.</string>
-    <string name="upgrade_screen_options_description">Ижил боломжууд, өөр өөр үнэ. Захиалга нь үнэгүй туршилтын хугацаатай бөгөөд хэдийд ч цуцлах боломжтой.</string>
-    <string name="upgrade_screen_options_description_no_trial">Ижил боломжууд, өөр өөр үнэ. Захиалгыг хэдийд ч цуцлах боломжтой.</string>
     <string name="upgrade_screen_subscription_trial_action">Үнэгүй туршилтыг эхлүүлэх</string>
     <string name="upgrade_screen_subscription_action">Жилээр захиалах</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/жил</string>
     <string name="upgrade_screen_iap_action">Нэг удаа худалдаж авах</string>
-    <string name="upgrade_screen_iap_action_hint">Нэг удаагийн худалдан авалт: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Худалдан авалтыг сэргээх</string>
-    <string name="upgrade_screen_restore_purchase_message">Худалдан авалт олдсонгүй. Та зөв бүртгэл ашиглаж байна уу?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Хэрэв та саяхан худалдаж авсан бол Google Play-д синхрончлогдохдоо бага зэрэг хугацаа шаардагдаж болно.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Хэрэв таны худалдан авалт харагдахгүй байвал хэдэн минутын дараа дахин оролдоно уу.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Худалдан авалт хийхдээ ашигласантай ижил Google бүртгэлээр нэвтэрсэн эсэхээ шалгана уу.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Олон бүртгэл Google Play-г төөрөгдүүлж болно. Google Play вэбсайтаар дамжуулан аппликейшныг суулгах нь тодорхой бүртгэлтэй холбоосыг албадаж өгддөг.</string>
     <string name="upgrade_screen_restore_banner_title">Аль хэдийн Pro хувилбарыг худалдаж авсан уу?</string>
     <string name="upgrade_screen_restore_banner_body">Та энэ төхөөрөмж дээр өмнө нь Pro хувилбарт шинэчилсэн бололтой. Дахин түгжээгүй болгохын тулд худалдан авалтаа сэргээнэ үү.</string>
     <string name="upgrade_screen_restore_success_message">Худалдан авалт сэргээгдлээ.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Танд CAPod Pro бий!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Таны захиалгаар түгжээ тайлагдсан. CAPod-ыг дэмжсэнд баярлалаа!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Таны нэг удаагийн худалдан авалтаар түгжээ тайлагдсан. CAPod-ыг дэмжсэнд баярлалаа!</string>
-    <string name="upgrade_screen_owned_sub_title">Жилийн захиалга</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Таны захиалга идэвхтэй бөгөөд шинэчлэгдэхээр тохируулагдсан. Төлбөрийг Google Play удирддаг.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Таны захиалга идэвхтэй боловч шинэчлэгдэхээр тохируулаагүй байна. Одоогийн хугацаа дуустал Pro ашиглах боломжтой хэвээр байна.</string>
     <string name="upgrade_screen_owned_iap_title">Нэг удаагийн худалдан авалт</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play सेवा अनुपलब्ध आहेत.</string>
-    <string name="upgrades_no_purchases_found_check_account">कोणतीही खरेदी आढळली नाही. तुम्ही योग्य खाते वापरत आहात का?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play त्रुटी</string>
     <string name="upgrades_gplay_billing_error_description">Google Play मध्ये त्रुटी आली. कृपया नंतर पुन्हा प्रयत्न करा किंवा तुमचा फोन रीबूट करा.\n\nत्रुटी: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play बिलिंग त्रुटी</string>
-    <string name="upgrades_gplay_billing_result_error_description">तुमच्या खरेदीचे तपशील Google Play कडून मिळवताना त्रुटी आली. Google Play कॅशे साफ करा आणि तुमचा फोन रीबूट करा.\n\nत्रुटी %s</string>
     <string name="upgrades_gplay_already_owned_label">आधीच खरेदी केली आहे?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play नुसार तुमच्याकडे आधीच हे अपग्रेड आहे, परंतु ते पुनर्संचयित करता आले नाही. तुम्ही ज्या Google खात्याने खरेदी केली आहे तेच वापरत असल्याची खात्री करा. Play Store समक्रमणास वेळ लागू शकतो — रीबूट करून पहा, Google Play कॅशे साफ करा किंवा फक्त थोडी प्रतीक्षा करा.</string>
-    <string name="upgrade_restore_action">खरेदी पुनर्संचयित करा</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s मिळवा</string>
     <string name="upgrade_preamble">CAPod एका व्यक्तीने विकसित केले आहे. अपग्रेड केल्याने अतिरिक्त वैशिष्ट्ये अनलॉक होतात आणि अॅप सुरू ठेवण्यास मदत होते.</string>
-    <string name="upgrade_screen_options_description">तीच वैशिष्ट्ये, वेगळी किंमत. सदस्यत्वामध्ये मोफत चाचणी समाविष्ट आहे आणि ते कधीही रद्द करता येते.</string>
-    <string name="upgrade_screen_options_description_no_trial">तीच वैशिष्ट्ये, वेगळी किंमत. सदस्यत्व कधीही रद्द करता येते.</string>
     <string name="upgrade_screen_subscription_trial_action">मोफत चाचणी सुरू करा</string>
     <string name="upgrade_screen_subscription_action">वार्षिक सदस्यता घ्या</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/वर्ष</string>
     <string name="upgrade_screen_iap_action">एकदा खरेदी करा</string>
-    <string name="upgrade_screen_iap_action_hint">एकवेळ खरेदी: %s</string>
     <string name="upgrade_screen_restore_purchase_action">खरेदी पुनर्संचयित करा</string>
-    <string name="upgrade_screen_restore_purchase_message">कोणतीही खरेदी आढळली नाही. तुम्ही योग्य खाते वापरत आहात का?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">जर तुम्ही अलीकडेच खरेदी केली असेल, तर Google Play ला समक्रमित होण्यास थोडा वेळ लागू शकतो.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">तुमची खरेदी दिसत नसल्यास काही मिनिटांनी पुन्हा प्रयत्न करा.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">खरेदीसाठी वापरलेल्या त्याच Google खात्याने तुम्ही साइन इन केले असल्याची खात्री करा.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">अनेक खाती असल्यास Google Play गोंधळून जाऊ शकते. Google Play वेबसाइटद्वारे अॅप इंस्टॉल केल्याने विशिष्ट खात्याशी संबंध जोडला जातो.</string>
     <string name="upgrade_screen_restore_banner_title">आधीच Pro खरेदी केले आहे?</string>
     <string name="upgrade_screen_restore_banner_body">असे दिसते की तुम्ही या डिव्हाइसवर आधी Pro मध्ये अपग्रेड केले होते. ते पुन्हा अनलॉक करण्यासाठी तुमची खरेदी पुनर्संचयित करा.</string>
     <string name="upgrade_screen_restore_success_message">खरेदी पुनर्संचयित झाली.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">तुमच्याकडे CAPod Pro आहे!</string>
     <string name="upgrade_screen_owned_hero_sub_body">तुमच्या सदस्यत्वामुळे अनलॉक झाले. CAPod ला पाठिंबा दिल्याबद्दल धन्यवाद!</string>
     <string name="upgrade_screen_owned_hero_iap_body">तुमच्या एकवेळच्या खरेदीमुळे अनलॉक झाले. CAPod ला पाठिंबा दिल्याबद्दल धन्यवाद!</string>
-    <string name="upgrade_screen_owned_sub_title">वार्षिक सदस्यत्व</string>
     <string name="upgrade_screen_owned_sub_renewing_body">तुमचे सदस्यत्व सक्रिय आहे आणि नूतनीकरणासाठी सेट केलेले आहे. बिलिंग Google Play द्वारे व्यवस्थापित केले जाते.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">तुमचे सदस्यत्व सक्रिय आहे, परंतु नूतनीकरणासाठी सेट केलेले नाही. सध्याचा कालावधी संपेपर्यंत Pro उपलब्ध राहील.</string>
     <string name="upgrade_screen_owned_iap_title">एकवेळ खरेदी</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Perkhidmatan Google Play tidak tersedia.</string>
-    <string name="upgrades_no_purchases_found_check_account">Tiada pembelian ditemui. Adakah anda menggunakan akaun yang betul?</string>
     <string name="upgrades_gplay_billing_error_label">Ralat Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Terdapat ralat dalam Google Play. Sila cuba lagi kemudian atau mulakan semula telefon anda.\n\nRalat: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Ralat Pengebilan Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Terdapat ralat semasa meminta butiran pembelian anda daripada Google Play. Kosongkan cache Google Play dan mulakan semula telefon anda.\n\nRalat %s</string>
     <string name="upgrades_gplay_already_owned_label">Sudah membeli?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play melaporkan bahawa anda sudah memiliki peningkatan ini, tetapi ia tidak dapat dipulihkan. Pastikan anda menggunakan akaun Google yang digunakan semasa pembelian. Penyegerakan Play Store mungkin mengambil masa — cuba mulakan semula peranti, kosongkan cache Google Play atau tunggu sebentar.</string>
-    <string name="upgrade_restore_action">Pulihkan pembelian</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Dapatkan %1$s</string>
     <string name="upgrade_preamble">CAPod dibangunkan oleh seorang individu. Peningkatan membuka kunci ciri tambahan dan membantu mengekalkan aplikasi ini.</string>
-    <string name="upgrade_screen_options_description">Ciri yang sama, harga yang berbeza. Langganan termasuk percubaan percuma dan boleh dibatalkan pada bila-bila masa.</string>
-    <string name="upgrade_screen_options_description_no_trial">Ciri yang sama, harga yang berbeza. Langganan boleh dibatalkan pada bila-bila masa.</string>
     <string name="upgrade_screen_subscription_trial_action">Mulakan percubaan percuma</string>
     <string name="upgrade_screen_subscription_action">Langgan setiap tahun</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/tahun</string>
     <string name="upgrade_screen_iap_action">Beli sekali</string>
-    <string name="upgrade_screen_iap_action_hint">Pembelian sekali sahaja: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Pulihkan pembelian</string>
-    <string name="upgrade_screen_restore_purchase_message">Tiada pembelian ditemui. Adakah anda menggunakan akaun yang betul?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Jika anda baru sahaja membuat pembelian, Google Play mungkin mengambil sedikit masa untuk menyegerakkan.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Cuba lagi dalam beberapa minit jika pembelian anda tidak muncul.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Pastikan anda log masuk dengan akaun Google yang sama yang digunakan untuk pembelian.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Pelbagai akaun boleh mengelirukan Google Play. Memasang aplikasi melalui laman web Google Play memaksa perkaitan dengan akaun tertentu.</string>
     <string name="upgrade_screen_restore_banner_title">Sudah membeli Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Nampaknya anda pernah meningkatkan ke Pro pada peranti ini sebelum ini. Pulihkan pembelian anda untuk membukanya semula.</string>
     <string name="upgrade_screen_restore_success_message">Pembelian dipulihkan.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Anda mempunyai CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dibuka kunci melalui langganan anda. Terima kasih kerana menyokong CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dibuka kunci melalui pembelian sekali sahaja anda. Terima kasih kerana menyokong CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Langganan tahunan</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Langganan anda aktif dan ditetapkan untuk diperbaharui. Pengebilan diuruskan oleh Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Langganan anda aktif, tetapi tidak ditetapkan untuk diperbaharui. Pro kekal tersedia sehingga tempoh semasa tamat.</string>
     <string name="upgrade_screen_owned_iap_title">Belian sekali</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play ဝန်ဆောင်မှုများ မရရှိနိုင်ပါ။</string>
-    <string name="upgrades_no_purchases_found_check_account">ဝယ်ယူမှုများ မတွေ့ပါ။ သင်အသုံးပြုနေသော အကောင့်မှန်ကန်ပါသလား။</string>
     <string name="upgrades_gplay_billing_error_label">Google Play အမှား</string>
     <string name="upgrades_gplay_billing_error_description">Google Play တွင် အမှားတစ်ခု ဖြစ်ပေါ်ခဲ့သည်။ ကျေးဇူးပြု၍ နောက်မှ ထပ်ကြိုးစားပါ သို့မဟုတ် သင့်ဖုန်းကို ပြန်လည်စတင်ပါ။\n\nအမှား: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play ငွေတောင်းခံမှု အမှား</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play မှ သင့်ဝယ်ယူမှု အသေးစိတ်အချက်အလက်များကို တောင်းဆိုရာတွင် အမှားတစ်ခု ဖြစ်ပေါ်ခဲ့သည်။ Google Play ကက်ရှ်ကို ရှင်းလင်းပြီး သင့်ဖုန်းကို ပြန်လည်စတင်ပါ။\n\nအမှား %s</string>
     <string name="upgrades_gplay_already_owned_label">ဝယ်ယူပြီးသားလား။</string>
     <string name="upgrades_gplay_already_owned_description">Google Play က ဤအဆင့်မြှင့်တင်မှုကို သင်ပိုင်ဆိုင်ပြီးသားဖြစ်ကြောင်း သတင်းပို့ခဲ့သော်လည်း ၎င်းကို ပြန်လည်ရယူ၍မရနိုင်ခဲ့ပါ။ သင်ဝယ်ယူခဲ့သည့် Google အကောင့်ကို အသုံးပြုနေကြောင်း သေချာပါစေ။ Play Store ထပ်တူပြုမှုသည် အချိန်အနည်းငယ်ကြာနိုင်ပါသည် — ပြန်လည်စတင်ကြည့်ပါ၊ Google Play ကက်ရှ်ကို ရှင်းလင်းကြည့်ပါ (သို့) စောင့်ဆိုင်းကြည့်ပါ။</string>
-    <string name="upgrade_restore_action">ဝယ်ယူမှုကို ပြန်လည်ရယူမည်</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ကို ရယူပါ</string>
     <string name="upgrade_preamble">CAPod ကို လူတစ်ဦးတည်းက ဖန်တီးထားခြင်းဖြစ်သည်။ အဆင့်မြှင့်တင်ခြင်းက ထပ်ဆောင်းအင်္ဂါရပ်များကို ဖွင့်ပေးပြီး အက်ပ်ကို ဆက်လက်တည်ရှိစေရန် ကူညီပေးပါသည်။</string>
-    <string name="upgrade_screen_options_description">အင်္ဂါရပ်များ တူညီပြီး စျေးနှုန်းသာ ကွာခြားပါသည်။ စာရင်းသွင်းမှုတွင် အခမဲ့စမ်းသပ်ကာလ ပါဝင်ပြီး အချိန်မရွေး ပယ်ဖျက်နိုင်ပါသည်။</string>
-    <string name="upgrade_screen_options_description_no_trial">အင်္ဂါရပ်များ တူညီပြီး စျေးနှုန်းသာ ကွာခြားပါသည်။ စာရင်းသွင်းမှုကို အချိန်မရွေး ပယ်ဖျက်နိုင်ပါသည်။</string>
     <string name="upgrade_screen_subscription_trial_action">အခမဲ့စမ်းသပ်ကာလ စတင်ပါ</string>
     <string name="upgrade_screen_subscription_action">နှစ်စဉ် စာရင်းသွင်းပါ</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/နှစ်</string>
     <string name="upgrade_screen_iap_action">တစ်ကြိမ်တည်း ဝယ်ယူပါ</string>
-    <string name="upgrade_screen_iap_action_hint">တစ်ကြိမ်တည်း ဝယ်ယူမှု- %s</string>
     <string name="upgrade_screen_restore_purchase_action">ဝယ်ယူမှုကို ပြန်လည်ရယူမည်</string>
-    <string name="upgrade_screen_restore_purchase_message">ဝယ်ယူမှုများ မတွေ့ပါ။ သင်အသုံးပြုနေသော အကောင့်မှန်ကန်ပါသလား။</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">မကြာသေးမီက ဝယ်ယူခဲ့ပါက Google Play ထပ်တူပြုရန် အချိန်အနည်းငယ် ကြာနိုင်ပါသည်။</string>
     <string name="upgrade_screen_restore_sync_patience_hint">သင့်ဝယ်ယူမှု မပေါ်လာပါက မိနစ်အနည်းငယ်ကြာပြီးမှ ထပ်စမ်းကြည့်ပါ။</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ဝယ်ယူမှုတွင် အသုံးပြုခဲ့သည့် Google အကောင့်တူနှင့် လက်မှတ်ရေးထိုးဝင်ထားကြောင်း သေချာပါစေ။</string>
-    <string name="upgrade_screen_restore_webinstall_hint">အကောင့်များစွာသည် Google Play ကို ရှုပ်ထွေးစေနိုင်သည်။ Google Play ဝဘ်ဆိုဒ်မှတစ်ဆင့် အက်ပ်ကို ထည့်သွင်းခြင်းသည် သတ်မှတ်ထားသော အကောင့်တစ်ခုနှင့် ချိတ်ဆက်မှုကို တွန်းအားပေးသည်။</string>
     <string name="upgrade_screen_restore_banner_title">Pro ကို ဝယ်ယူပြီးသားလား။</string>
     <string name="upgrade_screen_restore_banner_body">ဤစက်ပစ္စည်းတွင် သင် Pro သို့ အဆင့်မြှင့်ထားဖူးပုံရသည်။ ၎င်းကို ပြန်လည်ဖွင့်ရန် သင့်ဝယ်ယူမှုကို ပြန်လည်ရယူပါ။</string>
     <string name="upgrade_screen_restore_success_message">ဝယ်ယူမှု ပြန်လည်ရယူပြီးပါပြီ။</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">သင့်တွင် CAPod Pro ရှိပါပြီ!</string>
     <string name="upgrade_screen_owned_hero_sub_body">သင့်စာရင်းသွင်းမှုက ဖွင့်ပေးထားပါသည်။ CAPod ကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည်!</string>
     <string name="upgrade_screen_owned_hero_iap_body">သင့်တစ်ကြိမ်တည်း ဝယ်ယူမှုက ဖွင့်ပေးထားပါသည်။ CAPod ကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည်!</string>
-    <string name="upgrade_screen_owned_sub_title">နှစ်စဉ် စာရင်းသွင်းမှု</string>
     <string name="upgrade_screen_owned_sub_renewing_body">သင့်စာရင်းသွင်းမှုသည် အသက်ဝင်နေပြီး ပြန်လည်သက်တမ်းတိုးရန် သတ်မှတ်ထားပါသည်။ ငွေတောင်းခံမှုကို Google Play က စီမံခန့်ခွဲပါသည်။</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">သင့်စာရင်းသွင်းမှုသည် အသက်ဝင်နေသော်လည်း ပြန်လည်သက်တမ်းတိုးရန် မသတ်မှတ်ထားပါ။ လက်ရှိကာလ မကုန်ဆုံးမချင်း Pro ကို ဆက်လက်အသုံးပြုနိုင်ပါသည်။</string>
     <string name="upgrade_screen_owned_iap_title">တစ်ကြိမ်တည်း ဝယ်ယူမှု</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-tjenester er utilgjengelige.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-feil</string>
     <string name="upgrades_gplay_billing_error_description">Det oppstod en feil i Google Play. Prøv igjen senere eller start telefonen på nytt.\n\nFeil: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play-faktureringsfeil</string>
-    <string name="upgrades_gplay_billing_result_error_description">Det oppstod en feil da Google Play ble spurt om kjøpsdetaljene dine. Tøm Google Play-hurtigbufferen og start telefonen på nytt.\n\nFeil %s</string>
     <string name="upgrades_gplay_already_owned_label">Allerede kjøpt?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterer at du allerede eier denne oppgraderingen, men den kunne ikke gjenopprettes. Sørg for at du bruker Google-kontoen du kjøpte med. Synkronisering med Play Store kan ta tid — prøv å starte på nytt, tømme Google Play-hurtigbufferen eller bare vente.</string>
-    <string name="upgrade_restore_action">Gjenopprett kjøp</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Få %1$s</string>
     <string name="upgrade_preamble">CAPod er utviklet av én person. Oppgradering låser opp ekstra funksjoner og hjelper med å holde appen i live.</string>
-    <string name="upgrade_screen_options_description">Samme funksjoner, ulik prising. Abonnementet inkluderer en gratis prøveperiode og kan kanselleres når som helst.</string>
-    <string name="upgrade_screen_options_description_no_trial">Samme funksjoner, ulik prising. Abonnementet kan kanselleres når som helst.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner årlig</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/år</string>
     <string name="upgrade_screen_iap_action">Kjøp én gang</string>
-    <string name="upgrade_screen_iap_action_hint">Engangskjøp: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Gjenopprett kjøp</string>
-    <string name="upgrade_screen_restore_purchase_message">Ingen kjøp funnet. Bruker du riktig konto?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Hvis du nylig har kjøpt, kan det ta litt tid før Google Play synkroniserer.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Prøv igjen om noen minutter hvis kjøpet ditt ikke vises.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Sørg for at du er logget inn med den samme Google-kontoen som ble brukt til kjøpet.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Flere kontoer kan forvirre Google Play. Å installere appen via Google Play-nettsiden tvinger frem tilknytning til en bestemt konto.</string>
     <string name="upgrade_screen_restore_banner_title">Allerede kjøpt Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Det ser ut til at du har oppgradert til Pro på denne enheten tidligere. Gjenopprett kjøpet ditt for å låse det opp igjen.</string>
     <string name="upgrade_screen_restore_success_message">Kjøp gjenopprettet.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Du har CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Låst opp av abonnementet ditt. Takk for at du støtter CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Låst opp av engangskjøpet ditt. Takk for at du støtter CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Årlig abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Abonnementet ditt er aktivt og satt til å fornyes. Fakturering håndteres av Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Abonnementet ditt er aktivt, men ikke satt til å fornyes. Pro forblir tilgjengelig til inneværende periode utløper.</string>
     <string name="upgrade_screen_owned_iap_title">Engangskjøp</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play सेवाहरू अनुपलब्ध छन्।</string>
-    <string name="upgrades_no_purchases_found_check_account">कुनै खरिदहरू फेला परेनन्। के तपाईंले सही खाता प्रयोग गरिरहनुभएको छ?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play त्रुटि</string>
     <string name="upgrades_gplay_billing_error_description">Google Play मा त्रुटि भयो। कृपया पछि पुन: प्रयास गर्नुहोस् वा आफ्नो फोन रिबुट गर्नुहोस्।\n\nत्रुटि: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play बिलिङ त्रुटि</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play बाट तपाईंको खरिद विवरणहरू माग्दा त्रुटि भयो। Google Play क्यास खाली गर्नुहोस् र आफ्नो फोन रिबुट गर्नुहोस्।\n\nत्रुटि %s</string>
     <string name="upgrades_gplay_already_owned_label">पहिले नै खरिद गर्नुभयो?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play ले तपाईंसँग यो अपग्रेड पहिले नै छ भनी रिपोर्ट गर्छ, तर यसलाई पुनर्स्थापना गर्न सकिएन। तपाईंले खरिद गर्दा प्रयोग गरेको Google खाता नै प्रयोग गरिरहनुभएको सुनिश्चित गर्नुहोस्। Play Store समिकरणमा समय लाग्न सक्छ — रिबुट गर्ने, Google Play क्यास खाली गर्ने वा केही समय पर्खने प्रयास गर्नुहोस्।</string>
-    <string name="upgrade_restore_action">खरिद पुनर्स्थापना गर्नुहोस्</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s प्राप्त गर्नुहोस्</string>
     <string name="upgrade_preamble">CAPod एक जना व्यक्तिद्वारा विकास गरिएको हो। अपग्रेड गर्दा थप सुविधाहरू अनलक हुन्छन् र एपलाई जीवित राख्न मद्दत पुग्छ।</string>
-    <string name="upgrade_screen_options_description">उस्तै सुविधाहरू, फरक मूल्य निर्धारण। सदस्यतामा नि:शुल्क परीक्षण समावेश छ र यसलाई जुनसुकै बेला रद्द गर्न सकिन्छ।</string>
-    <string name="upgrade_screen_options_description_no_trial">उस्तै सुविधाहरू, फरक मूल्य निर्धारण। सदस्यतालाई जुनसुकै बेला रद्द गर्न सकिन्छ।</string>
     <string name="upgrade_screen_subscription_trial_action">नि:शुल्क परीक्षण सुरु गर्नुहोस्</string>
     <string name="upgrade_screen_subscription_action">वार्षिक सदस्यता लिनुहोस्</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/वर्ष</string>
     <string name="upgrade_screen_iap_action">एक पटक किन्नुहोस्</string>
-    <string name="upgrade_screen_iap_action_hint">एक-पटक खरिद: %s</string>
     <string name="upgrade_screen_restore_purchase_action">खरिद पुनर्स्थापना गर्नुहोस्</string>
-    <string name="upgrade_screen_restore_purchase_message">कुनै खरिदहरू फेला परेनन्। के तपाईंले सही खाता प्रयोग गरिरहनुभएको छ?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">यदि तपाईंले भर्खरै खरिद गर्नुभएको छ भने, Google Play समिकरण हुन केही समय लाग्न सक्छ।</string>
     <string name="upgrade_screen_restore_sync_patience_hint">यदि तपाईंको खरिद देखिँदैन भने, केही मिनेटपछि फेरि प्रयास गर्नुहोस्।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">खरिदको लागि प्रयोग गरिएको उही Google खातामा साइन इन गरिएको सुनिश्चित गर्नुहोस्।</string>
-    <string name="upgrade_screen_restore_webinstall_hint">धेरै खाताहरूले Google Play लाई भ्रमित गर्न सक्छ। Google Play वेबसाइट मार्फत एप स्थापना गर्दा विशिष्ट खातासँगको सम्बन्ध बल गर्दछ।</string>
     <string name="upgrade_screen_restore_banner_title">पहिले नै Pro किन्नुभयो?</string>
     <string name="upgrade_screen_restore_banner_body">यस्तो देखिन्छ कि तपाईंले यो यन्त्रमा पहिले नै Pro मा अपग्रेड गर्नुभएको थियो। यसलाई फेरि अनलक गर्न आफ्नो खरिद पुनर्स्थापना गर्नुहोस्।</string>
     <string name="upgrade_screen_restore_success_message">खरिद पुनर्स्थापना गरियो।</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">तपाईंसँग CAPod Pro छ!</string>
     <string name="upgrade_screen_owned_hero_sub_body">तपाईंको सदस्यताद्वारा अनलक गरिएको। CAPod लाई समर्थन गर्नुभएकोमा धन्यवाद!</string>
     <string name="upgrade_screen_owned_hero_iap_body">तपाईंको एक-पटक खरिदद्वारा अनलक गरिएको। CAPod लाई समर्थन गर्नुभएकोमा धन्यवाद!</string>
-    <string name="upgrade_screen_owned_sub_title">वार्षिक सदस्यता</string>
     <string name="upgrade_screen_owned_sub_renewing_body">तपाईंको सदस्यता सक्रिय छ र नवीकरण हुने गरी सेट गरिएको छ। बिलिङ्ग Google Play द्वारा व्यवस्थापन गरिन्छ।</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">तपाईंको सदस्यता सक्रिय छ, तर नवीकरण हुने गरी सेट गरिएको छैन। हालको अवधि समाप्त नभएसम्म Pro उपलब्ध रहनेछ।</string>
     <string name="upgrade_screen_owned_iap_title">एक-पटक खरिद</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">De Google Play-diensten zijn niet beschikbaar.</string>
-    <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je de juiste rekening?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Fout</string>
     <string name="upgrades_gplay_billing_error_description">Er is een fout opgetreden in Google Play. Probeer het later opnieuw of start je telefoon opnieuw op.\n\nFout: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Factureringsfout</string>
-    <string name="upgrades_gplay_billing_result_error_description">Er is een fout opgetreden bij het opvragen van je aankoopgegevens bij Google Play. Wis de cache van Google Play en start je telefoon opnieuw op.\n\nFout %s</string>
     <string name="upgrades_gplay_already_owned_label">Reeds gekocht?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play meldt dat je deze upgrade al bezit, maar deze kon niet worden hersteld. Zorg ervoor dat je het Google-account gebruikt waarmee je hebt gekocht. Synchronisatie van de Play Store kan tijd kosten — probeer opnieuw op te starten, de cache van Google Play te wissen of gewoon te wachten.</string>
-    <string name="upgrade_restore_action">Herstel aankoop</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Haal %1$s</string>
     <string name="upgrade_preamble">CAPod wordt ontwikkeld door één persoon. Upgraden ontgrendelt extra functies en helpt de app in leven te houden.</string>
-    <string name="upgrade_screen_options_description">Dezelfde functies, verschillende prijzen. Het abonnement bevat een gratis proefperiode en kan op elk moment worden opgezegd.</string>
-    <string name="upgrade_screen_options_description_no_trial">Dezelfde functies, andere prijzen. Het abonnement kan op elk moment worden opgezegd.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode</string>
     <string name="upgrade_screen_subscription_action">Jaarlijks abonneren</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/jaar</string>
     <string name="upgrade_screen_iap_action">Eenmalig kopen</string>
-    <string name="upgrade_screen_iap_action_hint">Eenmalige aankoop: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Herstel aankoop</string>
-    <string name="upgrade_screen_restore_purchase_message">Geen aankopen gevonden. Gebruikt je wel het juiste account?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Als je de app onlangs hebt gekocht, kan het even duren voordat Google Play de gegevens synchroniseert.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Probeer het over een paar minuten opnieuw als je aankoop niet verschijnt.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Zorg ervoor dat je bent aangemeld met hetzelfde Google-account dat is gebruikt voor de aankoop.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Meerdere accounts kunnen Google Play in verwarring brengen. Door de app via de website van Google Play te installeren, wordt de koppeling met een specifiek account afgedwongen.</string>
     <string name="upgrade_screen_restore_banner_title">Heb je de Pro-versie al gekocht?</string>
     <string name="upgrade_screen_restore_banner_body">Het lijkt erop dat je dit apparaat eerder al hebt geüpgraded naar Pro. Herstel je aankoop om het opnieuw te ontgrendelen.</string>
     <string name="upgrade_screen_restore_success_message">Aankoop hersteld.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Je hebt CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ontgrendeld door je abonnement. Bedankt voor het steunen van CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ontgrendeld door je eenmalige aankoop. Bedankt voor het steunen van CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Jaarlijks abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Je abonnement is actief en wordt automatisch verlengd. De facturering wordt beheerd door Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Je abonnement is actief, maar wordt niet verlengd. Pro blijft beschikbaar tot het einde van de huidige periode.</string>
     <string name="upgrade_screen_owned_iap_title">Eenmalige aankoop</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Usługi Google Play są niedostępne.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>
     <string name="upgrades_gplay_billing_error_label">Błąd Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Wystąpił błąd w Google Play. Spróbuj ponownie później lub uruchom ponownie telefon.\n\nBłąd: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Błąd płatności Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Wystąpił błąd podczas zapytania Google Play o szczegóły zakupu. Wyczyść pamięć podręczną Google Play i uruchom ponownie telefon.\n\nBłąd %s</string>
     <string name="upgrades_gplay_already_owned_label">Już zakupiono?</string>
     <string name="upgrades_gplay_already_owned_description">Sklep Google Play zgłasza, że już posiadasz tę aktualizację, ale nie udało się jej przywrócić. Upewnij się, że używasz konta Google, na które dokonano zakupu. Synchronizacja Sklepu Google Play może chwilę potrwać — spróbuj zrestartować urządzenie, wyczyścić pamięć podręczną Sklepu Google Play lub po prostu poczekaj.</string>
-    <string name="upgrade_restore_action">Przywróć zakup</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Uzyskaj %1$s</string>
     <string name="upgrade_preamble">CAPod jest rozwijany przez jedną osobę. Aktualizacja odblokowuje dodatkowe funkcje i pomaga utrzymać aplikację przy życiu.</string>
-    <string name="upgrade_screen_options_description">Te same funkcje, różne ceny. Subskrypcja obejmuje bezpłatny okres próbny i może zostać anulowana w dowolnym momencie.</string>
-    <string name="upgrade_screen_options_description_no_trial">Te same funkcje, inna cena. Subskrypcję możesz anulować w dowolnym momencie.</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij wersję próbną</string>
     <string name="upgrade_screen_subscription_action">Subskrybuj rocznie</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/rok</string>
     <string name="upgrade_screen_iap_action">Kup raz</string>
-    <string name="upgrade_screen_iap_action_hint">Jednorazowy zakup: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Przywróć zakup</string>
-    <string name="upgrade_screen_restore_purchase_message">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Jeśli niedawno dokonałeś zakupu, synchronizacja z Google Play może chwilę potrwać.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Spróbuj ponownie za kilka minut, jeśli twój zakup się nie pojawi.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Upewnij się, że jesteś zalogowany na to samo konto Google, które zostało użyte do zakupu.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Wiele kont może wprowadzić w błąd Sklep Google Play. Zainstalowanie aplikacji przez Sklep Google Play wymusza powiązanie z konkretnym kontem.</string>
     <string name="upgrade_screen_restore_banner_title">Już kupiłeś Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Wygląda na to, że na tym urządzeniu dokonałeś już wcześniej aktualizacji do wersji Pro. Przywróć zakup, aby ją ponownie odblokować.</string>
     <string name="upgrade_screen_restore_success_message">Zakup przywrócony.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Masz CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Odblokowane dzięki twojej subskrypcji. Dziękuję za wsparcie CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Odblokowane dzięki jednorazowemu zakupowi. Dziękuję za wsparcie CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Roczna subskrypcja</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Twoja subskrypcja jest aktywna i ustawiona na odnawianie. Płatnościami zarządza Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Twoja subskrypcja jest aktywna, ale nie zostanie odnowiona. Pro pozostaje dostępne do końca bieżącego okresu.</string>
     <string name="upgrade_screen_owned_iap_title">Jednorazowy zakup</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Os serviços do Google Play não estão disponíveis.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta certa?</string>
     <string name="upgrades_gplay_billing_error_label">Erro do Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Houve um erro no Google Play. Por favor, tente novamente mais tarde ou reinicie seu telefone.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Erro de faturamento do Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Houve um erro ao solicitar ao Google Play os seus detalhes de compra. Limpe o cache do Google Play e reinicie o seu telefone. \n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">Já comprou?</string>
     <string name="upgrades_gplay_already_owned_description">O Google Play informa que você já possui este upgrade, mas ele não pôde ser restaurado. Verifique se você está usando a conta Google com a qual fez a compra. A sincronização da Play Store pode levar algum tempo — tente reiniciar, limpar o cache do Google Play ou simplesmente aguardar.</string>
-    <string name="upgrade_restore_action">Restaurar a compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">O CAPod é desenvolvido por uma única pessoa. Fazer o upgrade desbloqueia recursos extras e ajuda a manter o aplicativo vivo.</string>
-    <string name="upgrade_screen_options_description">Os mesmos recursos, preços diferentes. A assinatura inclui um teste gratuito e pode ser cancelada a qualquer momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">Os mesmos recursos, preços diferentes. A assinatura pode ser cancelada a qualquer momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito</string>
     <string name="upgrade_screen_subscription_action">Assinar anualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ano</string>
     <string name="upgrade_screen_iap_action">Comprar uma vez</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar a compra</string>
-    <string name="upgrade_screen_restore_purchase_message">Nenhuma compra encontrada. Você está usando a conta certa?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Se você comprou recentemente, pode levar um tempo até o Google Play sincronizar.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Tente novamente em alguns minutos se sua compra não aparecer.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Verifique se você está conectado com a mesma conta Google usada na compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Várias contas podem confundir o Google Play. Instalar o aplicativo pelo site do Google Play força a associação a uma conta específica.</string>
     <string name="upgrade_screen_restore_banner_title">Já comprou o Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parece que você já fez o upgrade para o Pro neste dispositivo antes. Restaure sua compra para desbloqueá-lo novamente.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Você tem o CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloqueado pela sua assinatura. Obrigado por apoiar o CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloqueado pela sua compra única. Obrigado por apoiar o CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Assinatura anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Sua assinatura está ativa e configurada para renovar. A cobrança é gerenciada pelo Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Sua assinatura está ativa, mas não está configurada para renovar. O Pro continua disponível até o fim do período atual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra de uma só vez</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Os serviços do Google Play estão indisponíveis.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Está a usar a conta correta?</string>
     <string name="upgrades_gplay_billing_error_label">Erro do Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Ocorreu um erro no Google Play. Tente novamente mais tarde ou reinicie o telemóvel.\n\nErro: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Erro de faturação do Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Ocorreu um erro ao solicitar os detalhes da sua compra ao Google Play. Limpe a cache do Google Play e reinicie o telemóvel.\n\nErro %s</string>
     <string name="upgrades_gplay_already_owned_label">Já compraste?</string>
     <string name="upgrades_gplay_already_owned_description">O Google Play indica que já possuis esta atualização, mas não foi possível restaurá-la. Certifica-te de que estás a usar a conta Google com que efetuaste a compra. A sincronização da Play Store pode demorar algum tempo — tenta reiniciar, limpar a cache do Google Play ou simplesmente aguardar.</string>
-    <string name="upgrade_restore_action">Restaurar compra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obter %1$s</string>
     <string name="upgrade_preamble">O CAPod é desenvolvido por uma única pessoa. A atualização desbloqueia funcionalidades extra e ajuda a manter a aplicação viva.</string>
-    <string name="upgrade_screen_options_description">As mesmas funcionalidades, preços diferentes. A subscrição inclui um período de avaliação gratuito e pode ser cancelada a qualquer momento.</string>
-    <string name="upgrade_screen_options_description_no_trial">As mesmas funcionalidades, preços diferentes. A subscrição pode ser cancelada a qualquer momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar período de avaliação gratuito</string>
     <string name="upgrade_screen_subscription_action">Subscrever anualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ano</string>
     <string name="upgrade_screen_iap_action">Comprar uma vez</string>
-    <string name="upgrade_screen_iap_action_hint">Compra única: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
-    <string name="upgrade_screen_restore_purchase_message">Nenhuma compra encontrada. Está a usar a conta correta?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Se compraste recentemente, o Google Play pode demorar algum tempo a sincronizar.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Tenta novamente dentro de alguns minutos se a tua compra não aparecer.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Certifica-te de que tens sessão iniciada com a mesma conta Google utilizada na compra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Várias contas podem confundir o Google Play. Instalar a aplicação através do site do Google Play força a associação a uma conta específica.</string>
     <string name="upgrade_screen_restore_banner_title">Já compraste o Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parece que já atualizaste para o Pro neste dispositivo antes. Restaura a tua compra para o desbloquear novamente.</string>
     <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Tens o CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Desbloqueado pela tua subscrição. Obrigado por apoiares o CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Desbloqueado pela tua compra única. Obrigado por apoiares o CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Subscrição anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">A tua subscrição está ativa e configurada para renovar. A faturação é gerida pelo Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">A tua subscrição está ativa, mas não está configurada para renovar. O Pro mantém-se disponível até ao final do período atual.</string>
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Ils servezzans da Google Play n\'èn betg disponibels.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nagins acquists chattads. Utiliseschas ti il conto gist?</string>
     <string name="upgrades_gplay_billing_error_label">Errur da Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Igl ha dà ina errur en Google Play. Emprova per plaschair pli tard u reavvia tes telefon.\n\nErrur: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Errur da facturaziun da Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Igl ha dà ina errur cun la dumonda dals detagls da tes acquist tar Google Play. Stizza il cache da Google Play e reavvia tes telefon.\n\nErrur %s</string>
     <string name="upgrades_gplay_already_owned_label">Gia cumprà?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play rapporta che ti possedas gia quest upgrade, ma el n\'ha betg pudì vegnir restaurà. Controllescha che ti utiliseschias il conto Google cun il qual ti has cumprà. La sincronisaziun da Play Store po durar in pau temp — emprova da reaviar il apparat, svidar la cache da Google Play u simplamain spetgar.</string>
-    <string name="upgrade_restore_action">Restaurar la cumpra</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obtegnair %1$s</string>
     <string name="upgrade_preamble">CAPod vegn sviluppà da ina persuna suletta. In upgrade sblochescha funcziuns supplementaras ed ajuda a mantegnair l\'app en vita.</string>
-    <string name="upgrade_screen_options_description">Medemas funcziuns, autra tarifa. L\'abunament includa in emprova gratuita e po vegnir annullà da tut temp.</string>
-    <string name="upgrade_screen_options_description_no_trial">Medemas funcziuns, autra tarifa. L\'abunament po vegnir annullà da tut temp.</string>
     <string name="upgrade_screen_subscription_trial_action">Cumenzar l\'emprova gratuita</string>
     <string name="upgrade_screen_subscription_action">S\'abunar mintg\'onn</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/onn</string>
     <string name="upgrade_screen_iap_action">Cumprar ina giada</string>
-    <string name="upgrade_screen_iap_action_hint">Cumpra unica: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar la cumpra</string>
-    <string name="upgrade_screen_restore_purchase_message">Nagins acquists chattads. Utiliseschas ti il conto gist?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Sche ti has cumprà dacurt, po quai durar in mument enfin che Google Play sincroniseschia.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Emprova anc ina giada en paucas minutas sche tia cumpra n\'emprova betg.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Controllescha che ti sajas annunzià cun il medem conto Google ch\'ins ha duvrà per la cumpra.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Plirs contos pon confunder Google Play. L\'installaziun da l\'app tras la website da Google Play sfortscha l\'associaziun cun in conto specific.</string>
     <string name="upgrade_screen_restore_banner_title">Già cumprà Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Ei para che ti hajas già fatg l\'upgrade a Pro sin quest apparat. Restaura tia cumpra per la sblochar danovamain.</string>
     <string name="upgrade_screen_restore_success_message">Cumpra restaurada.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Ti has CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sblocca tras tes abunament. Grazia per sustegnair CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Sblocca tras tia cumpra unica. Grazia per sustegnair CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Abunament annual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tes abunament è activ ed è configurà per sa renovar. La facturaziun vegn administrada da Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tes abunament è activ, ma n\'è betg configurà per sa renovar. Pro resta disponibel enfin la fin dal perioda actuala.</string>
     <string name="upgrade_screen_owned_iap_title">Cumpra unica</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Serviciile Google Play nu sunt disponibile.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nu s-au găsit achiziții. Folosești contul corect?</string>
     <string name="upgrades_gplay_billing_error_label">Eroare Google Play</string>
     <string name="upgrades_gplay_billing_error_description">A apărut o eroare în Google Play. Vă rugăm să încercați din nou mai târziu sau reporniți telefonul.\n\nEroare: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Eroare de facturare Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">A apărut o eroare la solicitarea detaliilor achiziției de la Google Play. Ștergeți memoria cache Google Play și reporniți telefonul.\n\nEroare %s</string>
     <string name="upgrades_gplay_already_owned_label">Ai cumpărat deja?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play raportează că deții deja acest upgrade, dar nu a putut fi restaurat. Asigură-te că folosești contul Google cu care ai făcut achiziția. Sincronizarea Play Store poate dura ceva timp — încearcă să repornești telefonul, să ștergi memoria cache a Google Play sau pur și simplu așteaptă.</string>
-    <string name="upgrade_restore_action">Restabiliți achiziția</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Obține %1$s</string>
     <string name="upgrade_preamble">CAPod este dezvoltat de o singură persoană. Upgrade-ul deblochează funcții suplimentare și ajută la menținerea aplicației în viață.</string>
-    <string name="upgrade_screen_options_description">Aceleași funcții, prețuri diferite. Abonamentul include o perioadă de probă gratuită și poate fi anulat oricând.</string>
-    <string name="upgrade_screen_options_description_no_trial">Aceleași funcții, prețuri diferite. Abonamentul poate fi anulat oricând.</string>
     <string name="upgrade_screen_subscription_trial_action">Începe încercarea gratuită</string>
     <string name="upgrade_screen_subscription_action">Abonează-te anual</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/an</string>
     <string name="upgrade_screen_iap_action">Cumpără o dată</string>
-    <string name="upgrade_screen_iap_action_hint">Achiziție unică: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restabiliți achiziția</string>
-    <string name="upgrade_screen_restore_purchase_message">Nu s-au găsit achiziții. Folosești contul corect?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Dacă ai cumpărat recent, sincronizarea cu Google Play poate dura puțin.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Încearcă din nou peste câteva minute dacă achiziția ta nu apare.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Asigură-te că ești conectat cu același cont Google folosit pentru achiziție.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Mai multe conturi pot deruta Google Play. Instalarea aplicației prin site-ul Google Play forțează asocierea cu un anumit cont.</string>
     <string name="upgrade_screen_restore_banner_title">Ai cumpărat deja Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Se pare că ai făcut anterior upgrade la Pro pe acest dispozitiv. Restaurează achiziția pentru a-l debloca din nou.</string>
     <string name="upgrade_screen_restore_success_message">Achiziție restaurată.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Ai CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Deblocat de abonamentul tău. Mulțumim că susții CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Deblocat de achiziția ta unică. Mulțumim că susții CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Abonament anual</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Abonamentul tău este activ și setat să se reînnoiască. Facturarea este gestionată de Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Abonamentul tău este activ, dar nu este setat să se reînnoiască. Pro rămâne disponibil până la sfârșitul perioadei curente.</string>
     <string name="upgrade_screen_owned_iap_title">Achiziție unică</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Сервисы Google Play недоступны.</string>
-    <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Вы используете правильный аккаунт?</string>
     <string name="upgrades_gplay_billing_error_label">Ошибка Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Произошла ошибка Google Play. Пожалуйста, попробуйте позже или перезагрузите телефон.\n\nОшибка: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Ошибка оплаты Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Произошла ошибка при запросе Google Play о деталях Вашей покупки. Очистите кэш Google Play и перезагрузите телефон.\n\nОшибка %s</string>
     <string name="upgrades_gplay_already_owned_label">Уже приобретено?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play сообщает, что Вы купили это обновление, но его не удалось восстановить. Убедитесь, что Вы используете тот же аккаунт Google, с которого была совершена покупка. Синхронизация Play Store может занять некоторое время — попробуйте перезагрузить устройство, очистить кэш Google Play или просто подождать.</string>
-    <string name="upgrade_restore_action">Восстановить покупку</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Получить %1$s</string>
     <string name="upgrade_preamble">CAPod разработан одним человеком. Обновление открывает дополнительные функции и помогает поддерживать приложение.</string>
-    <string name="upgrade_screen_options_description">Одинаковые функции, разные цены. Подписка включает бесплатный пробный период и может быть отменена в любое время.</string>
-    <string name="upgrade_screen_options_description_no_trial">Одинаковые функции, разные цены. Подписку можно отменить в любое время.</string>
     <string name="upgrade_screen_subscription_trial_action">Начать бесплатный пробный период</string>
     <string name="upgrade_screen_subscription_action">Подписаться на год</string>
-    <string name="upgrade_screen_subscription_action_hint">%s в год</string>
     <string name="upgrade_screen_iap_action">Купить один раз</string>
-    <string name="upgrade_screen_iap_action_hint">Единовременная покупка: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Восстановить покупку</string>
-    <string name="upgrade_screen_restore_purchase_message">Покупки не найдены. Вы используете правильный аккаунт?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Если Вы недавно совершили покупку, Google Play может потребоваться некоторое время для синхронизации.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Попробуйте снова через несколько минут, если Ваша покупка не отображается.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Убедитесь, что Вы вошли в ту же учётную запись Google, которая использовалась при покупке.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Несколько аккаунтов могут запутать Google Play. Установка приложения через сайт Google Play привязывает его к определённому аккаунту.</string>
     <string name="upgrade_screen_restore_banner_title">Уже купили Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Похоже, что Вы уже обновились до Pro на этом устройстве. Восстановите свою покупку, чтобы разблокировать его снова.</string>
     <string name="upgrade_screen_restore_success_message">Покупка восстановлена.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">У вас есть CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Разблокировано благодаря вашей подписке. Спасибо, что поддерживаете CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Разблокировано благодаря разовой покупке. Спасибо, что поддерживаете CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Годовая подписка</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша подписка активна и будет продлена. Платежи управляются Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша подписка активна, но продление не включено. Pro остаётся доступен до конца текущего периода.</string>
     <string name="upgrade_screen_owned_iap_title">Единовременная покупка</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Servìtzios Google Play non sunt disponìbiles.</string>
-    <string name="upgrades_no_purchases_found_check_account">Perunu achistu agatadu. Ses usende su contu giustu?</string>
     <string name="upgrades_gplay_billing_error_label">Errore de Google Play</string>
     <string name="upgrades_gplay_billing_error_description">B\'at àpidu un errore in Google Play. Proa torra prus a tardu o torra a allùere su telèfonu.\n\nErrore: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Errore de fatturatzione de Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">B\'at àpidu un errore cando si cherent is detàllios de s\'achistu a Google Play. Isbòida sa cache de Google Play e torra a allùere su telèfonu.\n\nErrore %s</string>
     <string name="upgrades_gplay_already_owned_label">Comporadu giai?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play informat chi tenes giai custu megioramentu, ma no est istadu possìbile lu ripristinare. Assegura·ti de impreare su contu Google chi as impreadu pro comporare. Sa sincronizatzione de su Play Store podet leare tempus — proa a torrare a allutu su dispositivu, a bogare sa memoria cache de Google Play o solu a aspetare.</string>
-    <string name="upgrade_restore_action">Recùpera su cùmperu</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Otine %1$s</string>
     <string name="upgrade_preamble">CAPod est isvilupada de una persona sola. Su megioramentu isblocat funtziones in prus e agiudat a mantènnere s\'aplicatzione bia.</string>
-    <string name="upgrade_screen_options_description">Matessi funtziones, prètzios diferentes. S\'abbonamentu includet una proa gratùita e podet èssere cantzelladu in cale si siat momentu.</string>
-    <string name="upgrade_screen_options_description_no_trial">Matessi funtziones, prètzios diferentes. S\'abbonamentu podet èssere cantzelladu in cale si siat momentu.</string>
     <string name="upgrade_screen_subscription_trial_action">Cumintza sa proa gratùita</string>
     <string name="upgrade_screen_subscription_action">Abbòna·ti annualmente</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/annu</string>
     <string name="upgrade_screen_iap_action">Cùmpera una borta</string>
-    <string name="upgrade_screen_iap_action_hint">Cùmperu de una borta: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Recùpera su cùmperu</string>
-    <string name="upgrade_screen_restore_purchase_message">Perunu achistu agatadu. Ses usende su contu giustu?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Si as cumperadu de reghente, Google Play podet leare unu pagu de tempus pro sincronizare.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Torra a proare in pagos minutos si su cùmperu tuo no cumparit.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Assegura·ti de àere fatu s\'aciesu cun su matessi contu Google impreadu pro su cùmperu.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Contos mùltiplos podent cunfùndere Google Play. Instalende s\'aplicatzione dae su situ web de Google Play si fortzat s\'assotziatzione cun unu contu ispetzìficu.</string>
     <string name="upgrade_screen_restore_banner_title">As giai cumperadu Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Parit chi as giai atualizadu a Pro in custu dispositivu in antis. Ripristina su cùmperu tuo pro l\'isblocare torra.</string>
     <string name="upgrade_screen_restore_success_message">Cùmperu ripristinadu.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Tenes CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Isblocadu dae s\'abbonamentu tuo. Gràtzias pro sustènnere CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Isblocadu dae su cùmperu tuo de una borta. Gràtzias pro sustènnere CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Abbonamentu annuale</string>
     <string name="upgrade_screen_owned_sub_renewing_body">S\'abbonamentu tuo est atívu e programadu pro si rennovare. Sa fatturatzione est ghestida dae Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">S\'abbonamentu tuo est atívu, ma no est programadu pro si rennovare. Pro abarrat disponìbile finas a sa fine de su períodu atuale.</string>
     <string name="upgrade_screen_owned_iap_title">Cùmperu de una borta</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">ගූගල් ප්ලේ සේවා නොතිබේ.</string>
-    <string name="upgrades_no_purchases_found_check_account">කිසිදු මිලදී ගැනීමක් හමු නොවීය. ඔබ ትክክለኛ ගිණුම භාවිතා කරනවාද?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play දෝෂය</string>
     <string name="upgrades_gplay_billing_error_description">Google Play හි දෝෂයක් ඇති විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න හෝ ඔබේ දුරකථනය නැවත ආරම්භ කරන්න.\n\nදෝෂය: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play බිල්පත් දෝෂය</string>
-    <string name="upgrades_gplay_billing_result_error_description">ඔබේ මිලදී ගැනීමේ විස්තර සඳහා Google Play වෙත ඉල්ලීමේදී දෝෂයක් ඇති විය. Google Play හැඹිලිය හිස් කර ඔබේ දුරකථනය නැවත ආරම්භ කරන්න.\n\nදෝෂය %s</string>
     <string name="upgrades_gplay_already_owned_label">දැනටමත් මිලදී අරගෙනද?</string>
     <string name="upgrades_gplay_already_owned_description">ඔබ දැනටමත් මෙම උසස් කිරීම හිමිකරගෙන ඇති බව Google Play වාර්තා කරයි, නමුත් එය ප්‍රතිසාධනය කළ නොහැකි විය. ඔබ මිලදී ගැනීමට භාවිත කළ Google ගිණුමම භාවිත කරන බව තහවුරු කරගන්න. Play Store සමමුහුර්තකරණයට කාලය ගත විය හැක — නැවත ආරම්භ කිරීම, Google Play කෑෂය හිස් කිරීම, හෝ මදක් රැඳී සිටීම උත්සාහ කරන්න.</string>
-    <string name="upgrade_restore_action">මිලදී ගැනීම ප්‍රතිසාධනය කරන්න</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ලබා ගන්න</string>
     <string name="upgrade_preamble">CAPod සංවර්ධනය කරනු ලබන්නේ එක් පුද්ගලයෙකු විසිනි. උසස් කිරීම අමතර විශේෂාංග අගුළු හරින අතර යෙදුම ක්‍රියාත්මකව තබා ගැනීමට උපකාරී වේ.</string>
-    <string name="upgrade_screen_options_description">විශේෂාංග එකම ය, මිල ගණන් වෙනස් ය. දායකත්වයට නොමිලේ අත්හදා බැලීමක් ඇතුළත් වන අතර ඕනෑම වේලාවක එය අවලංගු කළ හැක.</string>
-    <string name="upgrade_screen_options_description_no_trial">විශේෂාංග එකම ය, මිල ගණන් වෙනස් ය. දායකත්වය ඕනෑම වේලාවක අවලංගු කළ හැක.</string>
     <string name="upgrade_screen_subscription_trial_action">නොමිලේ අත්හදාබැලීම ආරම්භ කරන්න</string>
     <string name="upgrade_screen_subscription_action">වාර්ෂිකව දායක වන්න</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/වර්ෂයකට</string>
     <string name="upgrade_screen_iap_action">එක් වරක් මිලදී ගන්න</string>
-    <string name="upgrade_screen_iap_action_hint">එක් වරක් මිලදී ගැනීම: %s</string>
     <string name="upgrade_screen_restore_purchase_action">මිලදී ගැනීම ප්‍රතිසාධනය කරන්න</string>
-    <string name="upgrade_screen_restore_purchase_message">කිසිදු මිලදී ගැනීමක් හමු නොවීය. ඔබ ትክክለኛ ගිණුම භාවිතා කරනවාද?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">ඔබ මෑතකදී මිලදී ගෙන ඇත්නම්, Google Play සමමුහුර්ත වීමට මොහොතක් ගත විය හැක.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ඔබේ මිලදී ගැනීම නොපෙනේ නම්, මිනිත්තු කිහිපයකින් නැවත උත්සාහ කරන්න.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">මිලදී ගැනීම සඳහා භාවිත කළ එම Google ගිණුමෙන්ම පුරන්ව ඇති බව තහවුරු කරගන්න.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">බහු ගිණුම් Google Play ව්‍යාකූල කළ හැක. Google Play වෙබ් අඩවිය හරහා යෙදුම ස්ථාපනය කිරීම නිශ්චිත ගිණුමක් සමඟ සම්බන්ධතා බල කරයි.</string>
     <string name="upgrade_screen_restore_banner_title">දැනටමත් Pro මිලදී අරගෙනද?</string>
     <string name="upgrade_screen_restore_banner_body">ඔබ මීට පෙර මෙම උපාංගයේ Pro වෙත උසස් කර ඇති බව පෙනේ. එය නැවත අගුළු හැරීමට ඔබේ මිලදී ගැනීම ප්‍රතිසාධනය කරන්න.</string>
     <string name="upgrade_screen_restore_success_message">මිලදී ගැනීම ප්‍රතිසාධනය කරන ලදී.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">ඔබ සතුව CAPod Pro තිබේ!</string>
     <string name="upgrade_screen_owned_hero_sub_body">ඔබේ දායකත්වය මගින් අගුළු හරින ලදී. CAPod ට සහාය දැක්වූ ඔබට ස්තූතියි!</string>
     <string name="upgrade_screen_owned_hero_iap_body">ඔබේ එක් වරක් මිලදී ගැනීම මගින් අගුළු හරින ලදී. CAPod ට සහාය දැක්වූ ඔබට ස්තූතියි!</string>
-    <string name="upgrade_screen_owned_sub_title">වාර්ෂික දායකත්වය</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ඔබේ දායකත්වය සක්‍රියයි සහ අළුත් කිරීමට සකසා ඇත. බිල්පත් කළමනාකරණය කරනු ලබන්නේ Google Play මගිනි.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ඔබේ දායකත්වය සක්‍රියයි, නමුත් අළුත් කිරීමට සකසා නැත. වත්මන් කාල සීමාව අවසන් වන තෙක් Pro ලබා ගත හැකිව පවතී.</string>
     <string name="upgrade_screen_owned_iap_title">එක් වරක් මිලදී ගැනීම</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Služby Google Play nie sú k dispozícii.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>
     <string name="upgrades_gplay_billing_error_label">Chyba Google Play</string>
     <string name="upgrades_gplay_billing_error_description">V službe Google Play sa vyskytla chyba. Skúste to prosím neskôr alebo reštartujte telefón.\n\nChyba: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Chyba fakturácie Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Pri získavaní podrobností o vašom nákupe z Google Play sa vyskytla chyba. Vymažte vyrovnávaciu pamäť Google Play a reštartujte telefón.\n\nChyba %s</string>
     <string name="upgrades_gplay_already_owned_label">Už ste si kúpili?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play hlási, že tento upgrade už vlastníte, no nepodarilo sa ho obnoviť. Uistite sa, že používate rovnaký účet Google, s ktorým ste nákup uskutočnili. Synchronizácia Play Store môže chvíľu trvať — skúste reštartovať zariadenie, vymazať vyrovnávaciu pamäť Google Play alebo jednoducho počkať.</string>
-    <string name="upgrade_restore_action">Obnoviť nákup</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Získať %1$s</string>
     <string name="upgrade_preamble">CAPod vyvíja jedna osoba. Upgradom odomknete ďalšie funkcie a pomôžete udržať aplikáciu nažive.</string>
-    <string name="upgrade_screen_options_description">Rovnaké funkcie, odlišná cena. Predplatné zahŕňa bezplatnú skúšobnú verziu a možno ho kedykoľvek zrušiť.</string>
-    <string name="upgrade_screen_options_description_no_trial">Rovnaké funkcie, odlišná cena. Predplatné možno kedykoľvek zrušiť.</string>
     <string name="upgrade_screen_subscription_trial_action">Vyskúšajte zadarmo</string>
     <string name="upgrade_screen_subscription_action">Predplatiť ročne</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/rok</string>
     <string name="upgrade_screen_iap_action">Kúpiť jednorazovo</string>
-    <string name="upgrade_screen_iap_action_hint">Jednorazový nákup: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnoviť nákup</string>
-    <string name="upgrade_screen_restore_purchase_message">Nenašli sa žiadne nákupy. Používate správny účet?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ak ste si nedávno niečo kúpili, synchronizácia v službe Google Play môže chvíľu trvať.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ak sa váš nákup nezobrazí, skúste to o niekoľko minút znova.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Uistite sa, že ste prihlásení s rovnakým účtom Google, ktorý ste použili pri nákupe.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Viacero účtov môže Google Play zmiasť. Inštalácia aplikácie cez webovú stránku Google Play vynúti priradenie ku konkrétnemu účtu.</string>
     <string name="upgrade_screen_restore_banner_title">Už ste si kúpili Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Vyzerá to, že ste si na tomto zariadení už predtým upgradovali na Pro. Obnovte svoj nákup, aby ste ho znova odomkli.</string>
     <string name="upgrade_screen_restore_success_message">Nákup obnovený.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Máte CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Odomknuté vaším predplatným. Ďakujeme, že podporujete CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Odomknuté vaším jednorazovým nákupom. Ďakujeme, že podporujete CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Ročné predplatné</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaše predplatné je aktívne a nastavené na obnovenie. Platby spravuje Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše predplatné je aktívne, ale nie je nastavené na obnovenie. Pro zostáva dostupné až do konca aktuálneho obdobia.</string>
     <string name="upgrade_screen_owned_iap_title">Jednorazový nákup</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Storitve Google Play niso na voljo.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ni najdenih nakupov. Ali uporabljate pravi račun?</string>
     <string name="upgrades_gplay_billing_error_label">Napaka Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Prišlo je do napake v storitvi Google Play. Poskusite znova pozneje ali znova zaženite telefon.\n\nNapaka: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Napaka pri obračunavanju Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Prišlo je do napake pri pridobivanju podrobnosti o vašem nakupu iz Google Play. Počistite predpomnilnik Google Play in znova zaženite telefon.\n\nNapaka %s</string>
     <string name="upgrades_gplay_already_owned_label">Že kupljeno?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play sporoča, da to nadgradnjo že imate, vendar je ni bilo mogoče obnoviti. Prepričajte se, da uporabljate Google račun, s katerim ste opravili nakup. Sinhronizacija Trgovine Play lahko traja nekaj časa — poskusite znova zagnati napravo, počistiti predpomnilnik Google Play ali preprosto počakajte.</string>
-    <string name="upgrade_restore_action">Obnovi nakup</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Pridobite %1$s</string>
     <string name="upgrade_preamble">CAPod razvija ena sama oseba. Nadgradnja odklene dodatne funkcije in pomaga ohranjati aplikacijo pri življenju.</string>
-    <string name="upgrade_screen_options_description">Enake funkcije, različno oblikovanje cen. Naročnina vključuje brezplačno preizkusno obdobje in jo je mogoče kadarkoli preklicati.</string>
-    <string name="upgrade_screen_options_description_no_trial">Enake funkcije, različno oblikovanje cen. Naročnino je mogoče kadarkoli preklicati.</string>
     <string name="upgrade_screen_subscription_trial_action">Začni brezplačno preizkusno obdobje</string>
     <string name="upgrade_screen_subscription_action">Naroči se letno</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/leto</string>
     <string name="upgrade_screen_iap_action">Kupi enkrat</string>
-    <string name="upgrade_screen_iap_action_hint">Enkratni nakup: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovi nakup</string>
-    <string name="upgrade_screen_restore_purchase_message">Ni najdenih nakupov. Ali uporabljate pravi račun?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Če ste pred kratkim opravili nakup, lahko traja trenutek, da se Google Play sinhronizira.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Poskusite znova čez nekaj minut, če se vaš nakup ne prikaže.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Prepričajte se, da ste prijavljeni z istim Google računom, uporabljenim za nakup.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Več računov lahko zmede Google Play. Namestitev aplikacije prek spletne strani Google Play vsili povezavo z določenim računom.</string>
     <string name="upgrade_screen_restore_banner_title">Že kupili Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Videti je, da ste na tej napravi predhodno nadgradili na Pro. Obnovite svoj nakup, da ga znova odklenete.</string>
     <string name="upgrade_screen_restore_success_message">Nakup obnovljen.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Imate CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Odklenjeno z vašo naročnino. Hvala, ker podpirate CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Odklenjeno z vašim enkratnim nakupom. Hvala, ker podpirate CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Letna naročnina</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaša naročnina je aktivna in nastavljena na samodejno podaljšanje. Zaračunavanje upravlja Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaša naročnina je aktivna, vendar ni nastavljena na samodejno podaljšanje. Pro ostane na voljo do konca trenutnega obdobja.</string>
     <string name="upgrade_screen_owned_iap_title">Enkratni nakup</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Shërbimet e Google Play nuk janë të disponueshme.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nuk u gjetën blerje. Po përdorni llogarinë e duhur?</string>
     <string name="upgrades_gplay_billing_error_label">Gabim i Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Kishte një gabim në Google Play. Ju lutemi provoni përsëri më vonë ose rinisni telefonin tuaj.\n\nGabim: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Gabim i faturimit të Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Kishte një gabim kur u kërkuan detajet e blerjes suaj nga Google Play. Pastroni memorien e përkohshme të Google Play dhe rinisni telefonin tuaj.\n\nGabim %s</string>
     <string name="upgrades_gplay_already_owned_label">E keni blerë tashmë?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play raporton se ju e zotëroni tashmë këtë përmirësim, por nuk mund të rikthehet. Sigurohuni që po përdorni llogarinë Google me të cilën keni bërë blerjen. Sinkronizimi i Play Store mund të marrë kohë — provoni ta rinisni pajisjen, të pastroni memorien e fshehtë (cache) të Google Play, ose thjesht të prisni.</string>
-    <string name="upgrade_restore_action">Rivendos blerjen</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Merrni %1$s</string>
     <string name="upgrade_preamble">CAPod zhvillohet nga një person i vetëm. Përmirësimi zhbllokon veçori shtesë dhe ndihmon të mbahet aplikacioni gjallë.</string>
-    <string name="upgrade_screen_options_description">Të njëjtat veçori, çmime të ndryshme. Abonimi përfshin një periudhë provë falas dhe mund të anulohet në çdo kohë.</string>
-    <string name="upgrade_screen_options_description_no_trial">Të njëjtat veçori, çmime të ndryshme. Abonimi mund të anulohet në çdo kohë.</string>
     <string name="upgrade_screen_subscription_trial_action">Fillo provën falas</string>
     <string name="upgrade_screen_subscription_action">Abonohu vjetor</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/vit</string>
     <string name="upgrade_screen_iap_action">Bli një herë</string>
-    <string name="upgrade_screen_iap_action_hint">Blerje një herë: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Rivendos blerjen</string>
-    <string name="upgrade_screen_restore_purchase_message">Nuk u gjetën blerje. Po përdorni llogarinë e duhur?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Nëse keni bërë blerjen së fundmi, mund të duhet pak kohë që Google Play të sinkronizohet.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Provoni përsëri pas disa minutash nëse blerja juaj nuk shfaqet.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Sigurohuni që keni hyrë me të njëjtën llogari Google që përdorët për blerjen.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Llogaritë e shumta mund të habisin Google Play. Instalimi i aplikacionit përmes faqes së internetit të Google Play detyron lidhjen me një llogari specifike.</string>
     <string name="upgrade_screen_restore_banner_title">E keni blerë tashmë Pro-n?</string>
     <string name="upgrade_screen_restore_banner_body">Duket sikur e keni përmirësuar më parë në Pro në këtë pajisje. Rikthejeni blerjen tuaj për ta zhbllokuar përsëri.</string>
     <string name="upgrade_screen_restore_success_message">Blerja u rikthye.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Ju keni CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Zhbllokuar nga abonimi juaj. Faleminderit që mbështetni CAPod-in!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Zhbllokuar nga blerja juaj një herë. Faleminderit që mbështetni CAPod-in!</string>
-    <string name="upgrade_screen_owned_sub_title">Abonim vjetor</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Abonimi juaj është aktiv dhe i caktuar për t\'u rinovuar. Faturimi menaxhohet nga Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Abonimi juaj është aktiv, por nuk është caktuar për t\'u rinovuar. Pro mbetet i disponueshëm deri në përfundimin e periudhës aktuale.</string>
     <string name="upgrade_screen_owned_iap_title">Blerje një herë</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play услуге нису доступне.</string>
-    <string name="upgrades_no_purchases_found_check_account">Није пронађена ниједна куповина. Да ли користите прави налог?</string>
     <string name="upgrades_gplay_billing_error_label">Грешка Google Play-а</string>
     <string name="upgrades_gplay_billing_error_description">Дошло је до грешке у Google Play-у. Покушајте поново касније или рестартујте телефон.\n\nГрешка: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Грешка наплате Google Play-а</string>
-    <string name="upgrades_gplay_billing_result_error_description">Дошло је до грешке при захтевању детаља о вашој куповини од Google Play-а. Обришите кеш Google Play-а и рестартујте телефон.\n\nГрешка %s</string>
     <string name="upgrades_gplay_already_owned_label">Већ сте купили?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play пријављује да већ поседујете ову надоградњу, али није могла да се обнови. Проверите да ли користите Google налог са којим сте извршили куповину. Синхронизација Play продавнице може потрајати — покушајте да рестартујете уређај, обришете кеш Google Play-а или једноставно сачекате.</string>
-    <string name="upgrade_restore_action">Врати куповину</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Узмите %1$s</string>
     <string name="upgrade_preamble">CAPod развија једна особа. Надоградња откључава додатне функције и помаже да апликација опстане.</string>
-    <string name="upgrade_screen_options_description">Исте функције, различите цене. Претплата укључује бесплатан пробни период и може се отказати у сваком тренутку.</string>
-    <string name="upgrade_screen_options_description_no_trial">Исте функције, различите цене. Претплата се може отказати у сваком тренутку.</string>
     <string name="upgrade_screen_subscription_trial_action">Започните бесплатан пробни период</string>
     <string name="upgrade_screen_subscription_action">Претплатите се годишње</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/год.</string>
     <string name="upgrade_screen_iap_action">Купите једном</string>
-    <string name="upgrade_screen_iap_action_hint">Једнократна куповина: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Врати куповину</string>
-    <string name="upgrade_screen_restore_purchase_message">Није пронађена ниједна куповина. Да ли користите прави налог?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ако сте недавно извршили куповину, синхронизација са Google Play-ом може потрајати.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Покушајте поново за неколико минута ако се куповина не појави.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Проверите да ли сте пријављени на исти Google налог који сте користили за куповину.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Више налога може збунити Google Play. Инсталирање апликације преко Google Play веб сајта приморава повезивање са одређеним налогом.</string>
     <string name="upgrade_screen_restore_banner_title">Већ сте купили Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Изгледа да сте раније надоградили на Pro на овом уређају. Обновите куповину да бисте га поново откључали.</string>
     <string name="upgrade_screen_restore_success_message">Куповина обновљена.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Имате CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Откључано вашом претплатом. Хвала вам што подржавате CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Откључано вашом једнократном куповином. Хвала вам што подржавате CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Годишња претплата</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша претплата је активна и подешена да се обнавља. Наплатом управља Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша претплата је активна, али није подешена да се обнавља. Pro остаје доступан до краја текућег периода.</string>
     <string name="upgrade_screen_owned_iap_title">Једнократна куповина</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-tjänster är inte tillgängliga.</string>
-    <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-fel</string>
     <string name="upgrades_gplay_billing_error_description">Det uppstod ett fel i Google Play. Försök igen senare eller starta om din telefon.\n\nFel: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play faktureringsfel</string>
-    <string name="upgrades_gplay_billing_result_error_description">Det uppstod ett fel vid hämtning av dina köpuppgifter från Google Play. Rensa Google Play-cachen och starta om din telefon.\n\nFel %s</string>
     <string name="upgrades_gplay_already_owned_label">Redan köpt?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play rapporterar att du redan äger den här uppgraderingen, men den kunde inte återställas. Kontrollera att du använder samma Google-konto som du köpte med. Synkroniseringen med Play Butik kan ta tid — prova att starta om, rensa cacheminnet för Google Play eller helt enkelt vänta.</string>
-    <string name="upgrade_restore_action">Återställ köp</string>
     <string name="upgrade_badge_label">Expert</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Skaffa %1$s</string>
     <string name="upgrade_preamble">CAPod utvecklas av en enda person. En uppgradering låser upp extra funktioner och hjälper till att hålla appen vid liv.</string>
-    <string name="upgrade_screen_options_description">Samma funktioner, olika priser. Prenumerationen inkluderar en kostnadsfri provperiod och kan avslutas när som helst.</string>
-    <string name="upgrade_screen_options_description_no_trial">Samma funktioner, olika priser. Prenumerationen kan avslutas när som helst.</string>
     <string name="upgrade_screen_subscription_trial_action">Starta kostnadsfri provperiod</string>
     <string name="upgrade_screen_subscription_action">Prenumerera årsvis</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/år</string>
     <string name="upgrade_screen_iap_action">Köp en gång</string>
-    <string name="upgrade_screen_iap_action_hint">Engångsköp: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Återställ köp</string>
-    <string name="upgrade_screen_restore_purchase_message">Inga köp hittades. Använder du rätt konto?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Om du nyligen har köpt kan det ta en stund innan Google Play synkroniserar.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Försök igen om några minuter om ditt köp inte visas.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Kontrollera att du är inloggad med samma Google-konto som användes för köpet.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Flera konton kan förvirra Google Play. Om du installerar appen via Google Play-webbplatsen tvingas kopplingen till ett specifikt konto.</string>
     <string name="upgrade_screen_restore_banner_title">Redan köpt Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Det ser ut som att du tidigare har uppgraderat till Pro på den här enheten. Återställ ditt köp för att låsa upp det igen.</string>
     <string name="upgrade_screen_restore_success_message">Köpet återställt.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Du har CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Upplåst av din prenumeration. Tack för att du stödjer CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Upplåst av ditt engångsköp. Tack för att du stödjer CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Årlig prenumeration</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Din prenumeration är aktiv och kommer att förnyas. Faktureringen hanteras av Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Din prenumeration är aktiv men kommer inte att förnyas. Pro fortsätter att vara tillgängligt tills den nuvarande perioden går ut.</string>
     <string name="upgrade_screen_owned_iap_title">Engångsköp</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Huduma za Google Play hazipatikani.</string>
-    <string name="upgrades_no_purchases_found_check_account">Hakuna manunuzi yaliyopatikana. Je, unatumia akaunti sahihi?</string>
     <string name="upgrades_gplay_billing_error_label">Hitilafu ya Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Kulikuwa na hitilafu katika Google Play. Tafadhali jaribu tena baadaye au uzime na uwashe simu yako.\n\nHitilafu: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Hitilafu ya malipo ya Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Kulikuwa na hitilafu wakati wa kuomba maelezo ya ununuzi wako kutoka Google Play. Futa kashe ya Google Play na uzime na uwashe simu yako.\n\nHitilafu %s</string>
     <string name="upgrades_gplay_already_owned_label">Je, umeshanunua?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play inaripoti kuwa tayari unamiliki uboreshaji huu, lakini haukuweza kurejeshwa. Hakikisha unatumia akaunti ya Google uliyotumia kununua. Usawazishaji wa Play Store unaweza kuchukua muda — jaribu kuwasha upya kifaa, kufuta hifadhi ya Google Play au kusubiri tu.</string>
-    <string name="upgrade_restore_action">Rejesha ununuzi</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Pata %1$s</string>
     <string name="upgrade_preamble">CAPod inatengenezwa na mtu mmoja tu. Kuboresha kunafungua vipengele vya ziada na kusaidia kuendeleza programu hii.</string>
-    <string name="upgrade_screen_options_description">Vipengele sawa, bei tofauti. Usajili unajumuisha jaribio la bure na unaweza kughairiwa wakati wowote.</string>
-    <string name="upgrade_screen_options_description_no_trial">Vipengele sawa, bei tofauti. Usajili unaweza kughairiwa wakati wowote.</string>
     <string name="upgrade_screen_subscription_trial_action">Anza jaribio la bure</string>
     <string name="upgrade_screen_subscription_action">Jisajili kila mwaka</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/mwaka</string>
     <string name="upgrade_screen_iap_action">Nunua mara moja</string>
-    <string name="upgrade_screen_iap_action_hint">Ununuzi wa mara moja: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Rejesha ununuzi</string>
-    <string name="upgrade_screen_restore_purchase_message">Hakuna manunuzi yaliyopatikana. Je, unatumia akaunti sahihi?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Ikiwa umenunua hivi karibuni, inaweza kuchukua muda kidogo kwa Google Play kusawazisha.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Jaribu tena baada ya dakika chache ikiwa ununuzi wako haujaonekana.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Hakikisha umeingia na akaunti ile ile ya Google uliyotumia kununua.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Akaunti nyingi zinaweza kuchanganya Google Play. Kusakinisha programu kupitia tovuti ya Google Play kunalazimisha uhusiano na akaunti mahususi.</string>
     <string name="upgrade_screen_restore_banner_title">Je, tayari umenunua Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Inaonekana ulishaboresha hadi Pro kwenye kifaa hiki hapo awali. Rejesha ununuzi wako ili kuifungua tena.</string>
     <string name="upgrade_screen_restore_success_message">Ununuzi umerejeshwa.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Una CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Imefunguliwa na usajili wako. Asante kwa kuunga mkono CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Imefunguliwa na ununuzi wako wa mara moja. Asante kwa kuunga mkono CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Usajili wa kila mwaka</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Usajili wako unatumika na umewekwa kujiongeza upya. Malipo yanasimamiwa na Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Usajili wako unatumika, lakini haujawekwa kujiongeza upya. Pro itaendelea kupatikana hadi kipindi cha sasa kitakapomalizika.</string>
     <string name="upgrade_screen_owned_iap_title">Ununuzi wa mara moja</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play சேவைகள் கிடைக்கவில்லை.</string>
-    <string name="upgrades_no_purchases_found_check_account">வாங்குதல்கள் எதுவும் இல்லை. நீங்கள் சரியான கணக்கைப் பயன்படுத்துகிறீர்களா?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play பிழை</string>
     <string name="upgrades_gplay_billing_error_description">Google Play இல் ஒரு பிழை ஏற்பட்டது. தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும் அல்லது உங்கள் தொலைபேசியை மறுதொடக்கம் செய்யவும்.\n\nபிழை: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play பில்லிங் பிழை</string>
-    <string name="upgrades_gplay_billing_result_error_description">உங்கள் வாங்குதல் விவரங்களை Google Play-யிடம் கேட்கும்போது ஒரு பிழை ஏற்பட்டது. Google Play கேச்-ஐ அழித்து உங்கள் தொலைபேசியை மறுதொடக்கம் செய்யவும்.\n\nபிழை %s</string>
     <string name="upgrades_gplay_already_owned_label">ஏற்கனவே வாங்கிவிட்டீர்களா?</string>
     <string name="upgrades_gplay_already_owned_description">இந்த மேம்படுத்தலை நீங்கள் ஏற்கனவே வைத்திருப்பதாக Google Play தெரிவிக்கிறது, ஆனால் அதை மீட்டெடுக்க முடியவில்லை. நீங்கள் வாங்கிய Google கணக்கைப் பயன்படுத்துகிறீர்களா எனச் சரிபார்க்கவும். Play Store ஒத்திசைவு சிறிது நேரம் எடுக்கலாம் — மறுதொடக்கம் செய்யவும், Google Play தேக்ககத்தை அழிக்கவும் அல்லது சிறிது காத்திருக்கவும்.</string>
-    <string name="upgrade_restore_action">வாங்குதலை மீட்டமை</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s ஐப் பெறுக</string>
     <string name="upgrade_preamble">CAPod ஒரே ஒரு நபரால் உருவாக்கப்படுகிறது. மேம்படுத்துவது கூடுதல் அம்சங்களைத் திறக்கும் மற்றும் ஆப்பை உயிருடன் வைத்திருக்க உதவும்.</string>
-    <string name="upgrade_screen_options_description">அதே அம்சங்கள், வேறு விலை. சந்தா இலவச சோதனைக் காலத்தை உள்ளடக்கியது மற்றும் எப்போது வேண்டுமானாலும் ரத்து செய்யலாம்.</string>
-    <string name="upgrade_screen_options_description_no_trial">அதே அம்சங்கள், வேறு விலை. சந்தாவை எப்போது வேண்டுமானாலும் ரத்து செய்யலாம்.</string>
     <string name="upgrade_screen_subscription_trial_action">இலவச சோதனையைத் தொடங்கு</string>
     <string name="upgrade_screen_subscription_action">ஆண்டுதோறும் சந்தா செய்</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ஆண்டு</string>
     <string name="upgrade_screen_iap_action">ஒரு முறை வாங்கு</string>
-    <string name="upgrade_screen_iap_action_hint">ஒரு முறை வாங்குதல்: %s</string>
     <string name="upgrade_screen_restore_purchase_action">வாங்குதலை மீட்டமை</string>
-    <string name="upgrade_screen_restore_purchase_message">வாங்குதல்கள் எதுவும் இல்லை. நீங்கள் சரியான கணக்கைப் பயன்படுத்துகிறீர்களா?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">நீங்கள் சமீபத்தில் வாங்கியிருந்தால், Google Play ஒத்திசைவாக சிறிது நேரம் ஆகலாம்.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">உங்கள் கொள்முதல் தோன்றவில்லை எனில் சில நிமிடங்களில் மீண்டும் முயற்சிக்கவும்.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">கொள்முதலுக்குப் பயன்படுத்திய அதே Google கணக்கில் நீங்கள் உள்நுழைந்துள்ளீர்களா எனச் சரிபார்க்கவும்.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">பல கணக்குகள் Google Playஐ குழப்பலாம். Google Play வலைத்தளம் வழியாக ஆப்பை நிறுவுவது குறிப்பிட்ட கணக்குடன் தொடர்பை கட்டாயப்படுத்துகிறது.</string>
     <string name="upgrade_screen_restore_banner_title">ஏற்கனவே Pro-வை வாங்கிவிட்டீர்களா?</string>
     <string name="upgrade_screen_restore_banner_body">இந்த சாதனத்தில் நீங்கள் முன்பே Pro-வுக்கு மேம்படுத்தியது போல் தெரிகிறது. அதை மீண்டும் திறக்க உங்கள் கொள்முதலை மீட்டெடுக்கவும்.</string>
     <string name="upgrade_screen_restore_success_message">கொள்முதல் மீட்டெடுக்கப்பட்டது.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">உங்களிடம் CAPod Pro உள்ளது!</string>
     <string name="upgrade_screen_owned_hero_sub_body">உங்கள் சந்தாவால் திறக்கப்பட்டது. CAPod-ஐ ஆதரித்ததற்கு நன்றி!</string>
     <string name="upgrade_screen_owned_hero_iap_body">உங்கள் ஒரு முறை வாங்குதலால் திறக்கப்பட்டது. CAPod-ஐ ஆதரித்ததற்கு நன்றி!</string>
-    <string name="upgrade_screen_owned_sub_title">ஆண்டு சந்தா</string>
     <string name="upgrade_screen_owned_sub_renewing_body">உங்கள் சந்தா செயலில் உள்ளது மற்றும் புதுப்பிக்க அமைக்கப்பட்டுள்ளது. பில்லிங் Google Play ஆல் நிர்வகிக்கப்படுகிறது.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">உங்கள் சந்தா செயலில் உள்ளது, ஆனால் புதுப்பிக்க அமைக்கப்படவில்லை. தற்போதைய காலம் முடியும் வரை Pro கிடைக்கும்.</string>
     <string name="upgrade_screen_owned_iap_title">ஒரு முறை வாங்குதல்</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play సేవలు అందుబాటులో లేవు.</string>
-    <string name="upgrades_no_purchases_found_check_account">కొనుగోళ్లు ఏవీ కనుగొనబడలేదు. మీరు సరైన ఖాతాను ఉపయోగిస్తున్నారా?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play లోపం</string>
     <string name="upgrades_gplay_billing_error_description">Google Play లో ఒక లోపం జరిగింది. దయచేసి తర్వాత మళ్లీ ప్రయత్నించండి లేదా మీ ఫోన్‌ను రీబూట్ చేయండి.\n\nలోపం: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Billing లోపం</string>
-    <string name="upgrades_gplay_billing_result_error_description">మీ కొనుగోలు వివరాల కోసం Google Play ను అడిగేటప్పుడు ఒక లోపం జరిగింది. Google Play క్యాష్‌ను క్లియర్ చేసి మీ ఫోన్‌ను రీబూట్ చేయండి.\n\nలోపం %s</string>
     <string name="upgrades_gplay_already_owned_label">ఇప్పటికే కొనుగోలు చేశారా?</string>
     <string name="upgrades_gplay_already_owned_description">మీరు ఇప్పటికే ఈ అప్‌గ్రేడ్‌ను కలిగి ఉన్నారని Google Play నివేదిస్తోంది, కానీ దాన్ని పునరుద్ధరించడం సాధ్యం కాలేదు. మీరు కొనుగోలు చేసిన అదే Google ఖాతాను ఉపయోగిస్తున్నారని నిర్ధారించుకోండి. Play Store సమకాలీకరణకు సమయం పట్టవచ్చు — పునఃప్రారంభించడం, Google Play కాష్‌ను క్లియర్ చేయడం లేదా కొంత సమయం వేచి ఉండటం ప్రయత్నించండి.</string>
-    <string name="upgrade_restore_action">కొనుగోలును పునరుద్ధరించండి</string>
     <string name="upgrade_badge_label">ప్రొ</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">పొందండి %1$s</string>
     <string name="upgrade_preamble">CAPodని ఒకే వ్యక్తి అభివృద్ధి చేస్తున్నారు. అప్‌గ్రేడ్ చేయడం అదనపు ఫీచర్లను అన్‌లాక్ చేస్తుంది మరియు యాప్‌ను సజీవంగా ఉంచడంలో సహాయపడుతుంది.</string>
-    <string name="upgrade_screen_options_description">అదే ఫీచర్లు, వేర్వేరు ధరలు. సబ్‌స్క్రిప్షన్‌లో ఉచిత ట్రయల్ ఉంటుంది మరియు దీన్ని ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
-    <string name="upgrade_screen_options_description_no_trial">అదే ఫీచర్లు, వేర్వేరు ధరలు. సబ్‌స్క్రిప్షన్‌ను ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
     <string name="upgrade_screen_subscription_trial_action">ఉచిత ప్రయత్నం ప్రారంభించండి</string>
     <string name="upgrade_screen_subscription_action">వార్షికంగా సబ్‌స్క్రైబ్ చేయండి</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/సంవత్సరం</string>
     <string name="upgrade_screen_iap_action">ఒకసారి కొనండి</string>
-    <string name="upgrade_screen_iap_action_hint">ఒకేసారి కొనుగోలు: %s</string>
     <string name="upgrade_screen_restore_purchase_action">కొనుగోలును పునరుద్ధరించండి</string>
-    <string name="upgrade_screen_restore_purchase_message">కొనుగోళ్లు ఏవీ కనుగొనబడలేదు. మీరు సరైన ఖాతాను ఉపయోగిస్తున్నారా?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">మీరు ఇటీవల కొనుగోలు చేసి ఉంటే, Google Play సమకాలీకరించడానికి కొంత సమయం పట్టవచ్చు.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">మీ కొనుగోలు కనిపించకపోతే కొన్ని నిమిషాల్లో మళ్ళీ ప్రయత్నించండి.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">కొనుగోలు కోసం ఉపయోగించిన అదే Google ఖాతాతో మీరు సైన్ ఇన్ అయి ఉన్నారని నిర్ధారించుకోండి.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">బహుళ ఖాతాలు Google Playని గందరగోళానికి గురిచేయవచ్చు. Google Play వెబ్‌సైట్ ద్వారా యాప్‌ను ఇన్స్టాల్ చేయడం వల్ల ఒక నిర్దిష్ట ఖాతాతో అనుబంధం నిర్బంధంగా ఏర్పడుతుంది.</string>
     <string name="upgrade_screen_restore_banner_title">ఇప్పటికే Pro కొన్నారా?</string>
     <string name="upgrade_screen_restore_banner_body">మీరు ఇంతకుముందు ఈ పరికరంలో Proకి అప్‌గ్రేడ్ చేసినట్లు కనిపిస్తోంది. దాన్ని మళ్ళీ అన్‌లాక్ చేయడానికి మీ కొనుగోలును పునరుద్ధరించండి.</string>
     <string name="upgrade_screen_restore_success_message">కొనుగోలు పునరుద్ధరించబడింది.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">మీకు CAPod Pro ఉంది!</string>
     <string name="upgrade_screen_owned_hero_sub_body">మీ సబ్‌స్క్రిప్షన్ ద్వారా అన్‌లాక్ చేయబడింది. CAPodకి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు!</string>
     <string name="upgrade_screen_owned_hero_iap_body">మీ ఒకేసారి కొనుగోలు ద్వారా అన్‌లాక్ చేయబడింది. CAPodకి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు!</string>
-    <string name="upgrade_screen_owned_sub_title">వార్షిక సబ్‌స్క్రిప్షన్</string>
     <string name="upgrade_screen_owned_sub_renewing_body">మీ సబ్‌స్క్రిప్షన్ యాక్టివ్‌గా ఉంది మరియు రెన్యూ అయ్యేలా సెట్ చేయబడింది. బిల్లింగ్‌ను Google Play నిర్వహిస్తుంది.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">మీ సబ్‌స్క్రిప్షన్ యాక్టివ్‌గా ఉంది, కానీ రెన్యూ అయ్యేలా సెట్ చేయబడలేదు. ప్రస్తుత వ్యవధి ముగిసే వరకు Pro అందుబాటులో ఉంటుంది.</string>
     <string name="upgrade_screen_owned_iap_title">ఒకేసారి కొనేయి</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">บริการ Google Play ไม่พร้อมใช้งาน</string>
-    <string name="upgrades_no_purchases_found_check_account">ไม่พบการสั่งซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่</string>
     <string name="upgrades_gplay_billing_error_label">ข้อผิดพลาด Google Play</string>
     <string name="upgrades_gplay_billing_error_description">เกิดข้อผิดพลาดใน Google Play โปรดลองอีกครั้งในภายหลังหรือรีบูตโทรศัพท์ของคุณ\n\nข้อผิดพลาด: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">ข้อผิดพลาดการเรียกเก็บเงินของ Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">เกิดข้อผิดพลาดขณะขอรายละเอียดการสั่งซื้อของคุณจาก Google Play ล้างแคช Google Play แล้วรีบูตโทรศัพท์ของคุณ\n\nข้อผิดพลาด %s</string>
     <string name="upgrades_gplay_already_owned_label">ซื้อไปแล้วใช่ไหม</string>
     <string name="upgrades_gplay_already_owned_description">Google Play รายงานว่าคุณเป็นเจ้าของการอัปเกรดนี้อยู่แล้ว แต่ไม่สามารถกู้คืนได้ ตรวจสอบให้แน่ใจว่าคุณใช้บัญชี Google เดียวกับที่ใช้ซื้อ การซิงค์ข้อมูลของ Play Store อาจใช้เวลาสักครู่ — ลองรีสตาร์ทเครื่อง ล้างแคชของ Google Play หรือรอสักครู่</string>
-    <string name="upgrade_restore_action">กู้คืนการซื้อ</string>
     <string name="upgrade_badge_label">โปร</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">รับ %1$s</string>
     <string name="upgrade_preamble">CAPod พัฒนาโดยคนคนเดียว การอัปเกรดจะปลดล็อกฟีเจอร์เพิ่มเติมและช่วยให้แอปนี้ยังคงอยู่ต่อไป</string>
-    <string name="upgrade_screen_options_description">ฟีเจอร์เหมือนกัน แต่ราคาต่างกัน การสมัครสมาชิกมีช่วงทดลองใช้ฟรีและสามารถยกเลิกได้ทุกเมื่อ</string>
-    <string name="upgrade_screen_options_description_no_trial">ฟีเจอร์เหมือนกัน แต่ราคาต่างกัน การสมัครสมาชิกสามารถยกเลิกได้ทุกเมื่อ</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้ฟรี</string>
     <string name="upgrade_screen_subscription_action">สมัครสมาชิกรายปี</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/ปี</string>
     <string name="upgrade_screen_iap_action">ซื้อครั้งเดียว</string>
-    <string name="upgrade_screen_iap_action_hint">ซื้อครั้งเดียว: %s</string>
     <string name="upgrade_screen_restore_purchase_action">กู้คืนการซื้อ</string>
-    <string name="upgrade_screen_restore_purchase_message">ไม่พบการสั่งซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">หากคุณเพิ่งซื้อไป Google Play อาจต้องใช้เวลาสักครู่ในการซิงค์ข้อมูล</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ลองอีกครั้งในอีกไม่กี่นาทีหากการซื้อของคุณไม่ปรากฏ</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ตรวจสอบให้แน่ใจว่าคุณลงชื่อเข้าใช้ด้วยบัญชี Google เดียวกับที่ใช้ซื้อ</string>
-    <string name="upgrade_screen_restore_webinstall_hint">บัญชีหลายบัญชีอาจทำให้ Google Play สับสน การติดตั้งแอปผ่านเว็บไซต์ Google Play จะบังคับให้เชื่อมโยงกับบัญชีที่ระบุ</string>
     <string name="upgrade_screen_restore_banner_title">ซื้อ Pro ไปแล้วใช่ไหม</string>
     <string name="upgrade_screen_restore_banner_body">ดูเหมือนว่าคุณเคยอัปเกรดเป็น Pro บนอุปกรณ์นี้มาก่อน กู้คืนการซื้อของคุณเพื่อปลดล็อกอีกครั้ง</string>
     <string name="upgrade_screen_restore_success_message">กู้คืนการซื้อแล้ว</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">คุณมี CAPod Pro แล้ว!</string>
     <string name="upgrade_screen_owned_hero_sub_body">ปลดล็อกโดยการสมัครสมาชิกของคุณ ขอบคุณที่สนับสนุน CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">ปลดล็อกโดยการซื้อครั้งเดียวของคุณ ขอบคุณที่สนับสนุน CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">การสมัครสมาชิกรายปี</string>
     <string name="upgrade_screen_owned_sub_renewing_body">การสมัครสมาชิกของคุณใช้งานอยู่และตั้งค่าให้ต่ออายุ การเรียกเก็บเงินจัดการโดย Google Play</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">การสมัครสมาชิกของคุณใช้งานอยู่ แต่ไม่ได้ตั้งค่าให้ต่ออายุ Pro จะยังคงใช้งานได้จนกว่ารอบปัจจุบันจะสิ้นสุด</string>
     <string name="upgrade_screen_owned_iap_title">ซื้อครั้งเดียว</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play hizmetleri kullanılamıyor.</string>
-    <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Hatası</string>
     <string name="upgrades_gplay_billing_error_description">Google Play üzerinde bir hata oluştu. Lütfen daha sonra tekrar deneyin veya telefonunuzu yeniden başlatın.\n\nHata: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Faturalandırma Hatası</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play üzerinden satın alma ayrıntılarınız istenirken bir hata oluştu. Google Play önbelleğini temizleyin ve telefonunuzu yeniden başlatın.\n\nHata %s</string>
     <string name="upgrades_gplay_already_owned_label">Zaten satın aldın mı?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play, bu yükseltmeye zaten sahip olduğunu bildiriyor ancak geri yüklenemedi. Satın alırken kullandığın Google hesabını kullandığından emin ol. Play Store senkronizasyonu zaman alabilir — yeniden başlatmayı, Google Play önbelleğini temizlemeyi veya biraz beklemeyi dene.</string>
-    <string name="upgrade_restore_action">Satın almayı geri yükle</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s\'i Al</string>
     <string name="upgrade_preamble">CAPod bir kişi tarafından geliştirilmiştir. Yükseltme ekstra özelliklerin kilidini açar ve uygulamanın canlı kalabilmesine yardımcı olur.</string>
-    <string name="upgrade_screen_options_description">Aynı özellikler, farklı fiyatlandırma. Abonelik ücretsiz deneme içerir ve istediğin zaman iptal edilebilirsin.</string>
-    <string name="upgrade_screen_options_description_no_trial">Aynı özellikler, farklı fiyatlandırma. Aboneliği istediğin zaman iptal edebilirsin.</string>
     <string name="upgrade_screen_subscription_trial_action">Ücretsiz deneme süresini başlatın</string>
     <string name="upgrade_screen_subscription_action">Yıllık abone ol</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/yıl</string>
     <string name="upgrade_screen_iap_action">Bir kez satın al</string>
-    <string name="upgrade_screen_iap_action_hint">Tek seferlik satın alma: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Satın almayı geri yükle</string>
-    <string name="upgrade_screen_restore_purchase_message">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Eğer yakın zamanda satın aldıysanız, Google Play\'in senkronize etmesi biraz zaman alabilir.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Satın alma işlemi görünmüyorsa birkaç dakika sonra tekrar deneyin.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Satın alma için kullanılan Google hesabıyla oturum açtığından emin ol.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Birden fazla hesap Google Play\'i karıştırabilir. Uygulamayı Google Play web sitesi üzerinden yüklemek, belirli bir hesapla ilişkilendirmeyi zorunlu kılar.</string>
     <string name="upgrade_screen_restore_banner_title">Pro\'yu zaten satın aldın mı?</string>
     <string name="upgrade_screen_restore_banner_body">Görünüşe göre bu cihazda daha önce Pro\'ya yükseltme yapmışsın. Tekrar kilidini açmak için satın alımını geri yükle.</string>
     <string name="upgrade_screen_restore_success_message">Satın alma geri yüklendi.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">CAPod Pro\'ya sahipsin!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Aboneliğinle kilidi açıldı. CAPod\'u desteklediğin için teşekkürler!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tek seferlik satın alımınla kilidi açıldı. CAPod\'u desteklediğin için teşekkürler!</string>
-    <string name="upgrade_screen_owned_sub_title">Yıllık abonelik</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Aboneliğin aktif ve yenilenecek şekilde ayarlı. Faturalandırma Google Play tarafından yönetilir.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Aboneliğin aktif ancak yenilenecek şekilde ayarlı değil. Pro, mevcut dönem sona erene kadar kullanılabilir kalır.</string>
     <string name="upgrade_screen_owned_iap_title">Tek seferlik satın alma</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Сервіси Google Play недоступні.</string>
-    <string name="upgrades_no_purchases_found_check_account">Покупок не знайдено. Ви справді використовуєте правильний обліковий запис?</string>
     <string name="upgrades_gplay_billing_error_label">Помилка Google Play</string>
     <string name="upgrades_gplay_billing_error_description">У Google Play сталася помилка. Спробуйте ще раз пізніше або перезавантажте телефон.\n\nПомилка: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Помилка платіжної системи Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Сталася помилка під час отримання даних про покупки з Google Play. Очистіть кеш Google Play та перезавантажте телефон.\n\nПомилка %s</string>
     <string name="upgrades_gplay_already_owned_label">Вже придбано?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play повідомляє, що ви вже маєте це оновлення, але його не вдалося відновити. Переконайтеся, що ви використовуєте обліковий запис Google, з яким здійснили покупку. Синхронізація Play Store може тривати деякий час — спробуйте перезавантажити пристрій, очистити кеш Google Play або просто зачекати.</string>
-    <string name="upgrade_restore_action">Відновити покупку</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Отримати %1$s</string>
     <string name="upgrade_preamble">CAPod розробляє одна людина. Оновлення розблоковує додаткові функції та допомагає підтримувати розвиток застосунку.</string>
-    <string name="upgrade_screen_options_description">Ті самі функції, різні варіанти оплати. Підписка включає безкоштовний пробний період і може бути скасована в будь-який час.</string>
-    <string name="upgrade_screen_options_description_no_trial">Ті самі функції, різні варіанти оплати. Підписку можна скасувати в будь-який час.</string>
     <string name="upgrade_screen_subscription_trial_action">Випробувати пробний період</string>
     <string name="upgrade_screen_subscription_action">Оформити річну підписку</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/рік</string>
     <string name="upgrade_screen_iap_action">Придбати одноразово</string>
-    <string name="upgrade_screen_iap_action_hint">Одноразова покупка: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Відновити покупку</string>
-    <string name="upgrade_screen_restore_purchase_message">Покупок не знайдено. Ви справді використовуєте правильний обліковий запис?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Якщо ви нещодавно здійснили покупку, Google Play може знадобитися трохи часу для синхронізації.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Спробуйте ще раз за кілька хвилин, якщо ваша покупка не з\'явиться.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Переконайтеся, що ви ввійшли в той самий обліковий запис Google, який використовували для покупки.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Кілька облікових записів можуть заплутати Google Play. Встановлення застосунку через вебсайт Google Play примусово прив\'язує його до конкретного облікового запису.</string>
     <string name="upgrade_screen_restore_banner_title">Уже придбали Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Схоже, ви вже оновлювалися до Pro на цьому пристрої раніше. Відновіть покупку, щоб розблокувати її знову.</string>
     <string name="upgrade_screen_restore_success_message">Покупку відновлено.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">У вас є CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Розблоковано вашою підпискою. Дякуємо за підтримку CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Розблоковано вашою одноразовою покупкою. Дякуємо за підтримку CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Річна підписка</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша підписка активна та налаштована на автоматичне продовження. Оплатою керує Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша підписка активна, але не буде продовжена автоматично. Pro залишається доступним до кінця поточного періоду.</string>
     <string name="upgrade_screen_owned_iap_title">Одноразова покупка</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play کی سروسز دستیاب نہیں ہیں۔</string>
-    <string name="upgrades_no_purchases_found_check_account">کوئی خریداری نہیں ملی۔ کیا آپ درست اکاؤنٹ استعمال کر رہے ہیں؟</string>
     <string name="upgrades_gplay_billing_error_label">Google Play خرابی</string>
     <string name="upgrades_gplay_billing_error_description">Google Play میں ایک خرابی پیش آئی۔ براہ کرم بعد میں دوبارہ کوشش کریں یا اپنا فون ری بوٹ کریں۔\n\nخرابی: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play بلنگ خرابی</string>
-    <string name="upgrades_gplay_billing_result_error_description">آپ کی خریداری کی تفصیلات کے لیے Google Play سے پوچھتے وقت ایک خرابی پیش آئی۔ Google Play کیش صاف کریں اور اپنا فون ری بوٹ کریں۔\n\nخرابی %s</string>
     <string name="upgrades_gplay_already_owned_label">پہلے ہی خرید چکے ہیں؟</string>
     <string name="upgrades_gplay_already_owned_description">گوگل پلے کے مطابق آپ پہلے ہی یہ اپ گریڈ خرید چکے ہیں، لیکن اسے بحال نہیں کیا جا سکا۔ یقینی بنائیں کہ آپ وہی گوگل اکاؤنٹ استعمال کر رہے ہیں جس سے آپ نے خریداری کی تھی۔ پلے سٹور کی ہم آہنگی میں وقت لگ سکتا ہے — دوبارہ شروع کرنے، گوگل پلے کیشے صاف کرنے یا محض انتظار کرنے کی کوشش کریں۔</string>
-    <string name="upgrade_restore_action">خریداری بحال کریں</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s حاصل کریں</string>
     <string name="upgrade_preamble">CAPod ایک ہی شخص کی طرف سے تیار کیا گیا ہے۔ اپ گریڈ کرنے سے اضافی خصوصیات کھلتی ہیں اور ایپ کو زندہ رکھنے میں مدد ملتی ہے۔</string>
-    <string name="upgrade_screen_options_description">وہی خصوصیات، مختلف قیمتیں۔ سبسکرپشن میں مفت ٹرائل شامل ہے اور اسے کسی بھی وقت منسوخ کیا جا سکتا ہے۔</string>
-    <string name="upgrade_screen_options_description_no_trial">وہی خصوصیات، مختلف قیمتیں۔ سبسکرپشن کو کسی بھی وقت منسوخ کیا جا سکتا ہے۔</string>
     <string name="upgrade_screen_subscription_trial_action">مفت ٹرائل شروع کریں</string>
     <string name="upgrade_screen_subscription_action">سالانہ سبسکرائب کریں</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/سال</string>
     <string name="upgrade_screen_iap_action">ایک بار خریدیں</string>
-    <string name="upgrade_screen_iap_action_hint">ایک بار کی خریداری: %s</string>
     <string name="upgrade_screen_restore_purchase_action">خریداری بحال کریں</string>
-    <string name="upgrade_screen_restore_purchase_message">کوئی خریداری نہیں ملی۔ کیا آپ درست اکاؤنٹ استعمال کر رہے ہیں؟</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">اگر آپ نے حال ہی میں خریدا ہے، تو گوگل پلے کو ہم آہنگ کرنے میں کچھ وقت لگ سکتا ہے۔</string>
     <string name="upgrade_screen_restore_sync_patience_hint">اگر آپ کی خریداری ظاہر نہیں ہوتی تو چند منٹ میں دوبارہ کوشش کریں۔</string>
     <string name="upgrade_screen_restore_multiaccount_hint">یقینی بنائیں کہ آپ وہی گوگل اکاؤنٹ سے سائن ان ہیں جو خریداری کے لیے استعمال ہوا تھا۔</string>
-    <string name="upgrade_screen_restore_webinstall_hint">متعدد اکاؤنٹس گوگل پلے کو الجھن میں ڈال سکتے ہیں۔ گوگل پلے ویب سائٹ کے ذریعے ایپ انسٹال کرنا ایک مخصوص اکاؤنٹ کے ساتھ تعلق لازمی بنا دیتا ہے۔</string>
     <string name="upgrade_screen_restore_banner_title">پہلے ہی Pro خرید چکے ہیں؟</string>
     <string name="upgrade_screen_restore_banner_body">ایسا لگتا ہے کہ آپ نے پہلے اس ڈیوائس پر Pro میں اپ گریڈ کیا تھا۔ اسے دوبارہ انلاک کرنے کے لیے اپنی خریداری بحال کریں۔</string>
     <string name="upgrade_screen_restore_success_message">خریداری بحال ہو گئی۔</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">آپ کے پاس CAPod Pro ہے!</string>
     <string name="upgrade_screen_owned_hero_sub_body">آپ کے سبسکرپشن سے ان لاک ہوا۔ CAPod کی حمایت کرنے کا شکریہ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">آپ کی ایک بار کی خریداری سے ان لاک ہوا۔ CAPod کی حمایت کرنے کا شکریہ!</string>
-    <string name="upgrade_screen_owned_sub_title">سالانہ سبسکرپشن</string>
     <string name="upgrade_screen_owned_sub_renewing_body">آپ کا سبسکرپشن فعال ہے اور تجدید ہونے کے لیے طے ہے۔ بلنگ گوگل پلے کے ذریعے سنبھالے جاتی ہے۔</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">آپ کا سبسکرپشن فعال ہے، لیکن تجدید ہونے کے لیے طے نہیں۔ Pro موجودہ مدت کے ختم ہونے تک دستیاب رہتا ہے۔</string>
     <string name="upgrade_screen_owned_iap_title">ایک بار کی خریداری</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play xizmatlari mavjud emas.</string>
-    <string name="upgrades_no_purchases_found_check_account">Xaridlar topilmadi. To‘g‘ri hisobdan foydalanayapsizmi?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play xatosi</string>
     <string name="upgrades_gplay_billing_error_description">Google Play’da xatolik yuz berdi. Iltimos, keyinroq qayta urinib ko‘ring yoki telefoningizni qayta ishga tushiring.\n\nXato: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Billing xatosi</string>
-    <string name="upgrades_gplay_billing_result_error_description">Google Play’dan xaridingiz tafsilotlarini so‘rashda xatolik yuz berdi. Google Play keshini tozalang va telefoningizni qayta ishga tushiring.\n\nXato %s</string>
     <string name="upgrades_gplay_already_owned_label">Allaqachon sotib olganmisiz?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play ushbu yangilanishga allaqachon ega ekanligingizni bildiradi, ammo uni tiklab bo\'lmadi. Xarid qilgan Google hisobingizdan foydalanayotganingizga ishonch hosil qiling. Play Store sinxronizatsiyasi vaqt olishi mumkin — qurilmani qayta ishga tushirib ko\'ring, Google Play keshini tozalang yoki shunchaki kuting.</string>
-    <string name="upgrade_restore_action">Xaridni tiklash</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">%1$s-ni oling</string>
     <string name="upgrade_preamble">CAPod yagona shaxs tomonidan ishlab chiqilmoqda. Yangilash qo\'shimcha funksiyalarni ochadi va ilovani tirik saqlashga yordam beradi.</string>
-    <string name="upgrade_screen_options_description">Xususiyatlar bir xil, narxlar boshqacha. Obuna bepul sinov muddatini o\'z ichiga oladi va istalgan vaqtda bekor qilinishi mumkin.</string>
-    <string name="upgrade_screen_options_description_no_trial">Xususiyatlar bir xil, narxlar boshqacha. Obunani istalgan vaqtda bekor qilish mumkin.</string>
     <string name="upgrade_screen_subscription_trial_action">Bepul sinovni boshlash</string>
     <string name="upgrade_screen_subscription_action">Yillik obuna bo\'lish</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/yil</string>
     <string name="upgrade_screen_iap_action">Bir marta sotib olish</string>
-    <string name="upgrade_screen_iap_action_hint">Bir martalik xarid: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Xaridni tiklash</string>
-    <string name="upgrade_screen_restore_purchase_message">Xaridlar topilmadi. To‘g‘ri hisobdan foydalanayapsizmi?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Yaqinda xarid qilgan bo\'lsangiz, Google Play sinxronlashishi uchun biroz vaqt ketishi mumkin.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Agar xaridingiz ko\'rinmasa, bir necha daqiqadan so\'ng qayta urinib ko\'ring.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Xarid uchun ishlatilgan Google hisobi bilan tizimga kirganingizga ishonch hosil qiling.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Bir nechta hisoblar Google Play\'ni chalkashtirib yuborishi mumkin. Ilovani Google Play veb-sayti orqali o\'rnatish uni ma\'lum bir hisob bilan bog\'lashni ta\'minlaydi.</string>
     <string name="upgrade_screen_restore_banner_title">Pro\'ni allaqachon sotib olganmisiz?</string>
     <string name="upgrade_screen_restore_banner_body">Ko\'rinishidan, siz avval ushbu qurilmada Pro\'ga yangilagansiz. Uni qayta ochish uchun xaridingizni tiklang.</string>
     <string name="upgrade_screen_restore_success_message">Xarid tiklandi.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Sizda CAPod Pro bor!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Obunangiz orqali ochilgan. CAPodni qo\'llab-quvvatlaganingiz uchun rahmat!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bir martalik xaridingiz orqali ochilgan. CAPodni qo\'llab-quvvatlaganingiz uchun rahmat!</string>
-    <string name="upgrade_screen_owned_sub_title">Yillik obuna</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Obunangiz faol va yangilanishga sozlangan. To\'lovlar Google Play tomonidan boshqariladi.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Obunangiz faol, ammo yangilanishga sozlanmagan. Pro joriy davr tugagunga qadar mavjud bo\'lib qoladi.</string>
     <string name="upgrade_screen_owned_iap_title">Bir martalik xarid</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Các dịch vụ của Google Play không khả dụng.</string>
-    <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch mua nào. Bạn có đang sử dụng đúng tài khoản không?</string>
     <string name="upgrades_gplay_billing_error_label">Lỗi Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Đã xảy ra lỗi trong Google Play. Vui lòng thử lại sau hoặc khởi động lại điện thoại của bạn.\n\nLỗi: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Lỗi thanh toán Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Đã xảy ra lỗi khi yêu cầu Google Play cung cấp chi tiết giao dịch mua của bạn. Hãy xóa bộ nhớ đệm của Google Play và khởi động lại điện thoại của bạn.\n\nLỗi %s</string>
     <string name="upgrades_gplay_already_owned_label">Đã mua?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play cho biết bạn đã sở hữu bản nâng cấp này, nhưng không thể khôi phục. Hãy đảm bảo bạn đang sử dụng đúng tài khoản Google mà bạn đã dùng để mua. Việc đồng bộ hóa Play Store có thể mất chút thời gian — hãy thử khởi động lại thiết bị, xóa bộ nhớ đệm của Google Play hoặc đơn giản là chờ đợi.</string>
-    <string name="upgrade_restore_action">Khôi phục thanh toán</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Nhận %1$s</string>
     <string name="upgrade_preamble">CAPod được phát triển bởi một người duy nhất. Việc nâng cấp sẽ mở khóa thêm các tính năng và giúp duy trì ứng dụng.</string>
-    <string name="upgrade_screen_options_description">Cùng tính năng, giá khác nhau. Gói đăng ký có bản dùng thử miễn phí và có thể hủy bất cứ lúc nào.</string>
-    <string name="upgrade_screen_options_description_no_trial">Cùng tính năng, giá khác nhau. Gói đăng ký có thể hủy bất cứ lúc nào.</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử miễn phí</string>
     <string name="upgrade_screen_subscription_action">Đăng ký theo năm</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/năm</string>
     <string name="upgrade_screen_iap_action">Mua một lần</string>
-    <string name="upgrade_screen_iap_action_hint">Mua một lần: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Khôi phục thanh toán</string>
-    <string name="upgrade_screen_restore_purchase_message">Không tìm thấy giao dịch mua nào. Bạn có đang sử dụng đúng tài khoản không?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Nếu bạn vừa mua gần đây, Google Play có thể cần một chút thời gian để đồng bộ.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Hãy thử lại sau vài phút nếu giao dịch mua của bạn không xuất hiện.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Hãy đảm bảo bạn đã đăng nhập bằng cùng tài khoản Google đã dùng để mua.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Nhiều tài khoản có thể khiến Google Play nhầm lẫn. Cài đặt ứng dụng thông qua trang web Google Play sẽ buộc liên kết với một tài khoản cụ thể.</string>
     <string name="upgrade_screen_restore_banner_title">Đã mua Pro rồi?</string>
     <string name="upgrade_screen_restore_banner_body">Có vẻ như bạn đã từng nâng cấp lên Pro trên thiết bị này. Hãy khôi phục giao dịch mua để mở khóa lại.</string>
     <string name="upgrade_screen_restore_success_message">Đã khôi phục giao dịch mua.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Bạn đã có CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Được mở khóa bởi gói đăng ký của bạn. Cảm ơn bạn đã ủng hộ CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Được mở khóa bởi giao dịch mua một lần của bạn. Cảm ơn bạn đã ủng hộ CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Gói đăng ký hàng năm</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Gói đăng ký của bạn đang hoạt động và được đặt để gia hạn. Việc thanh toán do Google Play quản lý.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Gói đăng ký của bạn đang hoạt động, nhưng không được đặt để gia hạn. Pro vẫn khả dụng cho đến khi kỳ hạn hiện tại kết thúc.</string>
     <string name="upgrade_screen_owned_iap_title">Thanh toán một lần</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play 服务不可用</string>
-    <string name="upgrades_no_purchases_found_check_account">未找到购买记录，您使用的帐户正确吗？</string>
     <string name="upgrades_gplay_billing_error_label">Google Play 错误</string>
     <string name="upgrades_gplay_billing_error_description">Google Play 出现错误。请稍后重试或重启手机。\n\n错误：%s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play 结算错误</string>
-    <string name="upgrades_gplay_billing_result_error_description">向 Google Play 请求您的购买详情时出错。请清除 Google Play 缓存并重启手机。\n\n错误 %s</string>
     <string name="upgrades_gplay_already_owned_label">已购买?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play 显示您已拥有此升级,但无法恢复。请确保您使用的是购买时所用的 Google 账号。Play 商店同步可能需要一些时间——请尝试重启设备、清除 Google Play 缓存,或耐心等待。</string>
-    <string name="upgrade_restore_action">恢复购买</string>
     <string name="upgrade_badge_label">专业版</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">获取 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一个人独立开发。升级可解锁更多功能,并帮助这款应用持续维护下去。</string>
-    <string name="upgrade_screen_options_description">功能相同,价格不同。订阅包含免费试用,并可随时取消。</string>
-    <string name="upgrade_screen_options_description_no_trial">功能相同,价格不同。订阅可随时取消。</string>
     <string name="upgrade_screen_subscription_trial_action">开始免费试用</string>
     <string name="upgrade_screen_subscription_action">按年订阅</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/年</string>
     <string name="upgrade_screen_iap_action">一次性购买</string>
-    <string name="upgrade_screen_iap_action_hint">一次性购买:%s</string>
     <string name="upgrade_screen_restore_purchase_action">恢复购买</string>
-    <string name="upgrade_screen_restore_purchase_message">未找到购买记录，您使用的帐户正确吗？</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">如果您最近才完成购买,Google Play 可能需要一些时间才能同步。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">如果购买记录未显示,请几分钟后再试。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">请确保您登录的 Google 账号与购买时使用的账号一致。</string>
-    <string name="upgrade_screen_restore_webinstall_hint">多个账号可能会让 Google Play 产生混淆。通过 Google Play 网站安装应用可强制关联到特定账号。</string>
     <string name="upgrade_screen_restore_banner_title">已购买 Pro?</string>
     <string name="upgrade_screen_restore_banner_body">此设备似乎曾经升级过 Pro。恢复购买即可重新解锁。</string>
     <string name="upgrade_screen_restore_success_message">购买已恢复。</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">您已拥有 CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">已通过您的订阅解锁。感谢您对 CAPod 的支持!</string>
     <string name="upgrade_screen_owned_hero_iap_body">已通过您的一次性购买解锁。感谢您对 CAPod 的支持!</string>
-    <string name="upgrade_screen_owned_sub_title">年度订阅</string>
     <string name="upgrade_screen_owned_sub_renewing_body">您的订阅当前有效,并将自动续订。账单由 Google Play 管理。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">您的订阅当前有效,但不会自动续订。Pro 功能将持续到当前周期结束。</string>
     <string name="upgrade_screen_owned_iap_title">一次性购买</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play 服務無法使用。</string>
-    <string name="upgrades_no_purchases_found_check_account">未找到訂單，確定帳戶無誤？</string>
     <string name="upgrades_gplay_billing_error_label">Google Play 錯誤</string>
     <string name="upgrades_gplay_billing_error_description">Google Play 發生錯誤。請稍後再試或重新啟動手機。\n\n錯誤：%s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play 結帳錯誤</string>
-    <string name="upgrades_gplay_billing_result_error_description">向 Google Play 請求購買明細時發生錯誤。請清除 Google Play 快取並重新啟動手機。\n\n錯誤：%s</string>
     <string name="upgrades_gplay_already_owned_label">已經購買？</string>
     <string name="upgrades_gplay_already_owned_description">Google Play 顯示你已經擁有此升級項目，但無法還原。請確保你使用購買時所用的 Google 帳戶。Play 商店同步可能需要一些時間——你可以嘗試重新啟動裝置、清除 Google Play 快取，或耐心等候。</string>
-    <string name="upgrade_restore_action">恢復購買</string>
     <string name="upgrade_badge_label">專業版</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">取得 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一個人開發。升級可解鎖額外功能，並有助維持應用程式繼續運作。</string>
-    <string name="upgrade_screen_options_description">功能相同，定價不同。訂閱方案包含免費試用，並可隨時取消。</string>
-    <string name="upgrade_screen_options_description_no_trial">功能相同，定價不同。訂閱方案可隨時取消。</string>
     <string name="upgrade_screen_subscription_trial_action">開始免費試用</string>
     <string name="upgrade_screen_subscription_action">按年訂閱</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/年</string>
     <string name="upgrade_screen_iap_action">一次性購買</string>
-    <string name="upgrade_screen_iap_action_hint">一次性購買：%s</string>
     <string name="upgrade_screen_restore_purchase_action">恢復購買</string>
-    <string name="upgrade_screen_restore_purchase_message">未找到訂單，確定帳戶無誤？</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">如果你最近才購買，Google Play 可能需要一些時間才能同步。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">如果購買記錄未有顯示，請於幾分鐘後再試。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">請確保你使用購買時所用的同一個 Google 帳戶登入。</string>
-    <string name="upgrade_screen_restore_webinstall_hint">多個帳戶可能會令 Google Play 混淆。透過 Google Play 網站安裝應用程式，可強制與特定帳戶建立關聯。</string>
     <string name="upgrade_screen_restore_banner_title">已經購買 Pro？</string>
     <string name="upgrade_screen_restore_banner_body">看來你之前曾在此裝置升級至 Pro。還原購買以再次解鎖。</string>
     <string name="upgrade_screen_restore_success_message">購買已還原。</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">你已擁有 CAPod Pro！</string>
     <string name="upgrade_screen_owned_hero_sub_body">由你的訂閱解鎖。感謝你支持 CAPod！</string>
     <string name="upgrade_screen_owned_hero_iap_body">由你的一次性購買解鎖。感謝你支持 CAPod！</string>
-    <string name="upgrade_screen_owned_sub_title">年度訂閱</string>
     <string name="upgrade_screen_owned_sub_renewing_body">你的訂閱有效，並設定為自動續訂。帳單由 Google Play 管理。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">你的訂閱有效，但未設定自動續訂。Pro 將維持可用，直到目前計費周期結束。</string>
     <string name="upgrade_screen_owned_iap_title">一次購買</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play 服務無法使用。</string>
-    <string name="upgrades_no_purchases_found_check_account">未找到訂單，確定帳戶無誤？</string>
     <string name="upgrades_gplay_billing_error_label">Google Play 錯誤</string>
     <string name="upgrades_gplay_billing_error_description">Google Play 發生錯誤。請稍後再試或重新啟動手機。\n\n錯誤：%s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play 結帳錯誤</string>
-    <string name="upgrades_gplay_billing_result_error_description">向 Google Play 請求購買明細時發生錯誤。請清除 Google Play 快取並重新啟動手機。\n\n錯誤：%s</string>
     <string name="upgrades_gplay_already_owned_label">已經購買了？</string>
     <string name="upgrades_gplay_already_owned_description">Google Play 回報您已擁有此升級項目，但無法還原。請確認您使用的是購買時所用的 Google 帳戶。Play 商店同步可能需要一些時間 — 請嘗試重新啟動裝置、清除 Google Play 快取或稍候片刻。</string>
-    <string name="upgrade_restore_action">還原購買</string>
     <string name="upgrade_badge_label">專業版</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">取得 %1$s</string>
     <string name="upgrade_preamble">CAPod 由一人獨立開發。升級可解鎖額外功能，並協助維持應用程式的運作。</string>
-    <string name="upgrade_screen_options_description">功能相同，價格不同。訂閱方案包含免費試用，且可隨時取消。</string>
-    <string name="upgrade_screen_options_description_no_trial">功能相同，價格不同。訂閱方案可隨時取消。</string>
     <string name="upgrade_screen_subscription_trial_action">開始免費試用</string>
     <string name="upgrade_screen_subscription_action">年繳訂閱</string>
-    <string name="upgrade_screen_subscription_action_hint">%s／年</string>
     <string name="upgrade_screen_iap_action">單次購買</string>
-    <string name="upgrade_screen_iap_action_hint">一次性購買：%s</string>
     <string name="upgrade_screen_restore_purchase_action">還原購買</string>
-    <string name="upgrade_screen_restore_purchase_message">未找到訂單，確定帳戶無誤？</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">如果您最近才購買，Google Play 可能需要一些時間才能同步。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">如果您的購買項目未顯示，請幾分鐘後再試一次。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">請確認您登入的是購買時所用的相同 Google 帳戶。</string>
-    <string name="upgrade_screen_restore_webinstall_hint">多個帳戶可能會讓 Google Play 產生混淆。透過 Google Play 網站安裝應用程式，可強制與特定帳戶建立關聯。</string>
     <string name="upgrade_screen_restore_banner_title">已經購買 Pro 了？</string>
     <string name="upgrade_screen_restore_banner_body">看起來您先前已在此裝置上升級為 Pro。還原購買項目即可再次解鎖。</string>
     <string name="upgrade_screen_restore_success_message">購買項目已還原。</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">您已擁有 CAPod Pro！</string>
     <string name="upgrade_screen_owned_hero_sub_body">已透過您的訂閱解鎖。感謝您支持 CAPod！</string>
     <string name="upgrade_screen_owned_hero_iap_body">已透過您的一次性購買解鎖。感謝您支持 CAPod！</string>
-    <string name="upgrade_screen_owned_sub_title">年繳訂閱</string>
     <string name="upgrade_screen_owned_sub_renewing_body">您的訂閱目前有效，並已設定自動續訂。帳單由 Google Play 管理。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">您的訂閱目前有效，但未設定續訂。Pro 將在目前訂閱期結束前持續可用。</string>
     <string name="upgrade_screen_owned_iap_title">一次購買</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Amasevisi e-Google Play awakutholakali.</string>
-    <string name="upgrades_no_purchases_found_check_account">Akukho ukuthenga okutholakele. Ingabe usebenzisa i-akhawunti efanele?</string>
     <string name="upgrades_gplay_billing_error_label">Iphutha le-Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Kube nephutha ku-Google Play. Sicela uzame futhi ngemuva kwesikhathi noma uqalise kabusha ifoni yakho.\n\nIphutha: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Iphutha Lokukhokha le-Google Play</string>
-    <string name="upgrades_gplay_billing_result_error_description">Kube nephutha lapho kucelwa ku-Google Play imininingwane yokuthenga kwakho. Sula inqolobane ye-Google Play bese uqalisa kabusha ifoni yakho.\n\nIphutha %s</string>
     <string name="upgrades_gplay_already_owned_label">Usuvele wathenga?</string>
     <string name="upgrades_gplay_already_owned_description">I-Google Play ibika ukuthi usuvele unalolu shintsho olusheshisiwe, kodwa alukwazanga ukubuyiselwa. Qinisekisa ukuthi usebenzisa i-akhawunti ye-Google owathenga ngayo. Ukuvumelanisa kwe-Play Store kungase kuthathe isikhathi — zama ukuqala kabusha idivayisi, ukususa i-cache ye-Google Play noma ulinde nje.</string>
-    <string name="upgrade_restore_action">Buyisela ukuthenga</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Thola %1$s</string>
     <string name="upgrade_preamble">I-CAPod yenziwe umuntu oyedwa. Ukuthuthukisa kuvula izici ezengeziwe futhi kusize ukugcina uhlelo lokusebenza luphila.</string>
-    <string name="upgrade_screen_options_description">Izici ezifanayo, amanani ahlukene. Ukubhalisa kufaka ukuzama kwamahhala futhi kungakhanselwa noma nini.</string>
-    <string name="upgrade_screen_options_description_no_trial">Izici ezifanayo, amanani ahlukene. Ukubhalisa kungakhanselwa noma nini.</string>
     <string name="upgrade_screen_subscription_trial_action">Qala ukuzama kwamahhala</string>
     <string name="upgrade_screen_subscription_action">Bhalisa minyaka yonke</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/unyaka</string>
     <string name="upgrade_screen_iap_action">Thenga kanye</string>
-    <string name="upgrade_screen_iap_action_hint">Ukuthenga kube kanye: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Buyisela ukuthenga</string>
-    <string name="upgrade_screen_restore_purchase_message">Akukho ukuthenga okutholakele. Ingabe usebenzisa i-akhawunti efanele?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">Uma usanda kuthenga, kungase kuthathe isikhashana ukuze i-Google Play ivumelanise.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Zama futhi emizuzwini embalwa uma ukuthenga kwakho kungabonakali.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Qinisekisa ukuthi ungene ngemvume nge-akhawunti ye-Google efanayo eyasetshenziswa ekutheneni.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Ama-akhawunti amaningi angadunga i-Google Play. Ukufaka uhlelo lokusebenza ngewebhusayithi ye-Google Play kuphoqa ukuhlobanisa ne-akhawunti ethile.</string>
     <string name="upgrade_screen_restore_banner_title">Usuvele wathenga i-Pro?</string>
     <string name="upgrade_screen_restore_banner_body">Kubonakala sengathi wake wathuthukisela ku-Pro kule divayisi ngaphambili. Buyisela ukuthenga kwakho ukuze uyivule futhi.</string>
     <string name="upgrade_screen_restore_success_message">Ukuthenga kubuyiselwe.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">Une-CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Kuvulwe ukubhalisa kwakho. Siyabonga ngokusekela i-CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kuvulwe ukuthenga kwakho okwenziwa kanye. Siyabonga ngokusekela i-CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Ukubhalisa kwaminyaka yonke</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ukubhalisa kwakho kuyasebenza futhi kuhlelelwe ukuvuselelwa. Ukukhokhiswa kuphathwa yi-Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ukubhalisa kwakho kuyasebenza, kodwa akuhlelelwe ukuvuselelwa. I-Pro ihlala itholakala kuze kuphele isikhathi samanje.</string>
     <string name="upgrade_screen_owned_iap_title">Ukuthenga kube kanye</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play services are unavailable.</string>
-    <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Error</string>
     <string name="upgrades_gplay_billing_error_description">There was an error in Google Play. Please try again later or reboot your phone.\n\nError: %s</string>
-    <string name="upgrades_gplay_billing_result_error_label">Google Play Billing Error</string>
-    <string name="upgrades_gplay_billing_result_error_description">There was an error when asking Google Play for your purchase details. Clear Google Play cache and reboot your phone.\n\nError %s</string>
     <string name="upgrades_gplay_already_owned_label">Already purchased?</string>
     <string name="upgrades_gplay_already_owned_description">Google Play reports that you already own this upgrade, but it couldn\'t be restored. Make sure you are using the Google account you purchased with. Play Store synchronization may take time — try rebooting, clearing the Google Play cache or simply waiting.</string>
-    <string name="upgrade_restore_action">Restore purchase</string>
     <string name="upgrade_badge_label">Pro</string>
     <!-- %1$s is the full localized brand ("CAPod Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Get %1$s</string>
     <string name="upgrade_preamble">CAPod is developed by a single person. Upgrading unlocks extra features and helps keep the app alive.</string>
-    <string name="upgrade_screen_options_description">Same features, different pricing. The subscription includes a free trial and can be cancelled at any time.</string>
-    <string name="upgrade_screen_options_description_no_trial">Same features, different pricing. The subscription can be cancelled at any time.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe yearly</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/year</string>
     <string name="upgrade_screen_iap_action">Buy once</string>
-    <string name="upgrade_screen_iap_action_hint">One-time purchase: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
-    <string name="upgrade_screen_restore_purchase_message">No purchases found. Are you using the right account?</string>
-    <string name="upgrade_screen_restore_troubleshooting_msg">If you\'ve recently purchased, it may take a moment for Google Play to sync.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Try again in a few minutes if your purchase doesn\'t appear.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Make sure you\'re signed in with the same Google account used for the purchase.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Multiple accounts can confuse Google Play. Installing the app through the Google Play website forces the association with a specific account.</string>
     <string name="upgrade_screen_restore_banner_title">Already bought Pro?</string>
     <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. Restore your purchase to unlock it again.</string>
     <string name="upgrade_screen_restore_success_message">Purchase restored.</string>
@@ -34,7 +23,6 @@
     <string name="upgrade_screen_owned_hero_title">You have CAPod Pro!</string>
     <string name="upgrade_screen_owned_hero_sub_body">Unlocked by your subscription. Thank you for supporting CAPod!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Unlocked by your one-time purchase. Thank you for supporting CAPod!</string>
-    <string name="upgrade_screen_owned_sub_title">Yearly subscription</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Your subscription is active and set to renew. Billing is managed by Google Play.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Your subscription is active, but not set to renew. Pro stays available until the current period ends.</string>
     <string name="upgrade_screen_owned_iap_title">One-time purchase</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Deel</string>
     <string name="general_done_action">Klaar</string>
     <string name="general_cancel_action">Kanselleer</string>
-    <string name="general_copy_action">Kopieer</string>
     <string name="general_thank_you_label">Dankie</string>
     <string name="general_upgrade_action">Opgradeer</string>
     <string name="general_retry_action">Probeer weer</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontroleer</string>
     <string name="general_close_action">Maak toe</string>
     <string name="general_dismiss_action">Maak toe</string>
-    <string name="general_edit_action">Redigeer</string>
     <string name="general_save_action">Stoor</string>
     <string name="general_guide_action">Gids</string>
     <string name="general_continue_action">Gaan voort</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Hervat musiek wanneer jy jou pods weer dra, maar slegs as Outopouseer dit gestop het. Pouses wat jy self geaktiveer het (foon, AirPods-steel, slaap) bly gepouseer.</string>
     <string name="settings_start_music_on_wear_label">Begin musiek by dra</string>
     <string name="settings_start_music_on_wear_description">Probeer altyd musiek speel wanneer jy jou pods opsit, selfs na \'n handmatige pouseer.</string>
-    <string name="settings_eardetection_info_label">Nota oor oorbespeuring</string>
     <string name="settings_eardetection_info_description">As oorbespeuring net vir een pod werk, is dit \'n Apple-beperking. Slegs die primêre pod (wat vir die mikrofoon gebruik word) word bespeur. Stel op Apple-toestelle op: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">Minimum seingehalte</string>
-    <string name="settings_signal_minimum_description">Die minimum seingehalte wat \'n toestel moet hê om as joune beskou te word.</string>
     <string name="settings_autoconnect_label">Outo-koppel</string>
     <string name="settings_autoconnect_description">As Android nie outomaties koppel nie, kan ons dit ook vra. Dit hou CAPod-monitering heeltyd op die agtergrond aan die gang.</string>
     <string name="settings_autoconnect_info_android12">Outo-verbinding steun op \'n stelselonskop wat Android 12 en nuwer beperk. Dit werk dalk nie op jou toestel nie.</string>
     <string name="settings_autoconnect_condition_label">Outo-koppelvoorwaarde</string>
-    <string name="settings_autoconnect_condition_description">Wanneer moet ons probeer om aan jou toestel te koppel?</string>
     <string name="settings_devices_label">Toestelle</string>
     <string name="settings_devices_description">Bestuur jou toestelle.</string>
     <string name="settings_reaction_label">Reaksies</string>
-    <string name="settings_category_yourdevice_label">Jou toestel</string>
     <string name="settings_category_compatibility_options_title">Verenigbaarheidsopsies</string>
     <string name="settings_category_compatibility_options_description">Moenie aanraak as alles werk nie ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Deaktiveer hardewarefiltrering</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Begin nou…</string>
     <string name="support_debuglog_label">Ontfoutingslog</string>
     <string name="support_debuglog_desc">Teken alles wat die toepassing doen aan in \'n tekslêer wat jy kan deel.</string>
-    <string name="debug_debuglog_size_label">Grootte</string>
-    <string name="debug_debuglog_size_compressed_label">Saamgeperste grootte</string>
-    <string name="debug_notification_channel_label">Ontfoutingskennisgewings</string>
-    <string name="debug_debuglog_file_label">Aangetekende loglêer</string>
-    <string name="debug_debuglog_recording_progress">Teken ontfoutingslog aan</string>
     <string name="debug_debuglog_record_action">Teken ontfoutingslog aan</string>
     <string name="debug_debuglog_stop_action">Stop aantekening</string>
     <string name="debug_debuglog_sensitive_information_message">Die gegenereerde lêer bevat sensitiewe inligting (bv. Bluetooth-toestelbesonderhede). Deel dit slegs met vertroude partye.</string>
     <string name="settings_debuglog_explanation">Hierdie kenmerk teken alles wat die toepassing doen aan in \'n deelbare lêer. Die gegenereerde lêer bevat sensitiewe inligting (bv. Bluetooth-toestelbesonderhede). Deel dit slegs met vertroude partye (bv. \'n ontwikkelaar wat \'n probleem oplos).</string>
-    <string name="settings_support_installid_label">Installeer-ID</string>
-    <string name="settings_support_installid_desc">Outomatiese foutverslae is anoniem. Deel jou installeer-ID as die ontwikkelaar jou foutverslae moet vind.</string>
     <string name="settings_support_label">Ondersteuning</string>
     <string name="settings_support_description">As jy hulp nodig het.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Geleerde gegevens herstel?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod sal hierdie toestel se gemete afvoer, laadsnelheid en luistertyd vergeet en opnuut met die gegradeerde batterylewensduur begin.</string>
     <string name="settings_acknowledgements_label">Erkennings</string>
-    <string name="settings_debug_autoreports_label">Outomatiese foutverslae</string>
-    <string name="settings_debug_autoreports_description">Rapporteer probleme outomaties, bv. besonderhede oor \'n toepassingstorting sodat ek kan uitvind hoe om dit reg te stel.</string>
-    <string name="settings_compatibility_mode_label">Verenigbaarheidsmodus</string>
-    <string name="settings_compatibility_mode_description">Deaktiveer optimalisasies om verenigbaarheid te verbeter. Probeer dit as jy geen data sien nie.</string>
     <string name="help_translate_label">Vertaling</string>
     <string name="help_translate_description">Help om hierdie toepassing in jou gunstelingtaal te vertaal.</string>
     <string name="translators_thanks_title">Vertalers</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sukses</string>
     <string name="troubleshooter_ble_result_success_body">BLE-advertensie-uitsendings word deur CAPod ontvang.</string>
     <string name="troubleshooter_ble_result_failure_title">Onsuksesvol</string>
-    <string name="troubleshooter_ble_result_failure_body">Probleemoplossing het misluk. Geen kombinasie van verenigbaarheidsopsies het gehelp nie.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Jou foon het glad nie enige BLE-data ontvang nie. Jy kan hierdie toets in \'n besige area probeer om te sien of databronne (anders as jou koptelefoon) ontvang kan word. Geen data wat ontvang word nie, dui op \'n probleem met jou foon se bedryfstelsel.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Jou foon het BLE-data ontvang, maar die data kom nie van enige ondersteunde toestel af nie. Is jou koptelefoon aangeskakel? Ondersteun CAPod jou koptelefoon?</string>
-    <string name="troubleshooter_ble_result_failure_action">Probeer weer</string>
-    <string name="troubleshoot_action">Probleemoplos</string>
     <string name="onboarding_body1">Hierdie toepassing voeg ondersteuning vir AirPod-spesifieke kenmerke by Android.</string>
     <string name="onboarding_body2">Nie alle Android-toestelle ondersteun die ekstra AirPod-kenmerke ten volle nie. Jou bedryfstelsel vereis \'n korrek werkende Bluetooth-Lae-Energie-implementasie.</string>
     <string name="onboarding_body3">CAPod het geen advertensies nie en versamel nie jou data nie.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Jou toestel is verbind, maar CAPod ontvang geen lewende data daarvan nie. Jou foon het dalk \'n versoenbaarheidsopsie nodig — die probleemoplosser kan probeer om een outomaties te vind.</string>
     <string name="overview_troubleshoot_suggestion_action">Voer probleemoplosser uit</string>
     <string name="overview_unmatched_devices_label">Ongepasde toestelle</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d toestel sonder ooreenstemmende profiel</item>
-        <item quantity="other">%d toestelle sonder ooreenstemmende profiel</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d toestel in die omgewing is sonder \'n passende profiel opgespoor. Wys dit vir beskikbare besonderhede. As dit joune is, voeg \'n profiel by vanaf Toestelle om dit te herken.</item>
         <item quantity="other">%d toestelle in die omgewing is sonder passende profiele opgespoor. Wys hulle vir beskikbare besonderhede. As een joune is, voeg \'n profiel by vanaf Toestelle om dit te herken.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod gebruik agtergrondliggingtoegang om kenmerke soos Wys opspringer en AutoConnect te aktiveer terwyl die toepassing gesluit is. Agtergrondliggingtoegang laat die toepassing toe om Bluetooth Low Energy-data te ontvang terwyl dit in die agtergrond is. Hierdie toepassing sal NIE Bluetooth-data gebruik om jou ligging te bepaal nie.</string>
     <string name="permission_ignore_battery_optimizations_label">Deaktiveer battery-optimalisasies</string>
     <string name="permission_ignore_battery_optimizations_description">Battery-optimalisasies keer dat hierdie toepassing Bluetooth-data betroubaar ontvang terwyl dit in die agtergrond is.</string>
-    <string name="permission_required_title">Die volgende toestemming is vereis:</string>
     <string name="permission_system_alert_window_label">Stelselwaarskuwingsvenster</string>
     <string name="permission_system_alert_window_description">Laat CAPod toe om oor ander toepassings te teken om die kenmerk Wys opspringer moontlik te maak.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Wanneer gesien</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">In oor</string>
     <string name="pods_dual_left_label">Linker pod</string>
     <string name="pods_dual_right_label">Regter pod</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">Kassie</string>
     <string name="battery_unavailable_label">Battery nie beskikbaar nie</string>
     <string name="battery_state_low_cd">Battery is laag</string>
     <string name="battery_state_critical_cd">Battery is krities laag</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Direkte verbinding aktief</string>
     <string name="signal_indicator_bars_cd">Seinsterkte: %1$d van 4 stawe</string>
     <string name="signal_indicator_disconnected_cd">Sein: ontkoppel</string>
-    <string name="pods_yours">Joune</string>
     <string name="headset_being_worn_label">Word gedra</string>
     <string name="headset_not_being_worn_label">Word nie gedra nie</string>
     <string name="pods_case_unknown_state">Onbekende status</string>
-    <string name="last_seen_x">Laas gesien: %s</string>
-    <string name="first_seen_x">Eerste keer gesien: %s</string>
     <string name="battery_cached_label">Laas bekend · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimum seingehalte</string>
     <string name="profiles_signal_quality_description">Bespeur slegs toestelle met seinsterkte bo hierdie drempel. Laer waardes vergroot opsporingsreikwydte maar kan vals positiewes veroorsaak. Moenie dit te hoog stel nie - Bluetooth-ontvangs is oor die algemeen swak en wissel met afstand en hindernisse.</string>
     <string name="profiles_identitykey_label">Identiteitsleutel</string>
-    <string name="profilessettings_maindevice_identitykey_description">Jou toestel se Identity Resolving Key (IRK), wat CAPod help om dit tussen nabygeleë toestelle te identifiseer.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods verander dikwels hul Bluetooth-adres vir privaatheid. Die IRK help CAPod om jou toestel te herken. Jy benodig eenmalige toegang tot \'n MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Enkripsiesleutel</string>
-    <string name="profiles_maindevice_encryptionkey_description">Jou toestel se enkripsiesleutel, wat CAPod toelaat om gedetailleerde statusinligting te verkry.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods stuur \'n statusboodskap, waarvan \'n deel geënkripteer is. Die enkripsiesleutel laat CAPod toe om die volle boodskap te dekripteer. Jy benodig eenmalige toegang tot \'n MacBook.</string>
     <string name="profiles_key_invalid_format">Ongeldige sleutelformaat</string>
     <string name="profiles_key_expected_format">Verwagte formaat: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Jy het ongestoorde veranderinge. Wat wil jy doen?</string>
     <string name="general_save_and_exit_action">Stoor en verlaat</string>
     <string name="general_discard_action">Verwerp</string>
-    <string name="general_keep_editing_action">Hou aan wysig</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Opname te kort</string>
     <string name="debug_debuglog_short_recording_message">\'n Ontfoutingslog moet die probleem vaslê terwyl dit gebeur. Hou aan opname, herproduseer die probleem, stop dan die opname.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Toestel-instellings</string>
     <string name="device_settings_subtitle_profile_prefix">Profiel: %s</string>
-    <string name="device_settings_info_name_label">Naam</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-toestelaanduiding</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Vervaardiger</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Miskien later</string>
     <string name="review_app_body">Wil jy graag vir CAPod \'n hersiening los? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Mikrofoon</string>
     <string name="device_settings_microphone_mode_description">Watter oorfoon as mikrofoon gebruik word</string>
     <string name="device_settings_microphone_mode_auto">Outomaties</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">አጋራ</string>
     <string name="general_done_action">ተከናውኗል</string>
     <string name="general_cancel_action">ሰርዝ</string>
-    <string name="general_copy_action">ቅዳ</string>
     <string name="general_thank_you_label">አመሰግናለሁ</string>
     <string name="general_upgrade_action">አሻሽል</string>
     <string name="general_retry_action">ድጋሚ ሞክር</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">ፈትሽ</string>
     <string name="general_close_action">ዝጋ</string>
     <string name="general_dismiss_action">አስወግድ</string>
-    <string name="general_edit_action">አርትዕ</string>
     <string name="general_save_action">አስቀምጥ</string>
     <string name="general_guide_action">መመሪያ</string>
     <string name="general_continue_action">ቀጥል</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">ፖዶቹን እንደገና ሲያጠቁ ሙዚቃን ቀጥል፣ ግን ራስ-አቆም ካቆመው ብቻ። ራስዎ ያቆሙት (ስልክ፣ የ AirPods ቀጭኑ፣ ወይም እንቅልፍ) ቆሞ ይቆያል።</string>
     <string name="settings_start_music_on_wear_label">ሲያጠቁ ሙዚቃ ጀምር</string>
     <string name="settings_start_music_on_wear_description">ፖዶቹን ሲያጠቁ ሁልጊዜ ሙዚቃ ለማጫወት ይሞክራል፣ እጅ ሲቆም ካቆሙ በኋላ እንኳን።</string>
-    <string name="settings_eardetection_info_label">የጆሮ ማወቂያ ማስታወሻ</string>
     <string name="settings_eardetection_info_description">የጆሮ ማወቂያ ለአንድ ፖድ ብቻ የሚሰራ ከሆነ ይህ የApple ገደብ ነው። \"ዋና ፖድ\" (ለማይክሮፎን የሚጠቅም) ብቻ ይታወቃል። በApple መሳሪያዎች ላይ ያዋቅሩ: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">ዝቅተኛ የሲግናል ጥራት</string>
-    <string name="settings_signal_minimum_description">አንድ መሣሪያ የእርስዎ ተደርጎ እንዲቆጠር ሊኖረው የሚገባው ዝቅተኛው የሲግናል ጥራት።</string>
     <string name="settings_autoconnect_label">ራስ-ሰር ግንኙነት</string>
     <string name="settings_autoconnect_description">Android ራሱ ከወቅቶ ስናገናኝ ካልቻለ፣ እኛም ሊጠየቅ ይችላሉ። ይህ CAPod ወደ ጀርባ ሙሉ ጊዜ ተከታተሎ ያቆየዋል።</string>
     <string name="settings_autoconnect_info_android12">ራስ-ሰር ግንኙነት Android 12 እና ከዚያ በኋላ ባሉ ስሪቶች ላይ ገደብ የሚደረግበት የስርዓት ባህሪ ላይ ይተማመናል። በእርስዎ መሳሪያ ላይ ላይሰራ ይችላል።</string>
     <string name="settings_autoconnect_condition_label">ራስ-ሰር የግንኙነት ሁኔታ</string>
-    <string name="settings_autoconnect_condition_description">ከመሳሪያዎ ጋር ለመገናኘት መቼ መሞከር አለብን?</string>
     <string name="settings_devices_label">መሳሪያዎች</string>
     <string name="settings_devices_description">መሳሪያዎችዎን ያስተዳድሩ።</string>
     <string name="settings_reaction_label">ግብረመልሶች</string>
-    <string name="settings_category_yourdevice_label">የእርስዎ መሣሪያ</string>
     <string name="settings_category_compatibility_options_title">የተኳኋኝነት አማራጮች</string>
     <string name="settings_category_compatibility_options_description">ሁሉም ነገር የሚሰራ ከሆነ አይንኩ ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">የሃርድዌር ማጣሪያን አሰናክል</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">ጀምሮ ነው…</string>
     <string name="support_debuglog_label">የማረሚያ ምዝግብ</string>
     <string name="support_debuglog_desc">መተግበሪያው የሚያደርገውን ሁሉ ሊያጋሩት በሚችሉት የጽሑፍ ፋይል ውስጥ ይመዝግቡ።</string>
-    <string name="debug_debuglog_size_label">መጠን</string>
-    <string name="debug_debuglog_size_compressed_label">የተጨመቀ መጠን</string>
-    <string name="debug_notification_channel_label">የማረሚያ ማሳወቂያዎች</string>
-    <string name="debug_debuglog_file_label">የተመዘገበ የሎግ ፋይል</string>
-    <string name="debug_debuglog_recording_progress">የማረሚያ ምዝግብ በመቅዳት ላይ</string>
     <string name="debug_debuglog_record_action">የማረሚያ ምዝግብ ቅዳ</string>
     <string name="debug_debuglog_stop_action">መቅዳት አቁም</string>
     <string name="debug_debuglog_sensitive_information_message">የተፈጠረው ፋይል ሚስጥራዊ መረጃ (ለምሳሌ የብሉቱዝ መሣሪያ ዝርዝሮች) ይዟል። ለታመኑ ወገኖች ብቻ ያጋሩት።</string>
     <string name="settings_debuglog_explanation">ይህ ባህሪ መተግበሪያው የሚያደርገውን ሁሉ ሊጋራ በሚችል ፋይል ውስጥ ይመዘግባል። የተፈጠረው ፋይል ሚስጥራዊ መረጃ (ለምሳሌ የብሉቱዝ መሣሪያ ዝርዝሮች) ይዟል። ለታመኑ ወገኖች ብቻ ያጋሩት (ለምሳሌ ችግርን እያስተካከለ ላለ ገንቢ)።</string>
-    <string name="settings_support_installid_label">የመጫኛ መለያ</string>
-    <string name="settings_support_installid_desc">ራስ-ሰር የስህተት ሪፖርቶች ስም-አልባ ናቸው። ገንቢው የእርስዎን የስህተት ሪፖርቶች ማግኘት ከፈለገ የመጫኛ መለያዎን ያጋሩ።</string>
     <string name="settings_support_label">ድጋፍ</string>
     <string name="settings_support_description">ጥቂት እርዳታ ከፈለጉ።</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">የተማረውን ዳታ ዳግም ያስጀምራሉ?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ይህ መሳሪያ የተለካው ወደዳ፣ ሙሎት ፍጥነት እና ማዳመጥ ጊዜን ይረሳል እና ተወሰነ ባትሪ ዕድሜ ሪጀምራል።</string>
     <string name="settings_acknowledgements_label">ምስጋናዎች</string>
-    <string name="settings_debug_autoreports_label">ራስ-ሰር የሳንካ ሪፖርቶች</string>
-    <string name="settings_debug_autoreports_description">ችግሮችን በራስ-ሰር ሪፖርት ያደርጋል፣ ለምሳሌ የመተግበሪያ ብልሽት ዝርዝሮችን እንዴት ማስተካከል እንዳለብኝ እንድገነዘብ።</string>
-    <string name="settings_compatibility_mode_label">የተኳኋኝነት ሁነታ</string>
-    <string name="settings_compatibility_mode_description">ተኳኋኝነትን ለማሻሻል ማመቻቸቶችን አሰናክል። ምንም መረጃ ካላዩ ይህንን ይሞክሩ።</string>
     <string name="help_translate_label">ትርጉም</string>
     <string name="help_translate_description">ይህንን መተግበሪያ ወደ እርስዎ ተወዳጅ ቋንቋ ለመተርጎም ያግዙ።</string>
     <string name="translators_thanks_title">ተርጓሚዎች</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">ስኬት</string>
     <string name="troubleshooter_ble_result_success_body">የBLE ማስታወቂያ ስርጭቶች በCAPod እየተቀበሉ ነው።</string>
     <string name="troubleshooter_ble_result_failure_title">ያልተሳካ</string>
-    <string name="troubleshooter_ble_result_failure_body">ችግር መፍታት አልተሳካም። ምንም አይነት የተኳኋኝነት አማራጮች ጥምረት አልረዳም።</string>
     <string name="troubleshooter_ble_result_failure_phone_body">ስልክዎ ምንም አይነት የBLE መረጃ አልተቀበለም። የመረጃ ምንጮች (ከጆሮ ማዳመጫዎ ውጪ) መቀበል መቻላቸውን ለማየት ይህንን ሙከራ በተጨናነቀ ቦታ እንደገና መሞከር ይችላሉ። ምንም መረጃ አለመቀበሉ የስልክዎ ኦፐሬቲንግ ሲስተም ላይ ችግር እንዳለ ያመለክታል።</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">ስልክዎ የBLE መረጃ ተቀብሏል፣ ነገር ግን መረጃው ከማንኛውም የሚደገፍ መሣሪያ የመጣ አይደለም። የጆሮ ማዳመጫዎችዎ በርተዋል? CAPod የእርስዎን የጆሮ ማዳመጫ ይደግፋል?</string>
-    <string name="troubleshooter_ble_result_failure_action">እንደገና ሞክር</string>
-    <string name="troubleshoot_action">ችግር ፍታ</string>
     <string name="onboarding_body1">ይህ መተግበሪያ ለኤርፖድ የተለዩ ባህሪያትን ለአንድሮይድ ይጨምራል።</string>
     <string name="onboarding_body2">ሁሉም የአንድሮይድ መሳሪያዎች ተጨማሪ የኤርፖድ ባህሪያትን ሙሉ በሙሉ አይደግፉም። የእርስዎ ኦፐሬቲንግ ሲስተም በትክክል የሚሰራ የብሉቱዝ-ዝቅተኛ-ኃይል ትግበራ ይፈልጋል።</string>
     <string name="onboarding_body3">CAPod ምንም ማስታወቂያ የለውም እና የእርስዎን መረጃ አይሰበስብም።</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">መሳሪያህ ተገናኝቷል፣ ግን CAPod ከእሱ ምንም ቀጥታ ዳታ አይቀበልም። ስልክህ የተኳሃኝነት አማራጭ ሊፈልግ ይችላል — ችግር ፈቺው በራስ-ሰር ለማግኘት ሊሞክር ይችላል።</string>
     <string name="overview_troubleshoot_suggestion_action">ችግር ፈቺን አስጀምር</string>
     <string name="overview_unmatched_devices_label">ያልተዛመዱ መሣሪያዎች</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">ተዛማጅ መገለጫ የሌለው %d መሣሪያ</item>
-        <item quantity="other">ተዛማጅ መገለጫ የሌላቸው %d መሣሪያዎች</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">ከመገለጫ ጋር የማይዛመድ %d አቅራቢያ ያለ መሣሪያ ተገኝቷል። ዝርዝሮችን ለማየት አሳይ። የእርስዎ ከሆነ፣ ለማወቅ ከመሣሪያዎች መገለጫ ያክሉ።</item>
         <item quantity="other">ከመገለጫዎች ጋር የማይዛመዱ %d አቅራቢያ ያሉ መሣሪያዎች ተገኝተዋል። ዝርዝሮችን ለማየት አሳያቸው። አንዱ የእርስዎ ከሆነ፣ ለማወቅ ከመሣሪያዎች መገለጫ ያክሉ።</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod መተግበሪያው ሲዘጋ \"ብቅ-ባይ አሳይ\" እና \"ራስ-ሰር ግንኙነት\" ያሉ ባህሪያትን ለማንቃት \"የዳራ አካባቢ ተደራሽነት\" ይጠቀማል። የዳራ አካባቢ ተደራሽነት መተግበሪያው በዳራ ውስጥ ሳለ Bluetooth Low Energy መረጃ እንዲቀበል ያስችለዋል። ይህ መተግበሪያ የእርስዎን አካባቢ ለመወሰን የBluetooth መረጃ አይጠቀምም።</string>
     <string name="permission_ignore_battery_optimizations_label">የባትሪ ማመቻቸቶችን አሰናክል</string>
     <string name="permission_ignore_battery_optimizations_description">የባትሪ ማመቻቸቶች ይህ መተግበሪያ በዳራ ውስጥ ሳለ በአስተማማኝ ሁኔታ Bluetooth መረጃ እንዳይቀበል ይከለክላል።</string>
-    <string name="permission_required_title">የሚከተለው ፈቃድ ያስፈልጋል:</string>
     <string name="permission_system_alert_window_label">የስርዓት ማስጠንቀቂያ መስኮት</string>
     <string name="permission_system_alert_window_description">\"ብቅ-ባይ አሳይ\" ባህሪውን ለማስቻል CAPod በሌሎች መተግበሪያዎች ላይ እንዲሳል ፍቀድ።</string>
     <string name="settings_reaction_autoconnect_whenseen_label">ሲታይ</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">በጆሮ ውስጥ</string>
     <string name="pods_dual_left_label">ግራ ፖድ</string>
     <string name="pods_dual_right_label">ቀኝ ፖድ</string>
-    <string name="pods_dual_left_short_label">ግ</string>
-    <string name="pods_dual_right_short_label">ቀ</string>
-    <string name="pods_case_label">ኬዝ</string>
     <string name="battery_unavailable_label">ባትሪ አይገኝም</string>
     <string name="battery_state_low_cd">ባትሪ ዝቅ</string>
     <string name="battery_state_critical_cd">ባትሪ በጣም ዝቅ</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">ቀጥተኛ ግንኙነት ንቁ ነው</string>
     <string name="signal_indicator_bars_cd">የምልክት ጥንካሬ: ከ4 አሞሌዎች %1$d</string>
     <string name="signal_indicator_disconnected_cd">ምልክት: ተቋርጧል</string>
-    <string name="pods_yours">የእርስዎ</string>
     <string name="headset_being_worn_label">ተለብሷል</string>
     <string name="headset_not_being_worn_label">አልተለበሰም</string>
     <string name="pods_case_unknown_state">ያልታወቀ ሁኔታ</string>
-    <string name="last_seen_x">ለመጨረሻ ጊዜ የታየው: %s</string>
-    <string name="first_seen_x">ለመጀመሪያ ጊዜ የታየው: %s</string>
     <string name="battery_cached_label">የመጨረሻ ታወቀ · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dሰ %2$dደ</string>
     <string name="battery_time_remaining_format_h">%1$dሰ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">ዝቅተኛ የሲግናል ጥራት</string>
     <string name="profiles_signal_quality_description">ከዚህ ገደብ በላይ የሲግናል ጥንካሬ ያላቸውን መሣሪያዎች ብቻ ይፈልጉ። ዝቅተኛ እሴቶች የፍለጋ ክልልን ይጨምራሉ ግን ውሸታም ውጤቶችን ሊያስከትሉ ይችላሉ። ይህንን በጣም ከፍ አያድርጉ - Bluetooth ምልክት በአጠቃላይ ደካማ ነው እና ከርቀት እና ከእንቅፋቶች ጋር ይለያያል።</string>
     <string name="profiles_identitykey_label">የማንነት ቁልፍ</string>
-    <string name="profilessettings_maindevice_identitykey_description">CAPod ከቅርብ መሣሪያዎች መካከል እንዲለየው የሚረዳ የመሣሪያዎ ማንነት መፍቻ ቁልፍ (IRK)።</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ለግላዊነት ብዙ ጊዜ የBluetooth አድራሻቸውን ይቀይራሉ። IRK CAPod መሣሪያዎን እንዲያውቅ ይረዳል። አንድ ጊዜ MacBook ላይ ተደራሽነት ያስፈልግዎታል።</string>
     <string name="profiles_maindevice_encryptionkey_label">የመመሰጫ ቁልፍ</string>
-    <string name="profiles_maindevice_encryptionkey_description">CAPod ዝርዝር የሁኔታ መረጃ እንዲያስገኝ የሚፈቅድ የመሣሪያዎ የመመሰጫ ቁልፍ።</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods የሁኔታ መልዕክት ይልካሉ፣ ክፍሉ የተመሰጠረ ነው። የመመሰጫ ቁልፉ CAPod ሙሉ መልዕክቱን እንዲፈታ ያስችለዋል። አንድ ጊዜ MacBook ላይ ተደራሽነት ያስፈልግዎታል።</string>
     <string name="profiles_key_invalid_format">ልክ ያልሆነ የቁልፍ ቅርጸት</string>
     <string name="profiles_key_expected_format">የሚጠበቅ ቅርጸት: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">ያልተቀመጡ ለውጦች አሉዎት። ምን ማድረግ ይፈልጋሉ?</string>
     <string name="general_save_and_exit_action">አስቀምጥ እና ውጣ</string>
     <string name="general_discard_action">ጣል</string>
-    <string name="general_keep_editing_action">ማረም ቀጥል</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ቀረጻ በጣም አጭር ነው</string>
     <string name="debug_debuglog_short_recording_message">የዲባግ ምዝግብ ማስታወሻ ችግሩ ሲከሰት ሊቀዳ ያስፈልጋል። ቀረጻ ቀጥሎ፣ ችግሩን እንደገና አስተውሎ፣ ቀረጻውን አቁም።</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">የመሣሪያ ቅንብሮች</string>
     <string name="device_settings_subtitle_profile_prefix">መገለጫ: %s</string>
-    <string name="device_settings_info_name_label">ስም</string>
     <string name="device_settings_info_bt_name_label">የብሉቱዝ መሳሪያ ስያሜ</string>
     <string name="device_settings_info_model_label">ሞዴል</string>
     <string name="device_settings_info_manufacturer_label">አምራች</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">ምናልባት በኋላ</string>
     <string name="review_app_body">ለCAPod ግምገማ ማስቀመጥ ይፈልጋሉ?️ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">አጠቃላይ</string>
     <string name="device_settings_microphone_mode_label">ማይክሮፎን</string>
     <string name="device_settings_microphone_mode_description">የትኛው ኢርባድ እንደ ማይክሮፎን ጥቅም ላይ እንደሚውል</string>
     <string name="device_settings_microphone_mode_auto">ራስ-ሰር</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">شارك</string>
     <string name="general_done_action">تمّ</string>
     <string name="general_cancel_action">ألغِ</string>
-    <string name="general_copy_action">انسخ</string>
     <string name="general_thank_you_label">شكرًا لك</string>
     <string name="general_upgrade_action">رقِّ</string>
     <string name="general_retry_action">أعِد المحاولة</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">افحص</string>
     <string name="general_close_action">أغلق</string>
     <string name="general_dismiss_action">تجاهَل</string>
-    <string name="general_edit_action">عدّل</string>
     <string name="general_save_action">احفظ</string>
     <string name="general_guide_action">الدليل</string>
     <string name="general_continue_action">تابع</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">يستأنف تشغيل الموسيقى عند ارتداء سمّاعات أيربودز مرّةً أخرى، ولكنْ فقط إذا أوقفها الإيقاف التلقائي. أمّا عمليات الإيقاف التي فعّلتها بنفسك (الهاتف، أو وضع سمّاعات أيربودز على قاعدة السمّاعات، أو وضع السكون) فتبقى متوقّفة.</string>
     <string name="settings_start_music_on_wear_label">شغّل الموسيقى عند ارتدائها</string>
     <string name="settings_start_music_on_wear_description">يحاول دائمًا تشغيل الموسيقى عند وضع سمّاعات الأذن، حتّى بعد إيقاف التشغيل يدويًّا.</string>
-    <string name="settings_eardetection_info_label">ملاحظة على راصد الأذن</string>
     <string name="settings_eardetection_info_description">إذا كان راصد الأذن يعمل مع سمّاعةٍ واحدةٍ فقط، فهذا قيدٌ من أبل. يتمّ رصد ”السمّاعة الرئيسة“ (المُستخدَمة للميكروفون) فقط. يمكنك ضبط الإعدادات على أجهزة أبل عبر: الإعدادات ← البلوتوث ← أيربودز ← الميكروفون.</string>
-    <string name="settings_signal_minimum_label">الحدّ الأدنى لجودة الإشارة</string>
-    <string name="settings_signal_minimum_description">الحدّ الأدنى لجودة الإشارة التي يجب أن يتمتّع بها الجهاز ليتمّ اعتباره ملكًا لك.</string>
     <string name="settings_autoconnect_label">الاتّصال التلقائي</string>
     <string name="settings_autoconnect_description">إذا لم يتّصل أندرويد تلقائيًّا، فيمكننا طلب ذلك منه أيضًا. هذا يُبقي نظام مراقبة كابود يعمل في الخلفية طوال الوقت.</string>
     <string name="settings_autoconnect_info_android12">تعتمد خاصّية الاتّصال التلقائي على مزيّةٍ نظاميةٍ يقيّدها أندرويد ١٢ والإصدارات الأحدث. قد لا تعمل هذه الخاصّية على جهازك.</string>
     <string name="settings_autoconnect_condition_label">شرط الاتّصال التلقائي</string>
-    <string name="settings_autoconnect_condition_description">متى يجب أن نحاول الاتّصال بجهازك؟</string>
     <string name="settings_devices_label">الأجهزة</string>
     <string name="settings_devices_description">أدِر أجهزتك.</string>
     <string name="settings_reaction_label">ردود الفعل</string>
-    <string name="settings_category_yourdevice_label">جهازك</string>
     <string name="settings_category_compatibility_options_title">خيارات التوافق</string>
     <string name="settings_category_compatibility_options_description">لا تلمسها إذا كان كلّ شيءٍ يعمل ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">تعطيل تصفية الأجهزة</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">يجري البدء…</string>
     <string name="support_debuglog_label">سجلّ تصحيح الأخطاء</string>
     <string name="support_debuglog_desc">يسجّل كلّما يفعله التطبيق في ملفٍّ نصيٍّ يمكنك مشاركته.</string>
-    <string name="debug_debuglog_size_label">الحجم</string>
-    <string name="debug_debuglog_size_compressed_label">الحجم المضغوط</string>
-    <string name="debug_notification_channel_label">إشعارات تصحيح الأخطاء</string>
-    <string name="debug_debuglog_file_label">ملفّ السجلّ المُسجَّل</string>
-    <string name="debug_debuglog_recording_progress">يجري تسجيل سجلّ تصحيح الأخطاء</string>
     <string name="debug_debuglog_record_action">سجّل سجلّ تصحيح الأخطاء</string>
     <string name="debug_debuglog_stop_action">أوقف التسجيل</string>
     <string name="debug_debuglog_sensitive_information_message">يحتوي الملفّ المُنشأ على معلوماتٍ حسّاسةٍ (مثل تفاصيل جهاز البلوتوث). لا تشاركه إلّا مع جهاتٍ موثوقة.</string>
     <string name="settings_debuglog_explanation">تسجّل هذه الخاصّية جميع أنشطة التطبيق في ملفٍّ قابلٍ للمشاركة. يحتوي الملفّ الناتج على معلوماتٍ حسّاسةٍ (مثل تفاصيل جهاز البلوتوث). لا تشاركه إلّا مع جهاتٍ موثوقةٍ (مثل مطوّرٍ يعمل على حلّ مشكلةٍ ما).</string>
-    <string name="settings_support_installid_label">معرّف التثبيت</string>
-    <string name="settings_support_installid_desc">تقارير الأخطاء التلقائية مجهولة المصدر. شارك معرّف التثبيت الخاصّ بك إذا احتاج المطوّر إلى العثور على تقارير الأخطاء الخاصّة بك.</string>
     <string name="settings_support_label">الدعم</string>
     <string name="settings_support_description">إذا كنت بحاجةٍ إلى بعض المساعدة.</string>
     <string name="settings_wiki_label">الموسوعة</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">هل ترغب في إعادة ضبط البيانات المُكتسَبة؟</string>
     <string name="device_battery_estimate_reset_confirm_message">سيتجاهل كابود معدّل استهلاك الطاقة المُقاس لهذا الجهاز، وسرعة الشحن، ووقت الاستماع، وسيبدأ من جديدٍ بناءً على عمر البطّارية المُقدَّر.</string>
     <string name="settings_acknowledgements_label">الشكر والتقدير</string>
-    <string name="settings_debug_autoreports_label">تقارير الأخطاء التلقائية</string>
-    <string name="settings_debug_autoreports_description">يبلغ تلقائيًّا عن المشاكل، على سبيل المثال: تفاصيل حول تعطّل التطبيق حتّى أتمكّن من معرفة كيفية إصلاحه.</string>
-    <string name="settings_compatibility_mode_label">وضع التوافق</string>
-    <string name="settings_compatibility_mode_description">يعطّل التحسينات لتحسين التوافق. جرّب هذا الحلّ إذا لم تكُن ترى أيّ بيانات.</string>
     <string name="help_translate_label">الترجمة</string>
     <string name="help_translate_description">ساعد في ترجمة هذا التطبيق إلى لغتك المُفضَّلة.</string>
     <string name="translators_thanks_title">المترجمون</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">نجاح</string>
     <string name="troubleshooter_ble_result_success_body">يتمّ استقبال عمليات بثّ إعلانات تقنية بلوتوث منخفضة الطاقة (BLE) بواسطة كابود.</string>
     <string name="troubleshooter_ble_result_failure_title">غير ناجح</string>
-    <string name="troubleshooter_ble_result_failure_body">فشلت عملية استكشاف الأخطاء وإصلاحها. لم تُجدِ أيٌّ من خيارات التوافق نفعًا.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">لم يستقبل هاتفك أيّ بياناتٍ عبر تقنية البلوتوث منخفضة الطاقة (BLE). يمكنك إعادة إجراء هذا الاختبار في منطقةٍ مزدحمةٍ لمعرفة ما إذا كان بالإمكان استقبال مصادر بياناتٍ أخرى (غير سمّاعات الرأس). يشير عدم استقبال أيّ بياناتٍ إلى وجود مشكلةٍ في نظام تشغيل هاتفك.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">استقبَل هاتفك بياناتٍ عبر تقنية بلوتوث منخفضة الطاقة (BLE)، لكنّ هذه البيانات لا تأتي من أيّ جهازٍ مدعوم. هل سمّاعات الرأس الخاصّة بك تعمل؟ هل يدعم كابود سمّاعات الرأس الخاصّة بك؟</string>
-    <string name="troubleshooter_ble_result_failure_action">حاول مرّةً أخرى</string>
-    <string name="troubleshoot_action">استكشف الأخطاء وأصلحها</string>
     <string name="onboarding_body1">يُضيف هذا التطبيق دعمًا لمزايا خاصّةٍ بسمّاعات أيربودز إلى أندرويد.</string>
     <string name="onboarding_body2">لا تدعم جميع الأجهزة التي تعمل بنظام أندرويد مزايا أيربودز الإضافية بشكلٍ كامل. يتطلّب نظام التشغيل الخاصّ بك تطبيقًا صحيحًا لتقنية بلوتوث منخفضة الطاقة.</string>
     <string name="onboarding_body3">لا يحتوي كابود على إعلانات ولا يجمع بياناتك.</string>
@@ -207,14 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">جهازك متّصلٌ، لكنّ كابود لا يستقبل أيّ بياناتٍ مباشِرةٍ منه. قد يحتاج هاتفك إلى خيار توافقٍ — يمكن لمستكشف الأخطاء ومصلحها محاولة عثور واحدٍ تلقائيًّا.</string>
     <string name="overview_troubleshoot_suggestion_action">شغّل مستكشف الأخطاء ومصلحها</string>
     <string name="overview_unmatched_devices_label">أجهزةٌ غير متطابقة</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="zero">لا توجد أجهزةٌ دون ملفّ تعريفٍ مطابق</item>
-        <item quantity="one">جهازٌ واحدٌ دون ملفّ تعريفٍ مطابق</item>
-        <item quantity="two">جهازان دون ملفّ تعريفٍ مطابق</item>
-        <item quantity="few">%d أجهزةٍ دون ملفّ تعريفٍ مطابق</item>
-        <item quantity="many">%d جهازًا دون ملفّ تعريفٍ مطابق</item>
-        <item quantity="other">%d جهازٍ دون ملفّ تعريفٍ مطابق</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="zero">لم يُعثَر على أيّ أجهزةٍ قريبةٍ دون ملفّات تعريفٍ مطابقة.</item>
         <item quantity="one">تمّ اكتشاف جهازٍ قريبٍ دون ملفّ تعريفٍ مطابق. اعرضه للاطّلاع على التفاصيل المُتاحة. إذا كان جهازك، فأضِف ملفّ تعريفٍ من قسم الأجهزة لكي يتمّ معرفته.</item>
@@ -243,7 +214,6 @@
     <string name="permission_background_location_description">يستخدم كابود خاصّية ”الوصول إلى الموقع في الخلفية“ لتمكين مزايا مثل ”إرسال إشعارٍ منبثق“ و”الاتّصال التلقائي“ حتّى عند إغلاق التطبيق. يسمح هذا الوصول للتطبيق باستقبال بيانات بلوتوث منخفضة الطاقة (BLE) في أثناء تشغيله في الخلفية. مع ذلك، لن يستخدم هذا التطبيق بيانات البلوتوث لتحديد موقعك.</string>
     <string name="permission_ignore_battery_optimizations_label">تعطيل تحسينات البطارية</string>
     <string name="permission_ignore_battery_optimizations_description">تعمل تحسينات البطّارية على منع هذا التطبيق من استقبال بيانات البلوتوث بشكلٍ موثوقٍ في أثناء تشغيل التطبيق في الخلفية.</string>
-    <string name="permission_required_title">يلزم الحصول على الإذن التالي:</string>
     <string name="permission_system_alert_window_label">نافذة تنبيه النظام</string>
     <string name="permission_system_alert_window_description">يسمح لكابود بالظهور فوق التطبيقات الأخرى لجعل مزيّة ”إرسال الإشعار المنبثق“ مُمكِنة.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">عند الرؤية</string>
@@ -251,9 +221,6 @@
     <string name="settings_reaction_autoconnect_inear_label">في الأذن</string>
     <string name="pods_dual_left_label">السمّاعة اليسرى</string>
     <string name="pods_dual_right_label">السمّاعة اليمنى</string>
-    <string name="pods_dual_left_short_label">يس</string>
-    <string name="pods_dual_right_short_label">يم</string>
-    <string name="pods_case_label">الحافظة</string>
     <string name="battery_unavailable_label">البطّارية غير متوفّرة</string>
     <string name="battery_state_low_cd">البطارية منخفضة</string>
     <string name="battery_state_critical_cd">البطارية منخفضة جدًا</string>
@@ -314,12 +281,9 @@
     <string name="signal_badge_aap_cd">الاتصال المباشر نشط</string>
     <string name="signal_indicator_bars_cd">قوة الإشارة: %1$d من 4 أشرطة</string>
     <string name="signal_indicator_disconnected_cd">الإشارة: غير متصلة</string>
-    <string name="pods_yours">ملكك</string>
     <string name="headset_being_worn_label">يتم ارتداؤها</string>
     <string name="headset_not_being_worn_label">لا يتم ارتداؤها</string>
     <string name="pods_case_unknown_state">حالة غير معروفة</string>
-    <string name="last_seen_x">آخر ظهور: %s</string>
-    <string name="first_seen_x">أول ظهور: %s</string>
     <string name="battery_cached_label">آخر معروف · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dس و%2$dد</string>
     <string name="battery_time_remaining_format_h">%1$dس</string>
@@ -349,10 +313,8 @@
     <string name="profiles_signal_quality_title">الحد الأدنى لجودة الإشارة</string>
     <string name="profiles_signal_quality_description">كشف الأجهزة التي تتجاوز قوة إشارتها هذا الحد فقط. القيم المنخفضة تزيد نطاق الكشف ولكنها قد تسبب نتائج إيجابية خاطئة. لا تضع هذا عاليًا جدًا - استقبال Bluetooth ضعيف بشكل عام ويتغير مع المسافة والعوائق.</string>
     <string name="profiles_identitykey_label">مفتاح الهوية</string>
-    <string name="profilessettings_maindevice_identitykey_description">مفتاح حل هوية جهازك (IRK)، الذي يساعد CAPod في التعرف عليه من بين الأجهزة القريبة.</string>
     <string name="profiles_maindevice_identitykey_explanation">تغير AirPods عنوان Bluetooth الخاص بها بشكل متكرر للخصوصية. يساعد IRK تطبيق CAPod في التعرف على جهازك. تحتاج إلى وصول لمرة واحدة إلى MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">مفتاح التشفير</string>
-    <string name="profiles_maindevice_encryptionkey_description">مفتاح تشفير جهازك، الذي يسمح لـ CAPod باسترداد معلومات الحالة التفصيلية.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">ترسل AirPods رسالة حالة، جزء منها مشفر. يسمح مفتاح التشفير لـ CAPod بفك تشفير الرسالة الكاملة. تحتاج إلى وصول لمرة واحدة إلى MacBook.</string>
     <string name="profiles_key_invalid_format">تنسيق مفتاح غير صالح</string>
     <string name="profiles_key_expected_format">التنسيق المتوقع: %1$s</string>
@@ -385,7 +347,6 @@
     <string name="general_unsaved_changes_message">لديك تغييرات غير محفوظة. ماذا تريد أن تفعل؟</string>
     <string name="general_save_and_exit_action">حفظ والخروج</string>
     <string name="general_discard_action">تجاهل</string>
-    <string name="general_keep_editing_action">متابعة التحرير</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">التسجيل قصير جداً</string>
     <string name="debug_debuglog_short_recording_message">يجب أن يلتقط سجل التصحيح المشكلة أثناء حدوثها. استمر التسجيل، أعد إنتاج المشكلة، ثم أوقف التسجيل.</string>
@@ -468,7 +429,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">إعدادات الجهاز</string>
     <string name="device_settings_subtitle_profile_prefix">الملف الشخصي: %s</string>
-    <string name="device_settings_info_name_label">الاسم</string>
     <string name="device_settings_info_bt_name_label">تسمية جهاز البلوتوث</string>
     <string name="device_settings_info_model_label">الطراز</string>
     <string name="device_settings_info_manufacturer_label">الشركة المصنّعة</string>
@@ -548,7 +508,6 @@
     <string name="review_app_dismiss_action">ربما لاحقًا</string>
     <string name="review_app_body">هل ترغب في ترك تعليق لـ CAPod؟ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">عام</string>
     <string name="device_settings_microphone_mode_label">ميكروفون</string>
     <string name="device_settings_microphone_mode_description">سمّاعة الأذن المستخدمة كميكروفون</string>
     <string name="device_settings_microphone_mode_auto">تلقائي</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Paylaş</string>
     <string name="general_done_action">Hazırdır</string>
     <string name="general_cancel_action">Ləğv et</string>
-    <string name="general_copy_action">Kopyala</string>
     <string name="general_thank_you_label">Təşəkkür edirik</string>
     <string name="general_upgrade_action">Yenilə</string>
     <string name="general_retry_action">Yenidən cəhd edin</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Yoxla</string>
     <string name="general_close_action">Bağla</string>
     <string name="general_dismiss_action">Rədd et</string>
-    <string name="general_edit_action">Redaktə et</string>
     <string name="general_save_action">Saxla</string>
     <string name="general_guide_action">Bələdçi</string>
     <string name="general_continue_action">Davam et</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Podlarınızı yenidən taxdıqda musiqini davam etdirin, lakin yalnız Avtomatik Fasilə onu dayandırdıqda. Özünüz dayandırdığınız fasilələr (telefon, AirPods sapı, yuxu) fasilə vəziyyətində qalır.</string>
     <string name="settings_start_music_on_wear_label">Taxdıqda musiqini başlat</string>
     <string name="settings_start_music_on_wear_description">Podlarınızı taxdıqda həmişə musiqi çalmağa çalışır, hətta əl ilə fasilə verdikdən sonra belə.</string>
-    <string name="settings_eardetection_info_label">Qulaq aşkarlama qeydi</string>
     <string name="settings_eardetection_info_description">Qulaq aşkarlama yalnız bir qulaqlıq üçün işləyirsə, bu Apple məhdudiyyətidir. Yalnız \"əsas qulaqlıq\" (mikrofon üçün istifadə olunan) aşkarlanır. Apple cihazlarında tənzimləyin: Parametrlər → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimum siqnal keyfiyyəti</string>
-    <string name="settings_signal_minimum_description">Bir cihazın sizə aid hesab edilməsi üçün malik olmalı olduğu minimum siqnal keyfiyyəti.</string>
     <string name="settings_autoconnect_label">Avtomatik qoşulma</string>
     <string name="settings_autoconnect_description">Android avtomatik qoşulmasa da, biz də ondan istəyə bilərik. Bu, CAPod-u hər zaman arxa planda monitorinq etməyi saxlayır.</string>
     <string name="settings_autoconnect_info_android12">Avtomatik qoşulma Android 12 və daha yeni versiyaların məhdudlaşdırdığı sistem funksiyasına əsaslanır. Bu, cihazınızda işləməyə bilər.</string>
     <string name="settings_autoconnect_condition_label">Avtomatik qoşulma şərti</string>
-    <string name="settings_autoconnect_condition_description">Cihazınıza nə vaxt qoşulmağa cəhd etməliyik?</string>
     <string name="settings_devices_label">Cihazlar</string>
     <string name="settings_devices_description">Cihazlarınızı idarə edin.</string>
     <string name="settings_reaction_label">Reaksiyalar</string>
-    <string name="settings_category_yourdevice_label">Sizin cihazınız</string>
     <string name="settings_category_compatibility_options_title">Uyğunluq seçimləri</string>
     <string name="settings_category_compatibility_options_description">Hər şey işləyirsə toxunmayın ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Aparat filtrasiyasını deaktiv edin</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Başlayır…</string>
     <string name="support_debuglog_label">Sazlama jurnalı</string>
     <string name="support_debuglog_desc">Tətbiqin etdiyi hər şeyi paylaşa biləcəyiniz bir mətn faylına yazın.</string>
-    <string name="debug_debuglog_size_label">Ölçü</string>
-    <string name="debug_debuglog_size_compressed_label">Sıxılmış ölçü</string>
-    <string name="debug_notification_channel_label">Sazlama bildirişləri</string>
-    <string name="debug_debuglog_file_label">Qeydə alınmış jurnal faylı</string>
-    <string name="debug_debuglog_recording_progress">Sazlama jurnalı qeydə alınır</string>
     <string name="debug_debuglog_record_action">Sazlama jurnalını qeydə al</string>
     <string name="debug_debuglog_stop_action">Qeydiyyatı dayandır</string>
     <string name="debug_debuglog_sensitive_information_message">Yaradılmış faylda həssas məlumatlar (məsələn, Bluetooth cihazı təfərrüatları) var. Yalnız etibarlı tərəflərlə paylaşın.</string>
     <string name="settings_debuglog_explanation">Bu xüsusiyyət tətbiqin etdiyi hər şeyi paylaşa biləcəyiniz bir fayla yazır. Yaradılmış faylda həssas məlumatlar (məsələn, Bluetooth cihazı təfərrüatları) var. Yalnız etibarlı tərəflərlə paylaşın (məsələn, bir problemi aradan qaldıran bir tərtibatçı).</string>
-    <string name="settings_support_installid_label">Quraşdırma ID-si</string>
-    <string name="settings_support_installid_desc">Avtomatik səhv hesabatları anonimdir. Tərtibatçının səhv hesabatlarınızı tapması lazımdırsa, quraşdırma ID-nizi paylaşın.</string>
     <string name="settings_support_label">Dəstək</string>
     <string name="settings_support_description">Əgər bir az köməyə ehtiyacınız varsa.</string>
     <string name="settings_wiki_label">Viki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Öyrənilmiş məlumatları sıfırla?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod bu cihazın ölçülmüş enerji istifadəsini, dolğunlaşma sürətini və dinləmə müddətini unudacaq, qiymətləndirilmiş batareya ömrünə qayıdıb yenidən başlayacaq.</string>
     <string name="settings_acknowledgements_label">Təşəkkürlər</string>
-    <string name="settings_debug_autoreports_label">Avtomatik səhv hesabatları</string>
-    <string name="settings_debug_autoreports_description">Problemləri avtomatik olaraq bildirir, məsələn, tətbiqin çökməsi ilə bağlı təfərrüatları, beləliklə onu necə düzəldəcəyimi anlaya bilim.</string>
-    <string name="settings_compatibility_mode_label">Uyğunluq rejimi</string>
-    <string name="settings_compatibility_mode_description">Uyğunluğu yaxşılaşdırmaq üçün optimallaşdırmaları deaktiv edin. Heç bir məlumat görmürsünüzsə, bunu sınayın.</string>
     <string name="help_translate_label">Tərcümə</string>
     <string name="help_translate_description">Bu tətbiqi sevdiyiniz dilə tərcümə etməyə kömək edin.</string>
     <string name="translators_thanks_title">Tərcüməçilər</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Uğurlu</string>
     <string name="troubleshooter_ble_result_success_body">BLE reklam yayımları CAPod tərəfindən qəbul edilir.</string>
     <string name="troubleshooter_ble_result_failure_title">Uğursuz</string>
-    <string name="troubleshooter_ble_result_failure_body">Problem aradan qaldırılması uğursuz oldu. Heç bir uyğunluq seçimi kombinasiyası kömək etmədi.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefonunuz heç bir BLE məlumatı almadı. Məlumat mənbələrinin (qulaqlıqlarınızdan başqa) qəbul edilib-edilmədiyini görmək üçün bu testi izdihamlı bir ərazidə yenidən sınaya bilərsiniz. Heç bir məlumatın alınmaması telefonunuzun əməliyyat sistemində bir problemə işarə edir.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefonunuz BLE məlumatı aldı, ancaq məlumat hər hansı dəstəklənən cihazdan gəlmir. Qulaqlıqlarınız açıqdırmı? CAPod qulaqlığınızı dəstəkləyirmi?</string>
-    <string name="troubleshooter_ble_result_failure_action">Yenidən cəhd edin</string>
-    <string name="troubleshoot_action">Problem Aradan Qaldır</string>
     <string name="onboarding_body1">Bu tətbiq Android üçün AirPod-a məxsus xüsusiyyətlərə dəstək əlavə edir.</string>
     <string name="onboarding_body2">Bütün Android cihazları əlavə AirPod xüsusiyyətlərini tam dəstəkləmir. Əməliyyat sisteminiz düzgün işləyən Bluetooth-Aşağı-Enerji tətbiqini tələb edir.</string>
     <string name="onboarding_body3">CAPod-da reklam yoxdur və məlumatlarınızı toplamır.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Cihazınız qoşulub, lakin CAPod ondan canlı məlumat almır. Telefonunuz uyğunluq seçiminə ehtiyac duya bilər — problem aradan qaldırıcı birini avtomatik tapmağa çalışa bilər.</string>
     <string name="overview_troubleshoot_suggestion_action">Problem aradan qaldırıcını işə sal</string>
     <string name="overview_unmatched_devices_label">Uyğunlaşdırılmamış cihazlar</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">Uyğun profili olmayan %d cihaz</item>
-        <item quantity="other">Uyğun profili olmayan %d cihaz</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d yaxınlıqdakı cihaz uyğun profilsiz aşkar edildi. Mövcud təfərrüatlar üçün onu göstərin. Əgər o sizinkidirsə, onu tanımaq üçün Cihazlar bölməsindən profil əlavə edin.</item>
         <item quantity="other">%d yaxınlıqdakı cihaz uyğun profilsiz aşkar edildi. Mövcud təfərrüatlar üçün onları göstərin. Əgər biri sizinkidirsə, onu tanımaq üçün Cihazlar bölməsindən profil əlavə edin.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod tətbiq bağlı olarkən \"Pop-up göstər\" və \"Avtomatik qoşulma\" kimi xüsusiyyətləri aktivləşdirmək üçün \"arxa plan məkan girişi\"ndən istifadə edir. Arxa plan məkan girişi tətbiqin arxa planda Bluetooth Low Energy məlumatlarını almasına imkan verir. Bu tətbiq məkanınızı müəyyən etmək üçün Bluetooth məlumatlarından İSTİFADƏ ETMƏYƏCƏK.</string>
     <string name="permission_ignore_battery_optimizations_label">Batareya optimallaşdırmasını deaktiv edin</string>
     <string name="permission_ignore_battery_optimizations_description">Batareya optimallaşdırmaları bu tətbiqin arxa planda Bluetooth məlumatlarını etibarlı şəkildə almasının qarşısını alır.</string>
-    <string name="permission_required_title">Aşağıdakı icazə tələb olunur:</string>
     <string name="permission_system_alert_window_label">Sistem xəbərdarlıq pəncərəsi</string>
     <string name="permission_system_alert_window_description">\"Pop-up göstər\" xüsusiyyətini mümkün etmək üçün CAPod-a digər tətbiqlərin üzərində çəkməyə icazə verin.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Görüldüyündə</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Qulaqda</string>
     <string name="pods_dual_left_label">Sol qulaqlıq</string>
     <string name="pods_dual_right_label">Sağ qulaqlıq</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">S</string>
-    <string name="pods_case_label">Qutu</string>
     <string name="battery_unavailable_label">Batareya məlumatı yoxdur</string>
     <string name="battery_state_low_cd">Batareya aşağı</string>
     <string name="battery_state_critical_cd">Batareya kritik şəkildə aşağı</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Birbaşa bağlantı aktivdir</string>
     <string name="signal_indicator_bars_cd">Siqnal gücü: 4 çubuqdan %1$d</string>
     <string name="signal_indicator_disconnected_cd">Siqnal: bağlantı kəsildi</string>
-    <string name="pods_yours">Sizinki</string>
     <string name="headset_being_worn_label">Taxılıb</string>
     <string name="headset_not_being_worn_label">Taxılmayıb</string>
     <string name="pods_case_unknown_state">Naməlum vəziyyət</string>
-    <string name="last_seen_x">Son görülmə: %s</string>
-    <string name="first_seen_x">İlk görülmə: %s</string>
     <string name="battery_cached_label">Son məlum · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dsa %2$ddəq</string>
     <string name="battery_time_remaining_format_h">%1$dsa</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimum siqnal keyfiyyəti</string>
     <string name="profiles_signal_quality_description">Yalnız bu həddən yuxarı siqnal gücünə malik cihazları aşkarlayın. Aşağı dəyərlər aşkarlama məsafəsini artırır, lakin yanlış müsbət nəticələrə səbəb ola bilər. Bunu çox yüksək təyin etməyin — Bluetooth qəbulu ümumiyyətlə zəifdir və məsafə və maneələrə görə dəyişir.</string>
     <string name="profiles_identitykey_label">Kimlik açarı</string>
-    <string name="profilessettings_maindevice_identitykey_description">Cihazınızın Identity Resolving Key (IRK), CAPod-a yaxınlıqdakı cihazlar arasında onu tanımağa kömək edir.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods məxfilik üçün Bluetooth ünvanını tez-tez dəyişdirir. IRK CAPod-a cihazınızı tanımağa kömək edir. Bir dəfə MacBook-a girişiniz olmalıdır.</string>
     <string name="profiles_maindevice_encryptionkey_label">Şifrələmə açarı</string>
-    <string name="profiles_maindevice_encryptionkey_description">Cihazınızın şifrələmə açarı, CAPod-a ətraflı status məlumatlarını əldə etməyə imkan verir.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods status mesajı göndərir, bunun bir hissəsi şifrələnmişdir. Şifrələmə açarı CAPod-a tam mesajı deşifrə etməyə imkan verir. Bir dəfə MacBook-a girişiniz olmalıdır.</string>
     <string name="profiles_key_invalid_format">Yanlış açar formatı</string>
     <string name="profiles_key_expected_format">Gözlənilən format: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Saxlanmamış dəyişiklikləriniz var. Nə etmək istərdiniz?</string>
     <string name="general_save_and_exit_action">Saxla &amp; Çıx</string>
     <string name="general_discard_action">İmtina et</string>
-    <string name="general_keep_editing_action">Redaktəyə davam et</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Yazılış çox qısa</string>
     <string name="debug_debuglog_short_recording_message">Sazlama jurnalı problemi baş verdəyi anda əks etdirməlidir. Yazışa davam edin, problemi təkrar edin, sonra yazışı dayandırın.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Cihaz Parametrləri</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Ad</string>
     <string name="device_settings_info_bt_name_label">Bluetooth Cihaz Etiketə</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">İstehsalcı</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Bəlkə sonra</string>
     <string name="review_app_body">CAPod üçün rəy yazmaq istərdinizmi? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Ümumi</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Mikrofon kimi hansı qulaqlıq istifadə olunur</string>
     <string name="device_settings_microphone_mode_auto">Avtomatik</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Падзяліцца</string>
     <string name="general_done_action">Гатова</string>
     <string name="general_cancel_action">Скасаваць</string>
-    <string name="general_copy_action">Капіяваць</string>
     <string name="general_thank_you_label">Дзякуй</string>
     <string name="general_upgrade_action">Абнавіць</string>
     <string name="general_retry_action">Паўтарыць</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Праверыць</string>
     <string name="general_close_action">Закрыць</string>
     <string name="general_dismiss_action">Адхіліць</string>
-    <string name="general_edit_action">Рэдагаваць</string>
     <string name="general_save_action">Захаваць</string>
     <string name="general_guide_action">Кіраўніцтва</string>
     <string name="general_continue_action">Працягнуць</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Аднавіць музыку пры паўторным надзяванні навушнікаў, але толькі калі яе спыніла аўтапаўза. Паўзы, якія вы самі ўключылі (тэлефон, ножка AirPods, сон), застаюцца.</string>
     <string name="settings_start_music_on_wear_label">Пачынаць музыку пры надзяванні</string>
     <string name="settings_start_music_on_wear_description">Заўсёды спрабуе прайграць музыку, калі вы надзяваеце навушнікі, нават пасля ручной паўзы.</string>
-    <string name="settings_eardetection_info_label">Заўвага пра вызначэнне вуха</string>
     <string name="settings_eardetection_info_description">Калі вызначэнне вуха працуе толькі для аднаго навушніка, гэта абмежаванне Apple. Вызначаецца толькі \"асноўны навушнік\" (выкарыстоўваецца для мікрафона). Наладзьце на прыладах Apple: Налады → Bluetooth → AirPods → Мікрафон.</string>
-    <string name="settings_signal_minimum_label">Мінімальная якасць сігналу</string>
-    <string name="settings_signal_minimum_description">Мінімальная якасць сігналу, якую павінна мець прылада, каб лічыцца вашай.</string>
     <string name="settings_autoconnect_label">Аўтаматычнае падключэнне</string>
     <string name="settings_autoconnect_description">Калі Android не падключаецца аўтаматычна, мы таксама можам запытаць гэта. Гэта ўсталюе для налады рэжыму маніторынгу значэнне \"Заўсёды\".</string>
     <string name="settings_autoconnect_info_android12">Аўтападключэнне залежыць ад сістэмнай функцыі, якую Android 12 і навейшыя версіі абмяжоўваюць. Магчыма, яно не будзе працаваць на вашай прыладзе.</string>
     <string name="settings_autoconnect_condition_label">Умова аўтаматычнага падключэння</string>
-    <string name="settings_autoconnect_condition_description">Калі мы павінны спрабаваць падключыцца да вашай прылады?</string>
     <string name="settings_devices_label">Прылады</string>
     <string name="settings_devices_description">Кіруйце вашымі прыладамі.</string>
     <string name="settings_reaction_label">Рэакцыі</string>
-    <string name="settings_category_yourdevice_label">Ваша прылада</string>
     <string name="settings_category_compatibility_options_title">Параметры сумяшчальнасці</string>
     <string name="settings_category_compatibility_options_description">Не чапайце, калі ўсё працуе ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Адключыць апаратную фільтрацыю</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Запускаецца…</string>
     <string name="support_debuglog_label">Журнал адладкі</string>
     <string name="support_debuglog_desc">Запішыце ўсё, што робіць праграма, у тэкставы файл, якім вы можаце падзяліцца.</string>
-    <string name="debug_debuglog_size_label">Памер</string>
-    <string name="debug_debuglog_size_compressed_label">Сціснуты памер</string>
-    <string name="debug_notification_channel_label">Апавяшчэнні адладкі</string>
-    <string name="debug_debuglog_file_label">Запісаны файл журнала</string>
-    <string name="debug_debuglog_recording_progress">Запіс журнала адладкі</string>
     <string name="debug_debuglog_record_action">Запісаць журнал адладкі</string>
     <string name="debug_debuglog_stop_action">Спыніць запіс</string>
     <string name="debug_debuglog_sensitive_information_message">Згенераваны файл змяшчае канфідэнцыйную інфармацыю (напрыклад, звесткі пра прыладу Bluetooth). Дзяліцеся ім толькі з даверанымі асобамі.</string>
     <string name="settings_debuglog_explanation">Гэта функцыя запісвае ўсё, што робіць праграма, у файл, якім можна падзяліцца. Згенераваны файл змяшчае канфідэнцыйную інфармацыю (напрыклад, звесткі пра прыладу Bluetooth). Дзяліцеся ім толькі з даверанымі асобамі (напрыклад, распрацоўшчыкам, які ліквідуе непаладку).</string>
-    <string name="settings_support_installid_label">ID усталёўкі</string>
-    <string name="settings_support_installid_desc">Аўтаматычныя справаздачы пра памылкі ананімныя. Падзяліцеся сваім ID усталёўкі, калі распрацоўшчыку трэба знайсці вашы справаздачы пра памылкі.</string>
     <string name="settings_support_label">Падтрымка</string>
     <string name="settings_support_description">Калі вам патрэбна дапамога.</string>
     <string name="settings_wiki_label">Вікі</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Скінуць вывучаныя даныя?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod забудзе вымераныя для гэтай прылады хуткасць разраджэння, хуткасць зарадкі і час слухання, і пачне нанова з намінальнага рэсурсу батарэі.</string>
     <string name="settings_acknowledgements_label">Падзякі</string>
-    <string name="settings_debug_autoreports_label">Аўтаматычныя справаздачы пра памылкі</string>
-    <string name="settings_debug_autoreports_description">Аўтаматычна паведамляе пра праблемы, напрыклад, звесткі пра збой праграмы, каб я мог зразумець, як гэта выправіць.</string>
-    <string name="settings_compatibility_mode_label">Рэжым сумяшчальнасці</string>
-    <string name="settings_compatibility_mode_description">Адключыце аптымізацыі для паляпшэння сумяшчальнасці. Паспрабуйце гэта, калі вы не бачыце ніякіх даных.</string>
     <string name="help_translate_label">Пераклад</string>
     <string name="help_translate_description">Дапамажыце перакласці гэту праграму на вашу любімую мову.</string>
     <string name="translators_thanks_title">Перакладчыкі</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Поспех</string>
     <string name="troubleshooter_ble_result_success_body">Трансляцыі рэкламных аб\'яў BLE прымаюцца CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Няўдача</string>
-    <string name="troubleshooter_ble_result_failure_body">Ліквідацыя непаладак не ўдалася. Ніякая камбінацыя параметраў сумяшчальнасці не дапамагла.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ваш тэлефон наогул не атрымаў ніякіх даных BLE. Вы можаце паўтарыць гэты тэст у людным месцы, каб убачыць, ці можна атрымаць крыніцы даных (акрамя вашых навушнікаў). Адсутнасць атрыманых даных паказвае на праблему з аперацыйнай сістэмай вашага тэлефона.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Ваш тэлефон атрымаў даныя BLE, але даныя не паступаюць ні з адной падтрымоўванай прылады. Вашы навушнікі ўключаны? Ці падтрымлівае CAPod вашы навушнікі?</string>
-    <string name="troubleshooter_ble_result_failure_action">Паспрабуйце яшчэ раз</string>
-    <string name="troubleshoot_action">Ліквідаваць непаладкі</string>
     <string name="onboarding_body1">Гэта праграма дадае падтрымку спецыфічных функцый AirPod для Android.</string>
     <string name="onboarding_body2">Не ўсе прылады Android цалкам падтрымліваюць дадатковыя функцыі AirPod. Ваша аперацыйная сістэма патрабуе правільна працуючай рэалізацыі Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod не мае рэкламы і не збірае вашы даныя.</string>
@@ -207,12 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Ваша прылада падлучана, але CAPod не атрымлівае ніякіх жывых дадзеных з яе. Вашаму тэлефону можа спатрэбіцца параметр сумяшчальнасці — ліквідатар непаладак можа паспрабаваць знайсці яго аўтаматычна.</string>
     <string name="overview_troubleshoot_suggestion_action">Запусціць ліквідатар непаладак</string>
     <string name="overview_unmatched_devices_label">Неадпаведныя прылады</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d прылада без адпаведнага профілю</item>
-        <item quantity="few">%d прылады без адпаведнага профілю</item>
-        <item quantity="many">%d прылад без адпаведнага профілю</item>
-        <item quantity="other">%d прылад без адпаведнага профілю</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Побач знойдзена %d прылада без адпаведнага профілю. Пакажыце яе, каб убачыць даступныя дэталі. Калі яна ваша, дадайце профіль у раздзеле «Прылады», каб яе распазнаць.</item>
         <item quantity="few">Побач знойдзена %d прылады без адпаведных профіляў. Пакажыце іх, каб убачыць даступныя дэталі. Калі адна з іх ваша, дадайце профіль у раздзеле «Прылады», каб яе распазнаць.</item>
@@ -237,7 +210,6 @@
     <string name="permission_background_location_description">CAPod выкарыстоўвае \"фонавы доступ да месцазнаходжання\" для ўключэння такіх функцый, як \"Паказаць усплывальнае акно\" і \"Аўтаматычнае падключэнне\" пры закрытай праграме. Фонавы доступ да месцазнаходжання дазваляе праграме атрымліваць даныя Bluetooth Low Energy у фонавым рэжыме. Гэта праграма НЕ будзе выкарыстоўваць даныя Bluetooth для вызначэння вашага месцазнаходжання.</string>
     <string name="permission_ignore_battery_optimizations_label">Адключыць аптымізацыю батарэі</string>
     <string name="permission_ignore_battery_optimizations_description">Аптымізацыя батарэі перашкаджае гэтай праграме надзейна атрымліваць даныя Bluetooth у фонавым рэжыме.</string>
-    <string name="permission_required_title">Патрабуецца наступны дазвол:</string>
     <string name="permission_system_alert_window_label">Сістэмнае акно папярэджання</string>
     <string name="permission_system_alert_window_description">Дазвольце CAPod маляваць паверх іншых праграм, каб зрабіць магчымай функцыю \"Паказаць усплывальнае акно\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Калі бачна</string>
@@ -245,9 +217,6 @@
     <string name="settings_reaction_autoconnect_inear_label">У вуху</string>
     <string name="pods_dual_left_label">Левы навушнік</string>
     <string name="pods_dual_right_label">Правы навушнік</string>
-    <string name="pods_dual_left_short_label">Л</string>
-    <string name="pods_dual_right_short_label">П</string>
-    <string name="pods_case_label">Корпус</string>
     <string name="battery_unavailable_label">Зарад недаступны</string>
     <string name="battery_state_low_cd">Батарэя нізька</string>
     <string name="battery_state_critical_cd">Батарэя крытычна нізька</string>
@@ -304,12 +273,9 @@
     <string name="signal_badge_aap_cd">Прамое злучэнне актыўна</string>
     <string name="signal_indicator_bars_cd">Сіла сігналу: %1$d з 4 паласок</string>
     <string name="signal_indicator_disconnected_cd">Сігнал: адключана</string>
-    <string name="pods_yours">Ваша</string>
     <string name="headset_being_worn_label">Надзета</string>
     <string name="headset_not_being_worn_label">Не надзета</string>
     <string name="pods_case_unknown_state">Невядомы стан</string>
-    <string name="last_seen_x">Апошні раз бачана: %s</string>
-    <string name="first_seen_x">Упершыню бачана: %s</string>
     <string name="battery_cached_label">Апошняе вядомае · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dг %2$dхв</string>
     <string name="battery_time_remaining_format_h">%1$dг</string>
@@ -339,10 +305,8 @@
     <string name="profiles_signal_quality_title">Мінімальная якасць сігналу</string>
     <string name="profiles_signal_quality_description">Вызначаць толькі прылады з сілай сігналу вышэй гэтага парогу. Ніжэйшыя значэнні павялічваюць дыяпазон вызначэння, але могуць выклікаць ілжывыя спрацоўванні. Не ўсталёўвайце гэта занадта высока - прыём Bluetooth звычайна слабы і залежыць ад адлегласці і перашкод.</string>
     <string name="profiles_identitykey_label">Ключ ідэнтыфікацыі</string>
-    <string name="profilessettings_maindevice_identitykey_description">Ключ вырашэння ідэнтыфікацыі (IRK) вашай прылады, які дапамагае CAPod ідэнтыфікаваць яе сярод бліжніх прылад.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods часта мяняюць свой адрас Bluetooth для прыватнасці. IRK дапамагае CAPod распазнаць вашу прыладу. Вам патрэбен аднаразовы доступ да MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ключ шыфравання</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ключ шыфравання вашай прылады, які дазваляе CAPod атрымліваць падрабязную інфармацыю пра стан.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods адпраўляюць паведамленне пра стан, частка якога зашыфравана. Ключ шыфравання дазваляе CAPod расшыфраваць поўнае паведамленне. Вам патрэбен аднаразовы доступ да MacBook.</string>
     <string name="profiles_key_invalid_format">Няправільны фармат ключа</string>
     <string name="profiles_key_expected_format">Чаканы фармат: %1$s</string>
@@ -375,7 +339,6 @@
     <string name="general_unsaved_changes_message">У вас ёсць незахаваныя змены. Што вы хочаце зрабіць?</string>
     <string name="general_save_and_exit_action">Захаваць і выйсці</string>
     <string name="general_discard_action">Адхіліць</string>
-    <string name="general_keep_editing_action">Працягнуць рэдагаванне</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Запіс занадта кароткі</string>
     <string name="debug_debuglog_short_recording_message">Журнал адладкі павінен захапіць праблему ў момант яе ўзнікнення. Працягвайце запіс, ўзнавіце праблему, затым спыніце запіс.</string>
@@ -452,7 +415,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Налады прылады</string>
     <string name="device_settings_subtitle_profile_prefix">Профіль: %s</string>
-    <string name="device_settings_info_name_label">Назва</string>
     <string name="device_settings_info_bt_name_label">Назва Bluetooth-прылады</string>
     <string name="device_settings_info_model_label">Мадэль</string>
     <string name="device_settings_info_manufacturer_label">Вытворца</string>
@@ -531,7 +493,6 @@
     <string name="review_app_dismiss_action">Магчыма пазней</string>
     <string name="review_app_body">Ці ты хочаш пакінуць водгук на CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Агульныя</string>
     <string name="device_settings_microphone_mode_label">Мікрафон</string>
     <string name="device_settings_microphone_mode_description">Які навушнік выкарыстоўваецца як мікрафон</string>
     <string name="device_settings_microphone_mode_auto">Аўта</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Споделяне</string>
     <string name="general_done_action">Готово</string>
     <string name="general_cancel_action">Отказ</string>
-    <string name="general_copy_action">Копиране</string>
     <string name="general_thank_you_label">Благодаря ви</string>
     <string name="general_upgrade_action">Надграждане</string>
     <string name="general_retry_action">Повтори</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Проверка</string>
     <string name="general_close_action">Затваряне</string>
     <string name="general_dismiss_action">Отхвърляне</string>
-    <string name="general_edit_action">Редактиране</string>
     <string name="general_save_action">Запазване</string>
     <string name="general_guide_action">Ръководство</string>
     <string name="general_continue_action">Продължи</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Възобновява музиката, когато отново сложите слушалките, но само ако е спряна от Автоматично пауза. Паузите, направени от вас (телефон, дръжка на AirPods, заспиване), остават.</string>
     <string name="settings_start_music_on_wear_label">Стартиране на музика при поставяне</string>
     <string name="settings_start_music_on_wear_description">Винаги се опитва да пусне музика, когато сложите слушалките, дори след ръчна пауза.</string>
-    <string name="settings_eardetection_info_label">Бележка за разпознаване на ухото</string>
     <string name="settings_eardetection_info_description">Ако разпознаването на ухото работи само за една слушалка, това е ограничение на Apple. Само \"основната слушалка\" (използвана за микрофон) се разпознава. Конфигурирайте на Apple устройства: Настройки → Bluetooth → AirPods → Микрофон.</string>
-    <string name="settings_signal_minimum_label">Минимално качество на сигнала</string>
-    <string name="settings_signal_minimum_description">Минималното качество на сигнала, което устройството трябва да има, за да се счита за ваше.</string>
     <string name="settings_autoconnect_label">Автоматично свързване</string>
     <string name="settings_autoconnect_description">Ако Android не се свърже автоматично, можем да го помолим и ние. Това поддържа CAPod активен във фонов режим по всяко време.</string>
     <string name="settings_autoconnect_info_android12">Автоматичното свързване разчита на системна функция, която Android 12 и по-нови версии ограничават. Може да не работи на вашето устройство.</string>
     <string name="settings_autoconnect_condition_label">Условие за автоматично свързване</string>
-    <string name="settings_autoconnect_condition_description">Кога трябва да се опитаме да се свържем с вашето устройство?</string>
     <string name="settings_devices_label">Устройства</string>
     <string name="settings_devices_description">Управлявайте устройствата си.</string>
     <string name="settings_reaction_label">Реакции</string>
-    <string name="settings_category_yourdevice_label">Вашето устройство</string>
     <string name="settings_category_compatibility_options_title">Опции за съвместимост</string>
     <string name="settings_category_compatibility_options_description">Не пипайте, ако всичко работи ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Деактивиране на хардуерното филтриране</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Стартиране…</string>
     <string name="support_debuglog_label">Журнал за отстраняване на грешки</string>
     <string name="support_debuglog_desc">Запишете всичко, което приложението прави, в текстов файл, който можете да споделите.</string>
-    <string name="debug_debuglog_size_label">Размер</string>
-    <string name="debug_debuglog_size_compressed_label">Компресиран размер</string>
-    <string name="debug_notification_channel_label">Известия за отстраняване на грешки</string>
-    <string name="debug_debuglog_file_label">Записан лог файл</string>
-    <string name="debug_debuglog_recording_progress">Записване на журнал за отстраняване на грешки</string>
     <string name="debug_debuglog_record_action">Запис на журнал за отстраняване на грешки</string>
     <string name="debug_debuglog_stop_action">Спиране на записа</string>
     <string name="debug_debuglog_sensitive_information_message">Генерираният файл съдържа чувствителна информация (напр. подробности за Bluetooth устройството). Споделяйте го само с доверени страни.</string>
     <string name="settings_debuglog_explanation">Тази функция записва всичко, което приложението прави, във файл за споделяне. Генерираният файл съдържа чувствителна информация (напр. подробности за Bluetooth устройството). Споделяйте го само с доверени страни (напр. разработчик, който отстранява проблем).</string>
-    <string name="settings_support_installid_label">Идентификатор на инсталацията</string>
-    <string name="settings_support_installid_desc">Автоматичните доклади за грешки са анонимни. Споделете своя идентификатор на инсталацията, ако разработчикът трябва да намери вашите доклади за грешки.</string>
     <string name="settings_support_label">Поддръжка</string>
     <string name="settings_support_description">Ако имате нужда от помощ.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Нулирай научените данни?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ще забрави измереното потребление, скоростта на зареждане и времето за слушане на това устройство и ще начне отново от номиналния живот на батерията.</string>
     <string name="settings_acknowledgements_label">Благодарности</string>
-    <string name="settings_debug_autoreports_label">Автоматични доклади за грешки</string>
-    <string name="settings_debug_autoreports_description">Автоматично докладва проблеми, напр. подробности за срив на приложението, за да мога да разбера как да го поправя.</string>
-    <string name="settings_compatibility_mode_label">Режим на съвместимост</string>
-    <string name="settings_compatibility_mode_description">Деактивирайте оптимизациите, за да подобрите съвместимостта. Опитайте това, ако не виждате никакви данни.</string>
     <string name="help_translate_label">Превод</string>
     <string name="help_translate_description">Помогнете да преведем това приложение на вашия любим език.</string>
     <string name="translators_thanks_title">Преводачи</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Успех</string>
     <string name="troubleshooter_ble_result_success_body">BLE рекламните излъчвания се получават от CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Неуспешно</string>
-    <string name="troubleshooter_ble_result_failure_body">Отстраняването на неизправности не успя. Никоя комбинация от опции за съвместимост не помогна.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Телефонът ви изобщо не е получил никакви BLE данни. Можете да опитате отново този тест в пренаселена зона, за да видите дали могат да бъдат получени източници на данни (различни от вашите слушалки). Липсата на получени данни сочи към проблем с операционната система на вашия телефон.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Телефонът ви е получил BLE данни, но данните не идват от никое поддържано устройство. Включени ли са слушалките ви? Поддържа ли CAPod вашите слушалки?</string>
-    <string name="troubleshooter_ble_result_failure_action">Опитайте отново</string>
-    <string name="troubleshoot_action">Отстраняване на неизправности</string>
     <string name="onboarding_body1">Това приложение добавя поддръжка за специфични за AirPod функции към Android.</string>
     <string name="onboarding_body2">Не всички устройства с Android поддържат напълно допълнителните функции на AirPod. Вашата операционна система изисква правилно работеща реализация на Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod няма реклами и не събира вашите данни.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Устройството ти е свързано, но CAPod не получава данни от него в реално време. Телефонът ти може да се нуждае от опция за съвместимост — инструментът за отстраняване на неизправности може да се опита да намери такава автоматично.</string>
     <string name="overview_troubleshoot_suggestion_action">Стартирай отстраняване на неизправности</string>
     <string name="overview_unmatched_devices_label">Несъвпадащи устройства</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d устройство без съвпадащ профил</item>
-        <item quantity="other">%d устройства без съвпадащ профил</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Открито е %d близко устройство без съответстващ профил. Покажете го за налична информация. Ако е ваше, добавете профил от „Устройства“, за да го разпознаете.</item>
         <item quantity="other">Открити са %d близки устройства без съответстващи профили. Покажете ги за налична информация. Ако някое е ваше, добавете профил от „Устройства“, за да го разпознаете.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod използва \"достъп до местоположение във фонов режим\", за да активира функции като \"Покажи изскачащ прозорец\" и \"Автоматично свързване\", докато приложението е затворено. Достъпът до местоположение във фонов режим позволява на приложението да получава Bluetooth Low Energy данни във фонов режим. Това приложение НЯМА да използва Bluetooth данни за определяне на вашето местоположение.</string>
     <string name="permission_ignore_battery_optimizations_label">Деактивиране на оптимизации на батерията</string>
     <string name="permission_ignore_battery_optimizations_description">Оптимизациите на батерията пречат на приложението надеждно да получава Bluetooth данни, докато е във фонов режим.</string>
-    <string name="permission_required_title">Необходимо е следното разрешение:</string>
     <string name="permission_system_alert_window_label">Системен изскачащ прозорец</string>
     <string name="permission_system_alert_window_description">Позволете на CAPod да рисува върху други приложения, за да направи функцията \"Покажи изскачащ прозорец\" възможна.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Когато е видяно</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">В ухото</string>
     <string name="pods_dual_left_label">Лява слушалка</string>
     <string name="pods_dual_right_label">Дясна слушалка</string>
-    <string name="pods_dual_left_short_label">Л</string>
-    <string name="pods_dual_right_short_label">Д</string>
-    <string name="pods_case_label">Калъф</string>
     <string name="battery_unavailable_label">Батерията е недостъпна</string>
     <string name="battery_state_low_cd">Слаба батерия</string>
     <string name="battery_state_critical_cd">Критично слаба батерия</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Директната връзка е активна</string>
     <string name="signal_indicator_bars_cd">Сила на сигнала: %1$d от 4 деления</string>
     <string name="signal_indicator_disconnected_cd">Сигнал: прекъснат</string>
-    <string name="pods_yours">Вашето</string>
     <string name="headset_being_worn_label">Носи се</string>
     <string name="headset_not_being_worn_label">Не се носи</string>
     <string name="pods_case_unknown_state">Неизвестно състояние</string>
-    <string name="last_seen_x">Последно видяно: %s</string>
-    <string name="first_seen_x">Първо видяно: %s</string>
     <string name="battery_cached_label">Последно известно · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dч %2$dм</string>
     <string name="battery_time_remaining_format_h">%1$dч</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Минимално качество на сигнала</string>
     <string name="profiles_signal_quality_description">Откривайте само устройства със сила на сигнала над този праг. По-ниските стойности увеличават обхвата на откриване, но могат да причинят фалшиви положителни резултати. Не задавайте твърде високо - Bluetooth приемането обикновено е слабо и варира с разстоянието и препятствията.</string>
     <string name="profiles_identitykey_label">Идентификационен ключ</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) на вашето устройство, който помага на CAPod да го идентифицира сред близките устройства.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods често сменят своя Bluetooth адрес за поверителност. IRK помага на CAPod да разпознае вашето устройство. Нужен ви е еднократен достъп до MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ключ за криптиране</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ключът за криптиране на вашето устройство, който позволява на CAPod да извлече подробна информация за състоянието.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods изпращат съобщение за състояние, част от което е криптирано. Ключът за криптиране позволява на CAPod да декриптира пълното съобщение. Нужен ви е еднократен достъп до MacBook.</string>
     <string name="profiles_key_invalid_format">Невалиден формат на ключа</string>
     <string name="profiles_key_expected_format">Очакван формат: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Имате незапазени промени. Какво искате да направите?</string>
     <string name="general_save_and_exit_action">Запази &amp; излез</string>
     <string name="general_discard_action">Отхвърли</string>
-    <string name="general_keep_editing_action">Продължи редактирането</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Записът е прекалък късък</string>
     <string name="debug_debuglog_short_recording_message">Журналът за отстраняване на грешки трябва да улови проблема по време на осъществяването му. Продължете записването, възпроизведете проблема и спрете записването.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Настройки на устройството</string>
     <string name="device_settings_subtitle_profile_prefix">Профил: %s</string>
-    <string name="device_settings_info_name_label">Наименование</string>
     <string name="device_settings_info_bt_name_label">Bluetooth етикет на устройство</string>
     <string name="device_settings_info_model_label">Модел</string>
     <string name="device_settings_info_manufacturer_label">Производител</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Може би по-късно</string>
     <string name="review_app_body">Бихте ли искали да оставите на CAPod оценка? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Общи</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
     <string name="device_settings_microphone_mode_description">Коя слушалка се използва като микрофон</string>
     <string name="device_settings_microphone_mode_auto">Автом.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">শেয়ার করুন</string>
     <string name="general_done_action">সম্পন্ন</string>
     <string name="general_cancel_action">বাতিল করুন</string>
-    <string name="general_copy_action">কপি করুন</string>
     <string name="general_thank_you_label">ধন্যবাদ</string>
     <string name="general_upgrade_action">আপগ্রেড করুন</string>
     <string name="general_retry_action">আবার চেষ্টা করুন</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">চেক করুন</string>
     <string name="general_close_action">বন্ধ করুন</string>
     <string name="general_dismiss_action">খারিজ করুন</string>
-    <string name="general_edit_action">সম্পাদনা করুন</string>
     <string name="general_save_action">সংরক্ষণ করুন</string>
     <string name="general_guide_action">নির্দেশিকা</string>
     <string name="general_continue_action">চালিয়ে যান</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">আপনার পড পুনরায় পরলে সংগীত চালু করুন, তবে শুধুমাত্র যদি অটো পজ এটি থামিয়ে দিয়ে থাকে। আপনি নিজে যে পজ করেছেন (ফোন, AirPods স্টেম, স্লিপ) সেগুলো পজ থাকবে।</string>
     <string name="settings_start_music_on_wear_label">পরলে সংগীত শুরু করুন</string>
     <string name="settings_start_music_on_wear_description">আপনি পড পরলে সবসময় সংগীত চালানোর চেষ্টা করে, এমনকি ম্যানুয়াল পজের পরেও।</string>
-    <string name="settings_eardetection_info_label">কান সনাক্তকরণ নোট</string>
     <string name="settings_eardetection_info_description">যদি কান সনাক্তকরণ শুধুমাত্র একটি পডের জন্য কাজ করে, এটি একটি Apple সীমাবদ্ধতা। শুধুমাত্র \"প্রাথমিক পড\" (মাইক্রোফোনের জন্য ব্যবহৃত) সনাক্ত করা হয়। Apple ডিভাইসে কনফিগার করুন: সেটিংস → Bluetooth → AirPods → মাইক্রোফোন।</string>
-    <string name="settings_signal_minimum_label">ন্যূনতম সংকেত গুণমান</string>
-    <string name="settings_signal_minimum_description">একটি ডিভাইসকে আপনার হিসাবে বিবেচনা করার জন্য ন্যূনতম সংকেত গুণমান থাকতে হবে।</string>
     <string name="settings_autoconnect_label">স্বয়ংক্রিয় সংযোগ</string>
     <string name="settings_autoconnect_description">Android যদি নিজে থেকে সংযোগ না করে, তাহলে আমরা এটিকে অনুরোধ করতে পারি। এতে CAPod সবসময় ব্যাকগ্রাউন্ডে নজরদারি চালিয়ে যায়।</string>
     <string name="settings_autoconnect_info_android12">অটো কানেক্ট একটি সিস্টেম ফিচারের উপর নির্ভর করে যা Android 12 এবং তার নতুন সংস্করণ সীমাবদ্ধ করেছে। এটি আপনার ডিভাইসে কাজ নাও করতে পারে।</string>
     <string name="settings_autoconnect_condition_label">স্বয়ংক্রিয় সংযোগের শর্ত</string>
-    <string name="settings_autoconnect_condition_description">কখন আমাদের আপনার ডিভাইসের সাথে সংযোগ করার চেষ্টা করা উচিত?</string>
     <string name="settings_devices_label">ডিভাইস</string>
     <string name="settings_devices_description">আপনার ডিভাইসগুলি পরিচালনা করুন।</string>
     <string name="settings_reaction_label">প্রতিক্রিয়া</string>
-    <string name="settings_category_yourdevice_label">আপনার ডিভাইস</string>
     <string name="settings_category_compatibility_options_title">সামঞ্জস্যতার বিকল্প</string>
     <string name="settings_category_compatibility_options_description">সবকিছু কাজ করলে স্পর্শ করবেন না ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">হার্ডওয়্যার ফিল্টারিং নিষ্ক্রিয় করুন</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">শুরু হচ্ছে…</string>
     <string name="support_debuglog_label">ডিবাগ লগ</string>
     <string name="support_debuglog_desc">অ্যাপটি যা কিছু করছে তা একটি শেয়ারযোগ্য টেক্সট ফাইলে রেকর্ড করুন।</string>
-    <string name="debug_debuglog_size_label">আকার</string>
-    <string name="debug_debuglog_size_compressed_label">সংকুচিত আকার</string>
-    <string name="debug_notification_channel_label">ডিবাগ বিজ্ঞপ্তি</string>
-    <string name="debug_debuglog_file_label">রেকর্ড করা লগ ফাইল</string>
-    <string name="debug_debuglog_recording_progress">ডিবাগ লগ রেকর্ড করা হচ্ছে</string>
     <string name="debug_debuglog_record_action">ডিবাগ লগ রেকর্ড করুন</string>
     <string name="debug_debuglog_stop_action">রেকর্ডিং বন্ধ করুন</string>
     <string name="debug_debuglog_sensitive_information_message">তৈরি করা ফাইলে সংবেদনশীল তথ্য (যেমন ব্লুটুথ ডিভাইসের বিবরণ) রয়েছে। শুধুমাত্র বিশ্বস্ত পক্ষের সাথে এটি শেয়ার করুন।</string>
     <string name="settings_debuglog_explanation">এই বৈশিষ্ট্যটি অ্যাপটি যা কিছু করছে তা একটি শেয়ারযোগ্য ফাইলে রেকর্ড করে। তৈরি করা ফাইলে সংবেদনশীল তথ্য (যেমন ব্লুটুথ ডিভাইসের বিবরণ) রয়েছে। শুধুমাত্র বিশ্বস্ত পক্ষের সাথে এটি শেয়ার করুন (যেমন একজন ডেভেলপার যিনি কোনো সমস্যা সমাধান করছেন)।</string>
-    <string name="settings_support_installid_label">ইনস্টল আইডি</string>
-    <string name="settings_support_installid_desc">স্বয়ংক্রিয় ত্রুটি প্রতিবেদনগুলি বেনামী। যদি ডেভেলপারের আপনার ত্রুটি প্রতিবেদনগুলি খুঁজে বের করতে হয় তবে আপনার ইনস্টল আইডি শেয়ার করুন।</string>
     <string name="settings_support_label">সহায়তা</string>
     <string name="settings_support_description">যদি আপনার কিছু সাহায্যের প্রয়োজন হয়।</string>
     <string name="settings_wiki_label">উইকি</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">শেখা ডেটা রিসেট করুন?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod এই ডিভাইসের পরিমাপ করা ড্রেইন, চার্জিং গতি এবং শ্রবণ সময় ভুলে যাবে এবং রেটেড ব্যাটারি আয়ু থেকে শুরু করবে।</string>
     <string name="settings_acknowledgements_label">স্বীকৃতি</string>
-    <string name="settings_debug_autoreports_label">স্বয়ংক্রিয় বাগ রিপোর্ট</string>
-    <string name="settings_debug_autoreports_description">স্বয়ংক্রিয়ভাবে সমস্যাগুলি রিপোর্ট করে, যেমন অ্যাপ ক্র্যাশের বিবরণ যাতে আমি এটি কীভাবে ঠিক করতে পারি তা বের করতে পারি।</string>
-    <string name="settings_compatibility_mode_label">সামঞ্জস্যতা মোড</string>
-    <string name="settings_compatibility_mode_description">সামঞ্জস্যতা উন্নত করতে অপ্টিমাইজেশান নিষ্ক্রিয় করুন। যদি আপনি কোনো ডেটা দেখতে না পান তবে এটি চেষ্টা করুন।</string>
     <string name="help_translate_label">অনুবাদ</string>
     <string name="help_translate_description">এই অ্যাপটি আপনার প্রিয় ভাষায় অনুবাদ করতে সাহায্য করুন।</string>
     <string name="translators_thanks_title">অনুবাদক</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">সফল</string>
     <string name="troubleshooter_ble_result_success_body">BLE বিজ্ঞাপন সম্প্রচার CAPod দ্বারা প্রাপ্ত হচ্ছে।</string>
     <string name="troubleshooter_ble_result_failure_title">ব্যর্থ</string>
-    <string name="troubleshooter_ble_result_failure_body">সমস্যা সমাধান ব্যর্থ হয়েছে। কোনো সামঞ্জস্যতার বিকল্পের সংমিশ্রণ সাহায্য করেনি।</string>
     <string name="troubleshooter_ble_result_failure_phone_body">আপনার ফোন কোনো BLE ডেটা পায়নি। ডেটা উত্স (আপনার হেডফোন ছাড়া) প্রাপ্ত করা যায় কিনা তা দেখতে আপনি এই পরীক্ষাটি একটি জনাকীর্ণ এলাকায় আবার চেষ্টা করতে পারেন। কোনো ডেটা প্রাপ্ত না হওয়া আপনার ফোনের অপারেটিং সিস্টেমে একটি সমস্যা নির্দেশ করে।</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">আপনার ফোন BLE ডেটা পেয়েছে, কিন্তু ডেটা কোনো সমর্থিত ডিভাইস থেকে আসছে না। আপনার হেডফোন কি চালু আছে? CAPod কি আপনার হেডফোন সমর্থন করে?</string>
-    <string name="troubleshooter_ble_result_failure_action">আবার চেষ্টা করুন</string>
-    <string name="troubleshoot_action">সমস্যা সমাধান করুন</string>
     <string name="onboarding_body1">এই অ্যাপটি অ্যান্ড্রয়েডে AirPod নির্দিষ্ট বৈশিষ্ট্যগুলির জন্য সমর্থন যোগ করে।</string>
     <string name="onboarding_body2">সব অ্যান্ড্রয়েড ডিভাইস সম্পূর্ণরূপে অতিরিক্ত AirPod বৈশিষ্ট্য সমর্থন করে না। আপনার অপারেটিং সিস্টেমের একটি সঠিকভাবে কাজ করা ব্লুটুথ-লো-এনার্জি বাস্তবায়ন প্রয়োজন।</string>
     <string name="onboarding_body3">CAPod-এ কোনো বিজ্ঞাপন নেই এবং আপনার ডেটা সংগ্রহ করে না।</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">আপনার ডিভাইসটি সংযুক্ত, কিন্তু CAPod এটি থেকে কোনো লাইভ ডেটা পাচ্ছে না। আপনার ফোনের একটি সামঞ্জস্যতা বিকল্পের প্রয়োজন হতে পারে — সমস্যা সমাধানকারী স্বয়ংক্রিয়ভাবে একটি খুঁজে পেতে চেষ্টা করতে পারে।</string>
     <string name="overview_troubleshoot_suggestion_action">সমস্যা সমাধানকারী চালান</string>
     <string name="overview_unmatched_devices_label">অমিলিত ডিভাইস</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">মিলিত প্রোফাইল ছাড়া %d ডিভাইস</item>
-        <item quantity="other">মিলিত প্রোফাইল ছাড়া %d ডিভাইস</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d-টি কাছাকাছি ডিভাইস মেলে এমন কোনো প্রোফাইল ছাড়াই শনাক্ত হয়েছে। উপলব্ধ বিবরণের জন্য এটি দেখান। এটি যদি আপনার হয়, তাহলে এটিকে শনাক্ত করতে ডিভাইস থেকে একটি প্রোফাইল যোগ করুন।</item>
         <item quantity="other">%d-টি কাছাকাছি ডিভাইস মেলে এমন কোনো প্রোফাইল ছাড়াই শনাক্ত হয়েছে। উপলব্ধ বিবরণের জন্য সেগুলি দেখান। এর মধ্যে একটি যদি আপনার হয়, তাহলে এটিকে শনাক্ত করতে ডিভাইস থেকে একটি প্রোফাইল যোগ করুন।</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod \"ব্যাকগ্রাউন্ড অবস্থান অ্যাক্সেস\" ব্যবহার করে অ্যাপ বন্ধ থাকাকালীন \"পপআপ দেখান\" এবং \"অটোকানেক্ট\" এর মতো বৈশিষ্ট্যগুলি সক্ষম করতে। ব্যাকগ্রাউন্ড অবস্থান অ্যাক্সেস অ্যাপটিকে ব্যাকগ্রাউন্ডে থাকাকালীন Bluetooth Low Energy ডেটা গ্রহণ করতে দেয়। এই অ্যাপ আপনার অবস্থান নির্ধারণ করতে Bluetooth ডেটা ব্যবহার করবে না।</string>
     <string name="permission_ignore_battery_optimizations_label">ব্যাটারি অপ্টিমাইজেশন নিষ্ক্রিয় করুন</string>
     <string name="permission_ignore_battery_optimizations_description">ব্যাটারি অপ্টিমাইজেশন এই অ্যাপটিকে ব্যাকগ্রাউন্ডে থাকাকালীন নির্ভরযোগ্যভাবে Bluetooth ডেটা গ্রহণ করতে বাধা দেয়।</string>
-    <string name="permission_required_title">নিম্নলিখিত অনুমতি প্রয়োজন:</string>
     <string name="permission_system_alert_window_label">সিস্টেম অ্যালার্ট উইন্ডো</string>
     <string name="permission_system_alert_window_description">\"পপআপ দেখান\" বৈশিষ্ট্যটি সম্ভব করতে CAPod-কে অন্যান্য অ্যাপের উপরে আঁকতে অনুমতি দিন।</string>
     <string name="settings_reaction_autoconnect_whenseen_label">দেখা গেলে</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">কানে</string>
     <string name="pods_dual_left_label">বাম পড</string>
     <string name="pods_dual_right_label">ডান পড</string>
-    <string name="pods_dual_left_short_label">বা</string>
-    <string name="pods_dual_right_short_label">ডা</string>
-    <string name="pods_case_label">কেস</string>
     <string name="battery_unavailable_label">ব্যাটারি অনুপলব্ধ</string>
     <string name="battery_state_low_cd">ব্যাটারি কম</string>
     <string name="battery_state_critical_cd">ব্যাটারি অত্যন্ত কম</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">সরাসরি সংযোগ সক্রিয়</string>
     <string name="signal_indicator_bars_cd">সিগন্যাল শক্তি: ৪ বারের মধ্যে %1$d</string>
     <string name="signal_indicator_disconnected_cd">সিগন্যাল: সংযোগ বিচ্ছিন্ন</string>
-    <string name="pods_yours">আপনার</string>
     <string name="headset_being_worn_label">পরিধান করা হচ্ছে</string>
     <string name="headset_not_being_worn_label">পরিধান করা হচ্ছে না</string>
     <string name="pods_case_unknown_state">অজানা অবস্থা</string>
-    <string name="last_seen_x">সর্বশেষ দেখা: %s</string>
-    <string name="first_seen_x">প্রথম দেখা: %s</string>
     <string name="battery_cached_label">শেষ জানা · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dঘ %2$dমি</string>
     <string name="battery_time_remaining_format_h">%1$dঘ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">ন্যূনতম সংকেত গুণমান</string>
     <string name="profiles_signal_quality_description">শুধুমাত্র এই থ্রেশহোল্ডের উপরে সংকেত শক্তি সহ ডিভাইস সনাক্ত করুন। কম মান সনাক্তকরণ পরিসীমা বাড়ায় কিন্তু মিথ্যা পজিটিভ হতে পারে। এটি খুব বেশি সেট করবেন না - Bluetooth রিসেপশন সাধারণত দুর্বল এবং দূরত্ব ও বাধার সাথে পরিবর্তিত হয়।</string>
     <string name="profiles_identitykey_label">আইডেন্টিটি কী</string>
-    <string name="profilessettings_maindevice_identitykey_description">আপনার ডিভাইসের আইডেন্টিটি রিজলভিং কী (IRK), যা CAPod-কে কাছের ডিভাইসগুলির মধ্যে এটি সনাক্ত করতে সাহায্য করে।</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods গোপনীয়তার জন্য ঘন ঘন তাদের Bluetooth ঠিকানা পরিবর্তন করে। IRK CAPod-কে আপনার ডিভাইস চিনতে সাহায্য করে। আপনার একটি MacBook-এ একবারের অ্যাক্সেস প্রয়োজন।</string>
     <string name="profiles_maindevice_encryptionkey_label">এনক্রিপশন কী</string>
-    <string name="profiles_maindevice_encryptionkey_description">আপনার ডিভাইসের এনক্রিপশন কী, যা CAPod-কে বিস্তারিত স্ট্যাটাস তথ্য পুনরুদ্ধার করতে দেয়।</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods একটি স্ট্যাটাস বার্তা পাঠায়, যার অংশবিশেষ এনক্রিপ্টেড। এনক্রিপশন কী CAPod-কে সম্পূর্ণ বার্তাটি ডিক্রিপ্ট করতে দেয়। আপনার একটি MacBook-এ একবারের অ্যাক্সেস প্রয়োজন।</string>
     <string name="profiles_key_invalid_format">অবৈধ কী বিন্যাস</string>
     <string name="profiles_key_expected_format">প্রত্যাশিত বিন্যাস: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">আপনার অসংরক্ষিত পরিবর্তন আছে। আপনি কী করতে চান?</string>
     <string name="general_save_and_exit_action">সংরক্ষণ করুন এবং প্রস্থান করুন</string>
     <string name="general_discard_action">বাতিল করুন</string>
-    <string name="general_keep_editing_action">সম্পাদনা চালিয়ে যান</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">রেকর্ডিং খুব সামান্য</string>
     <string name="debug_debuglog_short_recording_message">সমস্যা ঘটার সময় ডিবাগ লগকে তা ধারণ করতে হবে। রেকর্ডিং চালিয়ে রাখুন, সমস্যাটি পুনরুৎপাদন করুন, তারপর রেকর্ডিং থামান।</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ডিভাইস সেটিংস</string>
     <string name="device_settings_subtitle_profile_prefix">প্রোফাইল: %s</string>
-    <string name="device_settings_info_name_label">নাম</string>
     <string name="device_settings_info_bt_name_label">ব্লুটুথ ডিভাইস লেবেল</string>
     <string name="device_settings_info_model_label">মডেল</string>
     <string name="device_settings_info_manufacturer_label">প্রস্তুতকারক</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">হয়তো পরে</string>
     <string name="review_app_body">আপনি কি CAPodকে একটি পর্যালোচনা দিতে চান? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">সাধারণ</string>
     <string name="device_settings_microphone_mode_label">মাইক্রোফোন</string>
     <string name="device_settings_microphone_mode_description">কোন ইয়ারবাড মাইক্রোফোন হিসেবে ব্যবহার করা হয়</string>
     <string name="device_settings_microphone_mode_auto">স্বয়ংক্রিয়</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Comparteix</string>
     <string name="general_done_action">Fet</string>
     <string name="general_cancel_action">Cancel·la</string>
-    <string name="general_copy_action">Copia</string>
     <string name="general_thank_you_label">Gràcies</string>
     <string name="general_upgrade_action">Actualitza</string>
     <string name="general_retry_action">Reintenta</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Comprova</string>
     <string name="general_close_action">Tanca</string>
     <string name="general_dismiss_action">Ignora</string>
-    <string name="general_edit_action">Edita</string>
     <string name="general_save_action">Desa</string>
     <string name="general_guide_action">Guia</string>
     <string name="general_continue_action">Continua</string>
@@ -41,19 +39,14 @@
     <string name="settings_autoplay_description">Reprèn la música quan torneu a posar-vos els auriculars, però només si la pausa automàtica l\'havia aturat. Les pauses que heu activat vos mateix (telèfon, pliques dels AirPods, son) romanen en pausa.</string>
     <string name="settings_start_music_on_wear_label">Inicia la música en posar-vos els auriculars</string>
     <string name="settings_start_music_on_wear_description">Sempre intenta reproduir música quan us poseu els auriculars, fins i tot després d\'una pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota de detecció de l\'oïda</string>
     <string name="settings_eardetection_info_description">Si la detecció de l\'oïda només funciona per a un auricular, això és degut a una limitació d\'Apple. Només es detecta «l\'auricular principal» (utilitzat per al micròfon). Configureu-ho en dispositius Apple: Configuració → Bluetooth → AirPods → Micròfon.</string>
-    <string name="settings_signal_minimum_label">Qualitat de senyal mínima</string>
-    <string name="settings_signal_minimum_description">La qualitat de senyal mínima que ha de tenir un dispositiu per considerar-se vostre.</string>
     <string name="settings_autoconnect_label">Connexió automàtica</string>
     <string name="settings_autoconnect_description">Si l\'Android no es connecta automàticament, podem demanar-li que ho faci. Això manté el monitoratge del CAPod actiu en segon pla en tot moment.</string>
     <string name="settings_autoconnect_info_android12">La connexió automàtica depèn d\'una funció del sistema que l\'Android 12 i versions posteriors restringeixen. És possible que no funcioni al vostre dispositiu.</string>
     <string name="settings_autoconnect_condition_label">Condició de connexió automàtica</string>
-    <string name="settings_autoconnect_condition_description">Quan hem d\'intentar connectar-nos al vostre dispositiu?</string>
     <string name="settings_devices_label">Dispositius</string>
     <string name="settings_devices_description">Gestioneu els dispositius.</string>
     <string name="settings_reaction_label">Reaccions</string>
-    <string name="settings_category_yourdevice_label">El vostre dispositiu</string>
     <string name="settings_category_compatibility_options_title">Opcions de compatibilitat</string>
     <string name="settings_category_compatibility_options_description">No ho toqueu si tot funciona ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desactiva el filtratge de maquinari</string>
@@ -83,17 +76,10 @@
     <string name="monitor_notification_starting">S\'està iniciant…</string>
     <string name="support_debuglog_label">Registre de depuració</string>
     <string name="support_debuglog_desc">Enregistra tot el que fa l\'aplicació en un fitxer de text que podeu compartir.</string>
-    <string name="debug_debuglog_size_label">Mida</string>
-    <string name="debug_debuglog_size_compressed_label">Mida comprimida</string>
-    <string name="debug_notification_channel_label">Notificacions de depuració</string>
-    <string name="debug_debuglog_file_label">Fitxer de registre gravat</string>
-    <string name="debug_debuglog_recording_progress">Enregistrament del registre de depuració</string>
     <string name="debug_debuglog_record_action">Grava el registre de depuració</string>
     <string name="debug_debuglog_stop_action">Atura la gravació</string>
     <string name="debug_debuglog_sensitive_information_message">El fitxer generat conté informació sensible (p. ex. detalls del dispositiu Bluetooth). Compartiu-ho només amb persones de confiança.</string>
     <string name="settings_debuglog_explanation">Aquesta funció enregistra tot el que fa l\'aplicació en un fitxer compartible. El fitxer generat conté informació sensible (p. ex. detalls del dispositiu Bluetooth). Compartiu-ho només amb persones de confiança (p. ex. un desenvolupador que està solucionant un problema).</string>
-    <string name="settings_support_installid_label">ID d\'instal·lació</string>
-    <string name="settings_support_installid_desc">Els informes d\'error automàtics són anònims. Compartiu el vostre ID d\'instal·lació si el desenvolupador necessita trobar els vostres informes d\'error.</string>
     <string name="settings_support_label">Suport</string>
     <string name="settings_support_description">Si necessiteu ajuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -121,10 +107,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Voleu restablir les dades apreses?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod oblidarà el consum mesurat d\'aquest dispositiu, la velocitat de càrrega i el temps d\'escolta, i tornarà a començar des de la durada nominal de la bateria.</string>
     <string name="settings_acknowledgements_label">Agraïments</string>
-    <string name="settings_debug_autoreports_label">Informes automàtics d\'errors</string>
-    <string name="settings_debug_autoreports_description">Informa automàticament de problemes. Per exemple: detalls sobre un bloqueig de l\'aplicació perquè pugui esbrinar com solucionar-ho.</string>
-    <string name="settings_compatibility_mode_label">Mode de compatibilitat</string>
-    <string name="settings_compatibility_mode_description">Desactiva les optimitzacions per millorar la compatibilitat. Proveu això si no veieu cap dada.</string>
     <string name="help_translate_label">Traducció</string>
     <string name="help_translate_description">Ajudeu a traduir aquesta aplicació al vostre idioma preferit.</string>
     <string name="translators_thanks_title">Traductors</string>
@@ -174,11 +156,8 @@
     <string name="troubleshooter_ble_result_success_title">Correcte</string>
     <string name="troubleshooter_ble_result_success_body">El CAPod està rebent emissions d\'anuncis BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Incorrecte</string>
-    <string name="troubleshooter_ble_result_failure_body">La resolució de problemes ha fallat. No ha funcionat cap combinació d\'opcions de compatibilitat.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">El vostre telèfon no ha rebut cap dada BLE. Podeu tornar a executar aquesta prova en una zona plena de gent per veure si es poden rebre fonts de dades (que no siguin els vostres auriculars). No rebre dades indica un problema amb el sistema operatiu del telèfon.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">El vostre telèfon ha rebut dades BLE, però les dades no provenen de cap dispositiu compatible. Teniu els auriculars encesos? El CAPod és compatible amb els vostres auriculars?</string>
-    <string name="troubleshooter_ble_result_failure_action">Torna-ho a provar</string>
-    <string name="troubleshoot_action">Resolució de problemes</string>
     <string name="onboarding_body1">Aquesta aplicació afegeix suport per a funcions específiques d\'AirPod a l\'Android.</string>
     <string name="onboarding_body2">No tots els dispositius Android són compatibles completament amb les funcions addicionals d\'AirPod. El vostre sistema operatiu requereix una implementació de Bluetooth de baixa energia que funcioni correctament.</string>
     <string name="onboarding_body3">El CAPod no conté anuncis i no recull les vostres dades.</string>
@@ -208,10 +187,6 @@
     <string name="overview_troubleshoot_suggestion_description">El dispositiu està connectat, però el CAPod no rep dades en directe. El telèfon pot necessitar una opció de compatibilitat: el solucionador de problemes pot intentar trobar-ne una automàticament.</string>
     <string name="overview_troubleshoot_suggestion_action">Executa el solucionador de problemes</string>
     <string name="overview_unmatched_devices_label">Dispositius no coincidents</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositiu sense perfil coincident</item>
-        <item quantity="other">%d dispositius sense perfil coincident</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">S\'ha detectat %d dispositiu proper sense un perfil coincident. Mostreu-lo per veure els detalls disponibles. Si és vostre, afegiu un perfil des de Dispositius per reconèixer-lo.</item>
         <item quantity="other">S\'han detectat %d dispositius propers sense perfils coincidents. Mostreu-los per veure els detalls disponibles. Si algun és vostre, afegiu un perfil des de Dispositius per reconèixer-lo.</item>
@@ -232,7 +207,6 @@
     <string name="permission_background_location_description">El CAPod utilitza «accés a la ubicació de fons» per activar funcions com «Mostra la finestra emergent» i «Connexió automàtica» mentre l\'aplicació està tancada. L\'accés a la ubicació de fons permet que l\'aplicació rebi dades Bluetooth de baix consum mentre està en segon pla. Aquesta aplicació NO utilitzarà dades Bluetooth per determinar la vostra ubicació.</string>
     <string name="permission_ignore_battery_optimizations_label">Desactiva les optimitzacions de la bateria</string>
     <string name="permission_ignore_battery_optimizations_description">Les optimitzacions de la bateria impedeixen que aquesta aplicació rebi dades Bluetooth de manera fiable mentre l\'aplicació està en segon pla.</string>
-    <string name="permission_required_title">Cal el permís següent:</string>
     <string name="permission_system_alert_window_label">Finestra d\'alerta del sistema</string>
     <string name="permission_system_alert_window_description">Permet que el CAPod dibuixi sobre altres aplicacions per fer possible la característica «Mostra emergent».</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Quan es veu</string>
@@ -240,9 +214,6 @@
     <string name="settings_reaction_autoconnect_inear_label">A l\'orella</string>
     <string name="pods_dual_left_label">Auricular esquerre</string>
     <string name="pods_dual_right_label">Auricular dret</string>
-    <string name="pods_dual_left_short_label">E</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Funda</string>
     <string name="battery_unavailable_label">Bateria no disponible</string>
     <string name="battery_state_low_cd">Bateria baixa</string>
     <string name="battery_state_critical_cd">Bateria críticament baixa</string>
@@ -295,12 +266,9 @@
     <string name="signal_badge_aap_cd">Connexió directa activa</string>
     <string name="signal_indicator_bars_cd">Intensitat del senyal: %1$d de 4 barres</string>
     <string name="signal_indicator_disconnected_cd">Senyal: desconnectat</string>
-    <string name="pods_yours">Vostre</string>
     <string name="headset_being_worn_label">En ús</string>
     <string name="headset_not_being_worn_label">No s\'utilitzen</string>
     <string name="pods_case_unknown_state">Estat desconegut</string>
-    <string name="last_seen_x">Últim cop vist: %s</string>
-    <string name="first_seen_x">Primera vegada vist: %s</string>
     <string name="battery_cached_label">Última vegada vist · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -330,10 +298,8 @@
     <string name="profiles_signal_quality_title">Qualitat mínima del senyal</string>
     <string name="profiles_signal_quality_description">Només es detecten dispositius amb una intensitat de senyal superior a aquest llindar. Els valors més baixos augmenten el rang de detecció, però poden causar falsos positius. No configureu aquest valor massa alt: la recepció Bluetooth generalment és deficient i varia segons la distància i els obstacles.</string>
     <string name="profiles_identitykey_label">Clau d\'identitat</string>
-    <string name="profilessettings_maindevice_identitykey_description">La clau de resolució d\'identitat (IRK) del dispositiu ajuda al CAPod a identificar-lo entre els dispositius propers.</string>
     <string name="profiles_maindevice_identitykey_explanation">Els AirPods canvien sovint la seva adreça Bluetooth per motius de privadesa. L\'IRK ajuda al CAPod a reconèixer el vostre dispositiu. Necessiteu accés únic a un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Clau de xifratge</string>
-    <string name="profiles_maindevice_encryptionkey_description">La clau de xifratge del vostre dispositiu permet al CAPod recuperar informació detallada de l\'estat.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Els AirPods envien un missatge d\'estat, una part està xifrada. La clau de xifratge permet que el CAPod desxifri el missatge complet. Necessiteu accedir una sola vegada a un MacBook.</string>
     <string name="profiles_key_invalid_format">Format de clau no vàlid</string>
     <string name="profiles_key_expected_format">Format esperat: %1$s</string>
@@ -366,7 +332,6 @@
     <string name="general_unsaved_changes_message">Teniu canvis sense desar. Què voleu fer?</string>
     <string name="general_save_and_exit_action">Desa i surt</string>
     <string name="general_discard_action">Descarta</string>
-    <string name="general_keep_editing_action">Continua editant</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Gravació massa curta</string>
     <string name="debug_debuglog_short_recording_message">Un registre de depuració ha de capturar el problema mentre es produeix. Continueu la gravació, reproduïu el problema i després atureu-la.</string>
@@ -437,7 +402,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Configuració del dispositiu</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nom</string>
     <string name="device_settings_info_bt_name_label">Etiqueta del dispositiu Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Fabricant</string>
@@ -517,7 +481,6 @@
     <string name="review_app_dismiss_action">Potser més tard</string>
     <string name="review_app_body">Vols deixar una ressenya del CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micròfon</string>
     <string name="device_settings_microphone_mode_description">Quin auricular s\'utilitza com a micròfon</string>
     <string name="device_settings_microphone_mode_auto">Automàtic</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Sdílet</string>
     <string name="general_done_action">Hotovo</string>
     <string name="general_cancel_action">Zrušit</string>
-    <string name="general_copy_action">Kopírovat</string>
     <string name="general_thank_you_label">Děkuji Vám</string>
     <string name="general_upgrade_action">Upgradovat</string>
     <string name="general_retry_action">Opakovat</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Ověřit</string>
     <string name="general_close_action">Zavřít</string>
     <string name="general_dismiss_action">Zavřít</string>
-    <string name="general_edit_action">Upravit</string>
     <string name="general_save_action">Uložit</string>
     <string name="general_guide_action">Průvodce</string>
     <string name="general_continue_action">Pokračovat</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Obnoví přehrávání hudby po opětovném nasazení sluchátek, ale pouze pokud ji zastavilo Auto pozastavení. Pauzy, které jste spustili sami (telefon, ovladač AirPods, spánek), zůstanou pozastaveny.</string>
     <string name="settings_start_music_on_wear_label">Spustit hudbu při nasazení</string>
     <string name="settings_start_music_on_wear_description">Vždy se pokusí přehrát hudbu při nasazení sluchátek, i po ručním pozastavení.</string>
-    <string name="settings_eardetection_info_label">Poznámka k detekci ucha</string>
     <string name="settings_eardetection_info_description">Pokud detekce sluchátek funguje pouze pro jedno sluchátko, jedná se o omezení společnosti Apple. Detekováno je pouze \"primární sluchátko\" (používané jako mikrofon). Konfigurace na zařízeních Apple: Nastavení → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimální kvalita signálu</string>
-    <string name="settings_signal_minimum_description">Minimální kvalita signálu, kterou musí zařízení mít, aby bylo považováno za vaše.</string>
     <string name="settings_autoconnect_label">Automatické připojení</string>
     <string name="settings_autoconnect_description">Pokud se Android automaticky nepřipojí, můžeme ho o to požádat. Díky tomu CAPod stále monitoruje na pozadí.</string>
     <string name="settings_autoconnect_info_android12">Automatické připojení závisí na systémové funkci, kterou Android 12 a novější omezuje. Na vašem zařízení nemusí fungovat.</string>
     <string name="settings_autoconnect_condition_label">Stav automatického připojení</string>
-    <string name="settings_autoconnect_condition_description">Kdy se máme pokusit připojit k vašemu zařízení?</string>
     <string name="settings_devices_label">Zařízení</string>
     <string name="settings_devices_description">Správa zařízení.</string>
     <string name="settings_reaction_label">Reakce</string>
-    <string name="settings_category_yourdevice_label">Vaše zařízení</string>
     <string name="settings_category_compatibility_options_title">Možnosti kompatibility</string>
     <string name="settings_category_compatibility_options_description">Nedotýkejte se, pokud vše funguje ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Vypnout hardwarové filtrování</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Spouštění…</string>
     <string name="support_debuglog_label">Log ladění</string>
     <string name="support_debuglog_desc">Zaznamenávejte vše, co aplikace dělá, do textového souboru, který můžete sdílet.</string>
-    <string name="debug_debuglog_size_label">Velikost</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimovaná velikost</string>
-    <string name="debug_notification_channel_label">Oznámení o ladění</string>
-    <string name="debug_debuglog_file_label">Zaznamenaný log soubor</string>
-    <string name="debug_debuglog_recording_progress">Zaznamenávání logu ladění</string>
     <string name="debug_debuglog_record_action">Zaznamenat log ladění</string>
     <string name="debug_debuglog_stop_action">Ukončit zaznamenávání</string>
     <string name="debug_debuglog_sensitive_information_message">Vygenerovaný soubor obsahuje citlivé informace (např. podrobnosti o zařízení Bluetooth). Sdílejte ho pouze s důvěryhodnými stranami.</string>
     <string name="settings_debuglog_explanation">Tato funkce zaznamenává vše, co aplikace dělá do souboru pro sdílení. Vygenerovaný soubor obsahuje citlivé informace (např. detaily o zařízení Bluetooth). Sdílejte ho pouze s důvěryhodnými stranami (např. vývojář, který řeší problémy).</string>
-    <string name="settings_support_installid_label">ID instalace</string>
-    <string name="settings_support_installid_desc">Automatická hlášení chyb jsou anonymní. Sdílíte pouze své ID instalace, pokud vývojář potřebuje najít vaše chybová hlášení.</string>
     <string name="settings_support_label">Podpora</string>
     <string name="settings_support_description">Potřebujete-li pomoc.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Obnovit naučená data?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod zapomene naměřený úbytek, rychlost nabíjení a dobu poslechu tohoto zařízení a začne znovu od deklarované výdrže baterie.</string>
     <string name="settings_acknowledgements_label">Poděkování</string>
-    <string name="settings_debug_autoreports_label">Automatické hlášení chyb</string>
-    <string name="settings_debug_autoreports_description">Automatické hlášení chyb např. podrobnosti o pádech aplikace.</string>
-    <string name="settings_compatibility_mode_label">Režim kompatibility</string>
-    <string name="settings_compatibility_mode_description">Vypnutí optimalizace pro zlepšení kompatibility. Zkuste to, pokud se vám nezobrazují žádná data.</string>
     <string name="help_translate_label">Překlad</string>
     <string name="help_translate_description">Pomozte přeložit tuto aplikaci do svého oblíbeného jazyka.</string>
     <string name="translators_thanks_title">Překladatelé</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Úspěch</string>
     <string name="troubleshooter_ble_result_success_body">CAPod přijímá reklamní vysílání BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Neúspěšné</string>
-    <string name="troubleshooter_ble_result_failure_body">Řešení problémů se nezdařilo. Žádná kombinace možností kompatibility nepomohla.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefon nepřijal vůbec žádná data BLE. Tento test můžete zopakovat v přelidněném prostoru, abyste zjistili, zda lze přijímat i jiné zdroje dat (než vaše sluchátka). Nepřijímání dat ukazuje na problém s operačním systémem telefonu.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefon přijal data BLE, ale data nepocházejí z žádného podporovaného zařízení. Jsou sluchátka zapnutá? Podporuje CAPod vaše sluchátka?</string>
-    <string name="troubleshooter_ble_result_failure_action">Zkusit znovu</string>
-    <string name="troubleshoot_action">Vyřešit problém</string>
     <string name="onboarding_body1">Tato aplikace přidává do Androidu podporu specifických funkcí AirPods.</string>
     <string name="onboarding_body2">Ne všechna zařízení s Androidem plně podporují speciální funkce AirPods.</string>
     <string name="onboarding_body3">CAPod neobsahuje žádné reklamy a neshromažďuje vaše údaje.</string>
@@ -207,12 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Zařízení je připojeno, ale CAPod od něj nepřijímá žádná živá data. Váš telefon může potřebovat možnost kompatibility — řešení problémů ji může zkusit najít automaticky.</string>
     <string name="overview_troubleshoot_suggestion_action">Spustit řešení problémů</string>
     <string name="overview_unmatched_devices_label">Nepřiřazená zařízení</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d zařízení bez odpovídajícího profilu</item>
-        <item quantity="few">%d zařízení bez odpovídajícího profilu</item>
-        <item quantity="many">%d zařízení bez odpovídajícího profilu</item>
-        <item quantity="other">%d zařízení bez odpovídajícího profilu</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Bylo zjištěno %d blízké zařízení bez odpovídajícího profilu. Zobrazte je pro dostupné podrobnosti. Pokud je vaše, přidejte profil v Zařízeních, abyste ho rozpoznali.</item>
         <item quantity="few">Byla zjištěna %d blízká zařízení bez odpovídajících profilů. Zobrazte je pro dostupné podrobnosti. Pokud je jedno vaše, přidejte profil v Zařízeních, abyste ho rozpoznali.</item>
@@ -237,7 +210,6 @@
     <string name="permission_background_location_description">Aplikace CAPod používá \"přístup k poloze na pozadí\" pro funkce jako \"Zobrazit vyskakovací okno\" a \"Automatické připojení\", když je aplikace zavřená. Přístup k poloze na pozadí umožňuje aplikaci přijímat data Bluetooth Low Energy, když je na pozadí. Tato aplikace NEPOUŽÍVÁ data Bluetooth k určování vaší polohy.</string>
     <string name="permission_ignore_battery_optimizations_label">Vypnout optimalizaci baterie</string>
     <string name="permission_ignore_battery_optimizations_description">Optimalizace baterie zabraňuje této aplikaci spolehlivě přijímat data Bluetooth, pokud běží na pozadí.</string>
-    <string name="permission_required_title">Je vyžadováno následující oprávnění:</string>
     <string name="permission_system_alert_window_label">Okno systémových upozornění</string>
     <string name="permission_system_alert_window_description">Aby bylo možné použít unkci \"Zobrazit vyskakovací okno\", je nutné umožnit aplikaci CAPod vykreslení přes jiné aplikace.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Když je vidět</string>
@@ -245,9 +217,6 @@
     <string name="settings_reaction_autoconnect_inear_label">V uchu</string>
     <string name="pods_dual_left_label">Levé sluchátko</string>
     <string name="pods_dual_right_label">Pravé sluchátko</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">P</string>
-    <string name="pods_case_label">Pouzdro</string>
     <string name="battery_unavailable_label">Baterie nedostupná</string>
     <string name="battery_state_low_cd">Baterie je slabá</string>
     <string name="battery_state_critical_cd">Baterie je kriticky slabá</string>
@@ -304,12 +273,9 @@
     <string name="signal_badge_aap_cd">Přímé připojení aktivní</string>
     <string name="signal_indicator_bars_cd">Síla signálu: %1$d ze 4 dílků</string>
     <string name="signal_indicator_disconnected_cd">Signál: odpojeno</string>
-    <string name="pods_yours">Vaše</string>
     <string name="headset_being_worn_label">Používá se</string>
     <string name="headset_not_being_worn_label">Nepoužíváno</string>
     <string name="pods_case_unknown_state">Neznámý stav</string>
-    <string name="last_seen_x">Naposledy spatřeno: %s</string>
-    <string name="first_seen_x">Poprvé spatřeno: %s</string>
     <string name="battery_cached_label">Poslední známé \u00B7 %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -339,10 +305,8 @@
     <string name="profiles_signal_quality_title">Minimální kvalita signálu</string>
     <string name="profiles_signal_quality_description">Detekujte pouze zařízení s intenzitou signálu nad touto prahovou hodnotou. Nižší hodnoty zvyšují dosah detekce, ale mohou způsobit falešné poplachy. Nenastavujte tuto hodnotu příliš vysoko - příjem signálu Bluetooth je obecně slabý a mění se v závislosti na vzdálenosti a překážkách.</string>
     <string name="profiles_identitykey_label">Klíč identity</string>
-    <string name="profilessettings_maindevice_identitykey_description">Klíč identity (IRK) vašeho zařízení, který pomáhá aplikaci CAPod identifikovat jej mezi okolními zařízeními.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods často mění svou Bluetooth adresu pro ochranu soukromí. IRK pomáhá aplikaci CAPod rozpoznat vaše zařízení. Potřebujete jednorázový přístup k MacBooku.</string>
     <string name="profiles_maindevice_encryptionkey_label">Šifrovací klíč</string>
-    <string name="profiles_maindevice_encryptionkey_description">Šifrovací klíč vašeho zařízení, který umožňuje aplikaci CAPod získat podrobné informace o stavu.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods odesílají zprávu o stavu, jejíž část je zašifrovaná. Šifrovací klíč umožňuje aplikaci CAPod dešifrovat celou zprávu. Potřebujete jednorázový přístup k MacBooku.</string>
     <string name="profiles_key_invalid_format">Neplatný formát klíče</string>
     <string name="profiles_key_expected_format">Očekávaný formát: %1$s</string>
@@ -375,7 +339,6 @@
     <string name="general_unsaved_changes_message">Máte neuložené změny. Co chcete provést?</string>
     <string name="general_save_and_exit_action">Uložit a ukončit</string>
     <string name="general_discard_action">Zahodit</string>
-    <string name="general_keep_editing_action">Pokračovat v úpravách</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Záznam je příliš krátký</string>
     <string name="debug_debuglog_short_recording_message">Log ladění musí zachytit problém v okamžiku, kdy nastane. Pokračujte v zaznamenávání, reprodukujte problém a poté zaznamenávání ukončete.</string>
@@ -452,7 +415,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Nastavení zařízení</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Název</string>
     <string name="device_settings_info_bt_name_label">Název zařízení Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Výrobce</string>
@@ -532,7 +494,6 @@
     <string name="review_app_dismiss_action">Možná později</string>
     <string name="review_app_body">Chceš ohodnotit CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Obecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Které sluchátko je použito jako mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Autom.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Del</string>
     <string name="general_done_action">Færdig</string>
     <string name="general_cancel_action">Annuller</string>
-    <string name="general_copy_action">Kopiér</string>
     <string name="general_thank_you_label">Tak</string>
     <string name="general_upgrade_action">Opgrader</string>
     <string name="general_retry_action">Prøv igen</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontrollér</string>
     <string name="general_close_action">Luk</string>
     <string name="general_dismiss_action">Afvis</string>
-    <string name="general_edit_action">Rediger</string>
     <string name="general_save_action">Gem</string>
     <string name="general_guide_action">Vejledning</string>
     <string name="general_continue_action">Fortsæt</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Genoptag musik, når du sætter dine pods på igen, men kun hvis Auto pause stoppede det. Pauser du selv udløste (telefon, AirPods-stift, søvn) forbliver sat på pause.</string>
     <string name="settings_start_music_on_wear_label">Start musik ved iføring</string>
     <string name="settings_start_music_on_wear_description">Forsøger altid at afspille musik, når du sætter dine pods på, selv efter en manuel pause.</string>
-    <string name="settings_eardetection_info_label">Bemærkning om øredetektion</string>
     <string name="settings_eardetection_info_description">Hvis øredetektion kun virker for én pod, er dette en Apple-begrænsning. Kun den \"primære pod\" (brugt til mikrofon) detekteres. Konfigurer på Apple-enheder: Indstillinger → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimum signalkvalitet</string>
-    <string name="settings_signal_minimum_description">Den minimum signalkvalitet, en enhed skal have for at blive betragtet som din.</string>
     <string name="settings_autoconnect_label">Auto-tilslut</string>
     <string name="settings_autoconnect_description">Hvis Android ikke opretter forbindelse automatisk, kan vi bede det om det. Dette holder CAPod-overvågning kørende i baggrunden hele tiden.</string>
     <string name="settings_autoconnect_info_android12">Auto-forbindelse er afhængig af en systemfunktion, som Android 12 og nyere begrænser. Det virker muligvis ikke på din enhed.</string>
     <string name="settings_autoconnect_condition_label">Auto-tilslutningsbetingelse</string>
-    <string name="settings_autoconnect_condition_description">Hvornår skal vi forsøge at tilslutte til din enhed?</string>
     <string name="settings_devices_label">Enheder</string>
     <string name="settings_devices_description">Administrer dine enheder.</string>
     <string name="settings_reaction_label">Reaktioner</string>
-    <string name="settings_category_yourdevice_label">Din enhed</string>
     <string name="settings_category_compatibility_options_title">Kompatibilitetsindstillinger</string>
     <string name="settings_category_compatibility_options_description">Rør ikke, hvis alt virker ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Deaktiver hardwarefiltrering</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Starter op…</string>
     <string name="support_debuglog_label">Fejlfindingslog</string>
     <string name="support_debuglog_desc">Optag alt, hvad appen gør, i en tekstfil, som du kan dele.</string>
-    <string name="debug_debuglog_size_label">Størrelse</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimeret størrelse</string>
-    <string name="debug_notification_channel_label">Fejlfindingsnotifikationer</string>
-    <string name="debug_debuglog_file_label">Optaget logfil</string>
-    <string name="debug_debuglog_recording_progress">Optager fejlfindingslog</string>
     <string name="debug_debuglog_record_action">Optag fejlfindingslog</string>
     <string name="debug_debuglog_stop_action">Stop optagelse</string>
     <string name="debug_debuglog_sensitive_information_message">Den genererede fil indeholder følsomme oplysninger (f.eks. Bluetooth-enhedsdetaljer). Del den kun med betroede parter.</string>
     <string name="settings_debuglog_explanation">Denne funktion optager alt, hvad appen gør, i en delbar fil. Den genererede fil indeholder følsomme oplysninger (f.eks. Bluetooth-enhedsdetaljer). Del den kun med betroede parter (f.eks. en udvikler, der fejlfinder et problem).</string>
-    <string name="settings_support_installid_label">Installations-ID</string>
-    <string name="settings_support_installid_desc">Automatiske fejlrapporter er anonyme. Del dit installations-ID, hvis udvikleren har brug for at finde dine fejlrapporter.</string>
     <string name="settings_support_label">Support</string>
     <string name="settings_support_description">Hvis du har brug for hjælp.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Nulstil indlærte data?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod vil glemme denne enheds målte forbrug, opladningshastighed og lyttetid, og starte forfra fra den nominelle batterilevetid.</string>
     <string name="settings_acknowledgements_label">Anerkendelser</string>
-    <string name="settings_debug_autoreports_label">Automatiske fejlrapporter</string>
-    <string name="settings_debug_autoreports_description">Rapporterer automatisk problemer, f.eks. detaljer om et app-nedbrud, så jeg kan finde ud af, hvordan jeg løser det.</string>
-    <string name="settings_compatibility_mode_label">Kompatibilitetstilstand</string>
-    <string name="settings_compatibility_mode_description">Deaktiver optimeringer for at forbedre kompatibiliteten. Prøv dette, hvis du ikke ser nogen data.</string>
     <string name="help_translate_label">Oversættelse</string>
     <string name="help_translate_description">Hjælp med at oversætte denne app til dit yndlingssprog.</string>
     <string name="translators_thanks_title">Oversættere</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Succes</string>
     <string name="troubleshooter_ble_result_success_body">BLE-annonceudsendelser modtages af CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Mislykket</string>
-    <string name="troubleshooter_ble_result_failure_body">Fejlfinding mislykkedes. Ingen kombination af kompatibilitetsindstillinger hjalp.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Din telefon modtog slet ingen BLE-data. Du kan prøve denne test igen i et overfyldt område for at se, om datakilder (ud over dine hovedtelefoner) kan modtages. Ingen modtagne data peger på et problem med din telefons operativsystem.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Din telefon modtog BLE-data, men dataene kommer ikke fra nogen understøttet enhed. Er dine hovedtelefoner tændt? Understøtter CAPod dine hovedtelefoner?</string>
-    <string name="troubleshooter_ble_result_failure_action">Prøv igen</string>
-    <string name="troubleshoot_action">Fejlfind</string>
     <string name="onboarding_body1">Denne app tilføjer understøttelse af AirPod-specifikke funktioner til Android.</string>
     <string name="onboarding_body2">Ikke alle Android-enheder understøtter fuldt ud de ekstra AirPod-funktioner. Dit operativsystem kræver en korrekt fungerende Bluetooth Low Energy-implementering.</string>
     <string name="onboarding_body3">CAPod har ingen annoncer og indsamler ikke dine data.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Din enhed er forbundet, men CAPod modtager ikke live data fra den. Din telefon har måske brug for en kompatibilitetsindstilling — fejlfinderen kan prøve at finde en automatisk.</string>
     <string name="overview_troubleshoot_suggestion_action">Kør fejlfinder</string>
     <string name="overview_unmatched_devices_label">Uparrede enheder</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d enhed uden matchende profil</item>
-        <item quantity="other">%d enheder uden matchende profil</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Der blev registreret %d enhed i nærheden uden en matchende profil. Vis den for at se flere detaljer. Hvis den er din, kan du tilføje en profil fra Enheder for at genkende den.</item>
         <item quantity="other">Der blev registreret %d enheder i nærheden uden matchende profiler. Vis dem for at se flere detaljer. Hvis en af dem er din, kan du tilføje en profil fra Enheder for at genkende den.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod bruger \"baggrundsplaceringsadgang\" til at aktivere funktioner som \"Vis pop op\" og \"Auto-tilslut\", mens appen er lukket. Baggrundsplaceringsadgang gør det muligt for appen at modtage Bluetooth Low Energy-data, mens den er i baggrunden. Denne app vil IKKE bruge Bluetooth-data til at bestemme din placering.</string>
     <string name="permission_ignore_battery_optimizations_label">Deaktiver batterioptimeringer</string>
     <string name="permission_ignore_battery_optimizations_description">Batterioptimeringer forhindrer denne app i pålideligt at modtage Bluetooth-data, mens appen er i baggrunden.</string>
-    <string name="permission_required_title">Følgende tilladelse er påkrævet:</string>
     <string name="permission_system_alert_window_label">Systemalarmvindue</string>
     <string name="permission_system_alert_window_description">Tillad CAPod at tegne over andre apps for at gøre funktionen \"Vis pop op\" mulig.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Når den ses</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">I øret</string>
     <string name="pods_dual_left_label">Venstre pod</string>
     <string name="pods_dual_right_label">Højre pod</string>
-    <string name="pods_dual_left_short_label">V</string>
-    <string name="pods_dual_right_short_label">H</string>
-    <string name="pods_case_label">Etui</string>
     <string name="battery_unavailable_label">Batteri utilgængeligt</string>
     <string name="battery_state_low_cd">Batteri lavt</string>
     <string name="battery_state_critical_cd">Batteri kritisk lavt</string>
@@ -293,12 +264,9 @@
     <string name="signal_badge_aap_cd">Direkte forbindelse aktiv</string>
     <string name="signal_indicator_bars_cd">Signalstyrke: %1$d af 4 bjælker</string>
     <string name="signal_indicator_disconnected_cd">Signal: afbrudt</string>
-    <string name="pods_yours">Din</string>
     <string name="headset_being_worn_label">Bæres</string>
     <string name="headset_not_being_worn_label">Bæres ikke</string>
     <string name="pods_case_unknown_state">Ukendt tilstand</string>
-    <string name="last_seen_x">Sidst set: %s</string>
-    <string name="first_seen_x">Først set: %s</string>
     <string name="battery_cached_label">Sidst kendte · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dt %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dt</string>
@@ -328,10 +296,8 @@
     <string name="profiles_signal_quality_title">Minimum signalkvalitet</string>
     <string name="profiles_signal_quality_description">Registrer kun enheder med signalstyrke over denne tærskel. Lavere værdier øger registreringsrækkevidden, men kan forårsage falske positive resultater. Sæt den ikke for højt - Bluetooth-modtagelse er generelt dårlig og varierer med afstand og forhindringer.</string>
     <string name="profiles_identitykey_label">Identitetsnøgle</string>
-    <string name="profilessettings_maindevice_identitykey_description">Din enheds Identity Resolving Key (IRK), som hjælper CAPod med at identificere den blandt enheder i nærheden.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ændrer ofte deres Bluetooth-adresse af hensyn til privatlivet. IRK hjælper CAPod med at genkende din enhed. Du har brug for engangsadgang til en MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Krypteringsnøgle</string>
-    <string name="profiles_maindevice_encryptionkey_description">Din enheds krypteringsnøgle, som gør det muligt for CAPod at hente detaljerede statusoplysninger.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods sender en statusmeddelelse, hvoraf en del er krypteret. Krypteringsnøglen gør det muligt for CAPod at dekryptere hele meddelelsen. Du har brug for engangsadgang til en MacBook.</string>
     <string name="profiles_key_invalid_format">Ugyldigt nøgleformat</string>
     <string name="profiles_key_expected_format">Forventet format: %1$s</string>
@@ -364,7 +330,6 @@
     <string name="general_unsaved_changes_message">Du har ikke-gemte ændringer. Hvad vil du gøre?</string>
     <string name="general_save_and_exit_action">Gem &amp; Afslut</string>
     <string name="general_discard_action">Kassér</string>
-    <string name="general_keep_editing_action">Fortsæt redigering</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Optagelse for kort</string>
     <string name="debug_debuglog_short_recording_message">En fejllog skal optage problemet, mens det sker. Fortsæt optagelsen, genopret problemet, og stop så optagelsen.</string>
@@ -435,7 +400,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Enhedsindstillinger</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Navn</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-enhedsnavn</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producent</string>
@@ -515,7 +479,6 @@
     <string name="review_app_dismiss_action">Måske senere</string>
     <string name="review_app_body">Har du lyst til at give CAPod en anmeldelse? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Generel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Hvilken øretelefon der bruges som mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Teilen</string>
     <string name="general_done_action">Fertig</string>
     <string name="general_cancel_action">Abbrechen</string>
-    <string name="general_copy_action">Kopieren</string>
     <string name="general_thank_you_label">Danke</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="general_retry_action">Erneut versuchen</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Überprüfen</string>
     <string name="general_close_action">Schließen</string>
     <string name="general_dismiss_action">Ausblenden</string>
-    <string name="general_edit_action">Bearbeiten</string>
     <string name="general_save_action">Speichern</string>
     <string name="general_guide_action">Anleitung</string>
     <string name="general_continue_action">Fortfahren</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Musik fortsetzen, sobald du deine Pods wieder trägst – aber nur, wenn Auto-Pause sie gestoppt hat. Von dir selbst ausgelöste Pausen (Telefon, AirPods-Stiel, Schlaf) bleiben aktiv.</string>
     <string name="settings_start_music_on_wear_label">Musik fortsetzen beim Einsetzen</string>
     <string name="settings_start_music_on_wear_description">Versucht immer, Musik abzuspielen, wenn du deine Pods einsetzt – auch nach einer manuellen Pause.</string>
-    <string name="settings_eardetection_info_label">Hinweis zur Ohr-Erkennung</string>
     <string name="settings_eardetection_info_description">Wenn die Ohr-Erkennung nur für einen Pod funktioniert, ist das leider Apple-Einschränkung. Es wird dann nur der \"primäre Pod\" (Mikrofon) erkannt. Weitere Konfiguration auf Apple-Geräten: Einstellungen → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimale Signalqualität</string>
-    <string name="settings_signal_minimum_description">Die minimale Signalqualität, die ein Gerät haben muss, damit als Deins erkannt wird.</string>
     <string name="settings_autoconnect_label">Automatisch verbinden</string>
     <string name="settings_autoconnect_description">Wenn Android nicht automatisch verbindet, können wir es dazu auffordern. So läuft die CAPod-Überwachung durchgehend im Hintergrund.</string>
     <string name="settings_autoconnect_info_android12">Auto-Verbindung setzt eine Systemfunktion voraus, die Android 12 und neuer einschränkt. Es funktioniert möglicherweise nicht auf deinem Gerät.</string>
     <string name="settings_autoconnect_condition_label">Bedingung für automatische Verbindung</string>
-    <string name="settings_autoconnect_condition_description">Wann sollten wir versuchen, eine Verbindung zu Deinem Gerät herzustellen?</string>
     <string name="settings_devices_label">Geräte</string>
     <string name="settings_devices_description">Verwalte Deine Geräte.</string>
     <string name="settings_reaction_label">Reaktionen</string>
-    <string name="settings_category_yourdevice_label">Dein Gerät</string>
     <string name="settings_category_compatibility_options_title">Kompatibilitätsoptionen</string>
     <string name="settings_category_compatibility_options_description">Nicht anfassen, wenn alles funktioniert ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Hardware-Filterung deaktivieren</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Wird gestartet…</string>
     <string name="support_debuglog_label">Debug-Protokoll</string>
     <string name="support_debuglog_desc">Zeichne alle Aktivitäten der App in einer Textdatei auf, die du weitergeben kannst.</string>
-    <string name="debug_debuglog_size_label">Größe</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimierte Größe</string>
-    <string name="debug_notification_channel_label">Debug Benachrichtigungen</string>
-    <string name="debug_debuglog_file_label">Aufgezeichnete Protokolldatei</string>
-    <string name="debug_debuglog_recording_progress">Aufzeichnen des Debug-Protokolls</string>
     <string name="debug_debuglog_record_action">Debug-Protokoll aufzeichnen</string>
     <string name="debug_debuglog_stop_action">Aufnahme beenden</string>
     <string name="debug_debuglog_sensitive_information_message">Die generierte Datei enthält vertrauliche Informationen (z. B. Bluetooth-Gerätedetails). Gebe sie nur an vertrauenswürdige Parteien weiter.</string>
     <string name="settings_debuglog_explanation">Diese Funktion zeichnet alle Aktivitäten der App in einer gemeinsam nutzbaren Datei auf. Die generierte Datei enthält vertrauliche Informationen (z. B. Bluetooth-Gerätedetails). Gebe sie nur an vertrauenswürdige Parteien weiter (z. B. einen Entwickler, der ein Problem behebt).</string>
-    <string name="settings_support_installid_label">Installations-ID</string>
-    <string name="settings_support_installid_desc">Automatische Fehlermeldungen sind anonym. Teilen Sie Ihre Installations- ID dem Entwickler mit, wenn er Ihre Fehlerberichte finden muss.</string>
     <string name="settings_support_label">Unterstützung</string>
     <string name="settings_support_description">Wenn du Hilfe brauchst.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Gelernte Daten zurücksetzen?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod wird den gemessenen Verbrauch, die Ladegeschwindigkeit und die Hörzeit dieses Geräts zurücksetzen und mit der Nennlaufzeit neu beginnen.</string>
     <string name="settings_acknowledgements_label">Danksagungen</string>
-    <string name="settings_debug_autoreports_label">Automatische Fehlerberichte</string>
-    <string name="settings_debug_autoreports_description">Meldet Probleme automatisch, z.B. Details zu einem App-Absturz, damit ich herausfinden kann, wie ich ihn beheben kann.</string>
-    <string name="settings_compatibility_mode_label">Kompatibilitätsmodus</string>
-    <string name="settings_compatibility_mode_description">Deaktiviere Optimierungen, um die Kompatibilität zu verbessern. Probier diese Option, wenn gar keine Daten angezeigt werden.</string>
     <string name="help_translate_label">Übersetzung</string>
     <string name="help_translate_description">Hilf mit die App in deine Lieblingssprache zu übersetzen.</string>
     <string name="translators_thanks_title">Übersetzer</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Erfolg</string>
     <string name="troubleshooter_ble_result_success_body">BLE-Advertisement Pakete werden von CAPod empfangen.</string>
     <string name="troubleshooter_ble_result_failure_title">Fehlgeschlagen</string>
-    <string name="troubleshooter_ble_result_failure_body">Fehlerbehebung fehlgeschlagen. Keine Kombination von Kompatibilitätsoptionen hat geholfen.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Dein Telefon hat überhaupt keine BLE-Daten empfangen. Du könntest diesen Test in einem überfüllten Bereich wiederholen, um zu sehen, ob Datenquellen (außer Ihren Kopfhörern) empfangen werden können. Es werden keine Daten empfangen, was auf ein Problem mit dem Betriebssystem Ihres Telefons hindeutet.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Dein Telefon hat BLE-Daten empfangen, aber die Daten stammen von keinem unterstützten Gerät. Sind Deine Kopfhörer eingeschaltet? Unterstützt CAPod Deinen Kopfhörer?</string>
-    <string name="troubleshooter_ble_result_failure_action">Erneut versuchen</string>
-    <string name="troubleshoot_action">Fehlerbehebung</string>
     <string name="onboarding_body1">Diese App fügt Support für AirPod-Spezifische funkionen zu Android hinzu.</string>
     <string name="onboarding_body2">Nicht alle Android-Geräte unterstützen die zusätzlichen AirPod-Funktionen vollständig. Dein Betriebssystem braucht eine korrekt funktionierende Bluetooth-Low-Energy-Implementierung.</string>
     <string name="onboarding_body3">CAPod hat keine Werbung und sammelt Deine Daten nicht.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Dein Gerät ist verbunden, aber CAPod empfängt keine Livedaten. Dein Smartphone benötigt möglicherweise eine Kompatibilitätsoption – die Fehlersuche kann versuchen, automatisch eine zu finden.</string>
     <string name="overview_troubleshoot_suggestion_action">Fehlerbehebung starten</string>
     <string name="overview_unmatched_devices_label">Nicht zugeordnete Geräte</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d Gerät ohne passendes Profil</item>
-        <item quantity="other">%d Geräte ohne passendes Profil</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d nahegelegenes Gerät wurde ohne passendes Profil erkannt. Tippe darauf für verfügbare Details. Wenn es dir gehört, füge unter „Geräte“ ein Profil hinzu, um es zu erkennen.</item>
         <item quantity="other">%d nahegelegene Geräte wurden ohne passende Profile erkannt. Tippe darauf für verfügbare Details. Wenn eines davon dir gehört, füge unter „Geräte“ ein Profil hinzu, um es zu erkennen.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod nutzt \"Standort Zugriff im Hintergrund\" um Funktionen wie \"Pop-up anzeigen\" und \"AutoConnect\" zu verwenden während die App geschlossen ist. Standort Zugriff im Hintergrund erlaubt der App Bluetooth Low Energy Daten im Hintergrund zu erhalten und NICHT deinen Standort zu finden.</string>
     <string name="permission_ignore_battery_optimizations_label">Batterie Optimierung deaktivieren</string>
     <string name="permission_ignore_battery_optimizations_description">Batterie Optimierung hindert die App daran Bluetooth Daten zu erhalten während die App im Hintergrund ist.</string>
-    <string name="permission_required_title">Die folgende Genehmigung ist erforderlich:</string>
     <string name="permission_system_alert_window_label">Systemwarnungsfenster</string>
     <string name="permission_system_alert_window_description">Erlaube CAPod, PopUp Benachrichtigungen über anderen Apps anzuzeigen.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Wann gesehen</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Im Ohr</string>
     <string name="pods_dual_left_label">Linker Pod</string>
     <string name="pods_dual_right_label">Rechter Pod</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">Ladecase</string>
     <string name="battery_unavailable_label">Akku nicht verfügbar</string>
     <string name="battery_state_low_cd">Akku schwach</string>
     <string name="battery_state_critical_cd">Akku kritisch schwach</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Direkte Verbindung aktiv</string>
     <string name="signal_indicator_bars_cd">Signalstärke: %1$d von 4 Balken</string>
     <string name="signal_indicator_disconnected_cd">Signal: getrennt</string>
-    <string name="pods_yours">Deins</string>
     <string name="headset_being_worn_label">Wird Getragen</string>
     <string name="headset_not_being_worn_label">Wird nicht getragen</string>
     <string name="pods_case_unknown_state">Unbekannter Zustand</string>
-    <string name="last_seen_x">Zuletzt gesehen: %s</string>
-    <string name="first_seen_x">Zum ersten Mal gesehen: %s</string>
     <string name="battery_cached_label">Zuletzt bekannt · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d h %2$d Min</string>
     <string name="battery_time_remaining_format_h">%1$d h</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimale Signalqualität</string>
     <string name="profiles_signal_quality_description">Erkenne nur Geräte mit einer Signalstärke über diesem Schwellenwert. Niedrigere Werte erhöhen die Erkennungsreichweite, können jedoch zu Fehlalarmen führen. Setze diesen Wert nicht zu hoch – der Bluetooth-Empfang ist generell schwach und variiert je nach Entfernung und Hindernissen.</string>
     <string name="profiles_identitykey_label">Identitätsschlüssel</string>
-    <string name="profilessettings_maindevice_identitykey_description">Der Identity Resolving Key (IRK) deines Geräts, der CAPod dabei hilft, es unter Geräten in der Nähe zu identifizieren.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ändern häufig ihre Bluetooth-Adresse aus Datenschutzgründen. Der IRK hilft CAPod, dein Gerät zu erkennen. Du benötigst einmaligen Zugriff auf ein MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Verschlüsselungsschlüssel</string>
-    <string name="profiles_maindevice_encryptionkey_description">Der Verschlüsselungsschlüssel deines Geräts, der es CAPod ermöglicht, detaillierte Statusinformationen abzurufen.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods senden eine Statusnachricht, die teilweise verschlüsselt ist. Der Verschlüsselungsschlüssel ermöglicht es CAPod, die vollständige Nachricht zu entschlüsseln. Du benötigst einmaligen Zugriff auf ein MacBook.</string>
     <string name="profiles_key_invalid_format">Ungültiges Schlüsselformat</string>
     <string name="profiles_key_expected_format">Erwartetes Format: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Du hast nicht gespeicherte Änderungen. Was möchtest du tun?</string>
     <string name="general_save_and_exit_action">Sichern &amp; Beenden</string>
     <string name="general_discard_action">Verwerfen</string>
-    <string name="general_keep_editing_action">Weiter bearbeiten</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Aufnahme zu kurz</string>
     <string name="debug_debuglog_short_recording_message">Ein Debug-Log muss das Problem während des Auftretens aufzeichnen. Nimm weiter auf, reproduziere das Problem und stoppe dann die Aufnahme.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Geräteeinstellungen</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Name</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-Gerätebezeichnung</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Hersteller</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Vielleicht später</string>
     <string name="review_app_body">Möchtest du CAPod bewerten? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Allgemein</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Legt fest, welcher Ohrhörer als Mikrofon verwendet wird</string>
     <string name="device_settings_microphone_mode_auto">Automatisch</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Κοινοποίηση</string>
     <string name="general_done_action">Τέλος</string>
     <string name="general_cancel_action">Ακύρωση</string>
-    <string name="general_copy_action">Αντιγραφή</string>
     <string name="general_thank_you_label">Ευχαριστώ</string>
     <string name="general_upgrade_action">Αναβάθμιση</string>
     <string name="general_retry_action">Δοκιμάστε ξανά</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Έλεγχος</string>
     <string name="general_close_action">Κλείσιμο</string>
     <string name="general_dismiss_action">Κλείσιμο</string>
-    <string name="general_edit_action">Επεξεργασία</string>
     <string name="general_save_action">Αποθήκευση</string>
     <string name="general_guide_action">Οδηγός</string>
     <string name="general_continue_action">Συνέχεια</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Συνέχισε τη μουσική όταν ξαναφοράς τα pods, αλλά μόνο αν την σταμάτησε η Αυτόματη παύση. Οι παύσεις που έκανες εσύ (τηλέφωνο, στέλεχος AirPods, ύπνος) παραμένουν σε παύση.</string>
     <string name="settings_start_music_on_wear_label">Εκκίνηση μουσικής κατά τη χρήση</string>
     <string name="settings_start_music_on_wear_description">Προσπαθεί πάντα να αναπαράγει μουσική όταν φοράς τα pods, ακόμα και μετά από μη αυτόματη παύση.</string>
-    <string name="settings_eardetection_info_label">Σημείωση ανίχνευσης αυτιού</string>
     <string name="settings_eardetection_info_description">Εάν η ανίχνευση αυτιού λειτουργεί μόνο για ένα pod, αυτός είναι περιορισμός της Apple. Ανιχνεύεται μόνο το \"κύριο pod\" (που χρησιμοποιείται για μικρόφωνο). Ρυθμίστε σε συσκευές Apple: Ρυθμίσεις → Bluetooth → AirPods → Μικρόφωνο.</string>
-    <string name="settings_signal_minimum_label">Ελάχιστη ποιότητα σήματος</string>
-    <string name="settings_signal_minimum_description">Η ελάχιστη ποιότητα σήματος που πρέπει να έχει μια συσκευή για να θεωρηθεί δική σας.</string>
     <string name="settings_autoconnect_label">Αυτόματη σύνδεση</string>
     <string name="settings_autoconnect_description">Αν το Android δεν συνδέεται αυτόματα, μπορούμε να το ζητήσουμε κι εμείς. Αυτό κάνει το CAPod να παρακολουθεί στο παρασκήνιο πάντα.</string>
     <string name="settings_autoconnect_info_android12">Η αυτόματη σύνδεση βασίζεται σε λειτουργία συστήματος που το Android 12 και νεότερες εκδόσεις περιορίζουν. Ενδέχεται να μην λειτουργεί στη συσκευή σας.</string>
     <string name="settings_autoconnect_condition_label">Συνθήκη αυτόματης σύνδεσης</string>
-    <string name="settings_autoconnect_condition_description">Πότε πρέπει να προσπαθήσουμε να συνδεθούμε στη συσκευή σας;</string>
     <string name="settings_devices_label">Συσκευές</string>
     <string name="settings_devices_description">Διαχειριστείτε τις συσκευές σας.</string>
     <string name="settings_reaction_label">Αντιδράσεις</string>
-    <string name="settings_category_yourdevice_label">Η συσκευή σας</string>
     <string name="settings_category_compatibility_options_title">Επιλογές συμβατότητας</string>
     <string name="settings_category_compatibility_options_description">Μην αγγίζετε αν όλα λειτουργούν ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Απενεργοποίηση φιλτραρίσματος υλικού</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Ξεκίνημα…</string>
     <string name="support_debuglog_label">Αρχείο καταγραφής εντοπισμού σφαλμάτων</string>
     <string name="support_debuglog_desc">Καταγράψτε ό,τι κάνει η εφαρμογή σε ένα αρχείο κειμένου που μπορείτε να μοιραστείτε.</string>
-    <string name="debug_debuglog_size_label">Μέγεθος</string>
-    <string name="debug_debuglog_size_compressed_label">Συμπιεσμένο μέγεθος</string>
-    <string name="debug_notification_channel_label">Ειδοποιήσεις εντοπισμού σφαλμάτων</string>
-    <string name="debug_debuglog_file_label">Καταγεγραμμένο αρχείο καταγραφής</string>
-    <string name="debug_debuglog_recording_progress">Εγγραφή αρχείου καταγραφής εντοπισμού σφαλμάτων</string>
     <string name="debug_debuglog_record_action">Εγγραφή αρχείου καταγραφής εντοπισμού σφαλμάτων</string>
     <string name="debug_debuglog_stop_action">Διακοπή εγγραφής</string>
     <string name="debug_debuglog_sensitive_information_message">Το αρχείο που δημιουργήθηκε περιέχει ευαίσθητες πληροφορίες (π.χ. λεπτομέρειες συσκευής Bluetooth). Μοιραστείτε το μόνο με αξιόπιστα μέρη.</string>
     <string name="settings_debuglog_explanation">Αυτή η δυνατότητα καταγράφει ό,τι κάνει η εφαρμογή σε ένα κοινόχρηστο αρχείο. Το αρχείο που δημιουργήθηκε περιέχει ευαίσθητες πληροφορίες (π.χ. λεπτομέρειες συσκευής Bluetooth). Μοιραστείτε το μόνο με αξιόπιστα μέρη (π.χ. έναν προγραμματιστή που αντιμετωπίζει ένα πρόβλημα).</string>
-    <string name="settings_support_installid_label">Αναγνωριστικό εγκατάστασης</string>
-    <string name="settings_support_installid_desc">Οι αυτόματες αναφορές σφαλμάτων είναι ανώνυμες. Μοιραστείτε το αναγνωριστικό εγκατάστασής σας εάν ο προγραμματιστής πρέπει να βρει τις αναφορές σφαλμάτων σας.</string>
     <string name="settings_support_label">Υποστήριξη</string>
     <string name="settings_support_description">Εάν χρειάζεστε βοήθεια.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Επαναφορά μαθημένων δεδομένων;</string>
     <string name="device_battery_estimate_reset_confirm_message">Το CAPod θα ξεχάσει την μετρημένη κατανάλωση, την ταχύτητα φόρτισης και τον χρόνο ακρόασης αυτής της συσκευής, και θα ξεκινήσει ξανά από τη διάρκεια μπαταρίας που αναφέρεται.</string>
     <string name="settings_acknowledgements_label">Ευχαριστίες</string>
-    <string name="settings_debug_autoreports_label">Αυτόματες αναφορές σφαλμάτων</string>
-    <string name="settings_debug_autoreports_description">Αναφέρει αυτόματα προβλήματα, π.χ. λεπτομέρειες σχετικά με μια κατάρρευση της εφαρμογής, ώστε να μπορώ να καταλάβω πώς να το διορθώσω.</string>
-    <string name="settings_compatibility_mode_label">Λειτουργία συμβατότητας</string>
-    <string name="settings_compatibility_mode_description">Απενεργοποιήστε τις βελτιστοποιήσεις για να βελτιώσετε τη συμβατότητα. Δοκιμάστε το εάν δεν βλέπετε δεδομένα.</string>
     <string name="help_translate_label">Μετάφραση</string>
     <string name="help_translate_description">Βοηθήστε να μεταφράσετε αυτήν την εφαρμογή στην αγαπημένη σας γλώσσα.</string>
     <string name="translators_thanks_title">Μεταφραστές</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Επιτυχία</string>
     <string name="troubleshooter_ble_result_success_body">Οι εκπομπές διαφημίσεων BLE λαμβάνονται από το CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Ανεπιτυχής</string>
-    <string name="troubleshooter_ble_result_failure_body">Η αντιμετώπιση προβλημάτων απέτυχε. Κανένας συνδυασμός επιλογών συμβατότητας δεν βοήθησε.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Το τηλέφωνό σας δεν έλαβε καθόλου δεδομένα BLE. Μπορείτε να δοκιμάσετε ξανά αυτήν τη δοκιμή σε μια πολυσύχναστη περιοχή για να δείτε εάν μπορούν να ληφθούν πηγές δεδομένων (εκτός από τα ακουστικά σας). Η μη λήψη δεδομένων υποδεικνύει πρόβλημα με το λειτουργικό σύστημα του τηλεφώνου σας.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Το τηλέφωνό σας έλαβε δεδομένα BLE, αλλά τα δεδομένα δεν προέρχονται από καμία υποστηριζόμενη συσκευή. Είναι ενεργοποιημένα τα ακουστικά σας; Υποστηρίζει το CAPod τα ακουστικά σας;</string>
-    <string name="troubleshooter_ble_result_failure_action">Προσπαθήστε ξανά</string>
-    <string name="troubleshoot_action">Αντιμετώπιση προβλημάτων</string>
     <string name="onboarding_body1">Αυτή η εφαρμογή προσθέτει υποστήριξη για συγκεκριμένες λειτουργίες AirPod στο Android.</string>
     <string name="onboarding_body2">Δεν υποστηρίζουν όλες οι συσκευές Android πλήρως τις επιπλέον λειτουργίες AirPod. Το λειτουργικό σας σύστημα απαιτεί μια σωστά λειτουργούσα υλοποίηση Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">Το CAPod δεν έχει διαφημίσεις και δεν συλλέγει τα δεδομένα σας.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Η συσκευή σου είναι συνδεδεμένη, αλλά το CAPod δεν λαμβάνει ζωντανά δεδομένα από αυτήν. Το τηλέφωνό σου μπορεί να χρειαστεί μια επιλογή συμβατότητας — ο εντοπισμός προβλημάτων μπορεί να προσπαθήσει να βρει μία αυτόματα.</string>
     <string name="overview_troubleshoot_suggestion_action">Εκτέλεση εντοπισμού προβλημάτων</string>
     <string name="overview_unmatched_devices_label">Μη αντιστοιχισμένες συσκευές</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d συσκευή χωρίς αντίστοιχο προφίλ</item>
-        <item quantity="other">%d συσκευές χωρίς αντίστοιχο προφίλ</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Εντοπίστηκε %d κοντινή συσκευή χωρίς αντίστοιχο προφίλ. Εμφανίστε τη για διαθέσιμες λεπτομέρειες. Αν είναι δική σας, προσθέστε ένα προφίλ από τις Συσκευές για να την αναγνωρίσετε.</item>
         <item quantity="other">Εντοπίστηκαν %d κοντινές συσκευές χωρίς αντίστοιχα προφίλ. Εμφανίστε τις για διαθέσιμες λεπτομέρειες. Αν κάποια είναι δική σας, προσθέστε ένα προφίλ από τις Συσκευές για να την αναγνωρίσετε.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">Το CAPod χρησιμοποιεί \"πρόσβαση τοποθεσίας στο παρασκήνιο\" για να ενεργοποιήσει λειτουργίες όπως \"Εμφάνιση αναδυόμενου\" και \"Αυτόματη σύνδεση\" ενώ η εφαρμογή είναι κλειστή. Η πρόσβαση τοποθεσίας στο παρασκήνιο επιτρέπει στην εφαρμογή να λαμβάνει δεδομένα Bluetooth Low Energy ενώ βρίσκεται στο παρασκήνιο. Αυτή η εφαρμογή ΔΕΝ θα χρησιμοποιήσει δεδομένα Bluetooth για να προσδιορίσει την τοποθεσία σας.</string>
     <string name="permission_ignore_battery_optimizations_label">Απενεργοποίηση βελτιστοποιήσεων μπαταρίας</string>
     <string name="permission_ignore_battery_optimizations_description">Οι βελτιστοποιήσεις μπαταρίας εμποδίζουν αυτήν την εφαρμογή από τη αξιόπιστη λήψη δεδομένων Bluetooth ενώ βρίσκεται στο παρασκήνιο.</string>
-    <string name="permission_required_title">Απαιτείται η ακόλουθη άδεια:</string>
     <string name="permission_system_alert_window_label">Παράθυρο ειδοποίησης συστήματος</string>
     <string name="permission_system_alert_window_description">Επιτρέψτε στο CAPod να σχεδιάζει πάνω από άλλες εφαρμογές για να καταστεί δυνατή η λειτουργία \"Εμφάνιση αναδυόμενου\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Όταν εντοπιστεί</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Στο αυτί</string>
     <string name="pods_dual_left_label">Αριστερό pod</string>
     <string name="pods_dual_right_label">Δεξί pod</string>
-    <string name="pods_dual_left_short_label">Α</string>
-    <string name="pods_dual_right_short_label">Δ</string>
-    <string name="pods_case_label">Θήκη</string>
     <string name="battery_unavailable_label">Μπαταρία μη διαθέσιμη</string>
     <string name="battery_state_low_cd">Χαμηλή μπαταρία</string>
     <string name="battery_state_critical_cd">Κρίσιμα χαμηλή μπαταρία</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Άμεση σύνδεση ενεργή</string>
     <string name="signal_indicator_bars_cd">Ισχύς σήματος: %1$d από 4 μπάρες</string>
     <string name="signal_indicator_disconnected_cd">Σήμα: αποσυνδεδεμένο</string>
-    <string name="pods_yours">Δικό σας</string>
     <string name="headset_being_worn_label">Φοριέται</string>
     <string name="headset_not_being_worn_label">Δεν φοριέται</string>
     <string name="pods_case_unknown_state">Άγνωστη κατάσταση</string>
-    <string name="last_seen_x">Τελευταία εμφάνιση: %s</string>
-    <string name="first_seen_x">Πρώτη εμφάνιση: %s</string>
     <string name="battery_cached_label">Τελευταία γνωστή · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dώ %2$dλ</string>
     <string name="battery_time_remaining_format_h">%1$dώ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Ελάχιστη Ποιότητα Σήματος</string>
     <string name="profiles_signal_quality_description">Ανιχνεύστε μόνο συσκευές με ισχύ σήματος πάνω από αυτό το κατώφλι. Χαμηλότερες τιμές αυξάνουν το εύρος ανίχνευσης αλλά μπορεί να προκαλέσουν ψευδώς θετικά αποτελέσματα. Μην το ρυθμίσετε πολύ ψηλά - η λήψη Bluetooth είναι γενικά κακή και ποικίλλει ανάλογα με την απόσταση και τα εμπόδια.</string>
     <string name="profiles_identitykey_label">Κλειδί Ταυτότητας</string>
-    <string name="profilessettings_maindevice_identitykey_description">Το Κλειδί Επίλυσης Ταυτότητας (IRK) της συσκευής σας, το οποίο βοηθά το CAPod να την αναγνωρίσει μεταξύ κοντινών συσκευών.</string>
     <string name="profiles_maindevice_identitykey_explanation">Τα AirPods αλλάζουν συχνά τη διεύθυνση Bluetooth τους για λόγους απορρήτου. Το IRK βοηθά το CAPod να αναγνωρίσει τη συσκευή σας. Χρειάζεστε πρόσβαση σε MacBook μία φορά.</string>
     <string name="profiles_maindevice_encryptionkey_label">Κλειδί Κρυπτογράφησης</string>
-    <string name="profiles_maindevice_encryptionkey_description">Το κλειδί κρυπτογράφησης της συσκευής σας, το οποίο επιτρέπει στο CAPod να ανακτήσει λεπτομερείς πληροφορίες κατάστασης.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Τα AirPods στέλνουν ένα μήνυμα κατάστασης, μέρος του οποίου είναι κρυπτογραφημένο. Το κλειδί κρυπτογράφησης επιτρέπει στο CAPod να αποκρυπτογραφήσει το πλήρες μήνυμα. Χρειάζεστε πρόσβαση σε MacBook μία φορά.</string>
     <string name="profiles_key_invalid_format">Μη έγκυρη μορφή κλειδιού</string>
     <string name="profiles_key_expected_format">Αναμενόμενη μορφή: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Έχετε μη αποθηκευμένες αλλαγές. Τι θέλετε να κάνετε;</string>
     <string name="general_save_and_exit_action">Αποθήκευση &amp; Έξοδος</string>
     <string name="general_discard_action">Απόρριψη</string>
-    <string name="general_keep_editing_action">Συνέχιση επεξεργασίας</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Η εγγραφή είναι πολύ σύντομη</string>
     <string name="debug_debuglog_short_recording_message">Το αρχείο καταγραφής εντοπισμού σφαλμάτων πρέπει να καταγράψει το ζήτημα τη στιγμή που συμβαίνει. Συνεχίστε την εγγραφή, αναπαράγετε το πρόβλημα και στη συνέχεια διακόψτε την εγγραφή.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Ρυθμίσεις Συσκευής</string>
     <string name="device_settings_subtitle_profile_prefix">Προφίλ: %s</string>
-    <string name="device_settings_info_name_label">Όνομα</string>
     <string name="device_settings_info_bt_name_label">Ετικέτα Συσκευής Bluetooth</string>
     <string name="device_settings_info_model_label">Μοντέλο</string>
     <string name="device_settings_info_manufacturer_label">Κατασκευαστής</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Ίσως αργότερα</string>
     <string name="review_app_body">Θα θέλατε να αφήσετε μια αξιολόγηση για το CAPod; ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Γενικά</string>
     <string name="device_settings_microphone_mode_label">Μικρόφωνο</string>
     <string name="device_settings_microphone_mode_description">Ποιο ακουστικό χρησιμοποιείται ως μικρόφωνο</string>
     <string name="device_settings_microphone_mode_auto">Αυτόματο</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Compartir</string>
     <string name="general_done_action">Hecho</string>
     <string name="general_cancel_action">Cancelar</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Gracias</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="general_retry_action">Reintentar</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Cerrar</string>
     <string name="general_dismiss_action">Descartar</string>
-    <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Guardar</string>
     <string name="general_guide_action">Guía</string>
     <string name="general_continue_action">Continuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Reanuda la música al volver a ponerte los pods, pero solo si la pausa automática la detuvo. Las pausas que activaste vos mismo (teléfono, palanca de AirPods, suspensión) permanecen en pausa.</string>
     <string name="settings_start_music_on_wear_label">Iniciar música al ponérselos</string>
     <string name="settings_start_music_on_wear_description">Siempre intenta reproducir música cuando te ponés los pods, incluso después de una pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota sobre la detección de oídos</string>
     <string name="settings_eardetection_info_description">Si la detección de auriculares solo funciona para un pod, se trata de una limitación de Apple. Solo se detecta el «pod principal» (utilizado para el micrófono). Configuración en dispositivos Apple: Ajustes → Bluetooth → AirPods → Micrófono.</string>
-    <string name="settings_signal_minimum_label">Calidad de señal mínima</string>
-    <string name="settings_signal_minimum_description">La calidad de señal mínima que un dispositivo necesita tener para ser considerado tuyo.</string>
     <string name="settings_autoconnect_label">Conexión automática</string>
     <string name="settings_autoconnect_description">Si Android no se conecta automáticamente, podemos pedirle que lo haga. Esto mantiene el monitoreo de CAPod en segundo plano todo el tiempo.</string>
     <string name="settings_autoconnect_info_android12">La conexión automática depende de una función del sistema que Android 12 y versiones más nuevas restringen. Es posible que no funcione en tu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condición de conexión automática</string>
-    <string name="settings_autoconnect_condition_description">¿Cuándo deberíamos intentar conectarnos a tu dispositivo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Gestionar tus dispositivos.</string>
     <string name="settings_reaction_label">Reacciones</string>
-    <string name="settings_category_yourdevice_label">Tu dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opciones de compatibilidad</string>
     <string name="settings_category_compatibility_options_description">No tocar si todo funciona ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desactivar filtrado por hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Registro de depuración</string>
     <string name="support_debuglog_desc">Registrar todo lo que la app está haciendo en un archivo de texto que podés compartir.</string>
-    <string name="debug_debuglog_size_label">Tamaño</string>
-    <string name="debug_debuglog_size_compressed_label">Tamaño comprimido</string>
-    <string name="debug_notification_channel_label">Notificaciones de depuración</string>
-    <string name="debug_debuglog_file_label">Archivo de registro guardado</string>
-    <string name="debug_debuglog_recording_progress">Grabando registro de depuración</string>
     <string name="debug_debuglog_record_action">Grabar registro de depuración</string>
     <string name="debug_debuglog_stop_action">Detener grabación</string>
     <string name="debug_debuglog_sensitive_information_message">El archivo generado contiene información sensible (ej. detalles del dispositivo Bluetooth). Compartilo solo con personas de confianza.</string>
     <string name="settings_debuglog_explanation">Esta función registra todo lo que la app está haciendo en un archivo compartible. El archivo generado contiene información sensible (ej. detalles del dispositivo Bluetooth). Compartilo solo con personas de confianza (ej. un desarrollador que está solucionando un problema).</string>
-    <string name="settings_support_installid_label">ID de Instalación</string>
-    <string name="settings_support_installid_desc">Los reportes automáticos de errores son anónimos. Compartí tu ID de instalación si el desarrollador necesita encontrar tus reportes de errores.</string>
     <string name="settings_support_label">Soporte</string>
     <string name="settings_support_description">Si necesitás ayuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">¿Reiniciar datos aprendidos?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod olvidará el consumo medido, la velocidad de carga y el tiempo de escucha de este dispositivo, y comenzará de nuevo con la vida útil nominal de la batería.</string>
     <string name="settings_acknowledgements_label">Agradecimientos</string>
-    <string name="settings_debug_autoreports_label">Reportes automáticos de errores</string>
-    <string name="settings_debug_autoreports_description">Reporta problemas automáticamente, ej. detalles sobre un cierre inesperado de la app para que pueda averiguar cómo solucionarlo.</string>
-    <string name="settings_compatibility_mode_label">Modo de compatibilidad</string>
-    <string name="settings_compatibility_mode_description">Desactivar optimizaciones para mejorar la compatibilidad. Probá esto si no estás viendo ningún dato.</string>
     <string name="help_translate_label">Traducción</string>
     <string name="help_translate_description">Ayudá a traducir esta app a tu idioma favorito.</string>
     <string name="translators_thanks_title">Traductores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Éxito</string>
     <string name="troubleshooter_ble_result_success_body">CAPod está recibiendo las transmisiones de anuncios BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Sin éxito</string>
-    <string name="troubleshooter_ble_result_failure_body">La solución de problemas falló. Ninguna combinación de opciones de compatibilidad ayudó.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Tu teléfono no recibió ningún dato BLE. Podés reintentar esta prueba en un área concurrida para ver si se pueden recibir fuentes de datos (distintas de tus auriculares). No recibir datos apunta a un problema con el sistema operativo de tu teléfono.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Tu teléfono recibió datos BLE, pero los datos no provienen de ningún dispositivo compatible. ¿Están encendidos tus auriculares? ¿CAPod es compatible con tus auriculares?</string>
-    <string name="troubleshooter_ble_result_failure_action">Intentar de nuevo</string>
-    <string name="troubleshoot_action">Solucionar problemas</string>
     <string name="onboarding_body1">Esta aplicación agrega soporte para funciones específicas de los AirPods para Android.</string>
     <string name="onboarding_body2">No todos los dispositivos Android son totalmente compatibles con las funciones adicionales de los AirPods. Tu sistema operativo requiere una implementación de Bluetooth de baja energía que funcione correctamente.</string>
     <string name="onboarding_body3">CAPod no contiene anuncios y no recopila tus datos.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tu dispositivo está conectado, pero CAPod no está recibiendo datos en tiempo real. Tu teléfono puede necesitar una opción de compatibilidad: el solucionador de problemas puede intentar encontrar una automáticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Ejecutar solucionador de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos no emparejados</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo sin perfil coincidente</item>
-        <item quantity="other">%d dispositivos sin perfil coincidentes</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Se detectó %d dispositivo cercano sin un perfil coincidente. Mostralo para ver los detalles disponibles. Si es tuyo, agregá un perfil desde Dispositivos para reconocerlo.</item>
         <item quantity="other">Se detectaron %d dispositivos cercanos sin perfiles coincidentes. Mostralos para ver los detalles disponibles. Si alguno es tuyo, agregá un perfil desde Dispositivos para reconocerlo.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod utiliza el acceso a la ubicación en segundo plano para habilitar funciones como \"Mostrar ventana emergente\" y \"Conectar automáticamente\" mientras la aplicación está cerrada. Este acceso permite que la aplicación reciba datos de Bluetooth de bajo consumo mientras está en segundo plano. Esta aplicación NO utiliza datos de Bluetooth para determinar tu ubicación.</string>
     <string name="permission_ignore_battery_optimizations_label">Desactivar las optimizaciones de la batería</string>
     <string name="permission_ignore_battery_optimizations_description">Las optimizaciones de la batería impiden que esta aplicación reciba datos Bluetooth de forma fiable mientras se encuentra en segundo plano.</string>
-    <string name="permission_required_title">Se requiere el siguiente permiso:</string>
     <string name="permission_system_alert_window_label">Ventana emergente</string>
     <string name="permission_system_alert_window_description">Permite que CAPod se superponga a otras aplicaciones para que la función «Mostrar ventana emergente».</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Cuando está visible</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">En el oído</string>
     <string name="pods_dual_left_label">Auricular izquierdo</string>
     <string name="pods_dual_right_label">Auricular derecho</string>
-    <string name="pods_dual_left_short_label">I</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Estuche</string>
     <string name="battery_unavailable_label">Batería no disponible</string>
     <string name="battery_state_low_cd">Batería baja</string>
     <string name="battery_state_critical_cd">Batería críticamente baja</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Conexión directa activa</string>
     <string name="signal_indicator_bars_cd">Intensidad de señal: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Señal: desconectado</string>
-    <string name="pods_yours">Tuyos</string>
     <string name="headset_being_worn_label">En uso</string>
     <string name="headset_not_being_worn_label">No se usan</string>
     <string name="pods_case_unknown_state">Desconocido</string>
-    <string name="last_seen_x">Ultima vez conectado: %s</string>
-    <string name="first_seen_x">Primera vez conectados: %s</string>
     <string name="battery_cached_label">Último conocido · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Calidad mínima de la señal</string>
     <string name="profiles_signal_quality_description">Solo detecta dispositivos con una intensidad de señal superior a este umbral. Valores más bajos aumentan el rango de detección pero pueden causar falsos positivos. No lo configures demasiado alto; la recepción de Bluetooth es generalmente mala y varía con la distancia y los obstáculos.</string>
     <string name="profiles_identitykey_label">Clave de Identidad</string>
-    <string name="profilessettings_maindevice_identitykey_description">La Clave de Resolución de Identidad (IRK) de su dispositivo, que ayuda a CAPod a identificarlo entre los dispositivos cercanos.</string>
     <string name="profiles_maindevice_identitykey_explanation">Los AirPods cambian con frecuencia su dirección Bluetooth por motivos de privacidad. El IRK ayuda a CAPod a reconocer tu dispositivo. Necesitas acceso único a un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Clave de cifrado</string>
-    <string name="profiles_maindevice_encryptionkey_description">La clave de cifrado de tu dispositivo, que permite a CAPod recuperar información detallada sobre el estado.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Los AirPods envían un mensaje de estado, parte del cual está cifrado. La clave de cifrado permite a CAPod descifrar el mensaje completo. Se necesita acceso único a un MacBook.</string>
     <string name="profiles_key_invalid_format">El formato de la clave no es correcta</string>
     <string name="profiles_key_expected_format">Formato esperado: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Tienes cambios sin guardar. ¿Qué quieres hacer?</string>
     <string name="general_save_and_exit_action">Guardar y salir</string>
     <string name="general_discard_action">Descartar</string>
-    <string name="general_keep_editing_action">Seguir editando</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Grabación demasiado corta</string>
     <string name="debug_debuglog_short_recording_message">Un registro de depuración necesita capturar el problema mientras ocurre. Continuá grabando, reproducí el problema y luego detené la grabación.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Configuración del dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nombre</string>
     <string name="device_settings_info_bt_name_label">Nombre de dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Quizás más tarde</string>
     <string name="review_app_body">¿Te gustaría dejar una reseña de CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
     <string name="device_settings_microphone_mode_description">Qué auricular se usa como micrófono</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Compartir</string>
     <string name="general_done_action">Hecho</string>
     <string name="general_cancel_action">Cancelar</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Gracias</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="general_retry_action">Reintentar</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Cerrar</string>
     <string name="general_dismiss_action">Descartar</string>
-    <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Guardar</string>
     <string name="general_guide_action">Guía</string>
     <string name="general_continue_action">Continuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Reanuda la música al volver a usar tus pods, pero solo si Auto pausa la detuvo. Las pausas que activaste tú mismo (teléfono, varilla de AirPods, suspensión) siguen en pausa.</string>
     <string name="settings_start_music_on_wear_label">Iniciar música al ponerse</string>
     <string name="settings_start_music_on_wear_description">Siempre intenta reproducir música cuando te pones los pods, incluso después de una pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota sobre la detección de oídos</string>
     <string name="settings_eardetection_info_description">Si la detección de auriculares solo funciona para un pod, se trata de una limitación de Apple. Solo se detecta el «pod principal» (utilizado para el micrófono). Configuración en dispositivos Apple: Ajustes → Bluetooth → AirPods → Micrófono.</string>
-    <string name="settings_signal_minimum_label">Calidad de señal mínima</string>
-    <string name="settings_signal_minimum_description">La calidad de señal mínima que un dispositivo necesita tener para ser considerado tuyo.</string>
     <string name="settings_autoconnect_label">Conexión automática</string>
     <string name="settings_autoconnect_description">Si Android no conecta automáticamente, también podemos pedirle que lo haga. Esto mantiene CAPod monitoreando en segundo plano todo el tiempo.</string>
     <string name="settings_autoconnect_info_android12">La conexión automática depende de una función del sistema que Android 12 y versiones más recientes restringen. Es posible que no funcione en tu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condición de conexión automática</string>
-    <string name="settings_autoconnect_condition_description">¿Cuándo deberíamos intentar conectarnos a tu dispositivo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Gestionar tus dispositivos.</string>
     <string name="settings_reaction_label">Reacciones</string>
-    <string name="settings_category_yourdevice_label">Tu dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opciones de compatibilidad</string>
     <string name="settings_category_compatibility_options_description">No tocar si todo funciona ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desactivar filtrado por hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Registro de depuración</string>
     <string name="support_debuglog_desc">Registrar todo lo que la aplicación está haciendo en un archivo de texto que puedes compartir.</string>
-    <string name="debug_debuglog_size_label">Tamaño</string>
-    <string name="debug_debuglog_size_compressed_label">Tamaño comprimido</string>
-    <string name="debug_notification_channel_label">Notificaciones de depuración</string>
-    <string name="debug_debuglog_file_label">Archivo de registro guardado</string>
-    <string name="debug_debuglog_recording_progress">Grabando registro de depuración</string>
     <string name="debug_debuglog_record_action">Grabar registro de depuración</string>
     <string name="debug_debuglog_stop_action">Detener grabación</string>
     <string name="debug_debuglog_sensitive_information_message">El archivo generado contiene información sensible (ej. detalles del dispositivo Bluetooth). Compártelo solo con personas de confianza.</string>
     <string name="settings_debuglog_explanation">Esta función registra todo lo que la aplicación está haciendo en un archivo compartible. El archivo generado contiene información sensible (ej. detalles del dispositivo Bluetooth). Compártelo solo con personas de confianza (ej. un desarrollador que está solucionando un problema).</string>
-    <string name="settings_support_installid_label">ID de Instalación</string>
-    <string name="settings_support_installid_desc">Los reportes automáticos de errores son anónimos. Comparte tu ID de instalación si el desarrollador necesita encontrar tus reportes de errores.</string>
     <string name="settings_support_label">Soporte</string>
     <string name="settings_support_description">Si necesitas ayuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">¿Restablecer datos aprendidos?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod olvidará el consumo medido, la velocidad de carga y el tiempo de escucha de este dispositivo, y comenzará desde la vida útil nominal de la batería.</string>
     <string name="settings_acknowledgements_label">Agradecimientos</string>
-    <string name="settings_debug_autoreports_label">Reportes automáticos de errores</string>
-    <string name="settings_debug_autoreports_description">Reporta problemas automáticamente, ej. detalles sobre un cierre inesperado de la aplicación para que pueda averiguar cómo solucionarlo.</string>
-    <string name="settings_compatibility_mode_label">Modo de compatibilidad</string>
-    <string name="settings_compatibility_mode_description">Desactivar optimizaciones para mejorar la compatibilidad. Prueba esto si no estás viendo ningún dato.</string>
     <string name="help_translate_label">Traducción</string>
     <string name="help_translate_description">Ayuda a traducir esta aplicación a tu idioma favorito.</string>
     <string name="translators_thanks_title">Traductores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Éxito</string>
     <string name="troubleshooter_ble_result_success_body">CAPod está recibiendo las transmisiones de anuncios BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Sin éxito</string>
-    <string name="troubleshooter_ble_result_failure_body">La solución de problemas falló. Ninguna combinación de opciones de compatibilidad ayudó.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Tu teléfono no recibió ningún dato BLE. Puedes reintentar esta prueba en un área concurrida para ver si se pueden recibir fuentes de datos (distintas de tus auriculares). No recibir datos apunta a un problema con el sistema operativo de tu teléfono.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Tu teléfono recibió datos BLE, pero los datos no provienen de ningún dispositivo compatible. ¿Están encendidos tus auriculares? ¿CAPod es compatible con tus auriculares?</string>
-    <string name="troubleshooter_ble_result_failure_action">Intentar de nuevo</string>
-    <string name="troubleshoot_action">Solucionar problemas</string>
     <string name="onboarding_body1">Esta aplicación agrega soporte para funciones específicas de los AirPods para Android.</string>
     <string name="onboarding_body2">No todos los dispositivos Android son totalmente compatibles con las funciones adicionales de los AirPods. Tu sistema operativo requiere una implementación de Bluetooth de baja energía que funcione correctamente.</string>
     <string name="onboarding_body3">CAPod no contiene anuncios y no recopila tus datos.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tu dispositivo está conectado, pero CAPod no está recibiendo datos en tiempo real. Es posible que tu teléfono necesite una opción de compatibilidad — el solucionador de problemas puede intentar encontrar una automáticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Ejecutar solucionador de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos no emparejados</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo sin perfil coincidente</item>
-        <item quantity="other">%d dispositivos sin perfil coincidentes</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Se detectó %d dispositivo cercano sin un perfil coincidente. Muéstralo para ver los detalles disponibles. Si es tuyo, agrega un perfil desde Dispositivos para reconocerlo.</item>
         <item quantity="other">Se detectaron %d dispositivos cercanos sin perfiles coincidentes. Muéstralos para ver los detalles disponibles. Si alguno es tuyo, agrega un perfil desde Dispositivos para reconocerlo.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod utiliza el acceso a la ubicación en segundo plano para habilitar funciones como \"Mostrar ventana emergente\" y \"Conectar automáticamente\" mientras la aplicación está cerrada. Este acceso permite que la aplicación reciba datos de Bluetooth de bajo consumo mientras está en segundo plano. Esta aplicación NO utiliza datos de Bluetooth para determinar tu ubicación.</string>
     <string name="permission_ignore_battery_optimizations_label">Desactivar las optimizaciones de la batería</string>
     <string name="permission_ignore_battery_optimizations_description">Las optimizaciones de la batería impiden que esta aplicación reciba datos Bluetooth de forma fiable mientras se encuentra en segundo plano.</string>
-    <string name="permission_required_title">Se requiere el siguiente permiso:</string>
     <string name="permission_system_alert_window_label">Ventana emergente</string>
     <string name="permission_system_alert_window_description">Permite que CAPod se superponga a otras aplicaciones para que la función «Mostrar ventana emergente».</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Cuando está visible</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">En el oído</string>
     <string name="pods_dual_left_label">Auricular izquierdo</string>
     <string name="pods_dual_right_label">Auricular derecho</string>
-    <string name="pods_dual_left_short_label">I</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Estuche</string>
     <string name="battery_unavailable_label">Batería no disponible</string>
     <string name="battery_state_low_cd">Batería baja</string>
     <string name="battery_state_critical_cd">Batería críticamente baja</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Conexión directa activa</string>
     <string name="signal_indicator_bars_cd">Intensidad de señal: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Señal: desconectada</string>
-    <string name="pods_yours">Tuyos</string>
     <string name="headset_being_worn_label">En uso</string>
     <string name="headset_not_being_worn_label">No se usan</string>
     <string name="pods_case_unknown_state">Desconocido</string>
-    <string name="last_seen_x">Ultima vez conectado: %s</string>
-    <string name="first_seen_x">Primera vez conectados: %s</string>
     <string name="battery_cached_label">Último conocido · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Calidad mínima de la señal</string>
     <string name="profiles_signal_quality_description">Solo detecta dispositivos con una intensidad de señal superior a este umbral. Valores más bajos aumentan el rango de detección pero pueden causar falsos positivos. No lo configures demasiado alto; la recepción de Bluetooth es generalmente mala y varía con la distancia y los obstáculos.</string>
     <string name="profiles_identitykey_label">Clave de Identidad</string>
-    <string name="profilessettings_maindevice_identitykey_description">La Clave de Resolución de Identidad (IRK) de su dispositivo, que ayuda a CAPod a identificarlo entre los dispositivos cercanos.</string>
     <string name="profiles_maindevice_identitykey_explanation">Los AirPods cambian con frecuencia su dirección Bluetooth por motivos de privacidad. El IRK ayuda a CAPod a reconocer tu dispositivo. Necesitas acceso único a un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Clave de cifrado</string>
-    <string name="profiles_maindevice_encryptionkey_description">La clave de cifrado de tu dispositivo, que permite a CAPod recuperar información detallada sobre el estado.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Los AirPods envían un mensaje de estado, parte del cual está cifrado. La clave de cifrado permite a CAPod descifrar el mensaje completo. Se necesita acceso único a un MacBook.</string>
     <string name="profiles_key_invalid_format">El formato de la clave no es correcta</string>
     <string name="profiles_key_expected_format">Formato esperado: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Tienes cambios sin guardar. ¿Qué quieres hacer?</string>
     <string name="general_save_and_exit_action">Guardar y salir</string>
     <string name="general_discard_action">Descartar</string>
-    <string name="general_keep_editing_action">Seguir editando</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Grabación demasiado corta</string>
     <string name="debug_debuglog_short_recording_message">Un registro de depuración necesita capturar el problema mientras ocurre. Continúa grabando, reproduce el problema y luego detén la grabación.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Configuración del dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nombre</string>
     <string name="device_settings_info_bt_name_label">Etiqueta del dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Quizás más tarde</string>
     <string name="review_app_body">¿Te gustaría dejar una reseña de CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
     <string name="device_settings_microphone_mode_description">Qué audífono se usa como micrófono</string>
     <string name="device_settings_microphone_mode_auto">Automático</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Compartir</string>
     <string name="general_done_action">Hecho</string>
     <string name="general_cancel_action">Cancelar</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Gracias</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="general_retry_action">Reintentar</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Cerrar</string>
     <string name="general_dismiss_action">Descartar</string>
-    <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Guardar</string>
     <string name="general_guide_action">Guía</string>
     <string name="general_continue_action">Continuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Reanuda la música al volver a ponerte los auriculares, pero solo si fue Auto pausa quien la detuvo. Las pausas que hiciste tú (teléfono, varilla de los AirPods, suspensión) permanecen pausadas.</string>
     <string name="settings_start_music_on_wear_label">Iniciar música al ponérselos</string>
     <string name="settings_start_music_on_wear_description">Siempre intenta reproducir música cuando te pones los auriculares, incluso después de una pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota sobre la detección de oídos</string>
     <string name="settings_eardetection_info_description">Si la detección de auriculares solo funciona para un pod, se trata de una limitación de Apple. Solo se detecta el «pod principal» (utilizado para el micrófono). Configuración en dispositivos Apple: Ajustes → Bluetooth → AirPods → Micrófono.</string>
-    <string name="settings_signal_minimum_label">Calidad mínima de la señal</string>
-    <string name="settings_signal_minimum_description">La calidad mínima de la señal que debe tener un dispositivo para que se considere tuyo.</string>
     <string name="settings_autoconnect_label">Conexión automática</string>
     <string name="settings_autoconnect_description">Si Android no se conecta automáticamente, también podemos pedirle que lo haga. Esto mantiene CAPod monitoreando en segundo plano en todo momento.</string>
     <string name="settings_autoconnect_info_android12">La conexión automática depende de una función del sistema que Android 12 y versiones posteriores restringen. Es posible que no funcione en tu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condición de conexión automática</string>
-    <string name="settings_autoconnect_condition_description">¿Cuándo deberíamos intentar conectarnos a tu dispositivo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Gestionar tus dispositivos.</string>
     <string name="settings_reaction_label">Reacciones</string>
-    <string name="settings_category_yourdevice_label">Tu dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opciones de compatibilidad</string>
     <string name="settings_category_compatibility_options_description">No toques si todo funciona ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desactivar filtrado por hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Registro de depuración</string>
     <string name="support_debuglog_desc">Registra todo lo que hace la aplicación en un archivo de texto que puedes compartir.</string>
-    <string name="debug_debuglog_size_label">Tamaño</string>
-    <string name="debug_debuglog_size_compressed_label">Tamaño comprimido</string>
-    <string name="debug_notification_channel_label">Notificaciones de depuración</string>
-    <string name="debug_debuglog_file_label">Archivo de registro grabado</string>
-    <string name="debug_debuglog_recording_progress">Grabando registro de depuración</string>
     <string name="debug_debuglog_record_action">Grabar registro de depuración</string>
     <string name="debug_debuglog_stop_action">Detener grabación</string>
     <string name="debug_debuglog_sensitive_information_message">El archivo generado contiene información sensible (p. ej., detalles del dispositivo Bluetooth). Compártelo solo con partes de confianza.</string>
     <string name="settings_debuglog_explanation">Esta función registra todo lo que hace la aplicación en un archivo que se puede compartir. El archivo generado contiene información sensible (p. ej., detalles del dispositivo Bluetooth). Compártelo solo con partes de confianza (p. ej., un desarrollador que esté solucionando un problema).</string>
-    <string name="settings_support_installid_label">ID de instalación</string>
-    <string name="settings_support_installid_desc">Los informes de error automáticos son anónimos. Comparte tu ID de instalación si el desarrollador necesita encontrar tus informes de error.</string>
     <string name="settings_support_label">Soporte</string>
     <string name="settings_support_description">Si necesitas ayuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">¿Restablecer datos aprendidos?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod olvidará el consumo medido de este dispositivo, la velocidad de carga y el tiempo de escucha, y comenzará de nuevo desde la duración nominal de la batería.</string>
     <string name="settings_acknowledgements_label">Agradecimientos</string>
-    <string name="settings_debug_autoreports_label">Informes de error automáticos</string>
-    <string name="settings_debug_autoreports_description">Informa automáticamente de los problemas, p. ej., detalles sobre un fallo de la aplicación para que pueda averiguar cómo solucionarlo.</string>
-    <string name="settings_compatibility_mode_label">Modo de compatibilidad</string>
-    <string name="settings_compatibility_mode_description">Desactiva las optimizaciones para mejorar la compatibilidad. Prueba esto si no ves ningún dato.</string>
     <string name="help_translate_label">Traducción</string>
     <string name="help_translate_description">Ayuda a traducir esta aplicación a tu idioma favorito.</string>
     <string name="translators_thanks_title">Traductores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Éxito</string>
     <string name="troubleshooter_ble_result_success_body">CAPod está recibiendo las transmisiones de anuncios BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Sin éxito</string>
-    <string name="troubleshooter_ble_result_failure_body">La solución de problemas falló. Ninguna combinación de opciones de compatibilidad ayudó.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Tu teléfono no recibió ningún dato BLE en absoluto. Puedes volver a intentar esta prueba en una zona concurrida para ver si se pueden recibir fuentes de datos (distintas de tus auriculares). La no recepción de datos apunta a un problema con el sistema operativo de tu teléfono.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Tu teléfono recibió datos BLE, pero los datos no proceden de ningún dispositivo compatible. ¿Están encendidos tus auriculares? ¿Es CAPod compatible con tus auriculares?</string>
-    <string name="troubleshooter_ble_result_failure_action">Intentar de nuevo</string>
-    <string name="troubleshoot_action">Solucionar problemas</string>
     <string name="onboarding_body1">Esta aplicación añade compatibilidad con funciones específicas de los AirPods a Android.</string>
     <string name="onboarding_body2">No todos los dispositivos Android son totalmente compatibles con las funciones adicionales de los AirPods. Tu sistema operativo requiere una implementación de Bluetooth de baja energía que funcione correctamente.</string>
     <string name="onboarding_body3">CAPod no tiene anuncios y no recopila tus datos.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tu dispositivo está conectado, pero CAPod no está recibiendo datos en directo. Es posible que tu teléfono necesite una opción de compatibilidad: el solucionador de problemas puede intentar encontrar una automáticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Ejecutar solucionador de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos no emparejados</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo sin perfil coincidente</item>
-        <item quantity="other">%d dispositivos sin perfil coincidentes</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Se detectó %d dispositivo cercano sin un perfil coincidente. Muéstralo para ver los detalles disponibles. Si es tuyo, añade un perfil desde Dispositivos para reconocerlo.</item>
         <item quantity="other">Se detectaron %d dispositivos cercanos sin perfiles coincidentes. Muéstralos para ver los detalles disponibles. Si alguno es tuyo, añade un perfil desde Dispositivos para reconocerlo.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod utiliza el acceso a la ubicación en segundo plano para habilitar funciones como \"Mostrar ventana emergente\" y \"Conectar automáticamente\" mientras la aplicación está cerrada. Este acceso permite que la aplicación reciba datos de Bluetooth de bajo consumo mientras está en segundo plano. Esta aplicación NO utiliza datos de Bluetooth para determinar tu ubicación.</string>
     <string name="permission_ignore_battery_optimizations_label">Desactivar las optimizaciones de la batería</string>
     <string name="permission_ignore_battery_optimizations_description">Las optimizaciones de la batería impiden que esta aplicación reciba datos Bluetooth de forma fiable mientras se encuentra en segundo plano.</string>
-    <string name="permission_required_title">Se requiere el siguiente permiso:</string>
     <string name="permission_system_alert_window_label">Ventana emergente</string>
     <string name="permission_system_alert_window_description">Permite que CAPod se superponga a otras aplicaciones para que la función «Mostrar ventana emergente».</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Cuando está visible</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">En el oído</string>
     <string name="pods_dual_left_label">Auricular izquierdo</string>
     <string name="pods_dual_right_label">Auricular derecho</string>
-    <string name="pods_dual_left_short_label">I</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Estuche</string>
     <string name="battery_unavailable_label">Batería no disponible</string>
     <string name="battery_state_low_cd">Batería baja</string>
     <string name="battery_state_critical_cd">Batería críticamente baja</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Conexión directa activa</string>
     <string name="signal_indicator_bars_cd">Intensidad de señal: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Señal: desconectada</string>
-    <string name="pods_yours">Tuyos</string>
     <string name="headset_being_worn_label">En uso</string>
     <string name="headset_not_being_worn_label">No se usan</string>
     <string name="pods_case_unknown_state">Desconocido</string>
-    <string name="last_seen_x">Ultima vez conectado: %s</string>
-    <string name="first_seen_x">Primera vez conectados: %s</string>
     <string name="battery_cached_label">Último conocido · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Calidad mínima de la señal</string>
     <string name="profiles_signal_quality_description">Solo detecta dispositivos con una intensidad de señal superior a este umbral. Valores más bajos aumentan el rango de detección pero pueden causar falsos positivos. No lo configures demasiado alto; la recepción de Bluetooth es generalmente mala y varía con la distancia y los obstáculos.</string>
     <string name="profiles_identitykey_label">Clave de Identidad</string>
-    <string name="profilessettings_maindevice_identitykey_description">La Clave de Resolución de Identidad (IRK) de su dispositivo, que ayuda a CAPod a identificarlo entre los dispositivos cercanos.</string>
     <string name="profiles_maindevice_identitykey_explanation">Los AirPods cambian con frecuencia su dirección Bluetooth por motivos de privacidad. El IRK ayuda a CAPod a reconocer tu dispositivo. Necesitas acceso único a un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Clave de cifrado</string>
-    <string name="profiles_maindevice_encryptionkey_description">La clave de cifrado de tu dispositivo, que permite a CAPod recuperar información detallada sobre el estado.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Los AirPods envían un mensaje de estado, parte del cual está cifrado. La clave de cifrado permite a CAPod descifrar el mensaje completo. Se necesita acceso único a un MacBook.</string>
     <string name="profiles_key_invalid_format">El formato de la clave no es correcta</string>
     <string name="profiles_key_expected_format">Formato esperado: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Tienes cambios sin guardar. ¿Qué quieres hacer?</string>
     <string name="general_save_and_exit_action">Guardar y salir</string>
     <string name="general_discard_action">Descartar</string>
-    <string name="general_keep_editing_action">Seguir editando</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Grabación demasiado corta</string>
     <string name="debug_debuglog_short_recording_message">Un registro de depuración necesita capturar el problema mientras ocurre. Sigue grabando, reproduce el problema y luego detén la grabación.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Configuración del dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nombre</string>
     <string name="device_settings_info_bt_name_label">Etiqueta del dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Quizás más tarde</string>
     <string name="review_app_body">¿Te gustaría dejar una reseña de CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
     <string name="device_settings_microphone_mode_description">Qué auricular se usa como micrófono</string>
     <string name="device_settings_microphone_mode_auto">Automático</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Jaga</string>
     <string name="general_done_action">Valmis</string>
     <string name="general_cancel_action">Tühista</string>
-    <string name="general_copy_action">Kopeeri</string>
     <string name="general_thank_you_label">Tänan</string>
     <string name="general_upgrade_action">Uuenda</string>
     <string name="general_retry_action">Proovi uuesti</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontrolli</string>
     <string name="general_close_action">Sulge</string>
     <string name="general_dismiss_action">Sulge</string>
-    <string name="general_edit_action">Muuda</string>
     <string name="general_save_action">Salvesta</string>
     <string name="general_guide_action">Juhend</string>
     <string name="general_continue_action">Jätka</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Jätka muusika kuulamist, kui kannad taas kõrvaklappe, kuid ainult siis, kui isekäivitunud paus selle peatas. Isepausimise (telefon, AirPodsi vars, uni) puhul jääb paus kestma.</string>
     <string name="settings_start_music_on_wear_label">Esita muusikat kõrva panemisel</string>
     <string name="settings_start_music_on_wear_description">Proovib alati esitada muusikat, kui paned kõrvaklapid pähe, isegi pärast enda käivitatud pausi.</string>
-    <string name="settings_eardetection_info_label">Kõrva tuvastamisest</string>
     <string name="settings_eardetection_info_description">Kui tuvastatakse vaid üks klapp, siis seda põhjustab Apple\'i piirang. Tuvastatakse vaid peamine klapp (kasutatakse mikrofonina). Seadista Apple\'i seadmetes: Seaded (Settings) → Bluetooth → AirPods (AirPodid) → Mikrofon (Microphone).</string>
-    <string name="settings_signal_minimum_label">Väikseim signaali kvaliteet</string>
-    <string name="settings_signal_minimum_description">Väikseim signaali kvaliteet, mis seade peab omama, et seda peetaks teie omaks.</string>
     <string name="settings_autoconnect_label">Automaatne ühendamine</string>
     <string name="settings_autoconnect_description">Kui Android ei ühendu ise, saame seda paluda. See hoiab CAPodi töös taustal kogu aeg.</string>
     <string name="settings_autoconnect_info_android12">Iseühenduvus tugineb süsteemivõimalusele, mida Android 12 ja uuemad versioonid piiravad. See ei pruugi teie seadmel toimida.</string>
     <string name="settings_autoconnect_condition_label">Automaatse ühendamise tingimus</string>
-    <string name="settings_autoconnect_condition_description">Millal võime üritada ühendada teie seadet?</string>
     <string name="settings_devices_label">Seadmed</string>
     <string name="settings_devices_description">Seadmete haldamine.</string>
     <string name="settings_reaction_label">Reaktsioonid</string>
-    <string name="settings_category_yourdevice_label">Teie seade</string>
     <string name="settings_category_compatibility_options_title">Ühilduvuse valikud</string>
     <string name="settings_category_compatibility_options_description">Las jääda, kui kõik toimib ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Keela riistvara filtreerimine</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Käivitamine…</string>
     <string name="support_debuglog_label">Silumisinfo</string>
     <string name="support_debuglog_desc">Salvesta kogu rakenduse tegevus jagatavasse tekstifaili.</string>
-    <string name="debug_debuglog_size_label">Maht</string>
-    <string name="debug_debuglog_size_compressed_label">Maht pärast kokkusurumist</string>
-    <string name="debug_notification_channel_label">Silumisteated</string>
-    <string name="debug_debuglog_file_label">Salvestatud logifail</string>
-    <string name="debug_debuglog_recording_progress">Silumislogi salvestamine</string>
     <string name="debug_debuglog_record_action">Salvesta silumislogi</string>
     <string name="debug_debuglog_stop_action">Peata salvestamine</string>
     <string name="debug_debuglog_sensitive_information_message">Loodud fail sisaldab isikuandmeid (nt Bluetooth seadme tehnilisi näitajaid). Jagage seda vaid usaldusväärsetega.</string>
     <string name="settings_debuglog_explanation">See salvestab kogu rakenduse tegevuse jagatavasse tekstifaili. Loodud fail sisaldab isikuandmeid (nt Bluetooth seadme tehnilisi näitajaid). Jagage seda vaid usaldusväärsetega (nt probleemi lahendava arendajaga).</string>
-    <string name="settings_support_installid_label">Paigalduse tunnus</string>
-    <string name="settings_support_installid_desc">Automaatsed veateated on anonüümsed. Jagage oma paigalduse tunnust, kui arendaja peab leidma teie veateateid.</string>
     <string name="settings_support_label">Abi</string>
     <string name="settings_support_description">Jagatud mure on pool mure.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Lähtesta õpitud andmed?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod unustab selle seadme mõõdetud kulu, laadimiskiiruse ja kuulamisaja ning alustab uuesti nimiväärtustest.</string>
     <string name="settings_acknowledgements_label">Tunnustused</string>
-    <string name="settings_debug_autoreports_label">Automaatsed veateated</string>
-    <string name="settings_debug_autoreports_description">Teavitab vigadest ise, nt andmed rakenduse hangumise kohta, et saaksin mõista, kuidas olukorda lahendada.</string>
-    <string name="settings_compatibility_mode_label">Ühilduvusrežiim</string>
-    <string name="settings_compatibility_mode_description">Ühilduvuse parandamiseks keelake optimeeringud. Proovige seda, kui te ei näe mingeid andmeid.</string>
     <string name="help_translate_label">Tõlge</string>
     <string name="help_translate_description">Aita tõlkida seda rakendust oma emakeelde.</string>
     <string name="translators_thanks_title">Tõlkijad</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Õnnestus</string>
     <string name="troubleshooter_ble_result_success_body">CAPod võtab vastu madalama energiakuluga Bluetoothi kaudu reklaame.</string>
     <string name="troubleshooter_ble_result_failure_title">Nurjus</string>
-    <string name="troubleshooter_ble_result_failure_body">Parandamine nurjus. Ükski ühilduvuskombinatsioonidest ei toiminud.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefon ei võtnud vastu mingeid andmeid madalama energiakuluga Buetoothi kaudu. Üritage korrate rahvarohkes kohas, et näha, kas andmete allikaid (mis pole teie kõrvaklapid) saab kätte. Andmete saamise nurjumine viitab telefoni operatsioonisüsteemi veale.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefoni saabusid andmed madalama energiakuluga Bluetoothi kaudu aga andmed ei pärine ühestki ühilduvast seadmest. Kas CAPod ühildub teie kõrvaklapiga?</string>
-    <string name="troubleshooter_ble_result_failure_action">Proovi uuesti</string>
-    <string name="troubleshoot_action">Lahendamine</string>
     <string name="onboarding_body1">See rakendus lisab Androidile AirPodi võimalused.</string>
     <string name="onboarding_body2">Vaid mõned Androidi seadmed toetavad kõiki AirPodi võimalusi. Operatsioonisüsteem vajab õigesti toimivat madalama energiatarbimisega Bluetoothi tuge.</string>
     <string name="onboarding_body3">CAPodis pole reklaame ja see ei kogu andmeid.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Seade on ühendatud, kuid CAPod ei saa sellelt otseandmeid. Telefon vajab tõenäoliselt ühilduvuse valikut — abistaja kontrollib, kas suudab selle ise leida.</string>
     <string name="overview_troubleshoot_suggestion_action">Käivita abistaja</string>
     <string name="overview_unmatched_devices_label">Omavahel sobimatud seadmed</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d seade ei kattu profiiliga</item>
-        <item quantity="other">%d seadet ei kattu profiiliga</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Tuvastati %d lähedalasuv seade, millel puudub sobiv profiil. Kuva andmed. Kui see on sinu oma, lisa seadmete alt profiil selle tuvastamiseks.</item>
         <item quantity="other">Tuvastati %d lähedalasuvat seadet, millel puudub sobiv profiil. Kuva andmed. Kui mõni neist on sinu oma, lisa seadmete alt profiil selle tuvastamiseks.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod võimaldab sellega hüpikakende näitamist ja automaatset ühendumist, kui rakendus on suletud ning saada Bluetooth madala energiatarbimisega andmeid, kui rakendus töötab taustal. See rakendus ei tuvasta Bluetooth andmetega teie asukohta.</string>
     <string name="permission_ignore_battery_optimizations_label">Keela aku optimeerimine</string>
     <string name="permission_ignore_battery_optimizations_description">Aku optimeerimine takistab rakendusel Bluetooth andmete saamist taustal töötades.</string>
-    <string name="permission_required_title">Vaja on järgmist luba:</string>
     <string name="permission_system_alert_window_label">Süsteemi teate aken</string>
     <string name="permission_system_alert_window_description">Luba CAPodil toimetada teiste rakenduste kohal, et näha hüpikaknaid.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kui nähtaval</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Kõrvas</string>
     <string name="pods_dual_left_label">Vasak klapp</string>
     <string name="pods_dual_right_label">Parem klapp</string>
-    <string name="pods_dual_left_short_label">V</string>
-    <string name="pods_dual_right_short_label">P</string>
-    <string name="pods_case_label">Kaas</string>
     <string name="battery_unavailable_label">Aku pole saadaval</string>
     <string name="battery_state_low_cd">Aku madal</string>
     <string name="battery_state_critical_cd">Aku kriitiliselt madal</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Otseühendus aktiivne</string>
     <string name="signal_indicator_bars_cd">Signaali tugevus: %1$d 4 ribast</string>
     <string name="signal_indicator_disconnected_cd">Signaal: ühendus puudub</string>
-    <string name="pods_yours">Sinu</string>
     <string name="headset_being_worn_label">Kasutusel</string>
     <string name="headset_not_being_worn_label">Ei kasuta</string>
     <string name="pods_case_unknown_state">Tundmatu olek</string>
-    <string name="last_seen_x">Viimati kasutusel: %s</string>
-    <string name="first_seen_x">Esimesena kasutusel: %s</string>
     <string name="battery_cached_label">Viimati teadaolev · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dt %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dt</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Väikseim signaali kvaliteet</string>
     <string name="profiles_signal_quality_description">Kuvage ainult sellest lävest kõrgema signaalitugevusega seadmed. Väiksemad väärtused vähendavad tuvastamismäära, ent võivad valesti teavitada. Ärge seadistage seda liiga suureks, kuna Bluetooth vastuvõtmine on tavaliselt kehv ja sõltub vahemaast ning takistustest.</string>
     <string name="profiles_identitykey_label">Tuvastamisvõti</string>
-    <string name="profilessettings_maindevice_identitykey_description">Teie seadme tunnuse lahendamisvõti (IRK), mis võimaldab CAPodil tuvastada seda ümberkaudsete seadmete hulgast.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPodsid muudavad privaatsuse tõttu sageli oma Bluetooth aadressi. IRK aitab CAPodil tuvastada teie seadet. Vajate MacBooki jaoks ühekordset juurdepääsukoodi.</string>
     <string name="profiles_maindevice_encryptionkey_label">Krüpteerimisvõti</string>
-    <string name="profiles_maindevice_encryptionkey_description">Teie seadme krüpteerimisvõti, mis võimaldab CaPodil saada täpset oleku teavet.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPodsid saadavad olekuteateid, millest osad on krüptitut. Krüpteerimisvõti võimaldab CAPodil kogu teadet lugeda. Vajate MacBooki jaoks ühekordset juurdepääsukoodi.</string>
     <string name="profiles_key_invalid_format">Vigane loa vorming</string>
     <string name="profiles_key_expected_format">Eeldati vormingut: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Muudatused on salvestamata. Mida tahaksite teha?</string>
     <string name="general_save_and_exit_action">Salvesta ja välju</string>
     <string name="general_discard_action">Hülga</string>
-    <string name="general_keep_editing_action">Jätka muutmist</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Salvestis on liiga lühike</string>
     <string name="debug_debuglog_short_recording_message">Vealogi peab jäädvustama probleemi selle toimumise ajal. Jätkake salvestamist, korrake probleemi ja seejärel peatage salvestamine.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Seadme seaded</string>
     <string name="device_settings_subtitle_profile_prefix">Profiil: %s</string>
-    <string name="device_settings_info_name_label">Nimi</string>
     <string name="device_settings_info_bt_name_label">Bluetoothi seadme silt</string>
     <string name="device_settings_info_model_label">Mudel</string>
     <string name="device_settings_info_manufacturer_label">Tootja</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Võib-olla hiljem</string>
     <string name="review_app_body">Kas soovid kommenteerida CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Üldine</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Kumba kõrvaklappi kasutatakse mikrofonina</string>
     <string name="device_settings_microphone_mode_auto">Automaatne</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Partekatu</string>
     <string name="general_done_action">Eginda</string>
     <string name="general_cancel_action">Utzi</string>
-    <string name="general_copy_action">Kopiatu</string>
     <string name="general_thank_you_label">Eskerrik asko</string>
     <string name="general_upgrade_action">Bertsio-berritu</string>
     <string name="general_retry_action">Berriro saiatu</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Egiaztatu</string>
     <string name="general_close_action">Itxi</string>
     <string name="general_dismiss_action">Baztertu</string>
-    <string name="general_edit_action">Editatu</string>
     <string name="general_save_action">Gorde</string>
     <string name="general_guide_action">Gida</string>
     <string name="general_continue_action">Jarraitu</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Berriro jantzita musika errepikatzen du, baina soilik Eten automatikoak gelditu bazuen. Zuk eragindako etenak (telefonoa, AirPods beso, loa) etenda geratzen dira.</string>
     <string name="settings_start_music_on_wear_label">Hasi musika jantzitakoan</string>
     <string name="settings_start_music_on_wear_description">Beti saiatzen da musika erreproduzitzen aurrikulariak jartzen dituzunean, eskuzko eten baten ondoren ere.</string>
-    <string name="settings_eardetection_info_label">Belarri-detekzioaren oharra</string>
     <string name="settings_eardetection_info_description">Belarri-detekzioak pod batentzat soilik funtzionatzen badu, Apple-ren muga bat da. \"Pod nagusia\" (mikrofonorako erabiltzen dena) soilik detektatzen da. Konfiguratu Apple gailuetan: Ezarpenak → Bluetooth → AirPods → Mikrofonoa.</string>
-    <string name="settings_signal_minimum_label">Seinalearen gutxieneko kalitatea</string>
-    <string name="settings_signal_minimum_description">Gailu batek zurea dela kontsideratzeko izan behar duen seinalearen gutxieneko kalitatea.</string>
     <string name="settings_autoconnect_label">Automatikoki konektatu</string>
     <string name="settings_autoconnect_description">Androidek automatikoki konektatzen ez badu, guk ere eska diezaiokegu. Honek CAPod atzeko planoan etengabe monitorizatzen jarraitzea eragiten du.</string>
     <string name="settings_autoconnect_info_android12">Konexio automatikoak Android 12 eta berriagoak mugatzen duen sistema-funtzio batean oinarritzen da. Baliteke zure gailuan ez funtzionatzea.</string>
     <string name="settings_autoconnect_condition_label">Automatikoki konektatzeko baldintza</string>
-    <string name="settings_autoconnect_condition_description">Noiz saiatu behar gara zure gailura konektatzen?</string>
     <string name="settings_devices_label">Gailuak</string>
     <string name="settings_devices_description">Kudeatu zure gailuak.</string>
     <string name="settings_reaction_label">Erreakzioak</string>
-    <string name="settings_category_yourdevice_label">Zure gailua</string>
     <string name="settings_category_compatibility_options_title">Bateragarritasun aukerak</string>
     <string name="settings_category_compatibility_options_description">Ez ukitu dena ondo badabil ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desgaitu hardware bidezko iragazketa</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Abiarazten…</string>
     <string name="support_debuglog_label">Arazketa erregistroa</string>
     <string name="support_debuglog_desc">Grabatu aplikazioak egiten duen guztia parteka dezakezun testu fitxategi batean.</string>
-    <string name="debug_debuglog_size_label">Tamaina</string>
-    <string name="debug_debuglog_size_compressed_label">Tamaina konprimitua</string>
-    <string name="debug_notification_channel_label">Arazketa jakinarazpenak</string>
-    <string name="debug_debuglog_file_label">Grabatutako erregistro fitxategia</string>
-    <string name="debug_debuglog_recording_progress">Arazketa erregistroa grabatzen</string>
     <string name="debug_debuglog_record_action">Grabatu arazketa erregistroa</string>
     <string name="debug_debuglog_stop_action">Gelditu grabazioa</string>
     <string name="debug_debuglog_sensitive_information_message">Sortutako fitxategiak informazio sentikorra dauka (adib. Bluetooth gailuaren xehetasunak). Partekatu konfiantzazkoekin soilik.</string>
     <string name="settings_debuglog_explanation">Ezaugarri honek aplikazioak egiten duen guztia parteka daitekeen fitxategi batean grabatzen du. Sortutako fitxategiak informazio sentikorra dauka (adib. Bluetooth gailuaren xehetasunak). Partekatu konfiantzazkoekin soilik (adib. arazo bat konpontzen ari den garatzaile batekin).</string>
-    <string name="settings_support_installid_label">Instalazio IDa</string>
-    <string name="settings_support_installid_desc">Erroreen txosten automatikoak anonimoak dira. Partekatu zure instalazio IDa garatzaileak zure erroreen txostenak aurkitu behar baditu.</string>
     <string name="settings_support_label">Laguntza</string>
     <string name="settings_support_description">Laguntza behar baduzu.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Ikasitako datuak berrezarri?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod-ek gailu honetako neurtutako kontsumoa, kargatzeko abiadura eta entzuteko denbora ahaztuko ditu, eta kalifikatutako bateriaren bizitzatik berriro hasiko da.</string>
     <string name="settings_acknowledgements_label">Eskertzak</string>
-    <string name="settings_debug_autoreports_label">Erroreen txosten automatikoak</string>
-    <string name="settings_debug_autoreports_description">Automatikoki arazoak salatzen ditu, adib. aplikazioaren kraskaduraren xehetasunak, konpontzen jakin dezadan.</string>
-    <string name="settings_compatibility_mode_label">Bateragarritasun modua</string>
-    <string name="settings_compatibility_mode_description">Desgaitu optimizazioak bateragarritasuna hobetzeko. Saiatu hau daturik ikusten ez baduzu.</string>
     <string name="help_translate_label">Itzulpena</string>
     <string name="help_translate_description">Lagundu aplikazio hau zure hizkuntza gogokoenera itzultzen.</string>
     <string name="translators_thanks_title">Itzultzaileak</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Arrakasta</string>
     <string name="troubleshooter_ble_result_success_body">CAPod BLE iragarkien igorpenak jasotzen ari da.</string>
     <string name="troubleshooter_ble_result_failure_title">Arrakastarik gabe</string>
-    <string name="troubleshooter_ble_result_failure_body">Arazoak konpontzeak huts egin du. Ez du bateragarritasun aukeren konbinaziorik lagundu.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Zure telefonoak ez du BLE daturik jaso. Proba hau jendez gainezka dagoen leku batean errepika dezakezu datu iturriak (zure entzungailuak ez direnak) jaso daitezkeen ikusteko. Daturik ez jasotzeak zure telefonoaren sistema eragilearekin arazo bat dagoela adierazten du.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Zure telefonoak BLE datuak jaso ditu, baina datuak ez datoz batere onartutako gailu batetik. Zure entzungailuak piztuta al daude? CAPod-ek zure entzungailuak onartzen al ditu?</string>
-    <string name="troubleshooter_ble_result_failure_action">Saiatu berriro</string>
-    <string name="troubleshoot_action">Arazoak konpondu</string>
     <string name="onboarding_body1">Aplikazio honek AirPod-en ezaugarri espezifikoetarako euskarria gehitzen dio Android-i.</string>
     <string name="onboarding_body2">Android gailu guztiek ez dituzte AirPod-en ezaugarri gehigarriak guztiz onartzen. Zure sistema eragileak Bluetooth-Energia-Baxuko inplementazio zuzen bat behar du.</string>
     <string name="onboarding_body3">CAPod-ek ez du iragarkirik eta ez ditu zure datuak biltzen.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Zure gailua konektatuta dago, baina CAPod-ek ez du zuzeneko daturik jasotzen. Baliteke zure telefonoak bateragarritasun-aukera bat behar izatea — arazo-konpontzaileak automatikoki bila dezake.</string>
     <string name="overview_troubleshoot_suggestion_action">Exekutatu arazo-konpontzailea</string>
     <string name="overview_unmatched_devices_label">Bat ez datozen gailuak</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d gailu bat datorren profilik gabe</item>
-        <item quantity="other">%d gailu bat datozen profilik gabe</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Gertuko gailu %d bat antzeman da bat datorren profilik gabe. Erakutsi eskuragarri dauden xehetasunak ikusteko. Zurea bada, gehitu profil bat Gailuak ataletik ezagutzeko.</item>
         <item quantity="other">Gertuko %d gailu antzeman dira bat datozen profilik gabe. Erakutsi haiek eskuragarri dauden xehetasunak ikusteko. Bat zurea bada, gehitu profil bat Gailuak ataletik ezagutzeko.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod-ek \"atzeko planoko kokapen sarbidea\" erabiltzen du \"Erakutsi pop-up-a\" eta \"Automatikoki konektatu\" bezalako ezaugarriak gaitzeko aplikazioa itxita dagoenean. Atzeko planoko kokapen sarbideak aplikazioari Bluetooth Energia Baxuko datuak atzeko planoan jasotzea ahalbidetzen dio. Aplikazio honek EZ ditu Bluetooth datuak zure kokapena zehazteko erabiliko.</string>
     <string name="permission_ignore_battery_optimizations_label">Desgaitu bateria-optimizazioak</string>
     <string name="permission_ignore_battery_optimizations_description">Bateria-optimizazioek aplikazio honi Bluetooth datuak modu fidagarrian jasotzea eragozten diote atzeko planoan dagoenean.</string>
-    <string name="permission_required_title">Hurrengo baimena beharrezkoa da:</string>
     <string name="permission_system_alert_window_label">Sistemaren alerta-leihoa</string>
     <string name="permission_system_alert_window_description">Baimendu CAPod-i beste aplikazioen gainean marraztea \"Erakutsi pop-up-a\" ezaugarria posible egiteko.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Ikusten denean</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Belarrian</string>
     <string name="pods_dual_left_label">Ezkerreko pod-a</string>
     <string name="pods_dual_right_label">Eskuineko pod-a</string>
-    <string name="pods_dual_left_short_label">E</string>
-    <string name="pods_dual_right_short_label">E</string>
-    <string name="pods_case_label">Kaxa</string>
     <string name="battery_unavailable_label">Bateria ez dago erabilgarri</string>
     <!-- Case charges: how often the case can still fully recharge BOTH earbuds. Not charge cycles, and not a statement that anything is charging right now. -->
     <plurals name="battery_case_charges_approx">
@@ -291,12 +262,9 @@
     <string name="signal_badge_aap_cd">Zuzeneko konexioa aktibo</string>
     <string name="signal_indicator_bars_cd">Seinalearen intentsitatea: %1$d 4 barretatik</string>
     <string name="signal_indicator_disconnected_cd">Seinalea: deskonektatuta</string>
-    <string name="pods_yours">Zurea</string>
     <string name="headset_being_worn_label">Jantzita</string>
     <string name="headset_not_being_worn_label">Ez jantzita</string>
     <string name="pods_case_unknown_state">Egoera ezezaguna</string>
-    <string name="last_seen_x">Azkenekoz ikusia: %s</string>
-    <string name="first_seen_x">Lehen aldiz ikusia: %s</string>
     <string name="battery_cached_label">Azken ezaguna · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -326,10 +294,8 @@
     <string name="profiles_signal_quality_title">Seinalearen Gutxieneko Kalitatea</string>
     <string name="profiles_signal_quality_description">Atalase honen gaineko seinale-indarrarekin soilik detektatu gailuak. Balio txikiagoak detekzio-barrutia handitzen dute baina positibo faltsuak eragin ditzakete. Ez ezarri hau altuegia - Bluetooth-aren harrera orokorrean txarra da eta distantzia eta oztopoen arabera aldatzen da.</string>
     <string name="profiles_identitykey_label">Identitate Gakoa</string>
-    <string name="profilessettings_maindevice_identitykey_description">Zure gailuaren Identitate Ebazpen Gakoa (IRK), CAPod-i gertuko gailuen artean identifikatzen laguntzen diona.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods-ek maiz aldatzen dute euren Bluetooth helbidea pribatutasunerako. IRK-k CAPod-i zure gailua ezagutzen laguntzen dio. MacBook baterako behin-behineko sarbidea behar duzu.</string>
     <string name="profiles_maindevice_encryptionkey_label">Enkriptatze Gakoa</string>
-    <string name="profiles_maindevice_encryptionkey_description">Zure gailuaren enkriptatze gakoa, CAPod-i egoeraren informazio xehatua berreskuratzen uzten diona.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods-ek egoera-mezu bat bidaltzen dute, zeinaren zati bat enkriptatuta dagoen. Enkriptatze gakoak CAPod-i mezu osoa deszifratzea ahalbidetzen dio. MacBook baterako behin-behineko sarbidea behar duzu.</string>
     <string name="profiles_key_invalid_format">Gako-formatu baliogabea</string>
     <string name="profiles_key_expected_format">Espero den formatua: %1$s</string>
@@ -362,7 +328,6 @@
     <string name="general_unsaved_changes_message">Gorde gabeko aldaketak dituzu. Zer egin nahi duzu?</string>
     <string name="general_save_and_exit_action">Gorde &amp; Irten</string>
     <string name="general_discard_action">Baztertu</string>
-    <string name="general_keep_editing_action">Jarraitu editatzen</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Grabaketa motzegi</string>
     <string name="debug_debuglog_short_recording_message">Arazketa erregistro batek arazoa gertatzen ari den bitartean harrapatu behar du. Jarraitu grabatzen, erreproduzitu arazoa, eta gero gelditu grabaketa.</string>
@@ -433,7 +398,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Gailuaren ezarpenak</string>
     <string name="device_settings_subtitle_profile_prefix">Profila: %s</string>
-    <string name="device_settings_info_name_label">Izena</string>
     <string name="device_settings_info_bt_name_label">Bluetooth gailuaren etiketa</string>
     <string name="device_settings_info_model_label">Modeloa</string>
     <string name="device_settings_info_manufacturer_label">Fabrikatzailea</string>
@@ -512,7 +476,6 @@
     <string name="review_app_dismiss_action">Agian geroago</string>
     <string name="review_app_body">CAPod-i berrikuspen bat utzi nahi diozu? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Orokorra</string>
     <string name="device_settings_microphone_mode_label">Mikrofonoa</string>
     <string name="device_settings_microphone_mode_description">Zein entzungailu erabiltzen den mikrofono gisa</string>
     <string name="device_settings_microphone_mode_auto">Automatikoa</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">اشتراک‌گذاری</string>
     <string name="general_done_action">انجام شد</string>
     <string name="general_cancel_action">لغو</string>
-    <string name="general_copy_action">کپی</string>
     <string name="general_thank_you_label">متشکرم</string>
     <string name="general_upgrade_action">ارتقا</string>
     <string name="general_retry_action">تلاش مجدد</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">بررسی</string>
     <string name="general_close_action">بستن</string>
     <string name="general_dismiss_action">نادیده گرفتن</string>
-    <string name="general_edit_action">ویرایش</string>
     <string name="general_save_action">ذخیره</string>
     <string name="general_guide_action">راهنما</string>
     <string name="general_continue_action">ادامه</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">موسیقی را هنگام پوشیدن مجدد پادها از سر می‌گیرد، اما تنها اگر توقف خودکار آن را متوقف کرده باشد. توقف‌هایی که خودتان ایجاد کردید (تلفن، دکمه AirPods، خواب) همچنان متوقف می‌مانند.</string>
     <string name="settings_start_music_on_wear_label">شروع موسیقی هنگام پوشیدن</string>
     <string name="settings_start_music_on_wear_description">همیشه سعی می‌کند هنگام گذاشتن پادها موسیقی پخش کند، حتی پس از توقف دستی.</string>
-    <string name="settings_eardetection_info_label">توجه درباره تشخیص گوش</string>
     <string name="settings_eardetection_info_description">اگر تشخیص گوش فقط برای یک پاد کار می‌کند، این محدودیت Apple است. فقط \"پاد اصلی\" (که برای میکروفون استفاده می‌شود) تشخیص داده می‌شود. در دستگاه‌های Apple تنظیم کنید: تنظیمات → بلوتوث → AirPods → میکروفون.</string>
-    <string name="settings_signal_minimum_label">حداقل کیفیت سیگنال</string>
-    <string name="settings_signal_minimum_description">حداقل کیفیت سیگنالی که یک دستگاه باید داشته باشد تا متعلق به شما در نظر گرفته شود.</string>
     <string name="settings_autoconnect_label">اتصال خودکار</string>
     <string name="settings_autoconnect_description">اگر اندروید به‌طور خودکار متصل نشد، ما هم می‌توانیم از آن بخواهیم. این کار باعث می‌شود CAPod همیشه در پس‌زمینه نظارت را ادامه دهد.</string>
     <string name="settings_autoconnect_info_android12">اتصال خودکار به یک ویژگی سیستمی متکی است که اندروید ۱۲ و نسخه‌های جدیدتر آن را محدود کرده‌اند. ممکن است روی دستگاه شما کار نکند.</string>
     <string name="settings_autoconnect_condition_label">شرط اتصال خودکار</string>
-    <string name="settings_autoconnect_condition_description">چه زمانی باید سعی کنیم به دستگاه شما متصل شویم؟</string>
     <string name="settings_devices_label">دستگاه‌ها</string>
     <string name="settings_devices_description">مدیریت دستگاه‌های شما.</string>
     <string name="settings_reaction_label">واکنش‌ها</string>
-    <string name="settings_category_yourdevice_label">دستگاه شما</string>
     <string name="settings_category_compatibility_options_title">گزینه‌های سازگاری</string>
     <string name="settings_category_compatibility_options_description">اگر همه چیز کار می‌کند، دست نزنید ؛)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">غیرفعال کردن فیلتر سخت‌افزاری</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">درحال راه‌اندازی…</string>
     <string name="support_debuglog_label">گزارش اشکال‌زدایی</string>
     <string name="support_debuglog_desc">تمام کارهایی که برنامه انجام می‌دهد را در یک فایل متنی که می‌توانید به اشتراک بگذارید، ضبط کنید.</string>
-    <string name="debug_debuglog_size_label">اندازه</string>
-    <string name="debug_debuglog_size_compressed_label">اندازه فشرده‌شده</string>
-    <string name="debug_notification_channel_label">اعلان‌های اشکال‌زدایی</string>
-    <string name="debug_debuglog_file_label">فایل گزارش ضبط‌شده</string>
-    <string name="debug_debuglog_recording_progress">در حال ضبط گزارش اشکال‌زدایی</string>
     <string name="debug_debuglog_record_action">ضبط گزارش اشکال‌زدایی</string>
     <string name="debug_debuglog_stop_action">توقف ضبط</string>
     <string name="debug_debuglog_sensitive_information_message">فایل تولیدشده حاوی اطلاعات حساس است (مثلاً جزئیات دستگاه بلوتوث). آن را فقط با افراد مورداعتماد به اشتراک بگذارید.</string>
     <string name="settings_debuglog_explanation">این ویژگی تمام کارهایی که برنامه انجام می‌دهد را در یک فایل قابل اشتراک‌گذاری ضبط می‌کند. فایل تولیدشده حاوی اطلاعات حساس است (مثلاً جزئیات دستگاه بلوتوث). آن را فقط با افراد مورداعتماد به اشتراک بگذارید (مثلاً توسعه‌دهنده‌ای که در حال عیب‌یابی یک مشکل است).</string>
-    <string name="settings_support_installid_label">شناسه نصب</string>
-    <string name="settings_support_installid_desc">گزارش‌های خطای خودکار ناشناس هستند. اگر توسعه‌دهنده نیاز به یافتن گزارش‌های خطای شما دارد، شناسه نصب خود را به اشتراک بگذارید.</string>
     <string name="settings_support_label">پشتیبانی</string>
     <string name="settings_support_description">اگر به کمک نیاز دارید.</string>
     <string name="settings_wiki_label">ویکی</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">بازنشانی داده‌های یادگیری‌شده؟</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod داده‌های اندازه‌گیری‌شده این دستگاه (تخلیه، سرعت شارژ و زمان پخش) را فراموش خواهد کرد و دوباره از عمر اسمی باتری شروع خواهد کرد.</string>
     <string name="settings_acknowledgements_label">قدردانی‌ها</string>
-    <string name="settings_debug_autoreports_label">گزارش‌های خطای خودکار</string>
-    <string name="settings_debug_autoreports_description">مشکلات را به‌طور خودکار گزارش می‌دهد، مثلاً جزئیات مربوط به خرابی برنامه تا بتوانم نحوه رفع آن را بفهمم.</string>
-    <string name="settings_compatibility_mode_label">حالت سازگاری</string>
-    <string name="settings_compatibility_mode_description">بهینه‌سازی‌ها را برای بهبود سازگاری غیرفعال کنید. اگر هیچ داده‌ای نمی‌بینید، این را امتحان کنید.</string>
     <string name="help_translate_label">ترجمه</string>
     <string name="help_translate_description">به ترجمه این برنامه به زبان موردعلاقه خود کمک کنید.</string>
     <string name="translators_thanks_title">مترجمان</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">موفقیت</string>
     <string name="troubleshooter_ble_result_success_body">پخش‌های تبلیغاتی BLE توسط CAPod دریافت می‌شوند.</string>
     <string name="troubleshooter_ble_result_failure_title">ناموفق</string>
-    <string name="troubleshooter_ble_result_failure_body">عیب‌یابی ناموفق بود. هیچ ترکیبی از گزینه‌های سازگاری کمکی نکرد.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">تلفن شما اصلاً هیچ داده BLE دریافت نکرد. می‌توانید این آزمایش را در یک منطقه شلوغ دوباره امتحان کنید تا ببینید آیا می‌توان منابع داده (غیر از هدفون شما) را دریافت کرد. عدم دریافت هیچ داده‌ای نشان‌دهنده مشکلی در سیستم‌عامل تلفن شما است.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">تلفن شما داده‌های BLE دریافت کرد، اما داده‌ها از هیچ دستگاه پشتیبانی‌شده‌ای نمی‌آیند. آیا هدفون شما روشن است؟ آیا CAPod از هدفون شما پشتیبانی می‌کند؟</string>
-    <string name="troubleshooter_ble_result_failure_action">دوباره امتحان کنید</string>
-    <string name="troubleshoot_action">عیب‌یابی</string>
     <string name="onboarding_body1">این برنامه پشتیبانی از ویژگی‌های خاص AirPod را به Android اضافه می‌کند.</string>
     <string name="onboarding_body2">همه دستگاه‌های Android به‌طور کامل از ویژگی‌های اضافی AirPod پشتیبانی نمی‌کنند. سیستم‌عامل شما به یک پیاده‌سازی بلوتوث کم‌مصرف که به‌درستی کار کند نیاز دارد.</string>
     <string name="onboarding_body3">CAPod هیچ تبلیغی ندارد و داده‌های شما را جمع‌آوری نمی‌کند.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">دستگاه شما متصل است، اما CAPod هیچ داده زنده‌ای از آن دریافت نمی‌کند. ممکن است تلفن شما به یک گزینه سازگاری نیاز داشته باشد — عیب‌یاب می‌تواند به‌طور خودکار تلاش کند آن را پیدا کند.</string>
     <string name="overview_troubleshoot_suggestion_action">اجرای عیب‌یاب</string>
     <string name="overview_unmatched_devices_label">دستگاه‌های بدون تطابق</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d دستگاه بدون پروفایل منطبق</item>
-        <item quantity="other">%d دستگاه بدون پروفایل منطبق</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d دستگاه نزدیک بدون پروفایل منطبق شناسایی شد. برای مشاهده جزئیات موجود، آن را نمایش دهید. اگر مال شماست، از بخش «دستگاه‌ها» یک پروفایل اضافه کنید تا شناسایی شود.</item>
         <item quantity="other">%d دستگاه نزدیک بدون پروفایل منطبق شناسایی شدند. برای مشاهده جزئیات موجود، آن‌ها را نمایش دهید. اگر یکی از آن‌ها مال شماست، از بخش «دستگاه‌ها» یک پروفایل اضافه کنید تا شناسایی شود.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod از \"دسترسی به مکان در پس‌زمینه\" برای فعال‌سازی ویژگی‌هایی مانند \"نمایش پاپ‌آپ\" و \"اتصال خودکار\" در زمان بسته بودن برنامه استفاده می‌کند. دسترسی به مکان در پس‌زمینه به برنامه اجازه می‌دهد داده‌های بلوتوث کم‌مصرف را در پس‌زمینه دریافت کند. این برنامه از داده‌های بلوتوث برای تعیین مکان شما استفاده نخواهد کرد.</string>
     <string name="permission_ignore_battery_optimizations_label">غیرفعال کردن بهینه‌سازی باتری</string>
     <string name="permission_ignore_battery_optimizations_description">بهینه‌سازی باتری مانع دریافت قابل اعتماد داده‌های بلوتوث توسط این برنامه در پس‌زمینه می‌شود.</string>
-    <string name="permission_required_title">مجوز زیر مورد نیاز است:</string>
     <string name="permission_system_alert_window_label">پنجره هشدار سیستم</string>
     <string name="permission_system_alert_window_description">به CAPod اجازه دهید روی سایر برنامه‌ها نمایش دهد تا ویژگی \"نمایش پاپ‌آپ\" ممکن شود.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">وقتی دیده شود</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">در گوش</string>
     <string name="pods_dual_left_label">پاد چپ</string>
     <string name="pods_dual_right_label">پاد راست</string>
-    <string name="pods_dual_left_short_label">چ</string>
-    <string name="pods_dual_right_short_label">ر</string>
-    <string name="pods_case_label">کیس</string>
     <string name="battery_unavailable_label">باتری در دسترس نیست</string>
     <string name="battery_state_low_cd">باتری کم</string>
     <string name="battery_state_critical_cd">باتری بسیار کم</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">اتصال مستقیم فعال است</string>
     <string name="signal_indicator_bars_cd">قدرت سیگنال: %1$d از ۴ میله</string>
     <string name="signal_indicator_disconnected_cd">سیگنال: قطع شده</string>
-    <string name="pods_yours">مال شما</string>
     <string name="headset_being_worn_label">در حال استفاده</string>
     <string name="headset_not_being_worn_label">در حال استفاده نیست</string>
     <string name="pods_case_unknown_state">وضعیت ناشناخته</string>
-    <string name="last_seen_x">آخرین مشاهده: %s</string>
-    <string name="first_seen_x">اولین مشاهده: %s</string>
     <string name="battery_cached_label">آخرین · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d س %2$d د</string>
     <string name="battery_time_remaining_format_h">%1$d س</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">حداقل کیفیت سیگنال</string>
     <string name="profiles_signal_quality_description">فقط دستگاه‌هایی با قدرت سیگنال بالاتر از این آستانه شناسایی شوند. مقادیر پایین‌تر محدوده شناسایی را افزایش می‌دهند اما ممکن است مثبت‌های کاذب ایجاد کنند. این مقدار را خیلی بالا تنظیم نکنید - دریافت بلوتوث عموماً ضعیف است و با فاصله و موانع متفاوت است.</string>
     <string name="profiles_identitykey_label">کلید هویت</string>
-    <string name="profilessettings_maindevice_identitykey_description">کلید حل هویت (IRK) دستگاه شما، که به CAPod کمک می‌کند آن را در بین دستگاه‌های نزدیک شناسایی کند.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods مکرراً آدرس بلوتوث خود را برای حفظ حریم خصوصی تغییر می‌دهند. IRK به CAPod کمک می‌کند دستگاه شما را بشناسد. شما به دسترسی یک‌باره به MacBook نیاز دارید.</string>
     <string name="profiles_maindevice_encryptionkey_label">کلید رمزنگاری</string>
-    <string name="profiles_maindevice_encryptionkey_description">کلید رمزنگاری دستگاه شما، که به CAPod اجازه می‌دهد اطلاعات وضعیت دقیق را بازیابی کند.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods یک پیام وضعیت ارسال می‌کنند که بخشی از آن رمزنگاری شده است. کلید رمزنگاری به CAPod اجازه می‌دهد پیام کامل را رمزگشایی کند. شما به دسترسی یک‌باره به MacBook نیاز دارید.</string>
     <string name="profiles_key_invalid_format">فرمت کلید نامعتبر</string>
     <string name="profiles_key_expected_format">فرمت مورد انتظار: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">شما تغییرات ذخیره‌نشده دارید. می‌خواهید چه کاری انجام دهید؟</string>
     <string name="general_save_and_exit_action">ذخیره و خروج</string>
     <string name="general_discard_action">دور انداختن</string>
-    <string name="general_keep_editing_action">ادامه ویرایش</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ضبط خیلی کوتاه بود</string>
     <string name="debug_debuglog_short_recording_message">گزارش اشکال‌زدایی باید مشکل را در همان لحظه‌ای که رخ می‌دهد ثبت کند. ضبط را ادامه دهید، مشکل را دوباره ایجاد کنید، سپس ضبط را متوقف کنید.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">تنظیمات دستگاه</string>
     <string name="device_settings_subtitle_profile_prefix">پروفایل: %s</string>
-    <string name="device_settings_info_name_label">نام</string>
     <string name="device_settings_info_bt_name_label">برچسب دستگاه بلوتوث</string>
     <string name="device_settings_info_model_label">مدل</string>
     <string name="device_settings_info_manufacturer_label">سازنده</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">شاید بعداً</string>
     <string name="review_app_body">آیا می خواهید نظری برای CAPod بگذارید؟ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">میکروفون</string>
     <string name="device_settings_microphone_mode_description">کدام ایرباد به عنوان میکروفون استفاده می‌شود</string>
     <string name="device_settings_microphone_mode_auto">خودکار</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Jaa</string>
     <string name="general_done_action">Valmis</string>
     <string name="general_cancel_action">Peruuta</string>
-    <string name="general_copy_action">Kopioi</string>
     <string name="general_thank_you_label">Kiitos</string>
     <string name="general_upgrade_action">Päivitä</string>
     <string name="general_retry_action">Yritä uudelleen</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Tarkista</string>
     <string name="general_close_action">Sulje</string>
     <string name="general_dismiss_action">Hylkää</string>
-    <string name="general_edit_action">Muokkaa</string>
     <string name="general_save_action">Tallenna</string>
     <string name="general_guide_action">Opas</string>
     <string name="general_continue_action">Jatka</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Jatkaa musiikin toistoa, kun puet nappikuulokkeet uudelleen korviin – mutta vain jos Automaattinen tauko pysäytti sen. Itse käynnistämäsi tauot (puhelin, AirPods-varsi, uni) pysyvät tauolla.</string>
     <string name="settings_start_music_on_wear_label">Käynnistä musiikki pukiessa</string>
     <string name="settings_start_music_on_wear_description">Yrittää aina toistaa musiikkia, kun puet kuulokkeet korviin – myös manuaalisen tauon jälkeen.</string>
-    <string name="settings_eardetection_info_label">Huomautus korvan tunnistuksesta</string>
     <string name="settings_eardetection_info_description">Jos korvan tunnistus toimii vain yhdelle kuulokkeelle, tämä on Applen rajoitus. Vain \"ensisijainen kuuloke\" (jota käytetään mikrofonina) tunnistetaan. Määritä Apple-laitteissa: Asetukset → Bluetooth → AirPods → Mikrofoni.</string>
-    <string name="settings_signal_minimum_label">Signaalin vähimmäislaatu</string>
-    <string name="settings_signal_minimum_description">Signaalin vähimmäislaatu, joka laitteella on oltava, jotta se katsotaan omaksesi.</string>
     <string name="settings_autoconnect_label">Automaattinen yhdistäminen</string>
     <string name="settings_autoconnect_description">Jos Android ei yhdistä automaattisesti, voimme pyytää sitä tekemään niin. Näin CAPod pysyy jatkuvasti taustalla valvomassa.</string>
     <string name="settings_autoconnect_info_android12">Automaattinen yhteys perustuu järjestelmäominaisuuteen, jota Android 12 ja uudemmat rajoittavat. Se ei välttämättä toimi laitteellasi.</string>
     <string name="settings_autoconnect_condition_label">Automaattisen yhdistämisen ehto</string>
-    <string name="settings_autoconnect_condition_description">Milloin meidän pitäisi yrittää yhdistää laitteeseesi?</string>
     <string name="settings_devices_label">Laitteet</string>
     <string name="settings_devices_description">Hallitse laitteitasi.</string>
     <string name="settings_reaction_label">Reaktiot</string>
-    <string name="settings_category_yourdevice_label">Laitteesi</string>
     <string name="settings_category_compatibility_options_title">Yhteensopivuusasetukset</string>
     <string name="settings_category_compatibility_options_description">Älä koske, jos kaikki toimii ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Poista laitteistosuodatus käytöstä</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Käynnistyy…</string>
     <string name="support_debuglog_label">Virheenkorjausloki</string>
     <string name="support_debuglog_desc">Tallenna kaikki sovelluksen tekemiset tekstitiedostoon, jonka voit jakaa.</string>
-    <string name="debug_debuglog_size_label">Koko</string>
-    <string name="debug_debuglog_size_compressed_label">Pakattu koko</string>
-    <string name="debug_notification_channel_label">Virheenkorjausilmoitukset</string>
-    <string name="debug_debuglog_file_label">Tallennettu lokitiedosto</string>
-    <string name="debug_debuglog_recording_progress">Tallennetaan virheenkorjauslokia</string>
     <string name="debug_debuglog_record_action">Tallenna virheenkorjausloki</string>
     <string name="debug_debuglog_stop_action">Lopeta tallennus</string>
     <string name="debug_debuglog_sensitive_information_message">Luotu tiedosto sisältää arkaluonteista tietoa (esim. Bluetooth-laitteen tiedot). Jaa se vain luotettujen osapuolten kanssa.</string>
     <string name="settings_debuglog_explanation">Tämä ominaisuus tallentaa kaikki sovelluksen tekemiset jaettavaan tiedostoon. Luotu tiedosto sisältää arkaluonteista tietoa (esim. Bluetooth-laitteen tiedot). Jaa se vain luotettujen osapuolten kanssa (esim. kehittäjän kanssa, joka vianmäärittää ongelmaa).</string>
-    <string name="settings_support_installid_label">Asennustunnus</string>
-    <string name="settings_support_installid_desc">Automaattiset virheraportit ovat anonyymejä. Jaa asennustunnuksesi, jos kehittäjän on löydettävä virheraporttisi.</string>
     <string name="settings_support_label">Tuki</string>
     <string name="settings_support_description">Jos tarvitset apua.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Nollataan opitut tiedot?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod unohtaa tämän laitteen mitatun kulutuksen, latausnopeuden ja kuunteluajan, ja aloittaa alusta nimellisakun perusteella.</string>
     <string name="settings_acknowledgements_label">Kiitokset</string>
-    <string name="settings_debug_autoreports_label">Automaattiset virheraportit</string>
-    <string name="settings_debug_autoreports_description">Raportoi ongelmat automaattisesti, esim. tiedot sovelluksen kaatumisesta, jotta voin selvittää, miten se korjataan.</string>
-    <string name="settings_compatibility_mode_label">Yhteensopivuustila</string>
-    <string name="settings_compatibility_mode_description">Poista optimoinnit käytöstä yhteensopivuuden parantamiseksi. Kokeile tätä, jos et näe mitään tietoja.</string>
     <string name="help_translate_label">Käännös</string>
     <string name="help_translate_description">Auta kääntämään tämä sovellus suosikkikielellesi.</string>
     <string name="translators_thanks_title">Kääntäjät</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Onnistui</string>
     <string name="troubleshooter_ble_result_success_body">CAPod vastaanottaa BLE-mainoslähetyksiä.</string>
     <string name="troubleshooter_ble_result_failure_title">Epäonnistui</string>
-    <string name="troubleshooter_ble_result_failure_body">Vianmääritys epäonnistui. Mikään yhteensopivuusvaihtoehtojen yhdistelmä ei auttanut.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Puhelimesi ei vastaanottanut lainkaan BLE-tietoja. Voit yrittää tätä testiä uudelleen ruuhkaisella alueella nähdäksesi, voidaanko tietolähteitä (muita kuin kuulokkeitasi) vastaanottaa. Tietojen puuttuminen viittaa ongelmaan puhelimesi käyttöjärjestelmässä.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Puhelimesi vastaanotti BLE-tietoja, mutta tiedot eivät tule mistään tuetusta laitteesta. Ovatko kuulokkeesi päällä? Tukeeko CAPod kuulokkeitasi?</string>
-    <string name="troubleshooter_ble_result_failure_action">Yritä uudelleen</string>
-    <string name="troubleshoot_action">Vianmääritys</string>
     <string name="onboarding_body1">Tämä sovellus lisää tuen AirPod-kohtaisille ominaisuuksille Androidiin.</string>
     <string name="onboarding_body2">Kaikki Android-laitteet eivät täysin tue ylimääräisiä AirPod-ominaisuuksia. Käyttöjärjestelmäsi vaatii oikein toimivan Bluetooth Low Energy -toteutuksen.</string>
     <string name="onboarding_body3">CAPodissa ei ole mainoksia eikä se kerää tietojasi.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Laitteesi on yhdistetty, mutta CAPod ei vastaanota siitä reaaliaikaista dataa. Puhelimesi saattaa tarvita yhteensopivuusasetuksen — vianmääritys voi yrittää löytää sellaisen automaattisesti.</string>
     <string name="overview_troubleshoot_suggestion_action">Käynnistä vianmääritys</string>
     <string name="overview_unmatched_devices_label">Vastaavuudetta olevat laitteet</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d laite ilman vastaavaa profiilia</item>
-        <item quantity="other">%d laitetta ilman vastaavaa profiilia</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d lähellä oleva laite havaittiin ilman vastaavaa profiilia. Näytä se saadaksesi lisätietoja. Jos se on sinun, lisää profiili Laitteet-osiosta tunnistaaksesi sen.</item>
         <item quantity="other">%d lähellä olevaa laitetta havaittiin ilman vastaavaa profiilia. Näytä ne saadaksesi lisätietoja. Jos jokin niistä on sinun, lisää profiili Laitteet-osiosta tunnistaaksesi sen.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod käyttää \"taustasijaintioikeutta\" mahdollistaakseen ominaisuudet kuten \"Näytä ponnahdusikkuna\" ja \"Automaattinen yhdistäminen\" sovelluksen ollessa suljettuna. Taustasijaintioikeus antaa sovelluksen vastaanottaa Bluetooth Low Energy -tietoja taustalla. Tämä sovellus EI käytä Bluetooth-tietoja sijaintisi määrittämiseen.</string>
     <string name="permission_ignore_battery_optimizations_label">Poista akun optimointi käytöstä</string>
     <string name="permission_ignore_battery_optimizations_description">Akun optimointi estää tätä sovellusta vastaanottamasta Bluetooth-tietoja luotettavasti taustalla.</string>
-    <string name="permission_required_title">Seuraava lupa vaaditaan:</string>
     <string name="permission_system_alert_window_label">Järjestelmän hälytysikkuna</string>
     <string name="permission_system_alert_window_description">Salli CAPod-sovelluksen piirtää muiden sovellusten päälle mahdollistaakseen \"Näytä ponnahdusikkuna\" -ominaisuuden.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kun havaitaan</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Korvassa</string>
     <string name="pods_dual_left_label">Vasen kuuloke</string>
     <string name="pods_dual_right_label">Oikea kuuloke</string>
-    <string name="pods_dual_left_short_label">V</string>
-    <string name="pods_dual_right_short_label">O</string>
-    <string name="pods_case_label">Kotelo</string>
     <string name="battery_unavailable_label">Akku ei saatavilla</string>
     <string name="battery_state_low_cd">Akku heikko</string>
     <string name="battery_state_critical_cd">Akku kriittisen heikko</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Suora yhteys aktiivinen</string>
     <string name="signal_indicator_bars_cd">Signaalin voimakkuus: %1$d / 4 palkkia</string>
     <string name="signal_indicator_disconnected_cd">Signaali: yhteys katkennut</string>
-    <string name="pods_yours">Sinun</string>
     <string name="headset_being_worn_label">Käytössä</string>
     <string name="headset_not_being_worn_label">Ei käytössä</string>
     <string name="pods_case_unknown_state">Tuntematon tila</string>
-    <string name="last_seen_x">Viimeksi nähty: %s</string>
-    <string name="first_seen_x">Ensimmäisen kerran nähty: %s</string>
     <string name="battery_cached_label">Viimeksi nähty · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Signaalin vähimmäislaatu</string>
     <string name="profiles_signal_quality_description">Tunnista vain laitteet, joiden signaalin voimakkuus ylittää tämän kynnyksen. Matalammat arvot kasvattavat tunnistusaluetta, mutta voivat aiheuttaa vääriä tunnistuksia. Älä aseta tätä liian korkeaksi - Bluetooth-vastaanotto on yleensä heikkoa ja vaihtelee etäisyyden ja esteiden mukaan.</string>
     <string name="profiles_identitykey_label">Identiteettiavain</string>
-    <string name="profilessettings_maindevice_identitykey_description">Laitteesi identiteetin selvitysavain (IRK), joka auttaa CAPod-sovellusta tunnistamaan sen lähellä olevien laitteiden joukosta.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPodit vaihtavat Bluetooth-osoitettaan usein yksityisyyden vuoksi. IRK auttaa CAPod-sovellusta tunnistamaan laitteesi. Tarvitset kertaluonteisen pääsyn MacBookiin.</string>
     <string name="profiles_maindevice_encryptionkey_label">Salausavain</string>
-    <string name="profiles_maindevice_encryptionkey_description">Laitteesi salausavain, jonka avulla CAPod voi hakea yksityiskohtaisia tilatietoja.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPodit lähettävät tilaviestin, joka on osittain salattu. Salausavain mahdollistaa CAPod-sovelluksen purkaa koko viestin salauksen. Tarvitset kertaluonteisen pääsyn MacBookiin.</string>
     <string name="profiles_key_invalid_format">Virheellinen avainmuoto</string>
     <string name="profiles_key_expected_format">Odotettu muoto: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Sinulla on tallentamattomia muutoksia. Mitä haluat tehdä?</string>
     <string name="general_save_and_exit_action">Tallenna ja poistu</string>
     <string name="general_discard_action">Hylkää</string>
-    <string name="general_keep_editing_action">Jatka muokkaamista</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Tallennus liian lyhyt</string>
     <string name="debug_debuglog_short_recording_message">Virheenjäljitysloki tarvitsee siepata ongelman sen tapahtuessa. Jatka tallentamista, toista ongelma ja lopeta sitten tallennus.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Laiteasetukset</string>
     <string name="device_settings_subtitle_profile_prefix">Profiili: %s</string>
-    <string name="device_settings_info_name_label">Nimi</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-laitteen nimi</string>
     <string name="device_settings_info_model_label">Malli</string>
     <string name="device_settings_info_manufacturer_label">Valmistaja</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Ehkä myöhemmin</string>
     <string name="review_app_body">Haluaisitko jättää CAPodille arvostelun? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Yleiset</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>
     <string name="device_settings_microphone_mode_description">Mikä kuuloke toimii mikrofonina</string>
     <string name="device_settings_microphone_mode_auto">Automaattinen</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Ibahagi</string>
     <string name="general_done_action">Tapos Na</string>
     <string name="general_cancel_action">Kanselahin</string>
-    <string name="general_copy_action">Kopyahin</string>
     <string name="general_thank_you_label">Salamat</string>
     <string name="general_upgrade_action">Mag-upgrade</string>
     <string name="general_retry_action">Subukan ulit</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Suriin</string>
     <string name="general_close_action">Isara</string>
     <string name="general_dismiss_action">Huwag pansinin</string>
-    <string name="general_edit_action">Baguhin</string>
     <string name="general_save_action">I-save</string>
     <string name="general_guide_action">Gabay</string>
     <string name="general_continue_action">Magpatuloy</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">I-resume ang musika kapag suot mo ulit ang iyong pods, pero tanging kung ang Auto pause ang huminto nito. Ang mga pause na ikaw mismo ang nag-trigger (telepono, AirPods stem, tulog) ay nananatiling naka-pause.</string>
     <string name="settings_start_music_on_wear_label">Simulan ang musika kapag suot</string>
     <string name="settings_start_music_on_wear_description">Palaging sinusubukang i-play ang musika kapag nilagay mo ang iyong pods, kahit pagkatapos ng manu-manong pause.</string>
-    <string name="settings_eardetection_info_label">Paalala sa ear detection</string>
     <string name="settings_eardetection_info_description">Kung ang ear detection ay gumagana lang para sa isang pod, ito ay limitasyon ng Apple. Tanging ang \"pangunahing pod\" (ginagamit para sa mikropono) lang ang nadedetect. I-configure sa mga Apple device: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">Minimum na kalidad ng signal</string>
-    <string name="settings_signal_minimum_description">Ang minimum na kalidad ng signal na kailangan ng isang device para maituring na sa iyo.</string>
     <string name="settings_autoconnect_label">Auto connect</string>
     <string name="settings_autoconnect_description">Kung hindi awtomatikong kumokonekta ang Android, maaari din namin itong hilingin. Napapanatili nito ang CAPod monitoring sa background palagi.</string>
     <string name="settings_autoconnect_info_android12">Ang auto connect ay umaasa sa isang tampok ng system na pinipigilan ng Android 12 at mas bago. Maaaring hindi ito gumana sa iyong device.</string>
     <string name="settings_autoconnect_condition_label">Kondisyon ng auto connect</string>
-    <string name="settings_autoconnect_condition_description">Kailan tayo dapat sumubok kumonekta sa iyong device?</string>
     <string name="settings_devices_label">Mga Device</string>
     <string name="settings_devices_description">Pamahalaan ang iyong mga device.</string>
     <string name="settings_reaction_label">Mga Reaksyon</string>
-    <string name="settings_category_yourdevice_label">Iyong device</string>
     <string name="settings_category_compatibility_options_title">Mga opsyon sa compatibility</string>
     <string name="settings_category_compatibility_options_description">Huwag galawin kung gumagana ang lahat ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">I-disable ang hardware filtering</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Nagsisimula…</string>
     <string name="support_debuglog_label">Debug log</string>
     <string name="support_debuglog_desc">I-record ang lahat ng ginagawa ng app sa isang text file na maaari mong ibahagi.</string>
-    <string name="debug_debuglog_size_label">Sukat</string>
-    <string name="debug_debuglog_size_compressed_label">Sukat na naka-compress</string>
-    <string name="debug_notification_channel_label">Mga notipikasyon ng debug</string>
-    <string name="debug_debuglog_file_label">Naka-record na log file</string>
-    <string name="debug_debuglog_recording_progress">Nagre-record ng debug log</string>
     <string name="debug_debuglog_record_action">I-record ang debug log</string>
     <string name="debug_debuglog_stop_action">Itigil ang pagre-record</string>
     <string name="debug_debuglog_sensitive_information_message">Ang nabuong file ay naglalaman ng sensitibong impormasyon (hal. mga detalye ng Bluetooth device). Ibahagi lamang ito sa mga pinagkakatiwalaang partido.</string>
     <string name="settings_debuglog_explanation">Ang feature na ito ay nagre-record ng lahat ng ginagawa ng app sa isang naibabahaging file. Ang nabuong file ay naglalaman ng sensitibong impormasyon (hal. mga detalye ng Bluetooth device). Ibahagi lamang ito sa mga pinagkakatiwalaang partido (hal. isang developer na nag-troubleshoot ng isang isyu).</string>
-    <string name="settings_support_installid_label">Install ID</string>
-    <string name="settings_support_installid_desc">Ang mga awtomatikong ulat ng error ay anonymous. Ibahagi ang iyong install ID kung kailangan ng developer na mahanap ang iyong mga ulat ng error.</string>
     <string name="settings_support_label">Suporta</string>
     <string name="settings_support_description">Kung kailangan mo ng tulong.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Burahin ang natutunan na datos?</string>
     <string name="device_battery_estimate_reset_confirm_message">Makakalimutan ng CAPod ang sinusukat na paggamit ng kuryente, bilis ng pag-charge, at oras ng pakikinig ng device na ito, at magsisimula muli mula sa rated na buhay ng baterya.</string>
     <string name="settings_acknowledgements_label">Mga Pasasalamat</string>
-    <string name="settings_debug_autoreports_label">Mga awtomatikong ulat ng bug</string>
-    <string name="settings_debug_autoreports_description">Awtomatikong nag-uulat ng mga isyu, hal. mga detalye sa isang pag-crash ng app para malaman ko kung paano ito ayusin.</string>
-    <string name="settings_compatibility_mode_label">Compatibility mode</string>
-    <string name="settings_compatibility_mode_description">I-disable ang mga optimization para mapabuti ang compatibility. Subukan ito kung wala kang nakikitang data.</string>
     <string name="help_translate_label">Pagsasalin</string>
     <string name="help_translate_description">Tumulong sa pagsasalin ng app na ito sa iyong paboritong wika.</string>
     <string name="translators_thanks_title">Mga Tagasalin</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Tagumpay</string>
     <string name="troubleshooter_ble_result_success_body">Natatanggap ng CAPod ang mga BLE advertisement broadcast.</string>
     <string name="troubleshooter_ble_result_failure_title">Hindi matagumpay</string>
-    <string name="troubleshooter_ble_result_failure_body">Nabigo ang pag-troubleshoot. Walang kumbinasyon ng mga opsyon sa compatibility ang nakatulong.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Hindi nakatanggap ng anumang BLE data ang iyong telepono. Maaari mong subukang muli ang test na ito sa isang mataong lugar para makita kung matatanggap ang mga data source (maliban sa iyong mga headphone). Ang hindi pagtanggap ng data ay tumutukoy sa isang isyu sa operating system ng iyong telepono.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Nakatanggap ng BLE data ang iyong telepono, ngunit hindi nagmula ang data sa anumang suportadong device. Naka-on ba ang iyong mga headphone? Sinusuportahan ba ng CAPod ang iyong headphone?</string>
-    <string name="troubleshooter_ble_result_failure_action">Subukang muli</string>
-    <string name="troubleshoot_action">I-troubleshoot</string>
     <string name="onboarding_body1">Nagdaragdag ang app na ito ng suporta para sa mga partikular na feature ng AirPod sa Android.</string>
     <string name="onboarding_body2">Hindi lahat ng Android device ay ganap na sumusuporta sa mga dagdag na feature ng AirPod. Nangangailangan ang iyong operating system ng wastong gumaganang implementasyon ng Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">Walang mga ad ang CAPod at hindi nangongolekta ng iyong data.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Nakakonekta ang iyong device, ngunit hindi nakakatanggap ng live data ang CAPod mula rito. Maaaring kailanganin ng iyong telepono ng opsyon sa compatibility — maaaring subukang hanapin ito nang awtomatiko ng troubleshooter.</string>
     <string name="overview_troubleshoot_suggestion_action">Patakbuhin ang troubleshooter</string>
     <string name="overview_unmatched_devices_label">Mga hindi nakatugmang device</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d device na walang katugmang profile</item>
-        <item quantity="other">%d mga device na walang katugmang profile</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Natukoy ang %d katabing device na walang katugmang profile. Ipakita ito para sa mga available na detalye. Kung sa iyo ito, magdagdag ng profile mula sa Mga Device para makilala ito.</item>
         <item quantity="other">Natukoy ang %d katabing device na walang katugmang mga profile. Ipakita ang mga ito para sa mga available na detalye. Kung sa iyo ang isa, magdagdag ng profile mula sa Mga Device para makilala ito.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">Ginagamit ng CAPod ang \"access sa lokasyon sa background\" para paganahin ang mga feature tulad ng \"Ipakita ang PopUp\" at \"AutoConnect\" habang sarado ang app. Pinapayagan ng access sa lokasyon sa background ang app na makatanggap ng data ng Bluetooth Low Energy habang nasa background. HINDI gagamitin ng app na ito ang data ng Bluetooth para matukoy ang iyong lokasyon.</string>
     <string name="permission_ignore_battery_optimizations_label">I-disable ang mga battery optimization</string>
     <string name="permission_ignore_battery_optimizations_description">Pinipigilan ng mga battery optimization ang app na ito na mapagkakatiwalaang makatanggap ng data ng Bluetooth habang nasa background ang app.</string>
-    <string name="permission_required_title">Kailangan ang sumusunod na pahintulot:</string>
     <string name="permission_system_alert_window_label">System Alert Window</string>
     <string name="permission_system_alert_window_description">Payagan ang CAPod na mag-draw sa ibabaw ng ibang mga app para maging posible ang feature na \"Ipakita ang PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kapag nakita</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Nasa tainga</string>
     <string name="pods_dual_left_label">Kaliwang pod</string>
     <string name="pods_dual_right_label">Kanang pod</string>
-    <string name="pods_dual_left_short_label">K</string>
-    <string name="pods_dual_right_short_label">K</string>
-    <string name="pods_case_label">Case</string>
     <string name="battery_unavailable_label">Hindi available ang baterya</string>
     <string name="battery_state_low_cd">Mababa ang baterya</string>
     <string name="battery_state_critical_cd">Kritikal na mababa ang baterya</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Aktibong direktang koneksyon</string>
     <string name="signal_indicator_bars_cd">Lakas ng signal: %1$d sa 4 na bar</string>
     <string name="signal_indicator_disconnected_cd">Signal: hindi nakakonekta</string>
-    <string name="pods_yours">Sa iyo</string>
     <string name="headset_being_worn_label">Nakasuot</string>
     <string name="headset_not_being_worn_label">Hindi nakasuot</string>
     <string name="pods_case_unknown_state">Hindi kilalang estado</string>
-    <string name="last_seen_x">Huling nakita: %s</string>
-    <string name="first_seen_x">Unang nakita: %s</string>
     <string name="battery_cached_label">Huling kilala · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$d h</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimum na Kalidad ng Signal</string>
     <string name="profiles_signal_quality_description">Tukuyin lang ang mga device na may lakas ng signal na mas mataas sa threshold na ito. Ang mas mababang halaga ay nagpapalawak ng saklaw ng pagtukoy ngunit maaaring magdulot ng mga maling positibo. Huwag itong itakda ng masyadong mataas - ang pagtanggap ng Bluetooth ay karaniwang mahina at nagbabago depende sa distansya at mga hadlang.</string>
     <string name="profiles_identitykey_label">Identity Key</string>
-    <string name="profilessettings_maindevice_identitykey_description">Ang Identity Resolving Key (IRK) ng iyong device, na tumutulong sa CAPod na makilala ito sa mga kalapit na device.</string>
     <string name="profiles_maindevice_identitykey_explanation">Madalas nagpapalit ang AirPods ng kanilang Bluetooth address para sa privacy. Tinutulungan ng IRK ang CAPod na makilala ang iyong device. Kailangan mo ng isang beses na access sa isang MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Encryption Key</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ang encryption key ng iyong device, na nagpapahintulot sa CAPod na kunin ang detalyadong impormasyon ng status.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Nagpapadala ang AirPods ng status message, na ang bahagi ay naka-encrypt. Pinapayagan ng encryption key ang CAPod na i-decrypt ang buong mensahe. Kailangan mo ng isang beses na access sa isang MacBook.</string>
     <string name="profiles_key_invalid_format">Hindi wastong format ng key</string>
     <string name="profiles_key_expected_format">Inaasahang format: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Mayroon kang mga hindi na-save na pagbabago. Ano ang gusto mong gawin?</string>
     <string name="general_save_and_exit_action">I-save &amp; Lumabas</string>
     <string name="general_discard_action">I-discard</string>
-    <string name="general_keep_editing_action">Magpatuloy sa pag-edit</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Masyadong maikli ang recording</string>
     <string name="debug_debuglog_short_recording_message">Ang debug log ay kailangang makuha ang isyu habang nangyayari ito. Patuloy na i-record, i-reproduce ang problema, pagkatapos ay itigil ang recording.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Mga Setting ng Device</string>
     <string name="device_settings_subtitle_profile_prefix">Profile: %s</string>
-    <string name="device_settings_info_name_label">Pangalan</string>
     <string name="device_settings_info_bt_name_label">Label ng Bluetooth Device</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Tagagawa</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Siguro mamaya</string>
     <string name="review_app_body">Gusto ba ninyong mag-iwan ng pagsusuri para sa CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Pangkalahatan</string>
     <string name="device_settings_microphone_mode_label">Mikropono</string>
     <string name="device_settings_microphone_mode_description">Kung aling earbud ang ginagamit bilang mikropono</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Partager</string>
     <string name="general_done_action">Terminé</string>
     <string name="general_cancel_action">Annuler</string>
-    <string name="general_copy_action">Copier</string>
     <string name="general_thank_you_label">Merci</string>
     <string name="general_upgrade_action">Passer Pro</string>
     <string name="general_retry_action">Réessayer</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Vérifier</string>
     <string name="general_close_action">Fermer</string>
     <string name="general_dismiss_action">Fermer</string>
-    <string name="general_edit_action">Modifier</string>
     <string name="general_save_action">Enregistrer</string>
     <string name="general_guide_action">Guide</string>
     <string name="general_continue_action">Poursuivre</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Reprend la musique quand tu remets tes pods, mais seulement si la pause automatique l’a arrêtée. Les pauses que tu as déclenchées toi-même (téléphone, tige AirPods, veille) restent en pause.</string>
     <string name="settings_start_music_on_wear_label">Lancer la musique au port</string>
     <string name="settings_start_music_on_wear_description">Essaie toujours de lancer la musique quand tu mets tes pods, même après une pause manuelle.</string>
-    <string name="settings_eardetection_info_label">Note de détection de l’oreille</string>
     <string name="settings_eardetection_info_description">Si la détection de l’oreille ne fonctionne que pour un seul AirPod, cela est causé par une limitation d’Apple. Seul « l’AirPod principal » (utilisé pour le microphone) est détecté. Configurez dans les appareils Apple : Paramètres → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">Qualité minimale du signal</string>
-    <string name="settings_signal_minimum_description">Qualité minimale du signal qu’un appareil doit émettre pour être considéré le vôtre.</string>
     <string name="settings_autoconnect_label">Connexion automatique</string>
     <string name="settings_autoconnect_description">Si Android ne se connecte pas automatiquement, on peut le lui demander aussi. Cela garde CAPod en surveillance d\'arrière-plan en permanence.</string>
     <string name="settings_autoconnect_info_android12">La connexion automatique repose sur une fonctionnalité système restreinte par Android 12 et les versions ultérieures. Elle peut ne pas fonctionner sur votre appareil.</string>
     <string name="settings_autoconnect_condition_label">Condition de connexion automatique</string>
-    <string name="settings_autoconnect_condition_description">Quand devrions-nous tenter de nous connecter à votre appareil ?</string>
     <string name="settings_devices_label">Appareils</string>
     <string name="settings_devices_description">Gérez vos appareils.</string>
     <string name="settings_reaction_label">Réactions</string>
-    <string name="settings_category_yourdevice_label">Votre appareil</string>
     <string name="settings_category_compatibility_options_title">Options de compatibilité</string>
     <string name="settings_category_compatibility_options_description">Ne rien changer rien si tout fonctionne ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Désactiver le filtrage matériel</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Démarrage en cours…</string>
     <string name="support_debuglog_label">Journal de débogage</string>
     <string name="support_debuglog_desc">Enregistrez les actions de l\'appli dans un fichier texte que vous pouvez partager.</string>
-    <string name="debug_debuglog_size_label">Taille</string>
-    <string name="debug_debuglog_size_compressed_label">Taille compressée</string>
-    <string name="debug_notification_channel_label">Notifications de débogage</string>
-    <string name="debug_debuglog_file_label">Ficher journal enregistré</string>
-    <string name="debug_debuglog_recording_progress">Enregistrement du journal de débogage</string>
     <string name="debug_debuglog_record_action">Enregistrer le journal de débogage</string>
     <string name="debug_debuglog_stop_action">Arrêter l’enregistrement</string>
     <string name="debug_debuglog_sensitive_information_message">Le fichier généré comprend des renseignements sensibles (p. ex. les détails de l\'appareil Bluetooth). Ne le partagez qu\'avec des personnes de confiance.</string>
     <string name="settings_debuglog_explanation">Cette fonction enregistre les actions de l\'appli dans un fichier partageable. Le fichier généré comprend des renseignements sensibles (p. ex. les détails de l\'appareil Bluetooth). Ne le partagez qu\'avec des personnes de confiance (p. ex. un développeur qui tente de résoudre un problème).</string>
-    <string name="settings_support_installid_label">ID d’installation</string>
-    <string name="settings_support_installid_desc">Les relevés automatiques d’erreur sont anonymes. Partagez votre ID d’installation au cas où le développeur aurait besoin de trouver votre relevé d’erreur.</string>
     <string name="settings_support_label">Assistance</string>
     <string name="settings_support_description">Si vous avez besoin d’aide.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Réinitialiser les données apprises ?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod oubliera la consommation mesurée de cet appareil, sa vitesse de charge et son temps d\'écoute, et recommencera à partir de l\'autonomie nominale de la batterie.</string>
     <string name="settings_acknowledgements_label">Remerciements</string>
-    <string name="settings_debug_autoreports_label">Relevés de bogue automatiques</string>
-    <string name="settings_debug_autoreports_description">Signale automatiquement les problèmes, p. ex., les détails d’un plantage de l’appli, afin que je puisse essayer de les corriger.</string>
-    <string name="settings_compatibility_mode_label">Mode de compatibilité</string>
-    <string name="settings_compatibility_mode_description">Désactiver les optimisations pour améliorer la compatibilité. À essayer si vous ne voyez aucune donnée.</string>
     <string name="help_translate_label">Traduction</string>
     <string name="help_translate_description">Aidez à traduire cette appli dans votre langue préférée.</string>
     <string name="translators_thanks_title">Traducteurs</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Le dépannage est terminé</string>
     <string name="troubleshooter_ble_result_success_body">Les diffusions d’annonces BÉB sont reçues par CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Échec du dépannage</string>
-    <string name="troubleshooter_ble_result_failure_body">Le dépannage a échoué. Aucune des options de compatibilité n’a réglé la situation.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Votre téléphone n’a reçu aucune donnée BÉB. Vous pouvez relancer le test dans un endroit bondé pour voir si des sources de données (autres que votre casque d’écoute) sont reçues. Si aucune donnée n’est reçue, le problème pourrait provenir du système d’exploitation de votre téléphone.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Votre téléphone a reçu des données, mais les données ne proviennent pas d’un appareil pris en charge. Votre casque d’écoute est-il en fonction ? CAPod prend-il votre casque d’écoute en charge ?</string>
-    <string name="troubleshooter_ble_result_failure_action">Réessayer</string>
-    <string name="troubleshoot_action">Dépanner</string>
     <string name="onboarding_body1">Cette appli ajoute à Android des fonctions propres aux AirPods.</string>
     <string name="onboarding_body2">Tous les appareils Android ne prennent pas en charge les fonctions supplémentaires des AirPods. Votre système d’exploitation a besoin d’une mise en œuvre fonctionnelle du système à basse énergie Bluetooth.</string>
     <string name="onboarding_body3">CAPod ne présente aucune publicité et ne recueille pas vos données.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Votre appareil est connecté, mais CAPod ne reçoit aucune donnée en direct de sa part. Votre téléphone a peut-être besoin d’une option de compatibilité — le dépannage peut essayer d’en trouver une automatiquement.</string>
     <string name="overview_troubleshoot_suggestion_action">Lancer le dépannage</string>
     <string name="overview_unmatched_devices_label">Appareils sans correspondance</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d appareil sans profil correspondant</item>
-        <item quantity="other">%d appareils sans profil correspondant</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d appareil à proximité a été détecté sans profil correspondant. Affichez-le pour voir les détails disponibles. S’il est à vous, ajoutez un profil depuis Appareils pour le reconnaître.</item>
         <item quantity="other">%d appareils à proximité ont été détectés sans profil correspondant. Affichez-les pour voir les détails disponibles. Si l’un d’eux est à vous, ajoutez un profil depuis Appareils pour le reconnaître.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod utilise « l’accès à la position en arrière-plan » afin de permettre des fonctions telles qu’« Afficher une fenêtre contextuelle » et « Connexion automatique » alors que l’appli est fermée. L’accès à la position en arrière-plan permet à l’appli de recevoir les données « basse énergie » de Bluetooth. Elles ne seront PAS utilisées pour déterminer votre position géographique.</string>
     <string name="permission_ignore_battery_optimizations_label">Désactiver les optimisations de la batterie</string>
     <string name="permission_ignore_battery_optimizations_description">Les optimisations de la batterie empêchent l’appli de recevoir les données Bluetooth de manière fiable alors que l’appli est en arrière-plan.</string>
-    <string name="permission_required_title">L’autorisation suivante est nécessaire :</string>
     <string name="permission_system_alert_window_label">Fenêtre d’alerte système</string>
     <string name="permission_system_alert_window_description">Permettre à CAPod d’apparaître par-dessus les autres applis pour rendre la fonction « Afficher une fenêtre contextuelle » possible.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">S’il est visible</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">S’il est porté</string>
     <string name="pods_dual_left_label">AirPod gauche</string>
     <string name="pods_dual_right_label">AirPod droit</string>
-    <string name="pods_dual_left_short_label">G</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Étui</string>
     <string name="battery_unavailable_label">Batterie indisponible</string>
     <string name="battery_state_low_cd">Batterie faible</string>
     <string name="battery_state_critical_cd">Batterie critique</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Connexion directe active</string>
     <string name="signal_indicator_bars_cd">Intensité du signal : %1$d sur 4 barres</string>
     <string name="signal_indicator_disconnected_cd">Signal : déconnecté</string>
-    <string name="pods_yours">Les vôtres</string>
     <string name="headset_being_worn_label">Porté</string>
     <string name="headset_not_being_worn_label">Non porté</string>
     <string name="pods_case_unknown_state">État inconnu</string>
-    <string name="last_seen_x">Dernière connection : %s</string>
-    <string name="first_seen_x">Première connexion : %s</string>
     <string name="battery_cached_label">Dernière fois vu · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Qualité minimale du signal</string>
     <string name="profiles_signal_quality_description">Ne détecte que les appareils dont la force de signal est supérieure à ce seuil. Les valeurs inférieures augmentent la plage de détection, mais peuvent causer des faux positifs. Ne définissez pas ce seuil trop haut ; la réception Bluetooth est généralement faible et varie en fonction de la distance et des obstacles.</string>
     <string name="profiles_identitykey_label">Clé d’identité</string>
-    <string name="profilessettings_maindevice_identitykey_description">La clé de résolution d\'identité de votre appareil (CRI/IRK), qui aide CAPod à l\'identifier parmi les appareils proches.</string>
     <string name="profiles_maindevice_identitykey_explanation">Les AirPods changent fréquemment d’adresse Bluetooth pour des raisons de confidentialité. La CRI aide CAPod à reconnaître votre appareil. Un accès ponctuel à un MacBook est nécessaire.</string>
     <string name="profiles_maindevice_encryptionkey_label">Clé de chiffrement</string>
-    <string name="profiles_maindevice_encryptionkey_description">La clé de chiffrement de votre appareil, qui permet à CAPod de récupérer des renseignements détaillés sur l’état de l’appareil.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Les AirPods envoient un message d’état, dont une partie est chiffrée. La clé de chiffrement permet à CAPod de déchiffrer l’intégralité du message. Un accès ponctuel à un MacBook est nécessaire.</string>
     <string name="profiles_key_invalid_format">Le format de la clé est invalide</string>
     <string name="profiles_key_expected_format">Format attendu : %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Des changements ne sont pas enregistrés. Que voulez-vous faire ?</string>
     <string name="general_save_and_exit_action">Enregistrer et fermer</string>
     <string name="general_discard_action">Abandonner</string>
-    <string name="general_keep_editing_action">Continuer de modifier</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">L’enregistrement est trop court</string>
     <string name="debug_debuglog_short_recording_message">Un journal de débogage doit capturer le problème au moment où il se produit. Poursuivez l’enregistrement, reproduisez le problème, puis arrêtez l’enregistrement.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Paramètres de l’appareil</string>
     <string name="device_settings_subtitle_profile_prefix">Profil : %s</string>
-    <string name="device_settings_info_name_label">Nom</string>
     <string name="device_settings_info_bt_name_label">Étiquette de l’appareil Bluetooth</string>
     <string name="device_settings_info_model_label">Modèle</string>
     <string name="device_settings_info_manufacturer_label">Fabricant</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Plus tard, peut-être</string>
     <string name="review_app_body">Veux-tu évaluer CAPod ? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Général</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>
     <string name="device_settings_microphone_mode_description">Quel écouteur est utilisé comme microphone</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Compartir</string>
     <string name="general_done_action">Feito</string>
     <string name="general_cancel_action">Cancelar</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Grazas</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="general_retry_action">Reintentar</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Comprobar</string>
     <string name="general_close_action">Pechar</string>
     <string name="general_dismiss_action">Descartar</string>
-    <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Gardar</string>
     <string name="general_guide_action">Guía</string>
     <string name="general_continue_action">Continuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Retoma a música ao poñer os auriculares de novo, pero só se a pausa automática a detivo. As pausas que activaches ti mesmo (teléfono, botón dos AirPods, suspensión) permanecen en pausa.</string>
     <string name="settings_start_music_on_wear_label">Iniciar música ao poñer</string>
     <string name="settings_start_music_on_wear_description">Sempre intenta reproducir música cando pon os auriculares, incluso despois dunha pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota sobre detección no oído</string>
     <string name="settings_eardetection_info_description">Se a detección no oído só funciona para un auricular, esta é unha limitación de Apple. Só se detecta o \"auricular principal\" (usado para o micrófono). Configúrao en dispositivos Apple: Axustes → Bluetooth → AirPods → Micrófono.</string>
-    <string name="settings_signal_minimum_label">Calidade mínima do sinal</string>
-    <string name="settings_signal_minimum_description">A calidade mínima do sinal que un dispositivo necesita ter para ser considerado teu.</string>
     <string name="settings_autoconnect_label">Conexión automática</string>
     <string name="settings_autoconnect_description">Se Android non conecta automaticamente, nós tamén podemos pedirllo. Isto mantén a CAPod monitorizando en segundo plano en todo momento.</string>
     <string name="settings_autoconnect_info_android12">A conexión automática depende dunha función do sistema que Android 12 e versións posteriores restrinxen. É posible que non funcione no teu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condición de conexión automática</string>
-    <string name="settings_autoconnect_condition_description">Cando deberiamos tentar conectarnos ao teu dispositivo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Xestiona os teus dispositivos.</string>
     <string name="settings_reaction_label">Reaccións</string>
-    <string name="settings_category_yourdevice_label">O teu dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opcións de compatibilidade</string>
     <string name="settings_category_compatibility_options_description">Non tocar se todo funciona ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desactivar o filtrado por hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Rexistro de depuración</string>
     <string name="support_debuglog_desc">Grava todo o que fai a aplicación nun ficheiro de texto que podes compartir.</string>
-    <string name="debug_debuglog_size_label">Tamaño</string>
-    <string name="debug_debuglog_size_compressed_label">Tamaño comprimido</string>
-    <string name="debug_notification_channel_label">Notificacións de depuración</string>
-    <string name="debug_debuglog_file_label">Ficheiro de rexistro gravado</string>
-    <string name="debug_debuglog_recording_progress">Gravando rexistro de depuración</string>
     <string name="debug_debuglog_record_action">Gravar rexistro de depuración</string>
     <string name="debug_debuglog_stop_action">Deter gravación</string>
     <string name="debug_debuglog_sensitive_information_message">O ficheiro xerado contén información sensible (p. ex., detalles do dispositivo Bluetooth). Compárteo só con partes de confianza.</string>
     <string name="settings_debuglog_explanation">Esta función grava todo o que fai a aplicación nun ficheiro que se pode compartir. O ficheiro xerado contén información sensible (p. ex., detalles do dispositivo Bluetooth). Compárteo só con partes de confianza (p. ex., un programador que está a solucionar un problema).</string>
-    <string name="settings_support_installid_label">ID de instalación</string>
-    <string name="settings_support_installid_desc">Os informes de erros automáticos son anónimos. Comparte o teu ID de instalación se o programador necesita atopar os teus informes de erros.</string>
     <string name="settings_support_label">Soporte</string>
     <string name="settings_support_description">Se necesitas axuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Restablecer datos aprendidos?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod esquecerá a drenaxe medida deste dispositivo, a velocidade de carga e o tempo de escoita, e comezará de novo desde a vida útil da batería indicada.</string>
     <string name="settings_acknowledgements_label">Agradecementos</string>
-    <string name="settings_debug_autoreports_label">Informes de erros automáticos</string>
-    <string name="settings_debug_autoreports_description">Informa automaticamente de problemas, p. ex., detalles sobre un fallo da aplicación para que poida descubrir como solucionalo.</string>
-    <string name="settings_compatibility_mode_label">Modo de compatibilidade</string>
-    <string name="settings_compatibility_mode_description">Desactivar as optimizacións para mellorar a compatibilidade. Proba isto se non ves ningún dato.</string>
     <string name="help_translate_label">Tradución</string>
     <string name="help_translate_description">Axuda a traducir esta aplicación ao teu idioma favorito.</string>
     <string name="translators_thanks_title">Tradutores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Éxito</string>
     <string name="troubleshooter_ble_result_success_body">CAPod está a recibir as emisións de anuncios BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Sen éxito</string>
-    <string name="troubleshooter_ble_result_failure_body">A solución de problemas fallou. Ningunha combinación de opcións de compatibilidade axudou.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">O teu teléfono non recibiu ningún dato BLE. Podes tentalo de novo nunha zona concorrida para ver se se poden recibir fontes de datos (distintas dos teus auriculares). Non recibir datos apunta a un problema co sistema operativo do teu teléfono.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">O teu teléfono recibiu datos BLE, pero os datos non proveñen de ningún dispositivo compatible. Están acendidos os teus auriculares? CAPod é compatible cos teus auriculares?</string>
-    <string name="troubleshooter_ble_result_failure_action">Tentar de novo</string>
-    <string name="troubleshoot_action">Solucionar problemas</string>
     <string name="onboarding_body1">Esta aplicación engade soporte para funcións específicas de AirPod a Android.</string>
     <string name="onboarding_body2">Non todos os dispositivos Android admiten completamente as funcións adicionais de AirPod. O teu sistema operativo require unha implementación de Bluetooth de baixa enerxía que funcione correctamente.</string>
     <string name="onboarding_body3">CAPod non ten anuncios e non recompila os teus datos.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">O teu dispositivo está conectado, pero CAPod non está a recibir datos en tempo real del. O teu teléfono pode necesitar unha opción de compatibilidade — o solucionador de problemas pode tentar atopala automaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Executar o solucionador de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos sen perfil coincidente</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo sen perfil coincidente</item>
-        <item quantity="other">%d dispositivos sen perfil coincidente</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Detectouse %d dispositivo próximo sen un perfil coincidente. Amósao para ver os detalles dispoñibles. Se é teu, engade un perfil desde Dispositivos para recoñecelo.</item>
         <item quantity="other">Detectáronse %d dispositivos próximos sen perfís coincidentes. Amósaos para ver os detalles dispoñibles. Se algún é teu, engade un perfil desde Dispositivos para recoñecelo.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod usa o \"acceso á localización en segundo plano\" para activar funcións como \"Mostrar ventá emerxente\" e \"Conexión automática\" cando a aplicación está pechada. O acceso á localización en segundo plano permite que a aplicación reciba datos Bluetooth de baixa enerxía mentres está en segundo plano. Esta aplicación NON usará datos Bluetooth para determinar a túa localización.</string>
     <string name="permission_ignore_battery_optimizations_label">Desactivar optimizacións de batería</string>
     <string name="permission_ignore_battery_optimizations_description">As optimizacións de batería impiden que esta aplicación reciba datos Bluetooth de forma fiable mentres está en segundo plano.</string>
-    <string name="permission_required_title">É necesario o seguinte permiso:</string>
     <string name="permission_system_alert_window_label">Xanela de alerta do sistema</string>
     <string name="permission_system_alert_window_description">Permitir que CAPod debuxe sobre outras aplicacións para facer posible a función \"Mostrar PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Cando se ve</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">No oído</string>
     <string name="pods_dual_left_label">Auricular esquerdo</string>
     <string name="pods_dual_right_label">Auricular dereito</string>
-    <string name="pods_dual_left_short_label">E</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Funda</string>
     <string name="battery_unavailable_label">Batería non dispoñible</string>
     <string name="battery_state_low_cd">Batería baixa</string>
     <string name="battery_state_critical_cd">Batería criticamente baixa</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Conexión directa activa</string>
     <string name="signal_indicator_bars_cd">Intensidade do sinal: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Sinal: desconectado</string>
-    <string name="pods_yours">Teu</string>
     <string name="headset_being_worn_label">En uso</string>
     <string name="headset_not_being_worn_label">Non en uso</string>
     <string name="pods_case_unknown_state">Estado descoñecido</string>
-    <string name="last_seen_x">Visto por última vez: %s</string>
-    <string name="first_seen_x">Visto por primeira vez: %s</string>
     <string name="battery_cached_label">Último coñecido · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Calidade mínima do sinal</string>
     <string name="profiles_signal_quality_description">Detecta só dispositivos cunha intensidade de sinal por riba deste limiar. Valores máis baixos aumentan o alcance de detección, pero poden causar falsos positivos. Non poñas este valor demasiado alto: a recepción Bluetooth adoita ser pobre e varía coa distancia e os obstáculos.</string>
     <string name="profiles_identitykey_label">Chave de identidade</string>
-    <string name="profilessettings_maindevice_identitykey_description">A Chave de Resolución de Identidade (IRK) do teu dispositivo, que axuda a CAPod a identificalo entre dispositivos próximos.</string>
     <string name="profiles_maindevice_identitykey_explanation">Os AirPods cambian con frecuencia o seu enderezo Bluetooth por privacidade. A IRK axuda a CAPod a recoñecer o teu dispositivo. Necesitas acceso único a un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Chave de cifrado</string>
-    <string name="profiles_maindevice_encryptionkey_description">A chave de cifrado do teu dispositivo, que permite a CAPod obter información detallada do estado.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Os AirPods envían unha mensaxe de estado, parte da cal está cifrada. A chave de cifrado permite a CAPod descifrar a mensaxe completa. Necesitas acceso único a un MacBook.</string>
     <string name="profiles_key_invalid_format">Formato de chave non válido</string>
     <string name="profiles_key_expected_format">Formato esperado: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Tes cambios sen gardar. Que queres facer?</string>
     <string name="general_save_and_exit_action">Gardar e saír</string>
     <string name="general_discard_action">Descartar</string>
-    <string name="general_keep_editing_action">Seguir editando</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Gravación demasiado curta</string>
     <string name="debug_debuglog_short_recording_message">Un rexistro de depuración necesita capturar o problema mentres ocorre. Mantén a gravación, reproduce o problema e logo deten a gravación.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Configuración do dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nome</string>
     <string name="device_settings_info_bt_name_label">Etiqueta do dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Quizais máis tarde</string>
     <string name="review_app_body">Gustaríalle deixar unha valoración para CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Xeral</string>
     <string name="device_settings_microphone_mode_label">Micrófono</string>
     <string name="device_settings_microphone_mode_description">Cal auricular se usa como micrófono</string>
     <string name="device_settings_microphone_mode_auto">Automático</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">शेयर करें</string>
     <string name="general_done_action">हो गया</string>
     <string name="general_cancel_action">रद्द करें</string>
-    <string name="general_copy_action">कॉपी करें</string>
     <string name="general_thank_you_label">धन्यवाद</string>
     <string name="general_upgrade_action">अपग्रेड करें</string>
     <string name="general_retry_action">पुनः प्रयास करें</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">जाँचें</string>
     <string name="general_close_action">बंद करें</string>
     <string name="general_dismiss_action">खारिज करें</string>
-    <string name="general_edit_action">संपादन करें</string>
     <string name="general_save_action">सहेजें</string>
     <string name="general_guide_action">गाइड</string>
     <string name="general_continue_action">जारी रखें</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">अपने पॉड्स फिर पहनने पर संगीत फिर से शुरू करें, लेकिन केवल तभी जब ऑटो पॉज़ ने इसे रोका हो। आपके द्वारा स्वयं किए गए पॉज़ (फ़ोन, AirPods स्टेम, स्लीप) पॉज़ रहेंगे।</string>
     <string name="settings_start_music_on_wear_label">पहनने पर संगीत शुरू करें</string>
     <string name="settings_start_music_on_wear_description">जब आप अपने पॉड्स पहनते हैं तो हमेशा संगीत चलाने की कोशिश करता है, मैन्युअल पॉज़ के बाद भी।</string>
-    <string name="settings_eardetection_info_label">कान का पता लगाने की जानकारी</string>
     <string name="settings_eardetection_info_description">यदि कान का पता लगाना केवल एक पॉड के लिए काम करता है, तो यह Apple की सीमा है। केवल \"प्राथमिक पॉड\" (माइक्रोफ़ोन के लिए उपयोग किया जाने वाला) का पता लगाया जाता है। Apple डिवाइस पर कॉन्फ़िगर करें: सेटिंग्स → Bluetooth → AirPods → माइक्रोफ़ोन।</string>
-    <string name="settings_signal_minimum_label">न्यूनतम सिग्नल गुणवत्ता</string>
-    <string name="settings_signal_minimum_description">न्यूनतम सिग्नल गुणवत्ता जो किसी डिवाइस के पास आपकी मानी जाने के लिए होनी चाहिए।</string>
     <string name="settings_autoconnect_label">ऑटो-कनेक्ट</string>
     <string name="settings_autoconnect_description">यदि Android अपने आप कनेक्ट नहीं करता है, तो हम इसे भी पूछ सकते हैं। यह CAPod को हर समय पृष्ठभूमि में निगरानी रखता है।</string>
     <string name="settings_autoconnect_info_android12">ऑटो कनेक्ट एक सिस्टम फ़ीचर पर निर्भर करता है जिसे Android 12 और नए संस्करण प्रतिबंधित करते हैं। यह आपके डिवाइस पर काम नहीं कर सकता।</string>
     <string name="settings_autoconnect_condition_label">ऑटो-कनेक्ट शर्त</string>
-    <string name="settings_autoconnect_condition_description">हमें आपके डिवाइस से कनेक्ट करने का प्रयास कब करना चाहिए?</string>
     <string name="settings_devices_label">डिवाइस</string>
     <string name="settings_devices_description">अपने डिवाइस प्रबंधित करें।</string>
     <string name="settings_reaction_label">प्रतिक्रियाएँ</string>
-    <string name="settings_category_yourdevice_label">आपका डिवाइस</string>
     <string name="settings_category_compatibility_options_title">संगतता विकल्प</string>
     <string name="settings_category_compatibility_options_description">अगर सब कुछ काम कर रहा है तो स्पर्श न करें ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">हार्डवेयर फ़िल्टरिंग अक्षम करें</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">शुरू हो रहा है…</string>
     <string name="support_debuglog_label">डीबग लॉग</string>
     <string name="support_debuglog_desc">ऐप जो कुछ भी कर रहा है उसे एक टेक्स्ट फ़ाइल में रिकॉर्ड करें जिसे आप साझा कर सकते हैं।</string>
-    <string name="debug_debuglog_size_label">आकार</string>
-    <string name="debug_debuglog_size_compressed_label">संपीड़ित आकार</string>
-    <string name="debug_notification_channel_label">डीबग सूचनाएं</string>
-    <string name="debug_debuglog_file_label">रिकॉर्ड की गई लॉग फ़ाइल</string>
-    <string name="debug_debuglog_recording_progress">डीबग लॉग रिकॉर्ड किया जा रहा है</string>
     <string name="debug_debuglog_record_action">डीबग लॉग रिकॉर्ड करें</string>
     <string name="debug_debuglog_stop_action">रिकॉर्डिंग बंद करें</string>
     <string name="debug_debuglog_sensitive_information_message">उत्पन्न फ़ाइल में संवेदनशील जानकारी (जैसे ब्लूटूथ डिवाइस विवरण) होती है। इसे केवल विश्वसनीय पार्टियों के साथ साझा करें।</string>
     <string name="settings_debuglog_explanation">यह सुविधा ऐप द्वारा किए जा रहे सभी कार्यों को एक साझा करने योग्य फ़ाइल में रिकॉर्ड करती है। उत्पन्न फ़ाइल में संवेदनशील जानकारी (जैसे ब्लूटूथ डिवाइस विवरण) होती है। इसे केवल विश्वसनीय पार्टियों (जैसे किसी समस्या का निवारण करने वाले डेवलपर) के साथ साझा करें।</string>
-    <string name="settings_support_installid_label">इंस्टॉल आईडी</string>
-    <string name="settings_support_installid_desc">स्वचालित त्रुटि रिपोर्ट गुमनाम हैं। यदि डेवलपर को आपकी त्रुटि रिपोर्ट ढूंढनी है तो अपनी इंस्टॉल आईडी साझा करें।</string>
     <string name="settings_support_label">समर्थन</string>
     <string name="settings_support_description">यदि आपको कुछ सहायता चाहिए।</string>
     <string name="settings_wiki_label">विकी</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">सीखे गए डेटा को रीसेट करें?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod इस डिवाइस की मापी गई खपत, चार्जिंग गति और सुनने के समय को भूल जाएगा, और रेटेड बैटरी जीवन से फिर से शुरू करेगा।</string>
     <string name="settings_acknowledgements_label">स्वीकृतियाँ</string>
-    <string name="settings_debug_autoreports_label">स्वचालित बग रिपोर्ट</string>
-    <string name="settings_debug_autoreports_description">समस्याओं की स्वचालित रूप से रिपोर्ट करता है, जैसे ऐप क्रैश पर विवरण ताकि मैं यह पता लगा सकूं कि इसे कैसे ठीक किया जाए।</string>
-    <string name="settings_compatibility_mode_label">संगतता मोड</string>
-    <string name="settings_compatibility_mode_description">संगतता में सुधार के लिए अनुकूलन अक्षम करें। यदि आप कोई डेटा नहीं देख रहे हैं तो इसे आज़माएँ।</string>
     <string name="help_translate_label">अनुवाद</string>
     <string name="help_translate_description">इस ऐप को अपनी पसंदीदा भाषा में अनुवाद करने में सहायता करें।</string>
     <string name="translators_thanks_title">अनुवादक</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">सफलता</string>
     <string name="troubleshooter_ble_result_success_body">CAPod द्वारा BLE विज्ञापन प्रसारण प्राप्त किए जा रहे हैं।</string>
     <string name="troubleshooter_ble_result_failure_title">असफल</string>
-    <string name="troubleshooter_ble_result_failure_body">समस्या निवारण विफल रहा। संगतता विकल्पों का कोई संयोजन मदद नहीं कर सका।</string>
     <string name="troubleshooter_ble_result_failure_phone_body">आपके फ़ोन को कोई BLE डेटा बिल्कुल नहीं मिला। यह देखने के लिए कि क्या डेटा स्रोत (आपके हेडफ़ोन के अलावा) प्राप्त किए जा सकते हैं, आप इस परीक्षण को भीड़भाड़ वाले क्षेत्र में पुनः प्रयास कर सकते हैं। कोई डेटा प्राप्त न होना आपके फ़ोन के ऑपरेटिंग सिस्टम के साथ किसी समस्या की ओर इशारा करता है।</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">आपके फ़ोन को BLE डेटा मिला, लेकिन डेटा किसी समर्थित डिवाइस से नहीं आ रहा है। क्या आपके हेडफ़ोन चालू हैं? क्या CAPod आपके हेडफ़ोन का समर्थन करता है?</string>
-    <string name="troubleshooter_ble_result_failure_action">पुनः प्रयास करें</string>
-    <string name="troubleshoot_action">समस्या निवारण</string>
     <string name="onboarding_body1">यह ऐप एंड्रॉइड में एयरपॉड विशिष्ट सुविधाओं के लिए समर्थन जोड़ता है।</string>
     <string name="onboarding_body2">सभी एंड्रॉइड डिवाइस अतिरिक्त एयरपॉड सुविधाओं का पूरी तरह से समर्थन नहीं करते हैं। आपके ऑपरेटिंग सिस्टम को सही ढंग से काम करने वाले ब्लूटूथ-लो-एनर्जी कार्यान्वयन की आवश्यकता है।</string>
     <string name="onboarding_body3">CAPod में कोई विज्ञापन नहीं है और यह आपका डेटा एकत्र नहीं करता है।</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">आपका डिवाइस कनेक्टेड है, लेकिन CAPod उससे कोई लाइव डेटा प्राप्त नहीं कर रहा। आपके फ़ोन को एक संगतता विकल्प की ज़रूरत हो सकती है — समस्या निवारक इसे स्वचालित रूप से खोजने की कोशिश कर सकता है।</string>
     <string name="overview_troubleshoot_suggestion_action">समस्या निवारक चलाएँ</string>
     <string name="overview_unmatched_devices_label">बेमेल डिवाइस</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d डिवाइस बिना मेल खाते प्रोफ़ाइल के</item>
-        <item quantity="other">%d डिवाइस बिना मेल खाते प्रोफ़ाइल के</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d नज़दीकी डिवाइस बिना किसी मिलान प्रोफ़ाइल के मिला। उपलब्ध विवरण देखने के लिए इसे दिखाएँ। अगर यह आपका है, तो इसे पहचानने के लिए डिवाइस से एक प्रोफ़ाइल जोड़ें।</item>
         <item quantity="other">%d नज़दीकी डिवाइस बिना किसी मिलान प्रोफ़ाइल के मिले। उपलब्ध विवरण देखने के लिए इन्हें दिखाएँ। अगर इनमें से कोई आपका है, तो इसे पहचानने के लिए डिवाइस से एक प्रोफ़ाइल जोड़ें।</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod \"पृष्ठभूमि स्थान पहुँच\" का उपयोग \"पॉपअप दिखाएं\" और \"ऑटो-कनेक्ट\" जैसी सुविधाओं को ऐप बंद होने पर भी सक्षम करने के लिए करता है। पृष्ठभूमि स्थान पहुँच ऐप को पृष्ठभूमि में रहते हुए Bluetooth Low Energy डेटा प्राप्त करने की अनुमति देती है। यह ऐप आपका स्थान निर्धारित करने के लिए Bluetooth डेटा का उपयोग नहीं करेगा।</string>
     <string name="permission_ignore_battery_optimizations_label">बैटरी अनुकूलन अक्षम करें</string>
     <string name="permission_ignore_battery_optimizations_description">बैटरी अनुकूलन इस ऐप को पृष्ठभूमि में विश्वसनीय रूप से Bluetooth डेटा प्राप्त करने से रोकता है।</string>
-    <string name="permission_required_title">निम्नलिखित अनुमति आवश्यक है:</string>
     <string name="permission_system_alert_window_label">सिस्टम अलर्ट विंडो</string>
     <string name="permission_system_alert_window_description">CAPod को अन्य ऐप्स के ऊपर ड्रॉ करने की अनुमति दें ताकि \"पॉपअप दिखाएं\" सुविधा संभव हो सके।</string>
     <string name="settings_reaction_autoconnect_whenseen_label">जब देखा जाए</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">कान में</string>
     <string name="pods_dual_left_label">बायां पॉड</string>
     <string name="pods_dual_right_label">दायां पॉड</string>
-    <string name="pods_dual_left_short_label">बा</string>
-    <string name="pods_dual_right_short_label">दा</string>
-    <string name="pods_case_label">केस</string>
     <string name="battery_unavailable_label">बैटरी उपलब्ध नहीं</string>
     <string name="battery_state_low_cd">बैटरी कम</string>
     <string name="battery_state_critical_cd">बैटरी बेहद कम</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">डायरेक्ट कनेक्शन सक्रिय</string>
     <string name="signal_indicator_bars_cd">सिग्नल शक्ति: 4 में से %1$d बार</string>
     <string name="signal_indicator_disconnected_cd">सिग्नल: डिस्कनेक्ट</string>
-    <string name="pods_yours">आपका</string>
     <string name="headset_being_worn_label">पहना हुआ है</string>
     <string name="headset_not_being_worn_label">पहना नहीं है</string>
     <string name="pods_case_unknown_state">अज्ञात स्थिति</string>
-    <string name="last_seen_x">अंतिम बार देखा: %s</string>
-    <string name="first_seen_x">पहली बार देखा: %s</string>
     <string name="battery_cached_label">अंतिम ज्ञात · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">न्यूनतम सिग्नल गुणवत्ता</string>
     <string name="profiles_signal_quality_description">इस सीमा से ऊपर सिग्नल शक्ति वाले डिवाइस ही पहचानें। कम मान पहचान सीमा बढ़ाते हैं लेकिन गलत सकारात्मक हो सकते हैं। इसे बहुत अधिक सेट न करें - Bluetooth रिसेप्शन आम तौर पर खराब होती है और दूरी तथा बाधाओं के साथ बदलती है।</string>
     <string name="profiles_identitykey_label">पहचान कुंजी</string>
-    <string name="profilessettings_maindevice_identitykey_description">आपके डिवाइस की पहचान समाधान कुंजी (IRK), जो CAPod को पास के डिवाइसों में इसे पहचानने में मदद करती है।</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods गोपनीयता के लिए अक्सर अपना Bluetooth पता बदलते हैं। IRK CAPod को आपके डिवाइस को पहचानने में मदद करता है। आपको एक बार MacBook तक पहुँच की आवश्यकता है।</string>
     <string name="profiles_maindevice_encryptionkey_label">एन्क्रिप्शन कुंजी</string>
-    <string name="profiles_maindevice_encryptionkey_description">आपके डिवाइस की एन्क्रिप्शन कुंजी, जो CAPod को विस्तृत स्थिति जानकारी प्राप्त करने की अनुमति देती है।</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods एक स्थिति संदेश भेजते हैं, जिसका एक भाग एन्क्रिप्टेड होता है। एन्क्रिप्शन कुंजी CAPod को पूर्ण संदेश डिक्रिप्ट करने की अनुमति देती है। आपको एक बार MacBook तक पहुँच की आवश्यकता है।</string>
     <string name="profiles_key_invalid_format">अमान्य कुंजी प्रारूप</string>
     <string name="profiles_key_expected_format">अपेक्षित प्रारूप: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">आपके पास असहेजे परिवर्तन हैं। आप क्या करना चाहेंगे?</string>
     <string name="general_save_and_exit_action">सहेजें और बाहर निकलें</string>
     <string name="general_discard_action">त्यागें</string>
-    <string name="general_keep_editing_action">संपादन जारी रखें</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">रिकॉर्डिंग बहुत छोटी है</string>
     <string name="debug_debuglog_short_recording_message">डीबग लॉग को समस्या होने के दौरान उसे कैप्चर करना होगा। रिकॉर्डिंग जारी रखें, समस्या दोहराएं, फिर रिकॉर्डिंग रोकें।</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">डिवाइस सेटिंग्स</string>
     <string name="device_settings_subtitle_profile_prefix">प्रोफ़ाइल: %s</string>
-    <string name="device_settings_info_name_label">नाम</string>
     <string name="device_settings_info_bt_name_label">Bluetooth डिवाइस लेबल</string>
     <string name="device_settings_info_model_label">मॉडल</string>
     <string name="device_settings_info_manufacturer_label">निर्माता</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">शायद बाद में</string>
     <string name="review_app_body">क्या आप CAPod को एक समीक्षा देना चाहेंगे? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफ़ोन</string>
     <string name="device_settings_microphone_mode_description">कौन सा ईयरबड माइक्रोफ़ोन के रूप में उपयोग किया जाता है</string>
     <string name="device_settings_microphone_mode_auto">स्वतः</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Podijeli</string>
     <string name="general_done_action">Gotovo</string>
     <string name="general_cancel_action">Odustani</string>
-    <string name="general_copy_action">Kopiraj</string>
     <string name="general_thank_you_label">Hvala vam</string>
     <string name="general_upgrade_action">Nadogradi</string>
     <string name="general_retry_action">Pokušaj ponovno</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Provjeri</string>
     <string name="general_close_action">Zatvori</string>
     <string name="general_dismiss_action">Odbaci</string>
-    <string name="general_edit_action">Uredi</string>
     <string name="general_save_action">Spremi</string>
     <string name="general_guide_action">Vodič</string>
     <string name="general_continue_action">Nastavi</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Nastavi glazbu kad opet staviš slušalice, ali samo ako ju je zaustavio Auto pauza. Pauze koje si sam pokrenuo (telefon, AirPods drška, spavanje) ostaju pauzirane.</string>
     <string name="settings_start_music_on_wear_label">Pokreni glazbu pri nošenju</string>
     <string name="settings_start_music_on_wear_description">Uvijek pokušava reproducirati glazbu kad staviš slušalice, čak i nakon ručne pauze.</string>
-    <string name="settings_eardetection_info_label">Napomena o detekciji uha</string>
     <string name="settings_eardetection_info_description">Ako detekcija uha radi samo za jednu slušalicu, to je ograničenje Applea. Samo \"primarna slušalica\" (korištena za mikrofon) se detektira. Konfigurirajte na Apple uređajima: Postavke → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimalna kvaliteta signala</string>
-    <string name="settings_signal_minimum_description">Minimalna kvaliteta signala koju uređaj mora imati da bi se smatrao vašim.</string>
     <string name="settings_autoconnect_label">Automatsko povezivanje</string>
     <string name="settings_autoconnect_description">Ako se Android ne poveže automatski, možemo ga i mi zatražiti. Time CAPod uvijek nastavlja nadzor u pozadini.</string>
     <string name="settings_autoconnect_info_android12">Automatsko povezivanje oslanja se na sistemsku značajku koju Android 12 i noviji ograničavaju. Možda neće raditi na vašem uređaju.</string>
     <string name="settings_autoconnect_condition_label">Uvjet automatskog povezivanja</string>
-    <string name="settings_autoconnect_condition_description">Kada bismo se trebali pokušati povezati s vašim uređajem?</string>
     <string name="settings_devices_label">Uređaji</string>
     <string name="settings_devices_description">Upravljajte svojim uređajima.</string>
     <string name="settings_reaction_label">Reakcije</string>
-    <string name="settings_category_yourdevice_label">Vaš uređaj</string>
     <string name="settings_category_compatibility_options_title">Opcije kompatibilnosti</string>
     <string name="settings_category_compatibility_options_description">Ne dirajte ako sve radi ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Onemogući hardversko filtriranje</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Pokretanje…</string>
     <string name="support_debuglog_label">Zapisnik za ispravljanje pogrešaka</string>
     <string name="support_debuglog_desc">Zabilježite sve što aplikacija radi u tekstualnu datoteku koju možete podijeliti.</string>
-    <string name="debug_debuglog_size_label">Veličina</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimirana veličina</string>
-    <string name="debug_notification_channel_label">Obavijesti za ispravljanje pogrešaka</string>
-    <string name="debug_debuglog_file_label">Snimljena datoteka zapisnika</string>
-    <string name="debug_debuglog_recording_progress">Snimanje zapisnika za ispravljanje pogrešaka</string>
     <string name="debug_debuglog_record_action">Snimi zapisnik za ispravljanje pogrešaka</string>
     <string name="debug_debuglog_stop_action">Zaustavi snimanje</string>
     <string name="debug_debuglog_sensitive_information_message">Generirana datoteka sadrži osjetljive informacije (npr. detalje o Bluetooth uređaju). Podijelite je samo s pouzdanim stranama.</string>
     <string name="settings_debuglog_explanation">Ova značajka bilježi sve što aplikacija radi u datoteku koja se može dijeliti. Generirana datoteka sadrži osjetljive informacije (npr. detalje o Bluetooth uređaju). Podijelite je samo s pouzdanim stranama (npr. razvojnim programerom koji rješava problem).</string>
-    <string name="settings_support_installid_label">ID instalacije</string>
-    <string name="settings_support_installid_desc">Automatska izvješća o pogreškama su anonimna. Podijelite svoj ID instalacije ako razvojni programer treba pronaći vaša izvješća o pogreškama.</string>
     <string name="settings_support_label">Podrška</string>
     <string name="settings_support_description">Ako trebate pomoć.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Obriši naučene podatke?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod će zaboraviti izmjereno pražnjenje ovog uređaja, brzinu punjenja i vrijeme slušanja, te početi ponovno od ocijenjene životnosti baterije.</string>
     <string name="settings_acknowledgements_label">Zahvale</string>
-    <string name="settings_debug_autoreports_label">Automatska izvješća o pogreškama</string>
-    <string name="settings_debug_autoreports_description">Automatski prijavljuje probleme, npr. detalje o rušenju aplikacije kako bih mogao shvatiti kako to popraviti.</string>
-    <string name="settings_compatibility_mode_label">Način kompatibilnosti</string>
-    <string name="settings_compatibility_mode_description">Onemogućite optimizacije kako biste poboljšali kompatibilnost. Pokušajte ovo ako ne vidite nikakve podatke.</string>
     <string name="help_translate_label">Prijevod</string>
     <string name="help_translate_description">Pomozite prevesti ovu aplikaciju na svoj omiljeni jezik.</string>
     <string name="translators_thanks_title">Prevoditelji</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Uspjeh</string>
     <string name="troubleshooter_ble_result_success_body">CAPod prima BLE oglasne emisije.</string>
     <string name="troubleshooter_ble_result_failure_title">Neuspješno</string>
-    <string name="troubleshooter_ble_result_failure_body">Rješavanje problema nije uspjelo. Nijedna kombinacija opcija kompatibilnosti nije pomogla.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Vaš telefon uopće nije primio nikakve BLE podatke. Možete ponovno pokušati ovaj test na prometnom mjestu kako biste vidjeli mogu li se primiti izvori podataka (osim vaših slušalica). Neprimanje podataka ukazuje na problem s operativnim sustavom vašeg telefona.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Vaš telefon je primio BLE podatke, ali podaci ne dolaze s nijednog podržanog uređaja. Jesu li vaše slušalice uključene? Podržava li CAPod vaše slušalice?</string>
-    <string name="troubleshooter_ble_result_failure_action">Pokušaj ponovno</string>
-    <string name="troubleshoot_action">Riješi problem</string>
     <string name="onboarding_body1">Ova aplikacija dodaje podršku za značajke specifične za AirPod na Android.</string>
     <string name="onboarding_body2">Ne podržavaju svi Android uređaji u potpunosti dodatne značajke AirPoda. Vaš operativni sustav zahtijeva ispravno funkcionirajuću implementaciju Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod nema oglasa i ne prikuplja vaše podatke.</string>
@@ -207,11 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tvoj uređaj je spojen, ali CAPod ne prima žive podatke od njega. Tvoj telefon možda treba opciju kompatibilnosti — alat za rješavanje problema može pokušati pronaći jednu automatski.</string>
     <string name="overview_troubleshoot_suggestion_action">Pokreni rješavanje problema</string>
     <string name="overview_unmatched_devices_label">Nepodudarni uređaji</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d uređaj bez odgovarajućeg profila</item>
-        <item quantity="few">%d uređaja bez odgovarajućeg profila</item>
-        <item quantity="other">%d uređaja bez odgovarajućeg profila</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Otkriven je %d obližnji uređaj bez odgovarajućeg profila. Prikažite ga za dostupne pojedinosti. Ako je vaš, dodajte profil iz odjeljka Uređaji kako biste ga prepoznali.</item>
         <item quantity="few">Otkrivena su %d obližnja uređaja bez odgovarajućih profila. Prikažite ih za dostupne pojedinosti. Ako je jedan vaš, dodajte profil iz odjeljka Uređaji kako biste ga prepoznali.</item>
@@ -234,7 +208,6 @@
     <string name="permission_background_location_description">CAPod koristi \"pristup lokaciji u pozadini\" za omogućavanje značajki poput \"Prikaži skočni prozor\" i \"Automatsko povezivanje\" dok je aplikacija zatvorena. Pristup lokaciji u pozadini omogućuje aplikaciji primanje Bluetooth Low Energy podataka u pozadini. Ova aplikacija NEĆE koristiti Bluetooth podatke za određivanje vaše lokacije.</string>
     <string name="permission_ignore_battery_optimizations_label">Onemogući optimizacije baterije</string>
     <string name="permission_ignore_battery_optimizations_description">Optimizacije baterije sprječavaju ovu aplikaciju u pouzdanom primanju Bluetooth podataka dok je aplikacija u pozadini.</string>
-    <string name="permission_required_title">Sljedeća dozvola je potrebna:</string>
     <string name="permission_system_alert_window_label">Prozor sistemskog upozorenja</string>
     <string name="permission_system_alert_window_description">Dopustite CAPod-u crtanje preko drugih aplikacija kako bi omogućili značajku \"Prikaži skočni prozor\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kada je viđen</string>
@@ -242,9 +215,6 @@
     <string name="settings_reaction_autoconnect_inear_label">U uhu</string>
     <string name="pods_dual_left_label">Lijeva slušalica</string>
     <string name="pods_dual_right_label">Desna slušalica</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Kućište</string>
     <string name="battery_unavailable_label">Baterija nije dostupna</string>
     <string name="battery_state_low_cd">Baterija slaba</string>
     <string name="battery_state_critical_cd">Baterija kritično slaba</string>
@@ -299,12 +269,9 @@
     <string name="signal_badge_aap_cd">Izravna veza aktivna</string>
     <string name="signal_indicator_bars_cd">Jačina signala: %1$d od 4 crte</string>
     <string name="signal_indicator_disconnected_cd">Signal: nije povezano</string>
-    <string name="pods_yours">Vaš</string>
     <string name="headset_being_worn_label">Nosi se</string>
     <string name="headset_not_being_worn_label">Ne nosi se</string>
     <string name="pods_case_unknown_state">Nepoznato stanje</string>
-    <string name="last_seen_x">Zadnji put viđeno: %s</string>
-    <string name="first_seen_x">Prvi put viđeno: %s</string>
     <string name="battery_cached_label">Zadnje poznato · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -334,10 +301,8 @@
     <string name="profiles_signal_quality_title">Minimalna kvaliteta signala</string>
     <string name="profiles_signal_quality_description">Detektiraj samo uređaje s jačinom signala iznad ovog praga. Niže vrijednosti povećavaju domet detekcije, ali mogu uzrokovati lažne pozitivne rezultate. Ne postavljajte previsoko - Bluetooth prijem je općenito loš i varira s udaljenošću i preprekama.</string>
     <string name="profiles_identitykey_label">Identifikacijski ključ</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) vašeg uređaja, koji pomaže CAPod-u identificirati ga među obližnjim uređajima.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods često mijenjaju svoju Bluetooth adresu radi privatnosti. IRK pomaže CAPod-u prepoznati vaš uređaj. Potreban vam je jednokratni pristup MacBook-u.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ključ šifriranja</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ključ za šifriranje vašeg uređaja, koji omogućuje CAPod-u dohvaćanje detaljnih informacija o statusu.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods šalju statusnu poruku čiji je dio šifriran. Ključ za šifriranje omogućuje CAPod-u dešifriranje cijele poruke. Potreban vam je jednokratni pristup MacBook-u.</string>
     <string name="profiles_key_invalid_format">Nevažeći format ključa</string>
     <string name="profiles_key_expected_format">Očekivani format: %1$s</string>
@@ -370,7 +335,6 @@
     <string name="general_unsaved_changes_message">Imate nespremljene promjene. Što želite učiniti?</string>
     <string name="general_save_and_exit_action">Spremi &amp; izađi</string>
     <string name="general_discard_action">Odbaci</string>
-    <string name="general_keep_editing_action">Nastavi uređivanje</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Snimanje prekratko</string>
     <string name="debug_debuglog_short_recording_message">Debug zapisnik mora zabilježiti problem dok se događa. Nastavite snimanje, reproducirašte problem, a zatim zaustavite snimanje.</string>
@@ -444,7 +408,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Postavke uređaja</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Naziv</string>
     <string name="device_settings_info_bt_name_label">Oznaka Bluetooth uređaja</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Proizvođač</string>
@@ -524,7 +487,6 @@
     <string name="review_app_dismiss_action">Možda kasnije</string>
     <string name="review_app_body">Želiš li ostaviti recenziju za CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Općenito</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Koja slušalica se koristi kao mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Automatski</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Megosztás</string>
     <string name="general_done_action">Kész</string>
     <string name="general_cancel_action">Mégsem</string>
-    <string name="general_copy_action">Másolás</string>
     <string name="general_thank_you_label">Köszönöm</string>
     <string name="general_upgrade_action">Frissítés</string>
     <string name="general_retry_action">Újra próbálkozás</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Ellenőrzés</string>
     <string name="general_close_action">Bezár</string>
     <string name="general_dismiss_action">Elvetés</string>
-    <string name="general_edit_action">Szerkesztés</string>
     <string name="general_save_action">Mentés</string>
     <string name="general_guide_action">Útmutató</string>
     <string name="general_continue_action">Tovább</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Folytatja a zenét, ha újra felveszed a fülhallgatót, de csak akkor, ha az Auto szünet állította le. A te magad által kiváltott szünetek (telefon, AirPods szár, alvás) szüneteltetett állapotban maradnak.</string>
     <string name="settings_start_music_on_wear_label">Zene indítása felvételkor</string>
     <string name="settings_start_music_on_wear_description">Mindig megpróbál zenét lejátszani, ha felveszed a fülhallgatót, még kézi szünet után is.</string>
-    <string name="settings_eardetection_info_label">Fülészlelési megjegyzés</string>
     <string name="settings_eardetection_info_description">Ha a fülészlelés csak az egyik fülhallgatóval működik, ez egy Apple korlátozás. Csak az \"elsődleges fülhallgató\" (mikrofonhoz használt) érzékelhető. Beállítás Apple eszközökön: Beállítások → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimális jelerősség</string>
-    <string name="settings_signal_minimum_description">Vegye figyelembe a minimális jelerősséget, amelyre egy eszköznek szüksége van.</string>
     <string name="settings_autoconnect_label">Automatikus csatlakozás</string>
     <string name="settings_autoconnect_description">Ha az Android nem csatlakozik automatikusan, mi is kérhetjük tőle. Ez azt biztosítja, hogy a CAPod mindig figyel a háttérben.</string>
     <string name="settings_autoconnect_info_android12">Az automatikus csatlakozás olyan rendszerfunkcióra támaszkodik, amelyet az Android 12 és újabb verziók korlátoznak. Előfordulhat, hogy nem működik az eszközödön.</string>
     <string name="settings_autoconnect_condition_label">Automatikus csatlakozás állapota</string>
-    <string name="settings_autoconnect_condition_description">Mikor próbáljunk meg csatlakozni az eszközéhez?</string>
     <string name="settings_devices_label">Eszközök</string>
     <string name="settings_devices_description">Eszközök kezelése.</string>
     <string name="settings_reaction_label">Reakciók</string>
-    <string name="settings_category_yourdevice_label">Eszközei</string>
     <string name="settings_category_compatibility_options_title">Kompatibilitási opciók</string>
     <string name="settings_category_compatibility_options_description">Ezekhez ne nyúljon, ha minden jól műkődik ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Hardveres szűrés letiltása</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Indítás alatt…</string>
     <string name="support_debuglog_label">Hibakeresési napló</string>
     <string name="support_debuglog_desc">Rögzítse mindazt, amit az alkalmazás csinál, egy megosztható szövegfájlba.</string>
-    <string name="debug_debuglog_size_label">Méret</string>
-    <string name="debug_debuglog_size_compressed_label">Tömörített méret</string>
-    <string name="debug_notification_channel_label">Hibakeresési értesítések</string>
-    <string name="debug_debuglog_file_label">Rögzített naplófájl</string>
-    <string name="debug_debuglog_recording_progress">Hibakeresési napló rögzítése</string>
     <string name="debug_debuglog_record_action">Hibakeresési napló rögzítése</string>
     <string name="debug_debuglog_stop_action">Rögzítés leállítása</string>
     <string name="debug_debuglog_sensitive_information_message">A generált fájl érzékeny információkat tartalmaz (pl. a Bluetooth-eszköz adatait). Csak megbízható felekkel ossza meg.</string>
     <string name="settings_debuglog_explanation">Ez a funkció egy megosztható fájlba rögzíti mindazt, amit az alkalmazás csinál. A létrehozott fájl bizalmas információkat tartalmaz (például Bluetooth-eszköz adatait). Csak megbízható felekkel ossza meg (pl. egy fejlesztővel, aki egy probléma megoldását végzi).</string>
-    <string name="settings_support_installid_label">Telepítési azonosító</string>
-    <string name="settings_support_installid_desc">Az automatikus hibajelentések névtelenek. Ossza meg az azonosítót, ha fejlesztőnek meg kell keresnie a hibajelentésedet.</string>
     <string name="settings_support_label">Támogatás</string>
     <string name="settings_support_description">Ha segítségre van szüksége.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Megtanult adatok alaphelyzetbe állítása?</string>
     <string name="device_battery_estimate_reset_confirm_message">A CAPod elfelejti az eszköz mért fogyasztását, töltési sebességét és figyelési idejét, majd a névleges akkumulátor-élettartamtól kezd újra.</string>
     <string name="settings_acknowledgements_label">Köszönetnyilvánítás</string>
-    <string name="settings_debug_autoreports_label">Automatikus hibajelentések</string>
-    <string name="settings_debug_autoreports_description">Automatikusan jelenti a problémákat, például részleteket az alkalmazás összeomlásáról, hogy kitaláljam, hogyan javíthatom ki.</string>
-    <string name="settings_compatibility_mode_label">Kompatibilitási mód</string>
-    <string name="settings_compatibility_mode_description">A kompatibilitás javítása érdekében letiltja az optimalizálást. Próbálja ki ezt, ha nem lát semmilyen adatot.</string>
     <string name="help_translate_label">Fordítás</string>
     <string name="help_translate_description">Segítsen nekünk hogy az alkalmazás le legyen fordítva az Ön nyelvére.</string>
     <string name="translators_thanks_title">Fordító</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Siker</string>
     <string name="troubleshooter_ble_result_success_body">A CAPod fogadja a BLE állapotinformációkat.</string>
     <string name="troubleshooter_ble_result_failure_title">Nem sikerült</string>
-    <string name="troubleshooter_ble_result_failure_body">A hibaelhárítás nem sikerült. A kompatibilitási opciók nem segítettek.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">A telefon egyáltalán nem kapott BLE-adatokat. Megpróbálhatja újra ezt a tesztet egy zsúfolt területen, hogy lássa (hogy a fülhallgatóján kívül) más adatforrások is fogadhatók-e. Ha nem érkezik adat, az a telefon operációs rendszerével kapcsolatos problémára utal.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">A telefon BLE-adatokat fogadott, de az adatok nem egy támogatott eszközről származnak. Be van kapcsolva a fülhallgatója? Támogatja a CAPod a fülhallgatóját?</string>
-    <string name="troubleshooter_ble_result_failure_action">Próbálja újra</string>
-    <string name="troubleshoot_action">Hibaelhárító</string>
     <string name="onboarding_body1">Ez az alkalmazás AirPod specifikus funkciók támogatását adja hozzá az Android rendszerhez.</string>
     <string name="onboarding_body2">Nem minden Android eszköz támogatja teljes mértékben az extra AirPod szolgáltatásokat. Az eszköz operációs rendszere megfelelően működő Bluetooth-Low-Energy megvalósítást igényel.</string>
     <string name="onboarding_body3">A CAPod nem tartalmaz hirdetéseket, és nem gyűjti az adataidat.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Az eszköz csatlakoztatva van, de a CAPod nem kap élő adatot tőle. Előfordulhat, hogy a telefonodnak kompatibilitási beállításra van szüksége – a hibaelőárító automatikusan megpróbálhat egyet találni.</string>
     <string name="overview_troubleshoot_suggestion_action">Hibaelőárító futtatása</string>
     <string name="overview_unmatched_devices_label">Nem párosított eszközök</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d eszköz párosított profil nélkül</item>
-        <item quantity="other">%d eszköz párosított profil nélkül</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d közeli eszközt észleltünk illeszkedő profil nélkül. Nyisd meg a rendelkezésre álló részletekért. Ha a tiéd, adj hozzá egy profilt az Eszközök menüben, hogy felismerje.</item>
         <item quantity="other">%d közeli eszközt észleltünk illeszkedő profilok nélkül. Nyisd meg őket a rendelkezésre álló részletekért. Ha valamelyik a tiéd, adj hozzá egy profilt az Eszközök menüben, hogy felismerje.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">A CAPod a \"háttérbeli helyhozzáférést\" használja az olyan funkciók engedélyezéséhez, mint az \"Előugró ablak megjelenítése\" és az \"Automatikus csatlakozás\", miközben az alkalmazás zárva van. A háttérbeli helyhozzáférés lehetővé teszi az alkalmazás számára, hogy a háttérben is fogadja a Bluetooth Low Energy adatokat. Ez az alkalmazás NEM fogja a Bluetooth-adatokat a tartózkodási hely meghatározására használni.</string>
     <string name="permission_ignore_battery_optimizations_label">Akkumulátor-optimalizálás kikapcsolása</string>
     <string name="permission_ignore_battery_optimizations_description">Az akkumulátor-optimalizálás megakadályozza, hogy ez az alkalmazás megbízhatóan fogadja a Bluetooth-adatokat a háttérben.</string>
-    <string name="permission_required_title">A következő engedély szükséges:</string>
     <string name="permission_system_alert_window_label">Rendszer figyelmeztető ablak</string>
     <string name="permission_system_alert_window_description">Engedélyezze a CAPod-nak, hogy más alkalmazások fölé rajzoljon az \"Előugró ablak megjelenítése\" funkció lehetővé tételéhez.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Amikor észlelhető</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Fülben</string>
     <string name="pods_dual_left_label">Bal fülhallgató</string>
     <string name="pods_dual_right_label">Jobb fülhallgató</string>
-    <string name="pods_dual_left_short_label">B</string>
-    <string name="pods_dual_right_short_label">J</string>
-    <string name="pods_case_label">Tok</string>
     <string name="battery_unavailable_label">Az akkumulátor nem elérhető</string>
     <string name="battery_state_low_cd">Akkumulátor alacsony</string>
     <string name="battery_state_critical_cd">Akkumulátor kritikusan alacsony</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Közvetlen kapcsolat aktív</string>
     <string name="signal_indicator_bars_cd">Jelszint: %1$d / 4 sáv</string>
     <string name="signal_indicator_disconnected_cd">Jel: lecsatlakoztatva</string>
-    <string name="pods_yours">Saját</string>
     <string name="headset_being_worn_label">Viselve</string>
     <string name="headset_not_being_worn_label">Nincs viselve</string>
     <string name="pods_case_unknown_state">Ismeretlen állapot</string>
-    <string name="last_seen_x">Utoljára látva: %s</string>
-    <string name="first_seen_x">Először látva: %s</string>
     <string name="battery_cached_label">Utoljára ismert · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dó %2$dp</string>
     <string name="battery_time_remaining_format_h">%1$dó</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimális jelerősség</string>
     <string name="profiles_signal_quality_description">Csak az e küszöbérték feletti jelerősségű eszközöket észleli. Az alacsonyabb értékek növelik az észlelési hatótávolságot, de hamis pozitívumokat okozhatnak. Ne állítsa túl magasra - a Bluetooth vétel általában gyenge, és a távolsággal és az akadályokkal változik.</string>
     <string name="profiles_identitykey_label">Azonosítókulcs</string>
-    <string name="profilessettings_maindevice_identitykey_description">Az eszköze azonosítófeloldó kulcsa (IRK), amely segíti a CAPod-ot az eszköz azonosításában a közeli eszközök között.</string>
     <string name="profiles_maindevice_identitykey_explanation">Az AirPods gyakran változtatja a Bluetooth-címét az adatvédelem érdekében. Az IRK segít a CAPod-nak felismerni az eszközét. Egyszeri hozzáférés szükséges egy MacBookhoz.</string>
     <string name="profiles_maindevice_encryptionkey_label">Titkosítási kulcs</string>
-    <string name="profiles_maindevice_encryptionkey_description">Az eszköze titkosítási kulcsa, amely lehetővé teszi a CAPod számára a részletes állapotinformációk lekérését.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Az AirPods egy állapotüzenetet küld, amelynek egy része titkosított. A titkosítási kulcs lehetővé teszi a CAPod számára a teljes üzenet visszafejtését. Egyszeri hozzáférés szükséges egy MacBookhoz.</string>
     <string name="profiles_key_invalid_format">Érvénytelen kulcsformátum</string>
     <string name="profiles_key_expected_format">Várt formátum: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Nem mentett változtatásai vannak. Mit szeretne tenni?</string>
     <string name="general_save_and_exit_action">Mentés és kilépés</string>
     <string name="general_discard_action">Elvetés</string>
-    <string name="general_keep_editing_action">Szerkesztés folytatása</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">A felvétel túll rövid</string>
     <string name="debug_debuglog_short_recording_message">A hibanaplónak rögzítenie kell a problémát, miután az előfordul. Folytasd a rögzítést, reprodukáld a problémát, majd állítsd le a rögzítést.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Eszközbeállítások</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Név</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-eszköz neve</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Gyártó</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Talán később</string>
     <string name="review_app_body">Szeretnél véleményt hagyni a CAPodról? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Általános</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Melyik fülhallgató van mikrofonként használva</string>
     <string name="device_settings_microphone_mode_auto">Automatikus</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Կիսվել</string>
     <string name="general_done_action">Պատրաստ է</string>
     <string name="general_cancel_action">Չեղարկել</string>
-    <string name="general_copy_action">Պատճենել</string>
     <string name="general_thank_you_label">Շնորհակալություն</string>
     <string name="general_upgrade_action">Թարմացնել</string>
     <string name="general_retry_action">Կրկնել</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Ստուգել</string>
     <string name="general_close_action">Փակել</string>
     <string name="general_dismiss_action">Մերժել</string>
-    <string name="general_edit_action">Խմբագրել</string>
     <string name="general_save_action">Պահպանել</string>
     <string name="general_guide_action">Ուղեցույց</string>
     <string name="general_continue_action">Շարունակել</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Վերսկսել երաժշտությունը, երբ կրկին կրում եք ականջակալները, բայց միայն եթե Ավտոդադարը դադարեցրել է այն: Ձեր ձեռքով կատարած դադարները (հեռախոս, AirPods ոտք, քուն) մնում են դադարած:</string>
     <string name="settings_start_music_on_wear_label">Երաժշտություն սկսել կրելիս</string>
     <string name="settings_start_music_on_wear_description">Միշտ փորձում է նվագել երաժշտություն, երբ կկրեք ականջակալները, նույնիսկ ձեռքով դադարից հետո:</string>
-    <string name="settings_eardetection_info_label">Ականջում հայտնաբերման նշում</string>
     <string name="settings_eardetection_info_description">Եթե ականջում հայտնաբերումը աշխատում է միայն մեկ ականջակալի համար, սա Apple-ի սահմանափակում է։ Միայն \"հիմնական ականջակալը\" (որն օգտագործվում է բարձրախոսի համար) է հայտնաբերվում։ Կարգավորեք Apple սարքերում՝ Կարգավորումներ → Bluetooth → AirPods → Բարձրախոս։</string>
-    <string name="settings_signal_minimum_label">Ազդանշանի նվազագույն որակ</string>
-    <string name="settings_signal_minimum_description">Ազդանշանի նվազագույն որակը, որը պետք է ունենա սարքը՝ ձերը համարվելու համար։</string>
     <string name="settings_autoconnect_label">Ինքնամիացում</string>
     <string name="settings_autoconnect_description">Եթե Android-ը ինքնաբերաբար չի միանում, մենք կարող ենք այն հարցնել նաև: Սա պահում է CAPod մոնիտորինգը ֆոնային ռեժիմում ամբողջ ժամանակ:</string>
     <string name="settings_autoconnect_info_android12">Ավտոմատ կապը հիմնված է համակարգի հատկության վրա, որը Android 12-ը և ավելի նոր տարբերակները սահմանափակում են: Հնարավոր է այն չաշխատի ձեր սարքում:</string>
     <string name="settings_autoconnect_condition_label">Ինքնամիացման պայման</string>
-    <string name="settings_autoconnect_condition_description">Ե՞րբ պետք է փորձենք միանալ ձեր սարքին։</string>
     <string name="settings_devices_label">Սարքեր</string>
     <string name="settings_devices_description">Կառավարեք ձեր սարքերը։</string>
     <string name="settings_reaction_label">Արձագանքներ</string>
-    <string name="settings_category_yourdevice_label">Ձեր սարքը</string>
     <string name="settings_category_compatibility_options_title">Համատեղելիության ընտրանքներ</string>
     <string name="settings_category_compatibility_options_description">Մի դիպչեք, եթե ամեն ինչ աշխատում է ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Անջատել սարքակազմային զտումը</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Մեկնարկում է…</string>
     <string name="support_debuglog_label">Կարգաբերման մատյան</string>
     <string name="support_debuglog_desc">Գրանցեք այն ամենը, ինչ անում է հավելվածը տեքստային ֆայլում, որը կարող եք կիսվել։</string>
-    <string name="debug_debuglog_size_label">Չափը</string>
-    <string name="debug_debuglog_size_compressed_label">Սեղմված չափը</string>
-    <string name="debug_notification_channel_label">Կարգաբերման ծանուցումներ</string>
-    <string name="debug_debuglog_file_label">Գրանցված մատյանի ֆայլ</string>
-    <string name="debug_debuglog_recording_progress">Կարգաբերման մատյանի գրանցում</string>
     <string name="debug_debuglog_record_action">Գրանցել կարգաբերման մատյանը</string>
     <string name="debug_debuglog_stop_action">Դադարեցնել գրանցումը</string>
     <string name="debug_debuglog_sensitive_information_message">Ստեղծված ֆայլը պարունակում է զգայուն տեղեկատվություն (օրինակ՝ Bluetooth սարքի մանրամասները)։ Կիսվեք այն միայն վստահելի կողմերի հետ։</string>
     <string name="settings_debuglog_explanation">Այս գործառույթը գրանցում է այն ամենը, ինչ անում է հավելվածը, համօգտագործվող ֆայլում։ Ստեղծված ֆայլը պարունակում է զգայուն տեղեկատվություն (օրինակ՝ Bluetooth սարքի մանրամասները)։ Կիսվեք այն միայն վստահելի կողմերի հետ (օրինակ՝ մշակողի հետ, որը լուծում է խնդիրը)։</string>
-    <string name="settings_support_installid_label">Տեղադրման ID</string>
-    <string name="settings_support_installid_desc">Սխալների ավտոմատ հաշվետվություններն անանուն են։ Կիսվեք ձեր տեղադրման ID-ով, եթե մշակողը պետք է գտնի ձեր սխալների հաշվետվությունները։</string>
     <string name="settings_support_label">Աջակցություն</string>
     <string name="settings_support_description">Եթե օգնության կարիք ունեք։</string>
     <string name="settings_wiki_label">Վիքի</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Վերականգնել սովորած տվյալները?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod-ը կմոռանա այս սարքի չափված լիցքազրկումը, լիցքավորման արագությունը և լսելու ժամանակը, և կսկսի նորից գնահատված մարտկոցի կյանքից:</string>
     <string name="settings_acknowledgements_label">Շնորհակալագրեր</string>
-    <string name="settings_debug_autoreports_label">Սխալների ավտոմատ հաշվետվություններ</string>
-    <string name="settings_debug_autoreports_description">Ավտոմատ կերպով հաղորդում է խնդիրների մասին, օրինակ՝ հավելվածի խափանման մանրամասները, որպեսզի կարողանամ պարզել, թե ինչպես այն շտկել։</string>
-    <string name="settings_compatibility_mode_label">Համատեղելիության ռեժիմ</string>
-    <string name="settings_compatibility_mode_description">Անջատեք օպտիմիզացումները՝ համատեղելիությունը բարելավելու համար։ Փորձեք սա, եթե տվյալներ չեք տեսնում։</string>
     <string name="help_translate_label">Թարգմանություն</string>
     <string name="help_translate_description">Օգնեք թարգմանել այս հավելվածը ձեր սիրելի լեզվով։</string>
     <string name="translators_thanks_title">Թարգմանիչներ</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Հաջողություն</string>
     <string name="troubleshooter_ble_result_success_body">BLE գովազդային հեռարձակումները ստացվում են CAPod-ի կողմից։</string>
     <string name="troubleshooter_ble_result_failure_title">Անհաջող</string>
-    <string name="troubleshooter_ble_result_failure_body">Խնդիրների լուծումը ձախողվեց։ Համատեղելիության տարբերակների ոչ մի համակցություն չօգնեց։</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ձեր հեռախոսն ընդհանրապես BLE տվյալներ չի ստացել։ Կարող եք այս թեստն անցկացնել մարդաշատ վայրում՝ տեսնելու, թե արդյոք կարող են ստացվել տվյալների աղբյուրներ (բացի ձեր ականջակալներից)։ Տվյալներ չստանալը վկայում է ձեր հեռախոսի օպերացիոն համակարգի հետ կապված խնդրի մասին։</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Ձեր հեռախոսը BLE տվյալներ է ստացել, սակայն տվյալները չեն գալիս որևէ աջակցվող սարքից։ Ձեր ականջակալները միացվա՞ծ են։ CAPod-ն աջակցո՞ւմ է ձեր ականջակալներին։</string>
-    <string name="troubleshooter_ble_result_failure_action">Կրկին փորձել</string>
-    <string name="troubleshoot_action">Լուծել խնդիրները</string>
     <string name="onboarding_body1">Այս հավելվածը Android-ին ավելացնում է AirPod-ի հատուկ գործառույթների աջակցություն։</string>
     <string name="onboarding_body2">Ոչ բոլոր Android սարքերն են լիովին աջակցում AirPod-ի լրացուցիչ գործառույթները։ Ձեր օպերացիոն համակարգը պահանջում է Bluetooth-Low-Energy-ի ճիշտ աշխատող իրականացում։</string>
     <string name="onboarding_body3">CAPod-ը գովազդ չունի և չի հավաքում ձեր տվյալները։</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Ձեր սարքը միացված է, սակայն CAPod-ը կենդանի տվյալներ չի ստանում դրանից: Ձեր հեռախոսը կարող է կոմպատիբիլության տարբերակի կարիք ունենալ — խնդիրների լուծիչը կարող է ավտոմատ կերպով գտնել համապատասխանը:</string>
     <string name="overview_troubleshoot_suggestion_action">Գործարկել խնդիրների լուծիչը</string>
     <string name="overview_unmatched_devices_label">Չհամապատասխանող սարքեր</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d սարք՝ առանց համապատասխան պրոֆիլի</item>
-        <item quantity="other">%d սարք՝ առանց համապատասխան պրոֆիլի</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d մոտակա սարք հայտնաբերվեց առանց համապատասխան պրոֆիլի: Ցուցադրեք մատչելի մանրամասների համար: Եթե այն ձերն է, ավելացրեք պրոֆիլ Սարքեր բաժնից՝ այն ճանաչելու համար:</item>
         <item quantity="other">%d մոտակա սարքեր հայտնաբերվեցին առանց համապատասխան պրոֆիլների: Ցուցադրեք դրանք մատչելի մանրամասների համար: Եթե դրանցից մեկը ձերն է, ավելացրեք պրոֆիլ Սարքեր բաժնից՝ այն ճանաչելու համար:</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod-ը օգտագործում է \"ֆոնային տեղադրության մուտք\" թույլտվությունը՝ \"Ցուցադրել բացվող պատուհան\" և \"Ինքնամիացում\" գործառույթները միացնելու համար, երբ հավելվածը փակ է։ Ֆոնային տեղադրության մուտքը հավելվածին թույլ է տալիս ստանալ Bluetooth Low Energy տվյալներ, երբ այն ֆոնային ռեժիմում է։ Այս հավելվածը ՉԻ օգտագործի Bluetooth տվյալները ձեր տեղադրությունը որոշելու համար։</string>
     <string name="permission_ignore_battery_optimizations_label">Անջատել մարտկոցի օպտիմիզացումները</string>
     <string name="permission_ignore_battery_optimizations_description">Մարտկոցի օպտիմիզացումները թույլ չեն տալիս այս հավելվածին հուսալիորեն ստանալ Bluetooth տվյալներ, երբ այն ֆոնային ռեժիմում է։</string>
-    <string name="permission_required_title">Հետևյալ թույլտվությունն անհրաժեշտ է՝</string>
     <string name="permission_system_alert_window_label">Համակարգային զգուշացման պատուհան</string>
     <string name="permission_system_alert_window_description">Թույլ տվեք CAPod-ին նկարել այլ հավելվածների վերևում՝ \"Ցուցադրել բացվող պատուհան\" գործառույթը հնարավոր դարձնելու համար։</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Երբ տեսնվում է</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Ականջում է</string>
     <string name="pods_dual_left_label">Ձախ ականջակալ</string>
     <string name="pods_dual_right_label">Աջ ականջակալ</string>
-    <string name="pods_dual_left_short_label">Ձ</string>
-    <string name="pods_dual_right_short_label">Ա</string>
-    <string name="pods_case_label">Պատյան</string>
     <string name="battery_unavailable_label">Մարտկոցը անհասանելի է</string>
     <string name="battery_state_low_cd">Մարտկոցի ցածր լիցք</string>
     <string name="battery_state_critical_cd">Մարտկոցի կրիտիկական ցածր լիցք</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Ուղղակի կապն ակտիվ է</string>
     <string name="signal_indicator_bars_cd">Ազդանշանի ուժ՝ %1$d 4-ից</string>
     <string name="signal_indicator_disconnected_cd">Ազդանշան՝ անջատված</string>
-    <string name="pods_yours">Ձերը</string>
     <string name="headset_being_worn_label">Կրվում է</string>
     <string name="headset_not_being_worn_label">Չի կրվում</string>
     <string name="pods_case_unknown_state">Անհայտ վիճակ</string>
-    <string name="last_seen_x">Վերջին անգամ տեսնված՝ %s</string>
-    <string name="first_seen_x">Առաջին անգամ տեսնված՝ %s</string>
     <string name="battery_cached_label">Վերջին հայտնի · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dժ %2$dր</string>
     <string name="battery_time_remaining_format_h">%1$dժ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Ազդանշանի նվազագույն որակ</string>
     <string name="profiles_signal_quality_description">Հայտնաբերել միայն այն սարքերը, որոնց ազդանշանի ուժը բարձր է այս շեմից։ Ցածր արժեքները մեծացնում են հայտնաբերման տարածությունը, բայց կարող են առաջացնել սխալ դրական արդյունքներ։ Սա չափազանց բարձր մի՛ դրեք՝ Bluetooth ընդունումն ընդհանրապես թույլ է և փոխվում է՝ կախված հեռավորությունից և խոչընդոտներից։</string>
     <string name="profiles_identitykey_label">Ինքնության բանալի</string>
-    <string name="profilessettings_maindevice_identitykey_description">Ձեր սարքի ինքնության լուծման բանալին (IRK), որը օգնում է CAPod-ին նույնականացնել այն մոտակա սարքերի շարքում։</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods-ները հաճախ են փոխում իրենց Bluetooth հասցեն՝ գաղտնիության նպատակներով։ IRK-ն օգնում է CAPod-ին ճանաչել ձեր սարքը։ Ձեզ անհրաժեշտ է միանվագ մուտք MacBook։</string>
     <string name="profiles_maindevice_encryptionkey_label">Գաղտնագրման բանալի</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ձեր սարքի գաղտնագրման բանալին, որը թույլ է տալիս CAPod-ին ստանալ մանրամասն վիճակի տեղեկատվություն։</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods-ները ուղարկում են վիճակի հաղորդագրություն, որի մի մասը գաղտնագրված է։ Գաղտնագրման բանալին թույլ է տալիս CAPod-ին վերծանել ամբողջ հաղորդագրությունը։ Ձեզ անհրաժեշտ է միանվագ մուտք MacBook։</string>
     <string name="profiles_key_invalid_format">Անվավեր բանալու ձևաչափ</string>
     <string name="profiles_key_expected_format">Ակնկալվող ձևաչափ՝ %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Դուք ունեք չպահպանված փոփոխություններ։ Ի՞նչ եք ցանկանում անել։</string>
     <string name="general_save_and_exit_action">Պահպանել &amp; Դուրս գալ</string>
     <string name="general_discard_action">Մերժել</string>
-    <string name="general_keep_editing_action">Շարունակել խմբագրումը</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Ձայնագրությունը շատ կարճ է</string>
     <string name="debug_debuglog_short_recording_message">Կարգաբերման մատյանը պետք է գրանցի խնդիրը դրա այն տեղի է ունենում: Շարունակեք Ձայնագրությունը, վերարտադրեք խնդիրը, ապա դադարեցրեք Ձայնագրությունը:</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Սարքի կարգավորումներ</string>
     <string name="device_settings_subtitle_profile_prefix">Պրոֆիլ՝ %s</string>
-    <string name="device_settings_info_name_label">Անուն</string>
     <string name="device_settings_info_bt_name_label">Bluetooth սարքի անուն</string>
     <string name="device_settings_info_model_label">Մոդել</string>
     <string name="device_settings_info_manufacturer_label">Արտադրող</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Գուցե ավելի ուշ</string>
     <string name="review_app_body">Ցանկանո՞ւմ եք կարծիք թողնել CAPod-ի համար? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Ընդհանուր</string>
     <string name="device_settings_microphone_mode_label">Խոսափող</string>
     <string name="device_settings_microphone_mode_description">Որ ականջակալն օգտագործվում է որպես խոսափող</string>
     <string name="device_settings_microphone_mode_auto">Ավտոմատ</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Bagikan</string>
     <string name="general_done_action">Selesai</string>
     <string name="general_cancel_action">Batal</string>
-    <string name="general_copy_action">Salin</string>
     <string name="general_thank_you_label">Terima kasih</string>
     <string name="general_upgrade_action">Tingkatkan</string>
     <string name="general_retry_action">Coba Lagi</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Periksa</string>
     <string name="general_close_action">Tutup</string>
     <string name="general_dismiss_action">Tutup</string>
-    <string name="general_edit_action">Ubah</string>
     <string name="general_save_action">Simpan</string>
     <string name="general_guide_action">Panduan</string>
     <string name="general_continue_action">Lanjutkan</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Lanjutkan musik saat memakai pods lagi, tetapi hanya jika Auto jeda yang menghentikannya. Jeda yang kamu picu sendiri (telepon, batang AirPods, tidur) tetap dijeda.</string>
     <string name="settings_start_music_on_wear_label">Mulai musik saat dipakai</string>
     <string name="settings_start_music_on_wear_description">Selalu mencoba memutar musik saat kamu memakai pods, bahkan setelah jeda manual.</string>
-    <string name="settings_eardetection_info_label">Catatan deteksi telinga</string>
     <string name="settings_eardetection_info_description">Jika deteksi telinga hanya berfungsi untuk satu pod, ini adalah batasan Apple. Hanya \"pod utama\" (digunakan untuk mikrofon) yang terdeteksi. Konfigurasikan di perangkat Apple: Pengaturan → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Kualitas sinyal minimum</string>
-    <string name="settings_signal_minimum_description">Kualitas sinyal minimum yang harus dimiliki perangkat agar dianggap milik Anda.</string>
     <string name="settings_autoconnect_label">Sambungkan otomatis</string>
     <string name="settings_autoconnect_description">Jika Android tidak terhubung secara otomatis, kami dapat memintanya juga. Ini membuat CAPod terus memantau di latar belakang setiap saat.</string>
     <string name="settings_autoconnect_info_android12">Koneksi otomatis mengandalkan fitur sistem yang dibatasi oleh Android 12 dan yang lebih baru. Mungkin tidak berfungsi di perangkat Anda.</string>
     <string name="settings_autoconnect_condition_label">Kondisi sambung otomatis</string>
-    <string name="settings_autoconnect_condition_description">Kapan kami harus mencoba menyambung ke perangkat Anda?</string>
     <string name="settings_devices_label">Perangkat</string>
     <string name="settings_devices_description">Kelola perangkat Anda.</string>
     <string name="settings_reaction_label">Reaksi</string>
-    <string name="settings_category_yourdevice_label">Perangkat Anda</string>
     <string name="settings_category_compatibility_options_title">Opsi kompatibilitas</string>
     <string name="settings_category_compatibility_options_description">Jangan sentuh jika semuanya berfungsi ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Nonaktifkan pemfilteran perangkat keras</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Memulai...</string>
     <string name="support_debuglog_label">Log debug</string>
     <string name="support_debuglog_desc">Rekam semua yang dilakukan aplikasi dalam file teks yang dapat Anda bagikan.</string>
-    <string name="debug_debuglog_size_label">Ukuran</string>
-    <string name="debug_debuglog_size_compressed_label">Ukuran terkompresi</string>
-    <string name="debug_notification_channel_label">Notifikasi debug</string>
-    <string name="debug_debuglog_file_label">File log yang direkam</string>
-    <string name="debug_debuglog_recording_progress">Merekam log debug</string>
     <string name="debug_debuglog_record_action">Rekam log debug</string>
     <string name="debug_debuglog_stop_action">Hentikan perekaman</string>
     <string name="debug_debuglog_sensitive_information_message">File yang dihasilkan berisi informasi sensitif (misalnya detail perangkat Bluetooth). Bagikan hanya dengan pihak tepercaya.</string>
     <string name="settings_debuglog_explanation">Fitur ini merekam semua yang dilakukan aplikasi ke dalam file yang dapat dibagikan. File yang dihasilkan berisi informasi sensitif (misalnya detail perangkat Bluetooth). Bagikan hanya dengan pihak tepercaya (misalnya pengembang yang sedang memecahkan masalah).</string>
-    <string name="settings_support_installid_label">ID Instalasi</string>
-    <string name="settings_support_installid_desc">Laporan kesalahan otomatis bersifat anonim. Bagikan ID instalasi Anda jika pengembang perlu menemukan laporan kesalahan Anda.</string>
     <string name="settings_support_label">Dukungan</string>
     <string name="settings_support_description">Jika Anda membutuhkan bantuan.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Setel Ulang Data Terbelajar?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod akan melupakan pengurasan, kecepatan pengisian, dan waktu mendengarkan perangkat yang telah diukur, serta memulai dari awal dengan daya tahan baterai yang dinilai.</string>
     <string name="settings_acknowledgements_label">Ucapan Terima Kasih</string>
-    <string name="settings_debug_autoreports_label">Laporan bug otomatis</string>
-    <string name="settings_debug_autoreports_description">Melaporkan masalah secara otomatis, mis. detail tentang kerusakan aplikasi sehingga saya dapat mencari tahu cara memperbaikinya.</string>
-    <string name="settings_compatibility_mode_label">Mode kompatibilitas</string>
-    <string name="settings_compatibility_mode_description">Nonaktifkan pengoptimalan untuk meningkatkan kompatibilitas. Coba ini jika Anda tidak melihat data apa pun.</string>
     <string name="help_translate_label">Terjemahan</string>
     <string name="help_translate_description">Bantu terjemahkan aplikasi ini ke bahasa favorit Anda.</string>
     <string name="translators_thanks_title">Penerjemah</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sukses</string>
     <string name="troubleshooter_ble_result_success_body">Siaran iklan BLE diterima oleh CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Gagal</string>
-    <string name="troubleshooter_ble_result_failure_body">Pemecahan masalah gagal. Tidak ada kombinasi opsi kompatibilitas yang membantu.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ponsel Anda tidak menerima data BLE sama sekali. Anda dapat mencoba lagi pengujian ini di area yang ramai untuk melihat apakah sumber data (selain headphone Anda) dapat diterima. Tidak ada data yang diterima menunjukkan masalah dengan sistem operasi ponsel Anda.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telepon Anda menerima data BLE, tetapi data tersebut tidak berasal dari perangkat yang didukung. Apakah headphone Anda dihidupkan? Apakah CAPod mendukung headphone Anda?</string>
-    <string name="troubleshooter_ble_result_failure_action">Coba lagi</string>
-    <string name="troubleshoot_action">Pecahkan masalah</string>
     <string name="onboarding_body1">Aplikasi ini menambahkan dukungan untuk fitur khusus AirPod ke Android.</string>
     <string name="onboarding_body2">Tidak semua perangkat Android sepenuhnya mendukung fitur tambahan AirPod. Sistem operasi Anda memerlukan implementasi Bluetooth Hemat Energi yang berfungsi dengan baik.</string>
     <string name="onboarding_body3">CAPod tidak memiliki iklan dan tidak mengumpulkan data Anda.</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Perangkat terhubung, tetapi CAPod tidak menerima data langsung darinya. Ponsel mungkin memerlukan opsi kompatibilitas — pemecah masalah dapat mencoba menemukannya secara otomatis.</string>
     <string name="overview_troubleshoot_suggestion_action">Jalankan pemecah masalah</string>
     <string name="overview_unmatched_devices_label">Perangkat tidak cocok</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d perangkat tanpa profil yang cocok</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">%d perangkat di sekitar terdeteksi tanpa profil yang cocok. Tampilkan untuk melihat detail yang tersedia. Jika salah satunya milik Anda, tambahkan profil dari Perangkat untuk mengenalinya.</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod menggunakan \"akses lokasi latar belakang\" untuk mengaktifkan fitur seperti \"Tampilkan popup\" dan \"Sambung otomatis\" saat aplikasi ditutup. Akses lokasi latar belakang memungkinkan aplikasi menerima data Bluetooth Low Energy saat berada di latar belakang. Aplikasi ini TIDAK akan menggunakan data Bluetooth untuk menentukan lokasi Anda.</string>
     <string name="permission_ignore_battery_optimizations_label">Nonaktifkan pengoptimalan baterai</string>
     <string name="permission_ignore_battery_optimizations_description">Pengoptimalan baterai mencegah aplikasi ini menerima data Bluetooth secara andal saat di latar belakang.</string>
-    <string name="permission_required_title">Izin berikut diperlukan:</string>
     <string name="permission_system_alert_window_label">Jendela Peringatan Sistem</string>
     <string name="permission_system_alert_window_description">Izinkan CAPod menggambar di atas aplikasi lain untuk memungkinkan fitur \"Tampilkan PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Saat terlihat</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Di telinga</string>
     <string name="pods_dual_left_label">Pod kiri</string>
     <string name="pods_dual_right_label">Pod kanan</string>
-    <string name="pods_dual_left_short_label">K</string>
-    <string name="pods_dual_right_short_label">Ka</string>
-    <string name="pods_case_label">Casing</string>
     <string name="battery_unavailable_label">Baterai tidak tersedia</string>
     <string name="battery_state_low_cd">Baterai rendah</string>
     <string name="battery_state_critical_cd">Baterai sangat rendah</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">Koneksi langsung aktif</string>
     <string name="signal_indicator_bars_cd">Kekuatan sinyal: %1$d dari 4 bar</string>
     <string name="signal_indicator_disconnected_cd">Sinyal: terputus</string>
-    <string name="pods_yours">Milik Anda</string>
     <string name="headset_being_worn_label">Sedang dipakai</string>
     <string name="headset_not_being_worn_label">Tidak dipakai</string>
     <string name="pods_case_unknown_state">Status tidak diketahui</string>
-    <string name="last_seen_x">Terakhir terlihat: %s</string>
-    <string name="first_seen_x">Pertama terlihat: %s</string>
     <string name="battery_cached_label">Terakhir diketahui · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dj %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dj</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">Kualitas Sinyal Minimum</string>
     <string name="profiles_signal_quality_description">Hanya deteksi perangkat dengan kekuatan sinyal di atas ambang batas ini. Nilai lebih rendah meningkatkan jangkauan deteksi tetapi dapat menyebabkan positif palsu. Jangan atur terlalu tinggi - penerimaan Bluetooth umumnya buruk dan bervariasi dengan jarak dan penghalang.</string>
     <string name="profiles_identitykey_label">Kunci Identitas</string>
-    <string name="profilessettings_maindevice_identitykey_description">Kunci Penyelesaian Identitas (IRK) perangkat Anda, yang membantu CAPod mengidentifikasinya di antara perangkat di sekitar.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods sering mengubah alamat Bluetooth mereka demi privasi. IRK membantu CAPod mengenali perangkat Anda. Anda memerlukan akses satu kali ke MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Kunci Enkripsi</string>
-    <string name="profiles_maindevice_encryptionkey_description">Kunci enkripsi perangkat Anda, yang memungkinkan CAPod mengambil informasi status terperinci.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods mengirim pesan status, yang sebagian dienkripsi. Kunci enkripsi memungkinkan CAPod mendekripsi pesan lengkap. Anda memerlukan akses satu kali ke MacBook.</string>
     <string name="profiles_key_invalid_format">Format kunci tidak valid</string>
     <string name="profiles_key_expected_format">Format yang diharapkan: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">Anda memiliki perubahan yang belum disimpan. Apa yang ingin Anda lakukan?</string>
     <string name="general_save_and_exit_action">Simpan &amp; Keluar</string>
     <string name="general_discard_action">Buang</string>
-    <string name="general_keep_editing_action">Lanjutkan Mengedit</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Rekaman terlalu singkat</string>
     <string name="debug_debuglog_short_recording_message">Log debug perlu merekam masalah saat terjadi. Terus merekam, reproduksi masalah, lalu hentikan rekaman.</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Pengaturan Perangkat</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Nama</string>
     <string name="device_settings_info_bt_name_label">Label Perangkat Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Produsen</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">Lain kali</string>
     <string name="review_app_body">Mau menulis ulasan untuk CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Earbud mana yang digunakan sebagai mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Otomatis</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Deila</string>
     <string name="general_done_action">Lokið</string>
     <string name="general_cancel_action">Hætta við</string>
-    <string name="general_copy_action">Afrita</string>
     <string name="general_thank_you_label">Þakka þér fyrir</string>
     <string name="general_upgrade_action">Uppfæra</string>
     <string name="general_retry_action">Reyndu aftur</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Athuga</string>
     <string name="general_close_action">Loka</string>
     <string name="general_dismiss_action">Hafna</string>
-    <string name="general_edit_action">Breyta</string>
     <string name="general_save_action">Vista</string>
     <string name="general_guide_action">Leiðbeiningar</string>
     <string name="general_continue_action">Halda áfram</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Halda áfram tónlist þegar þú setur hlustunartækið á aftur, en aðeins ef Sjálfvirk hlé stöðvaði hana. Hlé sem þú settir sjálfur/sjálf (sími, AirPods stingill, svefn) haldast í bið.</string>
     <string name="settings_start_music_on_wear_label">Byrja tónlist þegar þú setur á</string>
     <string name="settings_start_music_on_wear_description">Reynir alltaf að spila tónlist þegar þú setur hlustunartækið á, jafnvel eftir handvirkt hlé.</string>
-    <string name="settings_eardetection_info_label">Athugasemd um eyraskynjun</string>
     <string name="settings_eardetection_info_description">Ef eyraskynjun virkar aðeins fyrir annað heyrnartólið er þetta takmörkun frá Apple. Aðeins \"aðalheyrnartólið\" (notað fyrir hljóðnema) er skynjað. Stilla á Apple tækjum: Stillingar → Bluetooth → AirPods → Hljóðnemi.</string>
-    <string name="settings_signal_minimum_label">Lágmarksgæði merkis</string>
-    <string name="settings_signal_minimum_description">Lágmarksgæði merkis sem tæki þarf að hafa til að teljast þitt.</string>
     <string name="settings_autoconnect_label">Sjálfvirk tenging</string>
     <string name="settings_autoconnect_description">Ef Android tengist ekki sjálfkrafa getum við beðið það um tengingu. Þetta heldur eftirliti virku á bakgrunninum alltaf.</string>
     <string name="settings_autoconnect_info_android12">Sjálfvirk tenging notar kerfiseiginleika sem Android 12 og nýrra takmarkar. Hún virkar hugsanlega ekki á tækinu þínu.</string>
     <string name="settings_autoconnect_condition_label">Skilyrði fyrir sjálfvirkri tengingu</string>
-    <string name="settings_autoconnect_condition_description">Hvenær ættum við að reyna að tengjast tækinu þínu?</string>
     <string name="settings_devices_label">Tæki</string>
     <string name="settings_devices_description">Hafa umsjón með tækjunum þínum.</string>
     <string name="settings_reaction_label">Viðbrögð</string>
-    <string name="settings_category_yourdevice_label">Tækið þitt</string>
     <string name="settings_category_compatibility_options_title">Samhæfisvalkostir</string>
     <string name="settings_category_compatibility_options_description">Ekki snerta ef allt virkar ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Slökkva á vélbúnaðarsíun</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Stofnar upp…</string>
     <string name="support_debuglog_label">Villuleitarskrá</string>
     <string name="support_debuglog_desc">Skráðu allt sem forritið gerir í textaskrá sem þú getur deilt.</string>
-    <string name="debug_debuglog_size_label">Stærð</string>
-    <string name="debug_debuglog_size_compressed_label">Þjöppuð stærð</string>
-    <string name="debug_notification_channel_label">Villuleitartilkynningar</string>
-    <string name="debug_debuglog_file_label">Skráð villuleitarskrá</string>
-    <string name="debug_debuglog_recording_progress">Skráir villuleitarskrá</string>
     <string name="debug_debuglog_record_action">Skrá villuleitarskrá</string>
     <string name="debug_debuglog_stop_action">Hætta skráningu</string>
     <string name="debug_debuglog_sensitive_information_message">Mynduð skrá inniheldur viðkvæmar upplýsingar (t.d. upplýsingar um Bluetooth tæki). Deildu henni aðeins með traustum aðilum.</string>
     <string name="settings_debuglog_explanation">Þessi aðgerð skráir allt sem forritið gerir í skrá sem hægt er að deila. Mynduð skrá inniheldur viðkvæmar upplýsingar (t.d. upplýsingar um Bluetooth tæki). Deildu henni aðeins með traustum aðilum (t.d. þróunaraðila sem er að leysa vandamál).</string>
-    <string name="settings_support_installid_label">Uppsetningarauðkenni</string>
-    <string name="settings_support_installid_desc">Sjálfvirkar villuskýrslur eru nafnlausar. Deildu uppsetningarauðkenninu þínu ef þróunaraðilinn þarf að finna villuskýrslurnar þínar.</string>
     <string name="settings_support_label">Aðstoð</string>
     <string name="settings_support_description">Ef þú þarft hjálp.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Endurstilla lærð gögn?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod mun gleyma mældum gangi, hleðsluhraða og hlustunartíma þessa tækis og byrja upp á nýtt frá tilgreindri rafhlöðuendingu.</string>
     <string name="settings_acknowledgements_label">Þakkir</string>
-    <string name="settings_debug_autoreports_label">Sjálfvirkar villuskýrslur</string>
-    <string name="settings_debug_autoreports_description">Tilkynnir sjálfkrafa um vandamál, t.d. upplýsingar um hrun forrits svo ég geti fundið út hvernig á að laga það.</string>
-    <string name="settings_compatibility_mode_label">Samhæfisstilling</string>
-    <string name="settings_compatibility_mode_description">Slökkva á hagræðingum til að bæta samhæfni. Prófaðu þetta ef þú sérð engin gögn.</string>
     <string name="help_translate_label">Þýðing</string>
     <string name="help_translate_description">Hjálpaðu til við að þýða þetta forrit á þitt uppáhalds tungumál.</string>
     <string name="translators_thanks_title">Þýðendur</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Tókst</string>
     <string name="troubleshooter_ble_result_success_body">CAPod tekur á móti BLE auglýsingaútsendingum.</string>
     <string name="troubleshooter_ble_result_failure_title">Mistókst</string>
-    <string name="troubleshooter_ble_result_failure_body">Villuleit mistókst. Engin samsetning samhæfisvalkosta hjálpaði.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Síminn þinn tók alls ekki á móti neinum BLE gögnum. Þú getur prófað þetta próf aftur á fjölmennum stað til að sjá hvort hægt sé að taka á móti gagnagjöfum (öðrum en heyrnartólunum þínum). Engin móttekin gögn benda til vandamáls með stýrikerfi símans þíns.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Síminn þinn tók á móti BLE gögnum, en gögnin koma ekki frá neinu studdu tæki. Eru heyrnartólin þín kveikt? Styður CAPod heyrnartólin þín?</string>
-    <string name="troubleshooter_ble_result_failure_action">Reyndu aftur</string>
-    <string name="troubleshoot_action">Leysa vandamál</string>
     <string name="onboarding_body1">Þetta forrit bætir við stuðningi fyrir AirPod sértæka eiginleika í Android.</string>
     <string name="onboarding_body2">Ekki öll Android tæki styðja að fullu viðbótar AirPod eiginleika. Stýrikerfið þitt krefst rétt virkandi Bluetooth-Low-Energy útfærslu.</string>
     <string name="onboarding_body3">CAPod hefur engar auglýsingar og safnar ekki gögnunum þínum.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tækið þitt er tengt, en CAPod er ekki að taka við lifandi gögnum frá því. Síminn þinn þarf kannski samhæfnismöguleika — villuleitin getur reynt að finna hann sjálfkrafa.</string>
     <string name="overview_troubleshoot_suggestion_action">Keyra villuleit</string>
     <string name="overview_unmatched_devices_label">Ópöruð tæki</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d tæki án samsvarandi sniðs</item>
-        <item quantity="other">%d tæki án samsvarandi sniðs</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d tæki í nágrenninu fannst án samsvarandi sniðs. Sýndu það til að sjá tiltækar upplýsingar. Ef það er þitt skaltu bæta við sniði frá Tækjum til að þekkja það.</item>
         <item quantity="other">%d tæki í nágrenninu fundust án samsvarandi sniða. Sýndu þau til að sjá tiltækar upplýsingar. Ef eitt þeirra er þitt skaltu bæta við sniði frá Tækjum til að þekkja það.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod notar \"bakgrunns staðsetningaraðgang\" til að virkja eiginleika eins og \"Sýna upplýsingaglugga\" og \"Sjálfvirk tenging\" á meðan forritið er lokað. Bakgrunns staðsetningaraðgangur gerir forritinu kleift að taka á móti Bluetooth Low Energy gögnum á meðan það er í bakgrunni. Þetta forrit mun EKKI nota Bluetooth gögn til að ákvarða staðsetningu þína.</string>
     <string name="permission_ignore_battery_optimizations_label">Slökkva á rafhlöðuhagræðingu</string>
     <string name="permission_ignore_battery_optimizations_description">Rafhlöðuhagræðing kemur í veg fyrir að þetta forrit taki á móti Bluetooth gögnum á áreiðanlegan hátt á meðan forritið er í bakgrunni.</string>
-    <string name="permission_required_title">Eftirfarandi heimild er nauðsynleg:</string>
     <string name="permission_system_alert_window_label">Kerfisviðvörunargluggi</string>
     <string name="permission_system_alert_window_description">Leyfðu CAPod að teikna yfir önnur forrit til að gera eiginleikann \"Sýna upplýsingaglugga\" mögulegan.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Þegar séð</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Í eyra</string>
     <string name="pods_dual_left_label">Vinstra heyrnartól</string>
     <string name="pods_dual_right_label">Hægra heyrnartól</string>
-    <string name="pods_dual_left_short_label">V</string>
-    <string name="pods_dual_right_short_label">H</string>
-    <string name="pods_case_label">Hulstur</string>
     <string name="battery_unavailable_label">Rafhlaða ekki tiltæk</string>
     <string name="battery_state_low_cd">Rafhlaðan er lítil</string>
     <string name="battery_state_critical_cd">Rafhlaðan er við endalok</string>
@@ -281,12 +252,9 @@
     <string name="signal_badge_aap_cd">Bein tenging virk</string>
     <string name="signal_indicator_bars_cd">Merkjastyrkur: %1$d af 4 strikum</string>
     <string name="signal_indicator_disconnected_cd">Merki: ótengd</string>
-    <string name="pods_yours">Þitt</string>
     <string name="headset_being_worn_label">Verið borið</string>
     <string name="headset_not_being_worn_label">Ekki verið borið</string>
     <string name="pods_case_unknown_state">Óþekkt staða</string>
-    <string name="last_seen_x">Síðast séð: %s</string>
-    <string name="first_seen_x">Fyrst séð: %s</string>
     <string name="battery_cached_label">Síðast þekkt · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -316,10 +284,8 @@
     <string name="profiles_signal_quality_title">Lágmarksgæði merkis</string>
     <string name="profiles_signal_quality_description">Greina aðeins tæki með merkisstyrkinn yfir þessum þröskuldi. Lægri gildi auka greiningarsvæðið en geta valdið röngum jákvæðum. Ekki stilla þetta of hátt — Bluetooth móttaka er yfirleitt léleg og breytist eftir fjarlægð og hindrunum.</string>
     <string name="profiles_identitykey_label">Auðkennislykill</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) tækisins þíns, sem hjálpar CAPod að bera kennsl á það meðal nálægra tækja.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods breyta Bluetooth vistfangi sínu reglulega vegna persónuverndar. IRK hjálpar CAPod að þekkja tækið þitt. Þú þarft einu sinni aðgang að MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Dulritunarlykill</string>
-    <string name="profiles_maindevice_encryptionkey_description">Dulritunarlykill tækisins þíns, sem gerir CAPod kleift að sækja nákvæmar stöðuupplýsingar.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods senda stöðuskilaboð, hluti þeirra er dulritaður. Dulritunarlykillinn gerir CAPod kleift að afkóða öll skilaboðin. Þú þarft einu sinni aðgang að MacBook.</string>
     <string name="profiles_key_invalid_format">Ógilt lyklasnið</string>
     <string name="profiles_key_expected_format">Vænt snið: %1$s</string>
@@ -352,7 +318,6 @@
     <string name="general_unsaved_changes_message">Þú ert með óvistaðar breytingar. Hvað viltu gera?</string>
     <string name="general_save_and_exit_action">Vista &amp; Hætta</string>
     <string name="general_discard_action">Henda</string>
-    <string name="general_keep_editing_action">Halda áfram að breyta</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Upptökun of stutt</string>
     <string name="debug_debuglog_short_recording_message">Villuloki þarf að taka upp vandamálið meðan það gerist. Haltu áfram að taka upp, endurskapa vandamálið og stöðvaðu síðan upptökuna.</string>
@@ -423,7 +388,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Tæki stillingar</string>
     <string name="device_settings_subtitle_profile_prefix">Prófíll: %s</string>
-    <string name="device_settings_info_name_label">Nafn</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-tækjaheiti</string>
     <string name="device_settings_info_model_label">Líkan</string>
     <string name="device_settings_info_manufacturer_label">Framleiðandi</string>
@@ -503,7 +467,6 @@
     <string name="review_app_dismiss_action">Kannski síðar</string>
     <string name="review_app_body">Viltu skilja eftir umsögn um CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Álmennt</string>
     <string name="device_settings_microphone_mode_label">Hljóðnemi</string>
     <string name="device_settings_microphone_mode_description">Hvaða hlustunartæki er notað sem hljóðnemi</string>
     <string name="device_settings_microphone_mode_auto">Sjálfvirkt</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Condividi</string>
     <string name="general_done_action">Fatto</string>
     <string name="general_cancel_action">Annulla</string>
-    <string name="general_copy_action">Copia</string>
     <string name="general_thank_you_label">Grazie</string>
     <string name="general_upgrade_action">Aggiorna</string>
     <string name="general_retry_action">Riprova</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Controlla</string>
     <string name="general_close_action">Chiudi</string>
     <string name="general_dismiss_action">Rimuovere</string>
-    <string name="general_edit_action">Modifica</string>
     <string name="general_save_action">Salva</string>
     <string name="general_guide_action">Guida</string>
     <string name="general_continue_action">Continua</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Riprendi la musica quando indossi di nuovo i pod, ma solo se l\'ha fermata la pausa automatica. Le pause che hai attivato tu stesso (telefono, stelo AirPods, sleep) rimangono in pausa.</string>
     <string name="settings_start_music_on_wear_label">Avvia musica all\'indossaggio</string>
     <string name="settings_start_music_on_wear_description">Cerca sempre di riprodurre musica quando indossi i pod, anche dopo una pausa manuale.</string>
-    <string name="settings_eardetection_info_label">Nota sul rilevamento dell\'orecchio</string>
     <string name="settings_eardetection_info_description">Se il rilevamento dell\'orecchio funziona solo per un auricolare, è una limitazione di Apple. Solo il \"pod principale\" (usato per il microfono) viene rilevato. Configura su dispositivi Apple: Impostazioni → Bluetooth → AirPods → Microfono.</string>
-    <string name="settings_signal_minimum_label">Qualità minima del segnale</string>
-    <string name="settings_signal_minimum_description">La qualità minima del segnale che un dispositivo deve avere per essere considerato tuo.</string>
     <string name="settings_autoconnect_label">Connessione automatica</string>
     <string name="settings_autoconnect_description">Se Android non si connette automaticamente, possiamo chiederglielo noi. Questo mantiene il monitoraggio di CAPod attivo in background in ogni momento.</string>
     <string name="settings_autoconnect_info_android12">La connessione automatica si basa su una funzione di sistema che Android 12 e versioni successive limitano. Potrebbe non funzionare sul tuo dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condizione di connessione automatica</string>
-    <string name="settings_autoconnect_condition_description">Quando dovremmo provare a connetterci al tuo dispositivo?</string>
     <string name="settings_devices_label">Dispositivi</string>
     <string name="settings_devices_description">Gestisci i tuoi dispositivi.</string>
     <string name="settings_reaction_label">Reazioni</string>
-    <string name="settings_category_yourdevice_label">Il tuo dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opzioni di compatibilità</string>
     <string name="settings_category_compatibility_options_description">Non toccare se tutto funziona ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Disabilita filtro hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Avvio in corso…</string>
     <string name="support_debuglog_label">Log di debug</string>
     <string name="support_debuglog_desc">Registra tutto ciò che l\'app fa in un file di testo che puoi condividere.</string>
-    <string name="debug_debuglog_size_label">Dimensione</string>
-    <string name="debug_debuglog_size_compressed_label">Dimensione compressa</string>
-    <string name="debug_notification_channel_label">Notifiche di debug</string>
-    <string name="debug_debuglog_file_label">File di log registrato</string>
-    <string name="debug_debuglog_recording_progress">Registrazione log di debug</string>
     <string name="debug_debuglog_record_action">Registra log di debug</string>
     <string name="debug_debuglog_stop_action">Interrompi registrazione</string>
     <string name="debug_debuglog_sensitive_information_message">Il file generato contiene informazioni sensibili (ad es. dettagli del dispositivo Bluetooth). Condividilo solo con parti fidate.</string>
     <string name="settings_debuglog_explanation">Questa funzione registra tutto ciò che l\'app fa in un file condivisibile. Il file generato contiene informazioni sensibili (ad es. dettagli del dispositivo Bluetooth). Condividilo solo con parti fidate (ad es. uno sviluppatore che sta risolvendo un problema).</string>
-    <string name="settings_support_installid_label">ID installazione</string>
-    <string name="settings_support_installid_desc">Le segnalazioni automatiche di errori sono anonime. Condividi il tuo ID di installazione se lo sviluppatore ha bisogno di trovare le tue segnalazioni di errori.</string>
     <string name="settings_support_label">Supporto</string>
     <string name="settings_support_description">Se hai bisogno di aiuto.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Reimpostare i dati acquisiti?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod dimenticherà il consumo misurato del dispositivo, la velocità di ricarica e la durata di ascolto, e ricomincerà dalla durata della batteria dichiarata.</string>
     <string name="settings_acknowledgements_label">Riconoscimenti</string>
-    <string name="settings_debug_autoreports_label">Segnalazioni automatiche di bug</string>
-    <string name="settings_debug_autoreports_description">Segnala automaticamente i problemi, ad es. dettagli su un arresto anomalo dell\'app in modo che io possa capire come risolverlo.</string>
-    <string name="settings_compatibility_mode_label">Modalità compatibilità</string>
-    <string name="settings_compatibility_mode_description">Disabilita le ottimizzazioni per migliorare la compatibilità. Prova questa opzione se non vedi alcun dato.</string>
     <string name="help_translate_label">Traduzione</string>
     <string name="help_translate_description">Aiuta a tradurre questa app nella tua lingua preferita.</string>
     <string name="translators_thanks_title">Traduttori</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Successo</string>
     <string name="troubleshooter_ble_result_success_body">CAPod sta ricevendo le trasmissioni pubblicitarie BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Fallito</string>
-    <string name="troubleshooter_ble_result_failure_body">La risoluzione dei problemi è fallita. Nessuna combinazione di opzioni di compatibilità è stata d\'aiuto.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Il tuo telefono non ha ricevuto alcun dato BLE. Puoi riprovare questo test in un\'area affollata per vedere se è possibile ricevere origini dati (diverse dalle tue cuffie). La mancata ricezione di dati indica un problema con il sistema operativo del tuo telefono.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Il tuo telefono ha ricevuto dati BLE, ma i dati non provengono da alcun dispositivo supportato. Le tue cuffie sono accese? CAPod supporta le tue cuffie?</string>
-    <string name="troubleshooter_ble_result_failure_action">Riprova</string>
-    <string name="troubleshoot_action">Risolvi problemi</string>
     <string name="onboarding_body1">Questa app aggiunge il supporto per funzionalità specifiche degli AirPods ad Android.</string>
     <string name="onboarding_body2">Non tutti i dispositivi Android supportano pienamente le funzionalità aggiuntive degli AirPods. Il tuo sistema operativo richiede un\'implementazione Bluetooth Low Energy correttamente funzionante.</string>
     <string name="onboarding_body3">CAPod non contiene pubblicità e non raccoglie i tuoi dati.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Il tuo dispositivo è connesso, ma CAPod non riceve dati live da esso. Il tuo telefono potrebbe aver bisogno di un\'opzione di compatibilità — lo strumento di risoluzione problemi può provare a trovarne una automaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Avvia risoluzione problemi</string>
     <string name="overview_unmatched_devices_label">Dispositivi non corrispondenti</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo senza profilo corrispondente</item>
-        <item quantity="other">%d dispositivi senza profilo corrispondente</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">È stato rilevato %d dispositivo nelle vicinanze senza un profilo corrispondente. Mostralo per i dettagli disponibili. Se è tuo, aggiungi un profilo da Dispositivi per riconoscerlo.</item>
         <item quantity="other">Sono stati rilevati %d dispositivi nelle vicinanze senza profili corrispondenti. Mostrali per i dettagli disponibili. Se uno è tuo, aggiungi un profilo da Dispositivi per riconoscerlo.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod utilizza l\'\"accesso alla posizione in background\" per abilitare funzionalità come \"Mostra pop-up\" e \"Connessione automatica\" mentre l\'app è chiusa. L\'accesso alla posizione in background consente all\'app di ricevere dati Bluetooth Low Energy in background. Questa app NON utilizzerà i dati Bluetooth per determinare la tua posizione.</string>
     <string name="permission_ignore_battery_optimizations_label">Disabilita ottimizzazioni batteria</string>
     <string name="permission_ignore_battery_optimizations_description">Le ottimizzazioni della batteria impediscono a questa app di ricevere in modo affidabile i dati Bluetooth quando l\'app è in background.</string>
-    <string name="permission_required_title">È richiesto il seguente permesso:</string>
     <string name="permission_system_alert_window_label">Finestra di avviso di sistema</string>
     <string name="permission_system_alert_window_description">Consenti a CAPod di disegnare sopra altre app per rendere possibile la funzionalità \"Mostra pop-up\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Quando rilevato</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Nell\'orecchio</string>
     <string name="pods_dual_left_label">Auricolare sinistro</string>
     <string name="pods_dual_right_label">Auricolare destro</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Custodia</string>
     <string name="battery_unavailable_label">Batteria non disponibile</string>
     <string name="battery_state_low_cd">Batteria scarica</string>
     <string name="battery_state_critical_cd">Batteria criticamente scarica</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Connessione diretta attiva</string>
     <string name="signal_indicator_bars_cd">Intensità del segnale: %1$d di 4 barre</string>
     <string name="signal_indicator_disconnected_cd">Segnale: disconnesso</string>
-    <string name="pods_yours">Tuo</string>
     <string name="headset_being_worn_label">Indossato</string>
     <string name="headset_not_being_worn_label">Non indossato</string>
     <string name="pods_case_unknown_state">Stato sconosciuto</string>
-    <string name="last_seen_x">Visto l\'ultima volta: %s</string>
-    <string name="first_seen_x">Visto la prima volta: %s</string>
     <string name="battery_cached_label">Ultimo noto · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Qualità minima del segnale</string>
     <string name="profiles_signal_quality_description">Rileva solo dispositivi con intensità del segnale superiore a questa soglia. Valori più bassi aumentano il raggio di rilevamento ma possono causare falsi positivi. Non impostare un valore troppo alto - la ricezione Bluetooth è generalmente scarsa e varia con la distanza e gli ostacoli.</string>
     <string name="profiles_identitykey_label">Chiave di identità</string>
-    <string name="profilessettings_maindevice_identitykey_description">La chiave di risoluzione dell\'identità (IRK) del tuo dispositivo, che aiuta CAPod a identificarlo tra i dispositivi nelle vicinanze.</string>
     <string name="profiles_maindevice_identitykey_explanation">Gli AirPods cambiano frequentemente il loro indirizzo Bluetooth per la privacy. L\'IRK aiuta CAPod a riconoscere il tuo dispositivo. È necessario un accesso una tantum a un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Chiave di crittografia</string>
-    <string name="profiles_maindevice_encryptionkey_description">La chiave di crittografia del tuo dispositivo, che consente a CAPod di recuperare informazioni dettagliate sullo stato.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Gli AirPods inviano un messaggio di stato, parte del quale è crittografato. La chiave di crittografia consente a CAPod di decrittografare l\'intero messaggio. È necessario un accesso una tantum a un MacBook.</string>
     <string name="profiles_key_invalid_format">Formato chiave non valido</string>
     <string name="profiles_key_expected_format">Formato previsto: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Hai modifiche non salvate. Cosa vorresti fare?</string>
     <string name="general_save_and_exit_action">Salva &amp; Esci</string>
     <string name="general_discard_action">Scarta</string>
-    <string name="general_keep_editing_action">Continua a modificare</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Registrazione troppo breve</string>
     <string name="debug_debuglog_short_recording_message">Un log di debug deve catturare il problema nel momento in cui si verifica. Continua a registrare, riproduci il problema, quindi interrompi la registrazione.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Impostazioni dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Profilo: %s</string>
-    <string name="device_settings_info_name_label">Nome</string>
     <string name="device_settings_info_bt_name_label">Etichetta dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modello</string>
     <string name="device_settings_info_manufacturer_label">Produttore</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Forse più tardi</string>
     <string name="review_app_body">Vuoi lasciare una recensione su CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfono</string>
     <string name="device_settings_microphone_mode_description">Quale auricolare viene usato come microfono</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">שתף</string>
     <string name="general_done_action">בוצע</string>
     <string name="general_cancel_action">בטל</string>
-    <string name="general_copy_action">העתק</string>
     <string name="general_thank_you_label">תודה רבה</string>
     <string name="general_upgrade_action">שידרוג</string>
     <string name="general_retry_action">נסה שוב</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">בדיקה</string>
     <string name="general_close_action">סגור</string>
     <string name="general_dismiss_action">דחה</string>
-    <string name="general_edit_action">עריכה</string>
     <string name="general_save_action">שמור</string>
     <string name="general_guide_action">מדריך</string>
     <string name="general_continue_action">המשך</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">ממשיך מוזיקה כשאתה חוזר לענוד את האוזניות, אך רק אם הפסקה אוטומטית עצרה אותה. הפסקות שהפעלת בעצמך (טלפון, גבעול AirPods, שינה) נשארות מושהות.</string>
     <string name="settings_start_music_on_wear_label">הפעל מוזיקה בלבישה</string>
     <string name="settings_start_music_on_wear_description">תמיד מנסה להשמיע מוזיקה כשאתה מניח את האוזניות, גם לאחר הפסקה ידנית.</string>
-    <string name="settings_eardetection_info_label">הערה לגבי זיהוי אוזן</string>
     <string name="settings_eardetection_info_description">אם זיהוי אוזן עובד רק עבור אוזניה אחת, זוהי מגבלה של Apple. רק \"האוזניה הראשית\" (המשמשת למיקרופון) מזוהה. הגדר במכשירי Apple: הגדרות → Bluetooth → AirPods → מיקרופון.</string>
-    <string name="settings_signal_minimum_label">איכות אות מינימלית</string>
-    <string name="settings_signal_minimum_description">איכות האות המינימלית שמכשיר צריך להתחשב עבורך.</string>
     <string name="settings_autoconnect_label">חיבור אוטומטי</string>
     <string name="settings_autoconnect_description">אם אנדרואיד לא מתחבר אוטומטית, אפשר לבקש ממנו בעצמנו. כך המעקב של CAPod ממשיך לפעול ברקע כל הזמן.</string>
     <string name="settings_autoconnect_info_android12">חיבור אוטומטי מסתמך על תכונת מערכת שאנדרואיד 12 ומעלה מגבילה. ייתכן שלא תפעל במכשיר שלך.</string>
     <string name="settings_autoconnect_condition_label">מצב חיבור אוטומטי</string>
-    <string name="settings_autoconnect_condition_description">מתי עלינו לנסות להתחבר למכשיר שלך?</string>
     <string name="settings_devices_label">מכשירים</string>
     <string name="settings_devices_description">ניהול המכשירים שלך.</string>
     <string name="settings_reaction_label">תגובות</string>
-    <string name="settings_category_yourdevice_label">המכשיר שלך</string>
     <string name="settings_category_compatibility_options_title">מצב תאימות</string>
     <string name="settings_category_compatibility_options_description">אל תיגע אם הכל עובד ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ביטול סינון בחומרה</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">מתחיל…</string>
     <string name="support_debuglog_label">יומן ניפוי באגים</string>
     <string name="support_debuglog_desc">הקלט את כל מה שהאפליקציה עושה בקובץ טקסט שתוכל לשתף.</string>
-    <string name="debug_debuglog_size_label">מידה</string>
-    <string name="debug_debuglog_size_compressed_label">גודל דחיסה</string>
-    <string name="debug_notification_channel_label">ניפוי באגים</string>
-    <string name="debug_debuglog_file_label">קובץ לוג מוקלט</string>
-    <string name="debug_debuglog_recording_progress">מקליט יומן ניפוי באגים</string>
     <string name="debug_debuglog_record_action">הקלט יומן ניפוי באגים</string>
     <string name="debug_debuglog_stop_action">עצור הקלטה</string>
     <string name="debug_debuglog_sensitive_information_message">הקובץ שנוצר מכיל מידע רגיש (למשל פרטי מכשיר Bluetooth). שתף אותו רק עם גורמים מהימנים.</string>
     <string name="settings_debuglog_explanation">תכונה זו מתעדת את כל מה שהאפליקציה עושה לקובץ שניתן לשתף. הקובץ שנוצר מכיל מידע רגיש (למשל פרטי מכשיר Bluetooth). שתף אותו רק עם גורמים מהימנים (למשל מפתח שפותר בעיות).</string>
-    <string name="settings_support_installid_label">מזהה התקנה</string>
-    <string name="settings_support_installid_desc">דוחות שגיאה אוטומטיים הם אנונימיים. שתף את מזהה ההתקנה שלך אם המפתח צריך למצוא את דוחות השגיאות שלך.</string>
     <string name="settings_support_label">תמיכה</string>
     <string name="settings_support_description">אם אתה צריך קצת עזרה.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">לאפס את הנתונים שנלמדו?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod תשכח את ניקוז הציוד שנמדד, מהירות הטעינה וזמן ההקשבה, והתחלה מחדש מחיי הסוללה המדורגים.</string>
     <string name="settings_acknowledgements_label">תודות</string>
-    <string name="settings_debug_autoreports_label">דוחות באגים אוטומטיים</string>
-    <string name="settings_debug_autoreports_description">מדווח אוטומטית על בעיות, למשל, פרטים על קריסת אפליקציה כדי שאוכל להבין איך לתקן את זה.</string>
-    <string name="settings_compatibility_mode_label">מצב תאימות</string>
-    <string name="settings_compatibility_mode_description">נטרול אופטימיזציה לשיפור התאימות. נסו את זה אם לא מוצגים נתונים כלל.</string>
     <string name="help_translate_label">תרגום</string>
     <string name="help_translate_description">עזרו בתרגום אפליקציה זו לשפה המועדפת עליכם.</string>
     <string name="translators_thanks_title">מתרגמים</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">הצלחה</string>
     <string name="troubleshooter_ble_result_success_body">שידורי פרסומת BLE מתקבלים על ידי CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">לא מוצלח</string>
-    <string name="troubleshooter_ble_result_failure_body">פתרון הבעיות נכשל. שום שילוב של אפשרויות תאימות לא עזר.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">הטלפון שלך לא קיבל נתוני BLE בכלל. אתה יכול לנסות שוב את הבדיקה הזו באזור צפוף כדי לראות אם ניתן לקבל מקורות נתונים נוספים (מלבד האוזניות שלך). אין מידע שמתקבל מצביע על בעיה במערכת ההפעלה של הטלפון שלך.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">טלפון שלך קיבל נתוני BLE, אך הנתונים אינם מגיעים ממכשיר אשר נתמך. האם האוזניות שלך מופעלות? האם CAPod תומך באוזניות שלך?</string>
-    <string name="troubleshooter_ble_result_failure_action">נסה שנית</string>
-    <string name="troubleshoot_action">פתרון בעיות</string>
     <string name="onboarding_body1">אפליקציה זו מוסיפה תמיכה בתכונות ספציפיות של AirPod לאנדרואיד.</string>
     <string name="onboarding_body2">לא כל מכשירי האנדרואיד תומכים באופן מלא בתכונות הנוספות של AirPod. מערכת ההפעלה שלך דורשת יישום תקין של Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">ב-CAPod אין מודעות ואיננו אוספים נתונים שלך.</string>
@@ -207,11 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">המכשיר שלך מחובר, אך CAPod אינו מקבל ממנו נתונים חיים. הטלפון שלך עשוי להזדקק לאפשרות תאימות — פותר הבעיות יכול לנסות למצוא אחת אוטומטית.</string>
     <string name="overview_troubleshoot_suggestion_action">הפעל פותר בעיות</string>
     <string name="overview_unmatched_devices_label">מכשירים ללא התאמה</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">מכשיר %d ללא פרופיל תואם</item>
-        <item quantity="two">%d מכשירים ללא פרופיל תואם</item>
-        <item quantity="other">%d מכשירים ללא פרופיל תואם</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d מכשיר קרוב זוהה ללא פרופיל תואם. הציגו אותו לפרטים זמינים. אם הוא שלכם, הוסיפו פרופיל מתוך מכשירים כדי לזהות אותו.</item>
         <item quantity="two">%d מכשירים קרובים זוהו ללא פרופילים תואמים. הציגו אותם לפרטים זמינים. אם אחד מהם שלכם, הוסיפו פרופיל מתוך מכשירים כדי לזהות אותו.</item>
@@ -234,7 +208,6 @@
     <string name="permission_background_location_description">CAPod משתמש ב\"גישה למיקום ברקע\" כדי לאפשר תכונות כמו \"הצג חלון קופץ\" ו\"חיבור אוטומטי\" כאשר האפליקציה סגורה. גישה למיקום ברקע מאפשרת לאפליקציה לקבל נתוני Bluetooth Low Energy כשהיא ברקע. אפליקציה זו לא תשתמש בנתוני Bluetooth כדי לקבוע את מיקומך.</string>
     <string name="permission_ignore_battery_optimizations_label">השבתת אופטימיזציית סוללה</string>
     <string name="permission_ignore_battery_optimizations_description">אופטימיזציית סוללה מונעת מאפליקציה זו לקבל נתוני Bluetooth באופן אמין כשהיא ברקע.</string>
-    <string name="permission_required_title">ההרשאה הבאה נדרשת:</string>
     <string name="permission_system_alert_window_label">חלון התראת מערכת</string>
     <string name="permission_system_alert_window_description">אפשר ל-CAPod לצייר מעל אפליקציות אחרות כדי לאפשר את תכונת \"הצג חלון קופץ\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">כשנראה</string>
@@ -242,9 +215,6 @@
     <string name="settings_reaction_autoconnect_inear_label">באוזן</string>
     <string name="pods_dual_left_label">אוזניה שמאלית</string>
     <string name="pods_dual_right_label">אוזניה ימנית</string>
-    <string name="pods_dual_left_short_label">ש</string>
-    <string name="pods_dual_right_short_label">י</string>
-    <string name="pods_case_label">מארז</string>
     <string name="battery_unavailable_label">הסוללה אינה זמינה</string>
     <string name="battery_state_low_cd">סוללה נמוכה</string>
     <string name="battery_state_critical_cd">סוללה במצב קריטי</string>
@@ -299,12 +269,9 @@
     <string name="signal_badge_aap_cd">חיבור ישיר פעיל</string>
     <string name="signal_indicator_bars_cd">עוצמת אות: %1$d מתוך 4 פסים</string>
     <string name="signal_indicator_disconnected_cd">אות: מנותק</string>
-    <string name="pods_yours">שלך</string>
     <string name="headset_being_worn_label">מורכב</string>
     <string name="headset_not_being_worn_label">לא מורכב</string>
     <string name="pods_case_unknown_state">מצב לא ידוע</string>
-    <string name="last_seen_x">נראה לאחרונה: %s</string>
-    <string name="first_seen_x">נראה לראשונה: %s</string>
     <string name="battery_cached_label">אחרון ידוע · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dש %2$dד</string>
     <string name="battery_time_remaining_format_h">%1$dש</string>
@@ -334,10 +301,8 @@
     <string name="profiles_signal_quality_title">איכות אות מינימלית</string>
     <string name="profiles_signal_quality_description">זהה רק מכשירים עם עוצמת אות מעל סף זה. ערכים נמוכים יותר מגדילים את טווח הזיהוי אך עלולים לגרום לזיהויים שגויים. אל תגדיר ערך גבוה מדי - קליטת Bluetooth בדרך כלל חלשה ומשתנה עם המרחק והמכשולים.</string>
     <string name="profiles_identitykey_label">מפתח זיהוי</string>
-    <string name="profilessettings_maindevice_identitykey_description">מפתח פענוח הזהות (IRK) של המכשיר שלך, שעוזר ל-CAPod לזהות אותו בין מכשירים קרובים.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods משנים לעיתים קרובות את כתובת ה-Bluetooth שלהם לצורכי פרטיות. ה-IRK עוזר ל-CAPod לזהות את המכשיר שלך. נדרשת גישה חד-פעמית ל-MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">מפתח הצפנה</string>
-    <string name="profiles_maindevice_encryptionkey_description">מפתח ההצפנה של המכשיר שלך, המאפשר ל-CAPod לאחזר מידע מפורט על המצב.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods שולחים הודעת מצב, שחלקה מוצפן. מפתח ההצפנה מאפשר ל-CAPod לפענח את ההודעה המלאה. נדרשת גישה חד-פעמית ל-MacBook.</string>
     <string name="profiles_key_invalid_format">פורמט מפתח לא חוקי</string>
     <string name="profiles_key_expected_format">פורמט צפוי: %1$s</string>
@@ -370,7 +335,6 @@
     <string name="general_unsaved_changes_message">יש לך שינויים שלא נשמרו. מה תרצה לעשות?</string>
     <string name="general_save_and_exit_action">שמור וצא</string>
     <string name="general_discard_action">בטל</string>
-    <string name="general_keep_editing_action">המשך לערוך</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ההקלטה קצרה מדי</string>
     <string name="debug_debuglog_short_recording_message">יומן איתור הבאגים צריך ללכוד את הבעיה בעת התרחשותה. המשך בהקלטה, שחזר על הבעיה, ולאחר מכן עצור את ההקלטה.</string>
@@ -444,7 +408,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">הגדרות מכשיר</string>
     <string name="device_settings_subtitle_profile_prefix">פרופיל: %s</string>
-    <string name="device_settings_info_name_label">שם</string>
     <string name="device_settings_info_bt_name_label">תווית התקן בלוטות\'</string>
     <string name="device_settings_info_model_label">דגם</string>
     <string name="device_settings_info_manufacturer_label">יצרן</string>
@@ -524,7 +487,6 @@
     <string name="review_app_dismiss_action">אולי מאוחר יותר</string>
     <string name="review_app_body">להשאיר ביקורת ל-CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">כללי</string>
     <string name="device_settings_microphone_mode_label">מיקרופון</string>
     <string name="device_settings_microphone_mode_description">איזה אוזנייה משמשת כמיקרופון</string>
     <string name="device_settings_microphone_mode_auto">אוטומטי</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">共有</string>
     <string name="general_done_action">完了</string>
     <string name="general_cancel_action">キャンセル</string>
-    <string name="general_copy_action">コピー</string>
     <string name="general_thank_you_label">ありがとう</string>
     <string name="general_upgrade_action">アップグレード</string>
     <string name="general_retry_action">再試行</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">確認</string>
     <string name="general_close_action">閉じる</string>
     <string name="general_dismiss_action">閉じる</string>
-    <string name="general_edit_action">編集</string>
     <string name="general_save_action">保存</string>
     <string name="general_guide_action">ガイド</string>
     <string name="general_continue_action">続行</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">自動一時停止で停止した場合のみ、ポッドを再装着したときに音楽を再開します。自分で一時停止した場合（電話、AirPodsステム、スリープ）は一時停止のままになります。</string>
     <string name="settings_start_music_on_wear_label">装着時に音楽を開始</string>
     <string name="settings_start_music_on_wear_description">手動で一時停止した後でも、ポッドを装着したときに常に音楽の再生を試みます。</string>
-    <string name="settings_eardetection_info_label">耳検出に関する注意</string>
     <string name="settings_eardetection_info_description">耳検出が片方のpodでしか動作しない場合、これはAppleの制限です。検出されるのは「primary pod」（マイクに使われる側）だけです。Appleデバイスで設定してください: 設定 → Bluetooth → AirPods → マイク。</string>
-    <string name="settings_signal_minimum_label">最小信号品質</string>
-    <string name="settings_signal_minimum_description">デバイスがあなたのものと見なされるために必要な最小信号品質。</string>
     <string name="settings_autoconnect_label">自動接続</string>
     <string name="settings_autoconnect_description">Androidが自動的に接続しない場合、CAPodから接続をリクエストすることができます。この機能をオンにすると、CAPodは常にバックグラウンドで監視を続けます。</string>
     <string name="settings_autoconnect_info_android12">自動接続はAndroid 12以降で制限されているシステム機能に依存しています。お使いのデバイスでは動作しない場合があります。</string>
     <string name="settings_autoconnect_condition_label">自動接続条件</string>
-    <string name="settings_autoconnect_condition_description">いつデバイスに接続しようとすべきですか？</string>
     <string name="settings_devices_label">デバイス</string>
     <string name="settings_devices_description">デバイスを管理します。</string>
     <string name="settings_reaction_label">リアクション</string>
-    <string name="settings_category_yourdevice_label">あなたのデバイス</string>
     <string name="settings_category_compatibility_options_title">互換性オプション</string>
     <string name="settings_category_compatibility_options_description">すべてが機能する場合は触れないでください ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ハードウェアフィルタリングを無効にする</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">起動中…</string>
     <string name="support_debuglog_label">デバッグログ</string>
     <string name="support_debuglog_desc">アプリが行っているすべてのことを、共有できるテキストファイルに記録します。</string>
-    <string name="debug_debuglog_size_label">サイズ</string>
-    <string name="debug_debuglog_size_compressed_label">圧縮サイズ</string>
-    <string name="debug_notification_channel_label">デバッグ通知</string>
-    <string name="debug_debuglog_file_label">記録されたログファイル</string>
-    <string name="debug_debuglog_recording_progress">デバッグログを記録中</string>
     <string name="debug_debuglog_record_action">デバッグログを記録</string>
     <string name="debug_debuglog_stop_action">記録を停止</string>
     <string name="debug_debuglog_sensitive_information_message">生成されたファイルには機密情報（Bluetoothデバイスの詳細など）が含まれています。信頼できる関係者とのみ共有してください。</string>
     <string name="settings_debuglog_explanation">この機能は、アプリが行っているすべてのことを共有可能なファイルに記録します。生成されたファイルには機密情報（Bluetoothデバイスの詳細など）が含まれています。信頼できる関係者（問題をトラブルシューティングしている開発者など）とのみ共有してください。</string>
-    <string name="settings_support_installid_label">インストールID</string>
-    <string name="settings_support_installid_desc">自動エラーレポートは匿名です。開発者がエラーレポートを見つける必要がある場合は、インストールIDを共有してください。</string>
     <string name="settings_support_label">サポート</string>
     <string name="settings_support_description">ヘルプが必要な場合。</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">学習データをリセットしますか？</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPodはこのデバイスの測定済み放電、充電速度、リスニング時間を忘れて、定格バッテリー寿命からやり直します。</string>
     <string name="settings_acknowledgements_label">謝辞</string>
-    <string name="settings_debug_autoreports_label">自動バグレポート</string>
-    <string name="settings_debug_autoreports_description">アプリのクラッシュに関する詳細など、問題を自動的に報告して、修正方法を把握できるようにします。</string>
-    <string name="settings_compatibility_mode_label">互換モード</string>
-    <string name="settings_compatibility_mode_description">互換性を向上させるために最適化を無効にします。データが表示されない場合は、これを試してください。</string>
     <string name="help_translate_label">翻訳</string>
     <string name="help_translate_description">このアプリをあなたの好きな言語に翻訳するのを手伝ってください。</string>
     <string name="translators_thanks_title">翻訳者</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">成功</string>
     <string name="troubleshooter_ble_result_success_body">BLEアドバタイズメントブロードキャストはCAPodによって受信されています。</string>
     <string name="troubleshooter_ble_result_failure_title">失敗</string>
-    <string name="troubleshooter_ble_result_failure_body">トラブルシューティングに失敗しました。互換性オプションの組み合わせは役に立ちませんでした。</string>
     <string name="troubleshooter_ble_result_failure_phone_body">お使いの電話機はBLEデータをまったく受信しませんでした。混雑した場所でこのテストを再試行して、データソース（ヘッドフォン以外）を受信できるかどうかを確認できます。データが受信されない場合は、電話機のオペレーティングシステムに問題があることを示しています。</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">お使いの電話機はBLEデータを受信しましたが、データはサポートされているどのデバイスからも送信されていません。ヘッドフォンはオンになっていますか？CAPodはヘッドフォンをサポートしていますか？</string>
-    <string name="troubleshooter_ble_result_failure_action">再試行</string>
-    <string name="troubleshoot_action">トラブルシューティング</string>
     <string name="onboarding_body1">このアプリは、AndroidにAirPod固有の機能のサポートを追加します。</string>
     <string name="onboarding_body2">すべてのAndroidデバイスが追加のAirPod機能を完全にサポートしているわけではありません。オペレーティングシステムには、正しく機能するBluetooth Low Energyの実装が必要です。</string>
     <string name="onboarding_body3">CAPodには広告がなく、データを収集しません。</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">デバイスは接続されていますが、CAPodはライブデータを受信していません。互換性オプションが必要な場合があります—トラブルシューターが自動的に検索を試みます。</string>
     <string name="overview_troubleshoot_suggestion_action">トラブルシューターを実行</string>
     <string name="overview_unmatched_devices_label">一致しないデバイス</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">一致するプロファイルがないデバイス %d 台</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">近くで一致するプロファイルのないデバイスが%d件検出されました。詳細を確認するには表示してください。ご自身のデバイスであれば、「デバイス」からプロファイルを追加すると認識されます。</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPodは、アプリが閉じている間に「ポップアップを表示」や「AutoConnect」などの機能を有効にするために「バックグラウンド位置情報アクセス」を使用します。バックグラウンド位置情報アクセスにより、アプリはバックグラウンドでもBluetooth Low Energyデータを受信できます。このアプリがBluetoothデータを使用して位置情報を特定することはありません。</string>
     <string name="permission_ignore_battery_optimizations_label">バッテリー最適化を無効化</string>
     <string name="permission_ignore_battery_optimizations_description">バッテリー最適化により、アプリがバックグラウンドでBluetoothデータを安定して受信できなくなります。</string>
-    <string name="permission_required_title">次の権限が必要です:</string>
     <string name="permission_system_alert_window_label">システムアラートウィンドウ</string>
     <string name="permission_system_alert_window_description">「ポップアップを表示」機能を有効にするため、CAPodが他のアプリの上に表示できるようにします。</string>
     <string name="settings_reaction_autoconnect_whenseen_label">検出時</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">装着時</string>
     <string name="pods_dual_left_label">左のpod</string>
     <string name="pods_dual_right_label">右のpod</string>
-    <string name="pods_dual_left_short_label">左</string>
-    <string name="pods_dual_right_short_label">右</string>
-    <string name="pods_case_label">ケース</string>
     <string name="battery_unavailable_label">バッテリー情報なし</string>
     <string name="battery_state_low_cd">バッテリー残量が少ない</string>
     <string name="battery_state_critical_cd">バッテリーが危機的に低い</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">直接接続中</string>
     <string name="signal_indicator_bars_cd">電波強度: 4バー中%1$d</string>
     <string name="signal_indicator_disconnected_cd">シグナル: 未接続</string>
-    <string name="pods_yours">あなたのデバイス</string>
     <string name="headset_being_worn_label">装着中</string>
     <string name="headset_not_being_worn_label">未装着</string>
     <string name="pods_case_unknown_state">不明な状態</string>
-    <string name="last_seen_x">最終確認: %s</string>
-    <string name="first_seen_x">初回確認: %s</string>
     <string name="battery_cached_label">最後の既知の位置 · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d時間%2$d分</string>
     <string name="battery_time_remaining_format_h">%1$d時間</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">最小信号品質</string>
     <string name="profiles_signal_quality_description">このしきい値を超える信号強度のデバイスのみ検出します。値を下げると検出範囲は広がりますが、誤検出が増える可能性があります。高くしすぎないでください。Bluetooth受信は一般的に不安定で、距離や障害物によって変動します。</string>
     <string name="profiles_identitykey_label">識別キー</string>
-    <string name="profilessettings_maindevice_identitykey_description">あなたのデバイスのIdentity Resolving Key（IRK）。近くのデバイスの中からCAPodがあなたのデバイスを識別するのに役立ちます。</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPodsはプライバシー保護のためBluetoothアドレスを頻繁に変更します。IRKによりCAPodがあなたのデバイスを認識できます。MacBookへの一時的なアクセスが必要です。</string>
     <string name="profiles_maindevice_encryptionkey_label">暗号化キー</string>
-    <string name="profiles_maindevice_encryptionkey_description">あなたのデバイスの暗号鍵。CAPodが詳細な状態情報を取得できるようになります。</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPodsは状態メッセージを送信しますが、その一部は暗号化されています。暗号鍵によりCAPodはメッセージ全体を復号できます。MacBookへの一時的なアクセスが必要です。</string>
     <string name="profiles_key_invalid_format">無効な鍵形式です</string>
     <string name="profiles_key_expected_format">期待される形式: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">未保存の変更があります。どうしますか？</string>
     <string name="general_save_and_exit_action">保存して終了</string>
     <string name="general_discard_action">破棄</string>
-    <string name="general_keep_editing_action">編集を続ける</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">記録時間が短すぎます</string>
     <string name="debug_debuglog_short_recording_message">デバッグログは問題発生中に記録する必要があります。記録を続けて問題を再現し、それから記録を停止してください。</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">デバイス設定</string>
     <string name="device_settings_subtitle_profile_prefix">プロファイル: %s</string>
-    <string name="device_settings_info_name_label">名前</string>
     <string name="device_settings_info_bt_name_label">Bluetoothデバイスラベル</string>
     <string name="device_settings_info_model_label">モデル</string>
     <string name="device_settings_info_manufacturer_label">メーカー</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">また後で</string>
     <string name="review_app_body">CAPodをレビューしませんか？ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">マイク</string>
     <string name="device_settings_microphone_mode_description">マイクとして使用するイヤーバッド</string>
     <string name="device_settings_microphone_mode_auto">自動</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">გაზიარება</string>
     <string name="general_done_action">შესრულებულია</string>
     <string name="general_cancel_action">გაუქმება</string>
-    <string name="general_copy_action">კოპირება</string>
     <string name="general_thank_you_label">გმადლობთ</string>
     <string name="general_upgrade_action">განახლება</string>
     <string name="general_retry_action">ხელახლა</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">შემოწმება</string>
     <string name="general_close_action">დახურვა</string>
     <string name="general_dismiss_action">გაუქმება</string>
-    <string name="general_edit_action">რედაქტირება</string>
     <string name="general_save_action">შენახვა</string>
     <string name="general_guide_action">სახელმძღვანელო</string>
     <string name="general_continue_action">გაგრძელება</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">მუსიკის განახლება ყურსასმენების ხელახლა ჩადებისას, მხოლოდ იმ შემთხვევაში, თუ ავტო-პაუზამ შეაჩერა. პაუზები, რომლებიც თქვენ თვითონ გააკეთეთ (ტელეფონი, AirPods ღერო, ძილი), პაუზირებულია.</string>
     <string name="settings_start_music_on_wear_label">მუსიკის დაწყება ჩადებისას</string>
     <string name="settings_start_music_on_wear_description">ყოველთვის ცდილობს მუსიკის დაკვრას ყურსასმენების ჩადებისას, მანუალური პაუზის შემდეგაც კი.</string>
-    <string name="settings_eardetection_info_label">ყურში აღმოჩენის შენიშვნა</string>
     <string name="settings_eardetection_info_description">თუ ყურში აღმოჩენა მხოლოდ ერთი ყურსასმენისთვის მუშაობს, ეს Apple-ის შეზღუდვაა. აღმოჩენილია მხოლოდ \"primary pod\" (მიკროფონისთვის გამოყენებული). კონფიგურაცია Apple მოწყობილობებზე: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">სიგნალის მინიმალური ხარისხი</string>
-    <string name="settings_signal_minimum_description">სიგნალის მინიმალური ხარისხი, რომელიც მოწყობილობას უნდა ჰქონდეს, რომ თქვენად ჩაითვალოს.</string>
     <string name="settings_autoconnect_label">ავტომატური დაკავშირება</string>
     <string name="settings_autoconnect_description">თუ Android ავტომატურად არ დაუკავშირდება, ჩვენც შეგვიძლია ვთხოვოთ მას ეს. ეს უზრუნველყოფს, რომ CAPod ფონურ რეჟიმში მუდმივად აკვირდება.</string>
     <string name="settings_autoconnect_info_android12">ავტო-კავშირი ეყრდნობა სისტემის ფუნქციას, რომელსაც Android 12 და უფრო ახალი ვერსიები ზღუდავს. შესაძლოა, თქვენს მოწყობილობაზე ეს ფუნქცია არ მუშაობდეს.</string>
     <string name="settings_autoconnect_condition_label">ავტომატური დაკავშირების პირობა</string>
-    <string name="settings_autoconnect_condition_description">როდის უნდა ვცადოთ თქვენს მოწყობილობასთან დაკავშირება?</string>
     <string name="settings_devices_label">მოწყობილობები</string>
     <string name="settings_devices_description">მართეთ თქვენი მოწყობილობები.</string>
     <string name="settings_reaction_label">რეაქციები</string>
-    <string name="settings_category_yourdevice_label">თქვენი მოწყობილობა</string>
     <string name="settings_category_compatibility_options_title">თავსებადობის პარამეტრები</string>
     <string name="settings_category_compatibility_options_description">არ შეეხოთ, თუ ყველაფერი მუშაობს ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">აპარატურული ფილტრაციის გამორთვა</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">გაშვება მიმდინარეობს…</string>
     <string name="support_debuglog_label">გამართვის ჟურნალი</string>
     <string name="support_debuglog_desc">ჩაწერეთ ყველაფერი, რასაც აპლიკაცია აკეთებს ტექსტურ ფაილში, რომლის გაზიარებაც შეგიძლიათ.</string>
-    <string name="debug_debuglog_size_label">ზომა</string>
-    <string name="debug_debuglog_size_compressed_label">შეკუმშული ზომა</string>
-    <string name="debug_notification_channel_label">გამართვის შეტყობინებები</string>
-    <string name="debug_debuglog_file_label">ჩაწერილი ჟურნალის ფაილი</string>
-    <string name="debug_debuglog_recording_progress">გამართვის ჟურნალის ჩაწერა</string>
     <string name="debug_debuglog_record_action">გამართვის ჟურნალის ჩაწერა</string>
     <string name="debug_debuglog_stop_action">ჩაწერის შეწყვეტა</string>
     <string name="debug_debuglog_sensitive_information_message">გენერირებული ფაილი შეიცავს მგრძნობიარე ინფორმაციას (მაგ. Bluetooth მოწყობილობის დეტალები). გააზიარეთ იგი მხოლოდ სანდო მხარეებთან.</string>
     <string name="settings_debuglog_explanation">ეს ფუნქცია ჩაწერს ყველაფერს, რასაც აპლიკაცია აკეთებს, გასაზიარებელ ფაილში. გენერირებული ფაილი შეიცავს მგრძნობიარე ინფორმაციას (მაგ. Bluetooth მოწყობილობის დეტალები). გააზიარეთ იგი მხოლოდ სანდო მხარეებთან (მაგ. დეველოპერთან, რომელიც პრობლემას აგვარებს).</string>
-    <string name="settings_support_installid_label">ინსტალაციის ID</string>
-    <string name="settings_support_installid_desc">შეცდომების ავტომატური ანგარიშები ანონიმურია. გააზიარეთ თქვენი ინსტალაციის ID, თუ დეველოპერს სჭირდება თქვენი შეცდომების ანგარიშების პოვნა.</string>
     <string name="settings_support_label">მხარდაჭერა</string>
     <string name="settings_support_description">თუ დახმარება გჭირდებათ.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">გადატვირთოთ მიღებული მონაცემები?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod დაავიწყდება ამ მოწყობილობის გაზომილი მოხმარება, დატენების სიჩქარე და მოსმენის დრო, და დაიწყებს ისევ შეფასებული ბატარეის სიცოცხლიდან.</string>
     <string name="settings_acknowledgements_label">მადლობები</string>
-    <string name="settings_debug_autoreports_label">შეცდომების ავტომატური ანგარიშები</string>
-    <string name="settings_debug_autoreports_description">ავტომატურად აცნობებს პრობლემების შესახებ, მაგ. აპლიკაციის ავარიის დეტალებს, რათა გავარკვიო, როგორ გამოვასწორო.</string>
-    <string name="settings_compatibility_mode_label">თავსებადობის რეჟიმი</string>
-    <string name="settings_compatibility_mode_description">გამორთეთ ოპტიმიზაციები თავსებადობის გასაუმჯობესებლად. სცადეთ ეს, თუ მონაცემებს ვერ ხედავთ.</string>
     <string name="help_translate_label">თარგმანი</string>
     <string name="help_translate_description">დაეხმარეთ ამ აპლიკაციის თქვენს საყვარელ ენაზე თარგმნაში.</string>
     <string name="translators_thanks_title">მთარგმნელები</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">წარმატება</string>
     <string name="troubleshooter_ble_result_success_body">BLE სარეკლამო მაუწყებლობა მიიღება CAPod-ის მიერ.</string>
     <string name="troubleshooter_ble_result_failure_title">წარუმატებელი</string>
-    <string name="troubleshooter_ble_result_failure_body">პრობლემების მოგვარება ვერ მოხერხდა. თავსებადობის ვარიანტების არცერთმა კომბინაციამ არ უშველა.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">თქვენმა ტელეფონმა საერთოდ არ მიიღო BLE მონაცემები. შეგიძლიათ ხელახლა სცადოთ ეს ტესტი ხალხმრავალ ადგილას, რათა ნახოთ, შესაძლებელია თუ არა მონაცემთა წყაროების (თქვენი ყურსასმენების გარდა) მიღება. მონაცემების არმიღება მიუთითებს თქვენი ტელეფონის ოპერაციულ სისტემასთან დაკავშირებულ პრობლემაზე.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">თქვენმა ტელეფონმა მიიღო BLE მონაცემები, მაგრამ მონაცემები არ მოდის არცერთი მხარდაჭერილი მოწყობილობიდან. ჩართულია თუ არა თქვენი ყურსასმენები? CAPod მხარს უჭერს თუ არა თქვენს ყურსასმენებს?</string>
-    <string name="troubleshooter_ble_result_failure_action">Კვლავ ცდა</string>
-    <string name="troubleshoot_action">პრობლემების მოგვარება</string>
     <string name="onboarding_body1">ეს აპლიკაცია Android-ს ამატებს AirPod-ის სპეციფიკური ფუნქციების მხარდაჭერას.</string>
     <string name="onboarding_body2">ყველა Android მოწყობილობა სრულად არ უჭერს მხარს AirPod-ის დამატებით ფუნქციებს. თქვენს ოპერაციულ სისტემას სჭირდება Bluetooth-Low-Energy-ის სწორად მომუშავე იმპლემენტაცია.</string>
     <string name="onboarding_body3">CAPod-ს არ აქვს რეკლამები და არ აგროვებს თქვენს მონაცემებს.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">თქვენი მოწყობილობა დაკავშირებულია, მაგრამ CAPod არ იღებს მისგან ცოცხალ მონაცემებს. თქვენს ტელეფონს შეიძლება სჭირდებოდეს თავსებადობის პარამეტრი — პრობლემების გადამჭრელი შეძლებს ავტომატურად მოძებნოს.</string>
     <string name="overview_troubleshoot_suggestion_action">პრობლემების გადამჭრელის გაშვება</string>
     <string name="overview_unmatched_devices_label">შეუთავსებელი მოწყობილობები</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d მოწყობილობა შესაბამისი პროფილის გარეშეა</item>
-        <item quantity="other">%d მოწყობილობა შესაბამისი პროფილის გარეშეა</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d ახლომდებარე მოწყობილობა აღმოჩენილია შესაბამისი პროფილის გარეშე. სანახავად გახსენით დეტალები. თუ ეს თქვენია, დაამატეთ პროფილი მოწყობილობებში მის ამოსაცნობად.</item>
         <item quantity="other">%d ახლომდებარე მოწყობილობა აღმოჩენილია შესაბამისი პროფილების გარეშე. სანახავად გახსენით დეტალები. თუ ერთ-ერთი თქვენია, დაამატეთ პროფილი მოწყობილობებში მისი ამოსაცნობად.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod იყენებს \"background location access\"-ს, რათა \"Show popup\" და \"AutoConnect\" ფუნქციები იმუშაოს მაშინაც, როცა აპი დახურულია. ფონური მდებარეობის წვდომა აპს საშუალებას აძლევს, Bluetooth Low Energy მონაცემები ფონურ რეჟიმში მიიღოს. ეს აპი Bluetooth მონაცემებს თქვენი მდებარეობის დასადგენად არ გამოიყენებს.</string>
     <string name="permission_ignore_battery_optimizations_label">ბატარეის ოპტიმიზაციების გამორთვა</string>
     <string name="permission_ignore_battery_optimizations_description">ბატარეის ოპტიმიზაციები ხელს უშლის ამ აპს ფონურ რეჟიმში Bluetooth მონაცემების საიმედოდ მიღებაში.</string>
-    <string name="permission_required_title">საჭიროა შემდეგი ნებართვა:</string>
     <string name="permission_system_alert_window_label">სისტემური გამაფრთხილებელი ფანჯარა</string>
     <string name="permission_system_alert_window_description">დაუშვით, რომ CAPod სხვა აპებზე ზემოდან გამოჩნდეს, რათა \"Show PopUp\" ფუნქცია შესაძლებელი გახდეს.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">როცა გამოჩნდება</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">ყურშია</string>
     <string name="pods_dual_left_label">მარცხენა ყურსასმენი</string>
     <string name="pods_dual_right_label">მარჯვენა ყურსასმენი</string>
-    <string name="pods_dual_left_short_label">მ</string>
-    <string name="pods_dual_right_short_label">მ</string>
-    <string name="pods_case_label">ქეისი</string>
     <string name="battery_unavailable_label">ბატარეა მიუწვდომელია</string>
     <string name="battery_state_low_cd">დაბალი ბატარეა</string>
     <string name="battery_state_critical_cd">კრიტიკულად დაბალი ბატარეა</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">პირდაპირი კავშირი აქტიურია</string>
     <string name="signal_indicator_bars_cd">სიგნალის სიძლიერე: %1$d / 4 ზოლი</string>
     <string name="signal_indicator_disconnected_cd">სიგნალი: გათიშულია</string>
-    <string name="pods_yours">თქვენია</string>
     <string name="headset_being_worn_label">ტარდება</string>
     <string name="headset_not_being_worn_label">არ ტარდება</string>
     <string name="pods_case_unknown_state">უცნობი მდგომარეობა</string>
-    <string name="last_seen_x">ბოლოს ნანახია: %s</string>
-    <string name="first_seen_x">პირველად ნანახია: %s</string>
     <string name="battery_cached_label">ბოლო ცნობილი · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dსთ %2$dწთ</string>
     <string name="battery_time_remaining_format_h">%1$dსთ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">სიგნალის მინიმალური ხარისხი</string>
     <string name="profiles_signal_quality_description">აღმოაჩინეთ მხოლოდ ის მოწყობილობები, რომელთა სიგნალის სიმძლავრე ამ ზღვარზე მაღალია. დაბალი მნიშვნელობები ზრდის აღმოჩენის არეალს, მაგრამ შეიძლება გამოიწვიოს მცდარი დადებითი შედეგები. ნუ დააყენებთ ამას ძალიან მაღლა - Bluetooth მიღება ჩვეულებრივ სუსტია და იცვლება მანძილისა და დაბრკოლებების მიხედვით.</string>
     <string name="profiles_identitykey_label">იდენტობის გასაღები</string>
-    <string name="profilessettings_maindevice_identitykey_description">თქვენი მოწყობილობის Identity Resolving Key (IRK), რომელიც CAPod-ს ეხმარება ახლომდებარე მოწყობილობებს შორის მის ამოცნობაში.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods კონფიდენციალურობისთვის ხშირად ცვლის Bluetooth მისამართს. IRK CAPod-ს ეხმარება თქვენი მოწყობილობის ამოცნობაში. საჭიროა MacBook-ზე ერთჯერადი წვდომა.</string>
     <string name="profiles_maindevice_encryptionkey_label">დაშიფვრის გასაღები</string>
-    <string name="profiles_maindevice_encryptionkey_description">თქვენი მოწყობილობის დაშიფვრის გასაღები, რომელიც CAPod-ს დეტალური სტატუსის ინფორმაციის მიღების საშუალებას აძლევს.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods აგზავნის სტატუსის შეტყობინებას, რომლის ნაწილიც დაშიფრულია. დაშიფვრის გასაღები CAPod-ს სრული შეტყობინების გაშიფვრის საშუალებას აძლევს. საჭიროა MacBook-ზე ერთჯერადი წვდომა.</string>
     <string name="profiles_key_invalid_format">გასაღების ფორმატი არასწორია</string>
     <string name="profiles_key_expected_format">მოსალოდნელი ფორმატი: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">გაქვთ შეუნახავი ცვლილებები. როგორ გსურთ გაგრძელება?</string>
     <string name="general_save_and_exit_action">შენახვა და გასვლა</string>
     <string name="general_discard_action">გაუქმება</string>
-    <string name="general_keep_editing_action">რედაქტირების გაგრძელება</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ჩანაწერი ძალიან მოკლე</string>
     <string name="debug_debuglog_short_recording_message">გამართვის ჟურნალმა პრობლემა უნდა დააფიქსიროს მის დროს. განაგრძეთ ჩაწერა, გაიმეორეთ პრობლემა, შემდეგ შეაჩერეთ ჩაწერა.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">მოწყობილობის პარამეტრები</string>
     <string name="device_settings_subtitle_profile_prefix">პროფილი: %s</string>
-    <string name="device_settings_info_name_label">სახელი</string>
     <string name="device_settings_info_bt_name_label">Bluetooth მოწყობილობის სახელი</string>
     <string name="device_settings_info_model_label">მოდელი</string>
     <string name="device_settings_info_manufacturer_label">მწარმოებელი</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">შესაძლოა მოგვიანებით</string>
     <string name="review_app_body">გნებავთ დატოვოთ CAPod-ს მიმოხილვა? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">ზოგადი</string>
     <string name="device_settings_microphone_mode_label">მიკროფონი</string>
     <string name="device_settings_microphone_mode_description">რომელი ყურსასმენი გამოიყენება მიკროფონად</string>
     <string name="device_settings_microphone_mode_auto">ავტო</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">ចែករំលែក</string>
     <string name="general_done_action">រួចរាល់</string>
     <string name="general_cancel_action">បោះបង់</string>
-    <string name="general_copy_action">ចម្លង</string>
     <string name="general_thank_you_label">សូមអរគុណ</string>
     <string name="general_upgrade_action">ដំឡើងកំណែ</string>
     <string name="general_retry_action">សាកល្បងម្តងទៀត</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">ពិនិត្យ</string>
     <string name="general_close_action">បិទ</string>
     <string name="general_dismiss_action">បដិសេធ</string>
-    <string name="general_edit_action">កែសម្រួល</string>
     <string name="general_save_action">រក្សាទុក</string>
     <string name="general_guide_action">មគ្គុទ្ទេសក៍</string>
     <string name="general_continue_action">បន្ត</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">បន្តតន្ត្រី នៅពេលពាក់ pods របស់អ្នកម្តងទៀត ប៉ុន្តែតែក្នុងករណីដែល Auto pause បានបញ្ឈប់វា។ ការផ្អាកដែលអ្នកបានធ្វើដោយខ្លួនឯង (ទូរស័ព្ទ, AirPods stem, ការគេង) នឹងនៅតែផ្អាក។</string>
     <string name="settings_start_music_on_wear_label">ចាប់ផ្តើមតន្ត្រីនៅពេលពាក់</string>
     <string name="settings_start_music_on_wear_description">តែងតែព្យាយាមចាក់តន្ត្រី នៅពេលអ្នកពាក់ pods សូម្បីតែបន្ទាប់ពីការផ្អាកដោយដៃ។</string>
-    <string name="settings_eardetection_info_label">ចំណាំការរកឃើញត្រចៀក</string>
     <string name="settings_eardetection_info_description">ប្រសិនបើការរកឃើញត្រចៀកដំណើរការតែសម្រាប់ផតមួយ នេះជាដែនកំណត់របស់ Apple។ មានតែ \"ផតចម្បង\" (ប្រើសម្រាប់មីក្រូហ្វូន) ប៉ុណ្ណោះត្រូវបានរកឃើញ។ កំណត់រចនាសម្ព័ន្ធនៅលើឧបករណ៍ Apple: ការកំណត់ → Bluetooth → AirPods → មីក្រូហ្វូន។</string>
-    <string name="settings_signal_minimum_label">គុណភាពសញ្ញាអប្បបរមា</string>
-    <string name="settings_signal_minimum_description">គុណភាពសញ្ញាអប្បបរមាដែលឧបករណ៍ត្រូវតែមានដើម្បីចាត់ទុកថាជារបស់អ្នក។</string>
     <string name="settings_autoconnect_label">ភ្ជាប់ដោយស្វ័យប្រវត្តិ</string>
     <string name="settings_autoconnect_description">ប្រសិនបើ Android មិនតភ្ជាប់ដោយស្វ័យប្រវត្តិទេ យើងអាចស្នើសុំវាបាន។ វារក្សាឱ្យ CAPod ត្រួតពិនិត្យនៅផ្ទៃខាងក្រោយជានិច្ច។</string>
     <string name="settings_autoconnect_info_android12">ការភ្ជាប់ស្វ័យប្រវត្តិពឹងផ្អែកលើមុខងារប្រព័ន្ធដែល Android 12 និងថ្មីជាងនេះដាក់កម្រិត។ វាប្រហែលជាមិនដំណើរការនៅលើឧបករណ៍របស់អ្នកទេ។</string>
     <string name="settings_autoconnect_condition_label">លក្ខខណ្ឌភ្ជាប់ដោយស្វ័យប្រវត្តិ</string>
-    <string name="settings_autoconnect_condition_description">តើយើងគួរព្យាយាមភ្ជាប់ទៅឧបករណ៍របស់អ្នកនៅពេលណា?</string>
     <string name="settings_devices_label">ឧបករណ៍</string>
     <string name="settings_devices_description">គ្រប់គ្រងឧបករណ៍របស់អ្នក។</string>
     <string name="settings_reaction_label">ប្រតិកម្ម</string>
-    <string name="settings_category_yourdevice_label">ឧបករណ៍របស់អ្នក</string>
     <string name="settings_category_compatibility_options_title">ជម្រើសភាពឆបគ្នា</string>
     <string name="settings_category_compatibility_options_description">កុំប៉ះប្រសិនបើអ្វីៗដំណើរការបានល្អ ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">បិទការត្រងផ្នែករឹង</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">កំពុងចាប់ផ្តើម…</string>
     <string name="support_debuglog_label">កំណត់ហេតុកែកំហុស</string>
     <string name="support_debuglog_desc">កត់ត្រាអ្វីគ្រប់យ៉ាងដែលកម្មវិធីកំពុងធ្វើទៅក្នុងឯកសារអត្ថបទដែលអ្នកអាចចែករំលែកបាន។</string>
-    <string name="debug_debuglog_size_label">ទំហំ</string>
-    <string name="debug_debuglog_size_compressed_label">ទំហំបានបង្ហាប់</string>
-    <string name="debug_notification_channel_label">ការជូនដំណឹងកែកំហុស</string>
-    <string name="debug_debuglog_file_label">ឯកសារកំណត់ហេតុបានកត់ត្រា</string>
-    <string name="debug_debuglog_recording_progress">កំពុងកត់ត្រាកំណត់ហេតុកែកំហុស</string>
     <string name="debug_debuglog_record_action">កត់ត្រាកំណត់ហេតុកែកំហុស</string>
     <string name="debug_debuglog_stop_action">បញ្ឈប់ការកត់ត្រា</string>
     <string name="debug_debuglog_sensitive_information_message">ឯកសារដែលបានបង្កើតមានព័ត៌មានរសើប (ឧ. ព័ត៌មានលម្អិតអំពីឧបករណ៍ Bluetooth)។ ចែករំលែកវាជាមួយភាគីដែលទុកចិត្តតែប៉ុណ្ណោះ។</string>
     <string name="settings_debuglog_explanation">មុខងារនេះកត់ត្រាអ្វីគ្រប់យ៉ាងដែលកម្មវិធីកំពុងធ្វើទៅក្នុងឯកសារដែលអាចចែករំលែកបាន។ ឯកសារដែលបានបង្កើតមានព័ត៌មានរសើប (ឧ. ព័ត៌មានលម្អិតអំពីឧបករណ៍ Bluetooth)។ ចែករំលែកវាជាមួយភាគីដែលទុកចិត្តតែប៉ុណ្ណោះ (ឧ. អ្នកអភិវឌ្ឍន៍ដែលកំពុងដោះស្រាយបញ្ហា)។</string>
-    <string name="settings_support_installid_label">ID ដំឡើង</string>
-    <string name="settings_support_installid_desc">របាយការណ៍កំហុសដោយស្វ័យប្រវត្តិគឺអនាមិក។ ចែករំលែក ID ដំឡើងរបស់អ្នក ប្រសិនបើអ្នកអភិវឌ្ឍន៍ត្រូវការស្វែងរករបាយការណ៍កំហុសរបស់អ្នក។</string>
     <string name="settings_support_label">ជំនួយ</string>
     <string name="settings_support_description">ប្រសិនបើអ្នកត្រូវការជំនួយខ្លះ។</string>
     <string name="settings_wiki_label">វិគឹ</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">លុបទិន្នន័យដែលរៀនឡើងវិញ?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod នឹងភ្លេចការរលាយដែលបានវាស់វែងរបស់ឧបករណ៍នេះ ល្បឿនសាក និងរយៈពេលស្តាប់ ហើយចាប់ផ្តើមម្តងទៀតពីរយៈពេលថ្មដែលបានវាយតម្លៃ។</string>
     <string name="settings_acknowledgements_label">ការទទួលស្គាល់</string>
-    <string name="settings_debug_autoreports_label">របាយការណ៍កំហុសដោយស្វ័យប្រវត្តិ</string>
-    <string name="settings_debug_autoreports_description">រាយការណ៍បញ្ហាដោយស្វ័យប្រវត្តិ ឧ. ព័ត៌មានលម្អិតអំពីការគាំងកម្មវិធី ដូច្នេះខ្ញុំអាចរកវិធីដោះស្រាយវាបាន។</string>
-    <string name="settings_compatibility_mode_label">របៀបភាពឆបគ្នា</string>
-    <string name="settings_compatibility_mode_description">បិទការបង្កើនប្រសិទ្ធភាពដើម្បីកែលម្អភាពឆបគ្នា។ សាកល្បងវានៅពេលអ្នកមិនឃើញទិន្នន័យណាមួយ។</string>
     <string name="help_translate_label">ការបកប្រែ</string>
     <string name="help_translate_description">ជួយបកប្រែកម្មវិធីនេះទៅជាភាសាដែលអ្នកចូលចិត្ត។</string>
     <string name="translators_thanks_title">អ្នកបកប្រែ</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">ជោគជ័យ</string>
     <string name="troubleshooter_ble_result_success_body">ការផ្សាយពាណិជ្ជកម្ម BLE កំពុងត្រូវបានទទួលដោយ CAPod។</string>
     <string name="troubleshooter_ble_result_failure_title">មិនជោគជ័យ</string>
-    <string name="troubleshooter_ble_result_failure_body">ការដោះស្រាយបញ្ហាមិនបានជោគជ័យ។ គ្មានការរួមបញ្ចូលជម្រើសភាពឆបគ្នាណាមួយជួយបានទេ។</string>
     <string name="troubleshooter_ble_result_failure_phone_body">ទូរស័ព្ទរបស់អ្នកមិនបានទទួលទិន្នន័យ BLE ទាល់តែសោះ។ អ្នកអាចសាកល្បងតេស្តនេះម្តងទៀតនៅក្នុងតំបន់ដែលមានមនុស្សច្រើន ដើម្បីមើលថាតើអាចទទួលប្រភពទិន្នន័យ (ក្រៅពីកាសស្តាប់ត្រចៀករបស់អ្នក) បានដែរឬទេ។ ការមិនទទួលបានទិន្នន័យណាមួយបង្ហាញពីបញ្ហាជាមួយប្រព័ន្ធប្រតិបត្តិការទូរស័ព្ទរបស់អ្នក។</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">ទូរស័ព្ទរបស់អ្នកបានទទួលទិន្នន័យ BLE ប៉ុន្តែទិន្នន័យមិនបានមកពីឧបករណ៍ដែលគាំទ្រណាមួយទេ។ តើកាសស្តាប់ត្រចៀករបស់អ្នកបានបើកទេ? តើ CAPod គាំទ្រកាសស្តាប់ត្រចៀករបស់អ្នកទេ?</string>
-    <string name="troubleshooter_ble_result_failure_action">ព្យាយាម​ម្តង​ទៀត</string>
-    <string name="troubleshoot_action">ដោះស្រាយបញ្ហា</string>
     <string name="onboarding_body1">កម្មវិធីនេះបន្ថែមការគាំទ្រសម្រាប់មុខងារជាក់លាក់របស់ AirPod ទៅ Android។</string>
     <string name="onboarding_body2">មិនមែនឧបករណ៍ Android ទាំងអស់គាំទ្រមុខងារបន្ថែមរបស់ AirPod ពេញលេញនោះទេ។ ប្រព័ន្ធប្រតិបត្តិការរបស់អ្នកត្រូវការការអនុវត្ត Bluetooth-Low-Energy ដែលដំណើរការបានត្រឹមត្រូវ។</string>
     <string name="onboarding_body3">CAPod មិនមានការផ្សាយពាណិជ្ជកម្ម ហើយមិនប្រមូលទិន្នន័យរបស់អ្នកទេ។</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">ឧបករណ៍របស់អ្នកបានភ្ជាប់ ប៉ុន្តែ CAPod មិនទទួលបានទិន្នន័យផ្ទាល់ណាមួយពីវាទេ។ ទូរស័ព្ទរបស់អ្នកប្រហែលជាត្រូវការជម្រើសសម្រាប់ភាពឆបគ្នា — កម្មវិធីដោះស្រាយបញ្ហាអាចព្យាយាមស្វែងរកមួយដោយស្វ័យប្រវត្តិ។</string>
     <string name="overview_troubleshoot_suggestion_action">ដំណើរការកម្មវិធីដោះស្រាយបញ្ហា</string>
     <string name="overview_unmatched_devices_label">ឧបករណ៍ដែលមិនត្រូវគ្នា</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">ឧបករណ៍ %d គ្មានទម្រង់ត្រូវគ្នា</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">បានរកឃើញឧបករណ៍នៅជិត %d ដោយគ្មានទម្រង់ដែលត្រូវគ្នា។ បង្ហាញឧបករណ៍ទាំងនោះដើម្បីមើលព័ត៌មានលម្អិតដែលមាន។ ប្រសិនបើមួយក្នុងចំណោមនោះជារបស់អ្នក សូមបន្ថែមទម្រង់ពីឧបករណ៍ដើម្បីស្គាល់វា។</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod ប្រើ \"ការចូលប្រើទីតាំងផ្ទៃខាងក្រោយ\" ដើម្បីបើកមុខងារដូចជា \"បង្ហាញផ្ទាំងលោត\" និង \"ភ្ជាប់ដោយស្វ័យប្រវត្តិ\" ខណៈពេលដែលកម្មវិធីត្រូវបានបិទ។ ការចូលប្រើទីតាំងផ្ទៃខាងក្រោយអនុញ្ញាតឱ្យកម្មវិធីទទួលទិន្នន័យ Bluetooth Low Energy ខណៈពេលដែលវានៅផ្ទៃខាងក្រោយ។ កម្មវិធីនេះនឹងមិនប្រើទិន្នន័យ Bluetooth ដើម្បីកំណត់ទីតាំងរបស់អ្នកទេ។</string>
     <string name="permission_ignore_battery_optimizations_label">បិទការបង្កើនប្រសិទ្ធភាពថ្ម</string>
     <string name="permission_ignore_battery_optimizations_description">ការបង្កើនប្រសិទ្ធភាពថ្មរារាំងកម្មវិធីនេះពីការទទួលទិន្នន័យ Bluetooth ដោយជឿជាក់នៅពេលកម្មវិធីស្ថិតក្នុងផ្ទៃខាងក្រោយ។</string>
-    <string name="permission_required_title">ការអនុញ្ញាតខាងក្រោមត្រូវបានទាមទារ:</string>
     <string name="permission_system_alert_window_label">បង្អួចជូនដំណឹងប្រព័ន្ធ</string>
     <string name="permission_system_alert_window_description">អនុញ្ញាតឱ្យ CAPod គូរពីលើកម្មវិធីផ្សេងទៀតដើម្បីធ្វើឱ្យមុខងារ \"បង្ហាញផ្ទាំងលោត\" អាចធ្វើទៅបាន។</string>
     <string name="settings_reaction_autoconnect_whenseen_label">នៅពេលឃើញ</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">ក្នុងត្រចៀក</string>
     <string name="pods_dual_left_label">ផតឆ្វេង</string>
     <string name="pods_dual_right_label">ផតស្តាំ</string>
-    <string name="pods_dual_left_short_label">ឆ្វេង</string>
-    <string name="pods_dual_right_short_label">ស្តាំ</string>
-    <string name="pods_case_label">ប្រអប់</string>
     <string name="battery_unavailable_label">ថ្មមិនអាចប្រើបាន</string>
     <string name="battery_state_low_cd">ថ្មទាប</string>
     <string name="battery_state_critical_cd">ថ្មក្រិតិកាល</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">ការភ្ជាប់ផ្ទាល់សកម្ម</string>
     <string name="signal_indicator_bars_cd">កម្លាំងសញ្ញា: %1$d នៃ 4 របារ</string>
     <string name="signal_indicator_disconnected_cd">សញ្ញា: ផ្តាច់ការតភ្ជាប់</string>
-    <string name="pods_yours">របស់អ្នក</string>
     <string name="headset_being_worn_label">កំពុងពាក់</string>
     <string name="headset_not_being_worn_label">មិនកំពុងពាក់</string>
     <string name="pods_case_unknown_state">ស្ថានភាពមិនស្គាល់</string>
-    <string name="last_seen_x">ឃើញចុងក្រោយ: %s</string>
-    <string name="first_seen_x">ឃើញដំបូង: %s</string>
     <string name="battery_cached_label">ដឹងចុងក្រោយ · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dម %2$dន</string>
     <string name="battery_time_remaining_format_h">%1$dម</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">គុណភាពសញ្ញាអប្បបរមា</string>
     <string name="profiles_signal_quality_description">រកឃើញតែឧបករណ៍ដែលមានកម្លាំងសញ្ញាលើសពីចំណុចកំណត់នេះ។ តម្លៃទាបបង្កើនចម្ងាយរកឃើញប៉ុន្តែអាចបណ្តាលឱ្យមានការវិជ្ជមានមិនពិត។ កុំកំណត់វាខ្ពស់ពេក — ការទទួល Bluetooth ជាទូទៅខ្សោយ ហើយប្រែប្រួលតាមចម្ងាយ និងឧបសគ្គ។</string>
     <string name="profiles_identitykey_label">សោអត្តសញ្ញាណ</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) របស់ឧបករណ៍អ្នក ដែលជួយ CAPod កំណត់អត្តសញ្ញាណវានៅក្នុងចំណោមឧបករណ៍ជិត។</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ផ្លាស់ប្តូរអាសយដ្ឋាន Bluetooth របស់ពួកគេជាញឹកញាប់សម្រាប់ភាពឯកជន។ IRK ជួយ CAPod ស្គាល់ឧបករណ៍របស់អ្នក។ អ្នកត្រូវការការចូលប្រើ MacBook តែម្តង។</string>
     <string name="profiles_maindevice_encryptionkey_label">សោអ៊ិនគ្រីប</string>
-    <string name="profiles_maindevice_encryptionkey_description">សោអ៊ិនគ្រីបរបស់ឧបករណ៍អ្នក ដែលអនុញ្ញាតឱ្យ CAPod ទាញយកព័ត៌មានស្ថានភាពលម្អិត។</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ផ្ញើសារស្ថានភាព ដែលផ្នែកមួយត្រូវបានអ៊ិនគ្រីប។ សោអ៊ិនគ្រីបអនុញ្ញាតឱ្យ CAPod ឌិគ្រីបសារពេញលេញ។ អ្នកត្រូវការការចូលប្រើ MacBook តែម្តង។</string>
     <string name="profiles_key_invalid_format">ទម្រង់សោមិនត្រឹមត្រូវ</string>
     <string name="profiles_key_expected_format">ទម្រង់រំពឹង: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">អ្នកមានការផ្លាស់ប្តូរមិនបានរក្សាទុក។ តើអ្នកចង់ធ្វើអ្វី?</string>
     <string name="general_save_and_exit_action">រក្សាទុក &amp; ចាកចេញ</string>
     <string name="general_discard_action">បោះបង់</string>
-    <string name="general_keep_editing_action">បន្តកែសម្រួល</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ការកត់ត្រាខ្លីពេក</string>
     <string name="debug_debuglog_short_recording_message">កំណត់ហេតុបំបាត់កំហុសត្រូវចាប្យកបញ្ហានៅពេលវាកើតើង។ បន្តការកត់ត្រា ធ្វើឥ្សរិយបញ្ហាកើតើងម្តងតឹត ហើយបន្ទាប់មកបញ្ជប់ការកត់ត្រា។</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ការកំណត់ឧបករណ៍</string>
     <string name="device_settings_subtitle_profile_prefix">ប្រវត្តិរូប: %s</string>
-    <string name="device_settings_info_name_label">ៀម្អៀះ</string>
     <string name="device_settings_info_bt_name_label">ស្លាកឧបករណ៍ Bluetooth</string>
     <string name="device_settings_info_model_label">គំរូ</string>
     <string name="device_settings_info_manufacturer_label">ក្រុមហ៊ុនផលិត</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">ប្រហែលពេលក្រោយ</string>
     <string name="review_app_body">តើអ្នកចង់ដាក់ពិនិត្យលើ CAPod ដែរឬទេ? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">ជាទូទៅ</string>
     <string name="device_settings_microphone_mode_label">មីក្រូហ្វូន</string>
     <string name="device_settings_microphone_mode_description">កាស​ណា​ដែល​ប្រើ​ជា​មីក្រូហ្វូន</string>
     <string name="device_settings_microphone_mode_auto">ស្វ័យប្រវត្តិ</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Parve bike</string>
     <string name="general_done_action">Qediya</string>
     <string name="general_cancel_action">Betal bike</string>
-    <string name="general_copy_action">Kopî bike</string>
     <string name="general_thank_you_label">Spas</string>
     <string name="general_upgrade_action">Nûjen bike</string>
     <string name="general_retry_action">Dîsan hewl bide</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontrol bike</string>
     <string name="general_close_action">Bigire</string>
     <string name="general_dismiss_action">Biser Bixe</string>
-    <string name="general_edit_action">Biguherîne</string>
     <string name="general_save_action">Tomar bike</string>
     <string name="general_guide_action">Rêber</string>
     <string name="general_continue_action">Berdewam bike</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Gava ku ji nû ve podên xwe li xwe dikî muzîkê berdewam bike, lê tenê heke Auto pause ew rawestandibe. Rawestandinên ku xwe kirine (têlefon, AirPods stem, xew) rawestayî dimînin.</string>
     <string name="settings_start_music_on_wear_label">Muzîkê li ser li xwe kirinê dest pê bike</string>
     <string name="settings_start_music_on_wear_description">Her hewl dide ku muzîkê lêbixe gava tu podên xwe li xwe dikî, tewra piştî rawestandinek destan.</string>
-    <string name="settings_eardetection_info_label">Nîşeya tespîtkirina guhê</string>
     <string name="settings_eardetection_info_description">Heke tespîtkirina guhê tenê ji bo yek podê dixebite, ev sînordariya Apple ye. Tenê \"poda sereke\" (ji bo mîkrofonê tê bikaranîn) tê tespîtkirin. Li ser amûrên Apple saz bikin: Mîheng → Bluetooth → AirPods → Mîkrofon.</string>
-    <string name="settings_signal_minimum_label">Qalîteya sînyala herî kêm</string>
-    <string name="settings_signal_minimum_description">Qalîteya sînyala herî kêm a ku divê amûrek hebe da ku ya we were hesibandin.</string>
     <string name="settings_autoconnect_label">Girêdana otomatîk</string>
     <string name="settings_autoconnect_description">Heke Android bixwe girênebike, em jî dê bipirsînin. Ev CAPod di paşxan de her demê bixweber vê tikan dike.</string>
     <string name="settings_autoconnect_info_android12">Girêdana xweser li ser taybetmendiyek pergalê ye ku Android 12 û nûtir sînor dike. Dibe ku li ser amûra we nexebite.</string>
     <string name="settings_autoconnect_condition_label">Şertê girêdana otomatîk</string>
-    <string name="settings_autoconnect_condition_description">Kengê divê em hewl bidin ku bi amûra we ve girêbidin?</string>
     <string name="settings_devices_label">Amûr</string>
     <string name="settings_devices_description">Amûrên xwe birêve bibin.</string>
     <string name="settings_reaction_label">Bertek</string>
-    <string name="settings_category_yourdevice_label">Amûra we</string>
     <string name="settings_category_compatibility_options_title">Vebijarkên lihevhatinê</string>
     <string name="settings_category_compatibility_options_description">Heke her tişt baş dixebite dest nedin ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Parzûnkirina hardware neçalak bike</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Destpêkirin…</string>
     <string name="support_debuglog_label">Tomara çareserkirinê</string>
     <string name="support_debuglog_desc">Her tiştê ku sepan dike di pelek nivîskî de tomar bike ku hûn dikarin parve bikin.</string>
-    <string name="debug_debuglog_size_label">Mezinahî</string>
-    <string name="debug_debuglog_size_compressed_label">Mezinahiya pêçandî</string>
-    <string name="debug_notification_channel_label">Agahdariyên çareserkirinê</string>
-    <string name="debug_debuglog_file_label">Pela tomara tomarkirî</string>
-    <string name="debug_debuglog_recording_progress">Tomara çareserkirinê tê tomarkirin</string>
     <string name="debug_debuglog_record_action">Tomara çareserkirinê tomar bike</string>
     <string name="debug_debuglog_stop_action">Tomarkirinê rawestîne</string>
     <string name="debug_debuglog_sensitive_information_message">Pela hatî çêkirin agahdariya hestiyar dihewîne (mînak hûrguliyên amûra Bluetooth). Wê tenê bi aliyên pêbawer re parve bikin.</string>
     <string name="settings_debuglog_explanation">Ev taybetmendî her tiştê ku sepan dike di pelek parvekirî de tomar dike. Pela hatî çêkirin agahdariya hestiyar dihewîne (mînak hûrguliyên amûra Bluetooth). Wê tenê bi aliyên pêbawer re parve bikin (mînak pêşvebirek ku pirsgirêkek çareser dike).</string>
-    <string name="settings_support_installid_label">Nasnameya sazkirinê</string>
-    <string name="settings_support_installid_desc">Raporên xeletiyan ên otomatîk nenas in. Nasnameya xwe ya sazkirinê parve bikin heke pêşvebir hewce bike ku raporên xeletiyên we bibîne.</string>
     <string name="settings_support_label">Piştgirî</string>
     <string name="settings_support_description">Heke hûn hewceyê hin alîkariyê ne.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Daneyên Fêrkirî Sifir Bike?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod wê xurina pîvandî ya vî amûrê, leza barkirînê û demê guhdariyê ji bîr bike, û ji jiyana pîlandinê ya rêz dîsa destpê bike.</string>
     <string name="settings_acknowledgements_label">Spasdarî</string>
-    <string name="settings_debug_autoreports_label">Raporên xeletiyan ên otomatîk</string>
-    <string name="settings_debug_autoreports_description">Pirsgirêkan bixweber rapor dike, mînak hûrguliyên li ser têkçûna sepanê da ku ez bikaribim fêhm bikim ka meriv çawa wê sererast bike.</string>
-    <string name="settings_compatibility_mode_label">Moda lihevhatinê</string>
-    <string name="settings_compatibility_mode_description">Ji bo baştirkirina lihevhatinê xweşbîniyan neçalak bikin. Heke hûn tu daneyan nabînin vê biceribînin.</string>
     <string name="help_translate_label">Werger</string>
     <string name="help_translate_description">Alîkariya wergerandina vê sepanê li zimanê xwe yê bijare bikin.</string>
     <string name="translators_thanks_title">Wergêr</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Serketî</string>
     <string name="troubleshooter_ble_result_success_body">Weşanên reklaman ên BLE ji hêla CAPod ve tên wergirtin.</string>
     <string name="troubleshooter_ble_result_failure_title">Neserketî</string>
-    <string name="troubleshooter_ble_result_failure_body">Çareserkirina pirsgirêkan bi ser neket. Tu tevliheviyek vebijarkên lihevhatinê alîkar nebû.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Têlefona we qet daneyên BLE wernegirt. Hûn dikarin vê ceribandinê li deverek qerebalix dîsa biceribînin da ku bibînin ka çavkaniyên daneyan (ji bilî guhêrên we) dikarin werin wergirtin. Wergirtina tu daneyan pirsgirêkek bi pergala xebitandinê ya têlefona we nîşan dide.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Têlefona we daneyên BLE wergirt, lê dane ji tu amûrek piştgirîkirî nayên. Gelo guhêrên we vekirî ne? Gelo CAPod guhêrên we piştgirî dike?</string>
-    <string name="troubleshooter_ble_result_failure_action">Dîsa biceribîne</string>
-    <string name="troubleshoot_action">Pirsgirêkan çareser bike</string>
     <string name="onboarding_body1">Ev sepan piştgiriyê ji bo taybetmendiyên taybet ên AirPod li Android zêde dike.</string>
     <string name="onboarding_body2">Ne hemî amûrên Android bi tevahî taybetmendiyên zêde yên AirPod piştgirî dikin. Pergala xebitandinê ya we pêkanînek Bluetooth-Kêm-Enerjiyê ya ku rast dixebite hewce dike.</string>
     <string name="onboarding_body3">CAPod reklam tune û daneyên we berhev nake.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Amûra te girêdayî ye, lê CAPod daneya zindî ji wê nagire. Dibe ku telefona te vebijarkek lihevhatinê hewce bike — çareserkerê pirsgirîkan dikare bixweber yek bibîne.</string>
     <string name="overview_troubleshoot_suggestion_action">Çareserkerê pirsgirîkan bixebitîne</string>
     <string name="overview_unmatched_devices_label">Amûrên nehevgirtî</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d amûr bê profîla hevgirtî</item>
-        <item quantity="other">%d amûr bê profîla hevgirtî</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d cîhazek nêzîk hate dîtin ku profîleke lihevhatî tune bû. Ji bo hûrgiliyên berdest nîşanî bide wê. Heke ew a te ye, ji rûpela Cîhazan profîlek zêde bike da ku were nasîn.</item>
         <item quantity="other">%d cîhazên nêzîk hatin dîtin ku profîlên wan ên lihevhatî tune bûn. Ji bo hûrgiliyên berdest nîşanî bide wan. Heke yek ji wan a te ye, ji rûpela Cîhazan profîlek zêde bike da ku were nasîn.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod \"gihîştina cihê paşîn\" bikar tîne da ku taybetmendiyên wekî \"Pop-up nîşan bide\" û \"Girêdana otomatîk\" dema ku sepan girtî ye çalak bike. Gihîştina cihê paşîn dihêle ku sepan di paşîn de daneyên Bluetooth Low Energy bistîne. Ev sepan daneyên Bluetooth ji bo destnîşankirina cihê we bikar NAYÎNE.</string>
     <string name="permission_ignore_battery_optimizations_label">Xweşbîniyên bataryayê neçalak bike</string>
     <string name="permission_ignore_battery_optimizations_description">Xweşbîniyên bataryayê rê li vê sepanê digirin ku dema di paşîn de daneyên Bluetooth bi pêbawerî bistîne.</string>
-    <string name="permission_required_title">Destûra jêrîn hewce ye:</string>
     <string name="permission_system_alert_window_label">Pencereya Hişyariya Pergalê</string>
     <string name="permission_system_alert_window_description">Destûrê bidin CAPod ku li ser sepanên din xêz bike da ku taybetmendiya \"Pop-Up Nîşan Bide\" gengaz bike.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Dema tê dîtin</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Di guhê de</string>
     <string name="pods_dual_left_label">Poda çepê</string>
     <string name="pods_dual_right_label">Poda rastê</string>
-    <string name="pods_dual_left_short_label">Ç</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">Qapax</string>
     <string name="battery_unavailable_label">Batarya berdest nêne</string>
     <string name="battery_state_low_cd">Pîlandin kêm e</string>
     <string name="battery_state_critical_cd">Pîlandin zor kêm e</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Girêdana rasterast çalak e</string>
     <string name="signal_indicator_bars_cd">Hêza nîşanê: %1$d ji 4 baran</string>
     <string name="signal_indicator_disconnected_cd">Nîşan: bêpêwendî</string>
-    <string name="pods_yours">Ya we</string>
     <string name="headset_being_worn_label">Tê lixwekirin</string>
     <string name="headset_not_being_worn_label">Nayê lixwekirin</string>
     <string name="pods_case_unknown_state">Rewşa nenas</string>
-    <string name="last_seen_x">Cara dawîn hat dîtin: %s</string>
-    <string name="first_seen_x">Cara yekem hat dîtin: %s</string>
     <string name="battery_cached_label">Dawî zanëbû · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Qalîteya Sînyala Herî Kêm</string>
     <string name="profiles_signal_quality_description">Tenê amûrên bi hêza sînyalê li jor vê bendê tespît bikin. Nirxên kêmtir rêza tespîtkirinê zêde dikin lê dibe ku encamên erênî yên derew bibin. Wê pir bilind mekin - wergirtina Bluetooth bi giştî xirab e û bi dûrahî û astengan re diguhere.</string>
     <string name="profiles_identitykey_label">Mifteya Nasnameyê</string>
-    <string name="profilessettings_maindevice_identitykey_description">Kilîta Çareserkirina Nasnameya (IRK) amûra we, ku alîkariya CAPod dike ku wê di nav amûrên nêzîk de nas bike.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ji bo nepenîtiyê pir caran navnîşana xwe ya Bluetooth diguherînin. IRK alîkariya CAPod dike ku amûra we nas bike. Ji we re carekê gihîştina MacBook-ê hewce ye.</string>
     <string name="profiles_maindevice_encryptionkey_label">Mifteya Şîfrelêdanê</string>
-    <string name="profiles_maindevice_encryptionkey_description">Kilîta şîfrekirinê ya amûra we, ku dihêle CAPod agahdariya rewşê ya berfireh bistîne.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods peyamek rewşê dişîne ku beşek wê şîfrekirî ye. Kilîta şîfrekirinê dihêle CAPod peyama tevahî veşîfre bike. Ji we re carekê gihîştina MacBook-ê hewce ye.</string>
     <string name="profiles_key_invalid_format">Formata kilîtê nederbasdar e</string>
     <string name="profiles_key_expected_format">Formata çaverêkirî: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Guhertinên we yên netomarkirî hene. Hûn dixwazin çi bikin?</string>
     <string name="general_save_and_exit_action">Tomar bike &amp; derkeve</string>
     <string name="general_discard_action">Bavêje</string>
-    <string name="general_keep_editing_action">Guherandinê bidomîne</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Tomarkirî pir kurte</string>
     <string name="debug_debuglog_short_recording_message">Têketinek debugê divê pirsgirêkê bigire dema ku ew diqewime. Tomarkirinê berdewam bike, pirsgirêkê dubare bike, paşê tomarkirinê rawestîne.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Mîhengen Cîhazê</string>
     <string name="device_settings_subtitle_profile_prefix">Profîl: %s</string>
-    <string name="device_settings_info_name_label">Nav</string>
     <string name="device_settings_info_bt_name_label">Navê Amûra Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Çêker</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Belkî paşê</string>
     <string name="review_app_body">Dixwazî tu CAPod nirx bikî? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Giştî</string>
     <string name="device_settings_microphone_mode_label">Mîkrofon</string>
     <string name="device_settings_microphone_mode_description">Kîjan guhêrk wek mîkrofon tê bikar anîn</string>
     <string name="device_settings_microphone_mode_auto">Xweber</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">ಹಂಚಿಕೊಳ್ಳಿ</string>
     <string name="general_done_action">ಮುಗಿದಿದೆ</string>
     <string name="general_cancel_action">ರದ್ದುಮಾಡಿ</string>
-    <string name="general_copy_action">ನಕಲಿಸಿ</string>
     <string name="general_thank_you_label">ಧನ್ಯವಾದಗಳು</string>
     <string name="general_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="general_retry_action">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">ಪರಿಶೀಲಿಸಿ</string>
     <string name="general_close_action">ಮುಚ್ಚಿ</string>
     <string name="general_dismiss_action">ತಿರಸ್ಕರಿಸಿ</string>
-    <string name="general_edit_action">ಸಂಪಾದಿಸಿ</string>
     <string name="general_save_action">ಉಳಿಸಿ</string>
     <string name="general_guide_action">ಮಾರ್ಗದರ್ಶಿ</string>
     <string name="general_continue_action">ಮುಂದುವರಿಸಿ</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">ನಿಮ್ಮ ಪಾಡ್‌ಗಳನ್ನು ಮತ್ತೆ ಧರಿಸಿದಾಗ ಸಂಗೀತವನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ, ಆದರೆ ಆಟೋ ಪಾಸ್ ನಿಲ್ಲಿಸಿದ್ದರೆ ಮಾತ್ರ. ನೀವೇ ಪ್ರಚೋದಿಸಿದ ವಿರಾಮಗಳು (ಫೋನ್, AirPods ಸ್ಟೆಮ್, ನಿದ್ರೆ) ವಿರಾಮದಲ್ಲಿ ಉಳಿಯುತ್ತವೆ.</string>
     <string name="settings_start_music_on_wear_label">ಧರಿಸಿದಾಗ ಸಂಗೀತ ಪ್ರಾರಂಭಿಸಿ</string>
     <string name="settings_start_music_on_wear_description">ನಿಮ್ಮ ಪಾಡ್‌ಗಳನ್ನು ಹಾಕಿಕೊಂಡಾಗ ಯಾವಾಗಲೂ ಸಂಗೀತ ಪ್ಲೇ ಮಾಡಲು ಪ್ರಯತ್ನಿಸುತ್ತದೆ, ಮ್ಯಾನ್ಯುವಲ್ ವಿರಾಮದ ನಂತರವೂ ಸಹ.</string>
-    <string name="settings_eardetection_info_label">ಕಿವಿ ಗುರುತಿಸುವಿಕೆ ಟಿಪ್ಪಣಿ</string>
     <string name="settings_eardetection_info_description">ಕಿವಿ ಗುರುತಿಸುವಿಕೆ ಒಂದು ಪಾಡ್‌ಗೆ ಮಾತ್ರ ಕೆಲಸ ಮಾಡಿದರೆ, ಇದು Apple ಮಿತಿಯಾಗಿದೆ. \"ಪ್ರಾಥಮಿಕ ಪಾಡ್\" (ಮೈಕ್ರೋಫೋನ್‌ಗಾಗಿ ಬಳಸಲಾಗುತ್ತದೆ) ಮಾತ್ರ ಗುರುತಿಸಲಾಗುತ್ತದೆ. Apple ಸಾಧನಗಳಲ್ಲಿ ಕಾನ್ಫಿಗರ್ ಮಾಡಿ: ಸೆಟ್ಟಿಂಗ್‌ಗಳು → Bluetooth → AirPods → ಮೈಕ್ರೋಫೋನ್.</string>
-    <string name="settings_signal_minimum_label">ಕನಿಷ್ಠ ಸಿಗ್ನಲ್ ಗುಣಮಟ್ಟ</string>
-    <string name="settings_signal_minimum_description">ನಿಮ್ಮದೆಂದು ಪರಿಗಣಿಸಲು ಸಾಧನವು ಹೊಂದಿರಬೇಕಾದ ಕನಿಷ್ಠ ಸಿಗ್ನಲ್ ಗುಣಮಟ್ಟ.</string>
     <string name="settings_autoconnect_label">ಸ್ವಯಂ-ಸಂಪರ್ಕ</string>
     <string name="settings_autoconnect_description">Android ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಂಪರ್ಕಿಸದಿದ್ದರೆ, ನಾವು ಅದನ್ನು ಕೇಳಬಹುದು. ಇದರಿಂದ CAPod ಯಾವಾಗಲೂ ಹಿನ್ನೆಲೆಯಲ್ಲಿ ಮಾನಿಟರಿಂಗ್ ಮುಂದುವರಿಸುತ್ತದೆ.</string>
     <string name="settings_autoconnect_info_android12">ಆಟೋ ಕನೆಕ್ಟ್ Android 12 ಮತ್ತು ಹೊಸ ಆವೃತ್ತಿಗಳು ನಿರ್ಬಂಧಿಸುವ ಸಿಸ್ಟಮ್ ವೈಶಿಷ್ಟ್ಯವನ್ನು ಅವಲಂಬಿಸಿದೆ. ಇದು ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಕಾರ್ಯ ನಿರ್ವಹಿಸದಿರಬಹುದು.</string>
     <string name="settings_autoconnect_condition_label">ಸ್ವಯಂ-ಸಂಪರ್ಕ ಸ್ಥಿತಿ</string>
-    <string name="settings_autoconnect_condition_description">ನಾವು ಯಾವಾಗ ನಿಮ್ಮ ಸಾಧನಕ್ಕೆ ಸಂಪರ್ಕಿಸಲು ಪ್ರಯತ್ನಿಸಬೇಕು?</string>
     <string name="settings_devices_label">ಸಾಧನಗಳು</string>
     <string name="settings_devices_description">ನಿಮ್ಮ ಸಾಧನಗಳನ್ನು ನಿರ್ವಹಿಸಿ.</string>
     <string name="settings_reaction_label">ಪ್ರತಿಕ್ರಿಯೆಗಳು</string>
-    <string name="settings_category_yourdevice_label">ನಿಮ್ಮ ಸಾಧನ</string>
     <string name="settings_category_compatibility_options_title">ಹೊಂದಾಣಿಕೆ ಆಯ್ಕೆಗಳು</string>
     <string name="settings_category_compatibility_options_description">ಎಲ್ಲವೂ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿದ್ದರೆ ಮುಟ್ಟಬೇಡಿ ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ಹಾರ್ಡ್‌ವೇರ್ ಫಿಲ್ಟರಿಂಗ್ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">ಪ್ರಾರಂಭಿಸಲಾಗುತ್ತಿದೆ…</string>
     <string name="support_debuglog_label">ಡೀಬಗ್ ಲಾಗ್</string>
     <string name="support_debuglog_desc">ಅಪ್ಲಿಕೇಶನ್ ಮಾಡುವ ಎಲ್ಲವನ್ನೂ ನೀವು ಹಂಚಿಕೊಳ್ಳಬಹುದಾದ ಪಠ್ಯ ಫೈಲ್‌ನಲ್ಲಿ ರೆಕಾರ್ಡ್ ಮಾಡಿ.</string>
-    <string name="debug_debuglog_size_label">ಗಾತ್ರ</string>
-    <string name="debug_debuglog_size_compressed_label">ಸಂಕುಚಿತ ಗಾತ್ರ</string>
-    <string name="debug_notification_channel_label">ಡೀಬಗ್ ಅಧಿಸೂಚನೆಗಳು</string>
-    <string name="debug_debuglog_file_label">ರೆಕಾರ್ಡ್ ಮಾಡಿದ ಲಾಗ್ ಫೈಲ್</string>
-    <string name="debug_debuglog_recording_progress">ಡೀಬಗ್ ಲಾಗ್ ರೆಕಾರ್ಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
     <string name="debug_debuglog_record_action">ಡೀಬಗ್ ಲಾಗ್ ರೆಕಾರ್ಡ್ ಮಾಡಿ</string>
     <string name="debug_debuglog_stop_action">ರೆಕಾರ್ಡಿಂಗ್ ನಿಲ್ಲಿಸಿ</string>
     <string name="debug_debuglog_sensitive_information_message">ರಚಿಸಲಾದ ಫೈಲ್ ಸೂಕ್ಷ್ಮ ಮಾಹಿತಿಯನ್ನು (ಉದಾ. Bluetooth ಸಾಧನದ ವಿವರಗಳು) ಒಳಗೊಂಡಿದೆ. ಅದನ್ನು ವಿಶ್ವಾಸಾರ್ಹ ಪಕ್ಷಗಳೊಂದಿಗೆ ಮಾತ್ರ ಹಂಚಿಕೊಳ್ಳಿ.</string>
     <string name="settings_debuglog_explanation">ಈ ವೈಶಿಷ್ಟ್ಯವು ಅಪ್ಲಿಕೇಶನ್ ಮಾಡುವ ಎಲ್ಲವನ್ನೂ ಹಂಚಿಕೊಳ್ಳಬಹುದಾದ ಫೈಲ್‌ನಲ್ಲಿ ರೆಕಾರ್ಡ್ ಮಾಡುತ್ತದೆ. ರಚಿಸಲಾದ ಫೈಲ್ ಸೂಕ್ಷ್ಮ ಮಾಹಿತಿಯನ್ನು (ಉದಾ. Bluetooth ಸಾಧನದ ವಿವರಗಳು) ಒಳಗೊಂಡಿದೆ. ಅದನ್ನು ವಿಶ್ವಾಸಾರ್ಹ ಪಕ್ಷಗಳೊಂದಿಗೆ ಮಾತ್ರ ಹಂಚಿಕೊಳ್ಳಿ (ಉದಾ. ಸಮಸ್ಯೆಯನ್ನು ನಿವಾರಿಸುತ್ತಿರುವ ಡೆವಲಪರ್).</string>
-    <string name="settings_support_installid_label">ಇನ್‌ಸ್ಟಾಲ್ ಐಡಿ</string>
-    <string name="settings_support_installid_desc">ಸ್ವಯಂಚಾಲಿತ ದೋಷ ವರದಿಗಳು ಅನಾಮಧೇಯವಾಗಿವೆ. ಡೆವಲಪರ್‌ಗೆ ನಿಮ್ಮ ದೋಷ ವರದಿಗಳನ್ನು ಹುಡುಕಬೇಕಾದರೆ ನಿಮ್ಮ ಇನ್‌ಸ್ಟಾಲ್ ಐಡಿಯನ್ನು ಹಂಚಿಕೊಳ್ಳಿ.</string>
     <string name="settings_support_label">ಬೆಂಬಲ</string>
     <string name="settings_support_description">ನಿಮಗೆ ಸ್ವಲ್ಪ ಸಹಾಯ ಬೇಕಾದರೆ.</string>
     <string name="settings_wiki_label">ವಿಕಿ</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">ಕಲಿತ ಮಾಹಿತಿ ಮರುಸೆಟ್ ಮಾಡಬೇಕೇ?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ಈ ಸಾಧನದ ಅಳೆದ ಡ್ರೈನ್, ಚಾರ್ಜಿಂಗ ವೇಗ ಮತ್ತು ಶ್ರವಣ ಸಮಯವನ್ನು ಮರೆಯುತ್ತದೆ ಮತ್ತು ರೇಟ್ ಮಾಡಿದ ಬ್ಯಾಟರಿ ಆಯುಷ್ಯದಿಂದ ಮತ್ತೆ ಪ್ರಾರಂಭಿಸುತ್ತದೆ.</string>
     <string name="settings_acknowledgements_label">ಕೃತಜ್ಞತೆಗಳು</string>
-    <string name="settings_debug_autoreports_label">ಸ್ವಯಂಚಾಲಿತ ಬಗ್ ವರದಿಗಳು</string>
-    <string name="settings_debug_autoreports_description">ಸಮಸ್ಯೆಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ವರದಿ ಮಾಡುತ್ತದೆ, ಉದಾ. ಅಪ್ಲಿಕೇಶನ್ ಕ್ರ್ಯಾಶ್ ಕುರಿತು ವಿವರಗಳು ಇದರಿಂದ ಅದನ್ನು ಹೇಗೆ ಸರಿಪಡಿಸುವುದು ಎಂದು ನಾನು ಕಂಡುಹಿಡಿಯಬಹುದು.</string>
-    <string name="settings_compatibility_mode_label">ಹೊಂದಾಣಿಕೆ ಮೋಡ್</string>
-    <string name="settings_compatibility_mode_description">ಹೊಂದಾಣಿಕೆಯನ್ನು ಸುಧಾರಿಸಲು ಆಪ್ಟಿಮೈಸೇಶನ್‌ಗಳನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ. ನೀವು ಯಾವುದೇ ಡೇಟಾವನ್ನು ನೋಡದಿದ್ದರೆ ಇದನ್ನು ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="help_translate_label">ಅನುವಾದ</string>
     <string name="help_translate_description">ಈ ಅಪ್ಲಿಕೇಶನ್ ಅನ್ನು ನಿಮ್ಮ ನೆಚ್ಚಿನ ಭಾಷೆಗೆ ಅನುವಾದಿಸಲು ಸಹಾಯ ಮಾಡಿ.</string>
     <string name="translators_thanks_title">ಅನುವಾದಕರು</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">ಯಶಸ್ಸು</string>
     <string name="troubleshooter_ble_result_success_body">BLE ಜಾಹೀರಾತು ಪ್ರಸಾರಗಳನ್ನು CAPod ಸ್ವೀಕರಿಸುತ್ತಿದೆ.</string>
     <string name="troubleshooter_ble_result_failure_title">ವಿಫಲವಾಗಿದೆ</string>
-    <string name="troubleshooter_ble_result_failure_body">ಸಮಸ್ಯೆ ನಿವಾರಣೆ ವಿಫಲವಾಗಿದೆ. ಹೊಂದಾಣಿಕೆ ಆಯ್ಕೆಗಳ ಯಾವುದೇ ಸಂಯೋಜನೆಯು ಸಹಾಯ ಮಾಡಲಿಲ್ಲ.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">ನಿಮ್ಮ ಫೋನ್ ಯಾವುದೇ BLE ಡೇಟಾವನ್ನು ಸ್ವೀಕರಿಸಲಿಲ್ಲ. ಡೇಟಾ ಮೂಲಗಳನ್ನು (ನಿಮ್ಮ ಹೆಡ್‌ಫೋನ್‌ಗಳನ್ನು ಹೊರತುಪಡಿಸಿ) ಸ್ವೀಕರಿಸಬಹುದೇ ಎಂದು ನೋಡಲು ನೀವು ಈ ಪರೀಕ್ಷೆಯನ್ನು ಜನನಿಬಿಡ ಪ್ರದೇಶದಲ್ಲಿ ಮರುಪ್ರಯತ್ನಿಸಬಹುದು. ಯಾವುದೇ ಡೇಟಾವನ್ನು ಸ್ವೀಕರಿಸದಿರುವುದು ನಿಮ್ಮ ಫೋನ್‌ನ ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಮ್‌ನಲ್ಲಿನ ಸಮಸ್ಯೆಯನ್ನು ಸೂಚಿಸುತ್ತದೆ.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">ನಿಮ್ಮ ಫೋನ್ BLE ಡೇಟಾವನ್ನು ಸ್ವೀಕರಿಸಿದೆ, ಆದರೆ ಡೇಟಾ ಯಾವುದೇ ಬೆಂಬಲಿತ ಸಾಧನದಿಂದ ಬರುತ್ತಿಲ್ಲ. ನಿಮ್ಮ ಹೆಡ್‌ಫೋನ್‌ಗಳು ಆನ್ ಆಗಿವೆಯೇ? CAPod ನಿಮ್ಮ ಹೆಡ್‌ಫೋನ್‌ಗಳನ್ನು ಬೆಂಬಲಿಸುತ್ತದೆಯೇ?</string>
-    <string name="troubleshooter_ble_result_failure_action">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
-    <string name="troubleshoot_action">ಸಮಸ್ಯೆ ನಿವಾರಿಸಿ</string>
     <string name="onboarding_body1">ಈ ಅಪ್ಲಿಕೇಶನ್ Android ಗೆ AirPod ನಿರ್ದಿಷ್ಟ ವೈಶಿಷ್ಟ್ಯಗಳಿಗೆ ಬೆಂಬಲವನ್ನು ಸೇರಿಸುತ್ತದೆ.</string>
     <string name="onboarding_body2">ಎಲ್ಲಾ Android ಸಾಧನಗಳು ಹೆಚ್ಚುವರಿ AirPod ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಂಪೂರ್ಣವಾಗಿ ಬೆಂಬಲಿಸುವುದಿಲ್ಲ. ನಿಮ್ಮ ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಮ್‌ಗೆ ಸರಿಯಾಗಿ ಕಾರ್ಯನಿರ್ವಹಿಸುವ ಬ್ಲೂಟೂತ್-ಕಡಿಮೆ-ಶಕ್ತಿಯ ಅನುಷ್ಠಾನದ ಅಗತ್ಯವಿದೆ.</string>
     <string name="onboarding_body3">CAPod ಯಾವುದೇ ಜಾಹೀರಾತುಗಳನ್ನು ಹೊಂದಿಲ್ಲ ಮತ್ತು ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಸಂಗ್ರಹಿಸುವುದಿಲ್ಲ.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">ನಿಮ್ಮ ಸಾಧನ ಸಂಪರ್ಕಿಸಲಾಗಿದೆ, ಆದರೆ CAPod ಅದರಿಂದ ಯಾವುದೇ ಲೈವ್ ಡೇಟಾ ಸ್ವೀಕರಿಸುತ್ತಿಲ್ಲ. ನಿಮ್ಮ ಫೋನ್‌ಗೆ ಹೊಂದಾಣಿಕೆ ಆಯ್ಕೆಯ ಅಗತ್ಯವಿರಬಹುದು — ಸಮಸ್ಯೆ ನಿವಾರಕ ಒಂದನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹುಡುಕಲು ಪ್ರಯತ್ನಿಸಬಹುದು.</string>
     <string name="overview_troubleshoot_suggestion_action">ಸಮಸ್ಯೆ ನಿವಾರಕ ರನ್ ಮಾಡಿ</string>
     <string name="overview_unmatched_devices_label">ಹೊಂದಿಕೆಯಾಗದ ಸಾಧನಗಳು</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">ಹೊಂದಿಕೆಯಾಗುವ ಪ್ರೊಫೈಲ್ ಇಲ್ಲದ %d ಸಾಧನ</item>
-        <item quantity="other">ಹೊಂದಿಕೆಯಾಗುವ ಪ್ರೊಫೈಲ್ ಇಲ್ಲದ %d ಸಾಧನಗಳು</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d ಸಮೀಪದ ಸಾಧನವು ಹೊಂದಾಣಿಕೆಯ ಪ್ರೊಫೈಲ್ ಇಲ್ಲದೆ ಪತ್ತೆಯಾಗಿದೆ. ಲಭ್ಯವಿರುವ ವಿವರಗಳಿಗಾಗಿ ಅದನ್ನು ತೋರಿಸಿ. ಇದು ನಿಮ್ಮದಾಗಿದ್ದರೆ, ಅದನ್ನು ಗುರುತಿಸಲು ಸಾಧನಗಳಿಂದ ಪ್ರೊಫೈಲ್ ಸೇರಿಸಿ.</item>
         <item quantity="other">%d ಸಮೀಪದ ಸಾಧನಗಳು ಹೊಂದಾಣಿಕೆಯ ಪ್ರೊಫೈಲ್‌ಗಳಿಲ್ಲದೆ ಪತ್ತೆಯಾಗಿವೆ. ಲಭ್ಯವಿರುವ ವಿವರಗಳಿಗಾಗಿ ಅವುಗಳನ್ನು ತೋರಿಸಿ. ಒಂದು ನಿಮ್ಮದಾಗಿದ್ದರೆ, ಅದನ್ನು ಗುರುತಿಸಲು ಸಾಧನಗಳಿಂದ ಪ್ರೊಫೈಲ್ ಸೇರಿಸಿ.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">ಅಪ್ಲಿಕೇಶನ್ ಮುಚ್ಚಿರುವಾಗ \"ಪಾಪ್‌ಅಪ್ ತೋರಿಸಿ\" ಮತ್ತು \"ಸ್ವಯಂ-ಸಂಪರ್ಕ\" ನಂತಹ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು CAPod \"ಹಿನ್ನೆಲೆ ಸ್ಥಳ ಪ್ರವೇಶ\" ಬಳಸುತ್ತದೆ. ಹಿನ್ನೆಲೆ ಸ್ಥಳ ಪ್ರವೇಶವು ಅಪ್ಲಿಕೇಶನ್ ಹಿನ್ನೆಲೆಯಲ್ಲಿರುವಾಗ Bluetooth Low Energy ಡೇಟಾವನ್ನು ಸ್ವೀಕರಿಸಲು ಅನುಮತಿಸುತ್ತದೆ. ಈ ಅಪ್ಲಿಕೇಶನ್ ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ನಿರ್ಧರಿಸಲು Bluetooth ಡೇಟಾವನ್ನು ಬಳಸುವುದಿಲ್ಲ.</string>
     <string name="permission_ignore_battery_optimizations_label">ಬ್ಯಾಟರಿ ಆಪ್ಟಿಮೈಸೇಶನ್‌ಗಳನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ</string>
     <string name="permission_ignore_battery_optimizations_description">ಬ್ಯಾಟರಿ ಆಪ್ಟಿಮೈಸೇಶನ್‌ಗಳು ಅಪ್ಲಿಕೇಶನ್ ಹಿನ್ನೆಲೆಯಲ್ಲಿರುವಾಗ Bluetooth ಡೇಟಾವನ್ನು ವಿಶ್ವಾಸಾರ್ಹವಾಗಿ ಸ್ವೀಕರಿಸುವುದನ್ನು ತಡೆಯುತ್ತವೆ.</string>
-    <string name="permission_required_title">ಕೆಳಗಿನ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ:</string>
     <string name="permission_system_alert_window_label">ಸಿಸ್ಟಮ್ ಅಲರ್ಟ್ ವಿಂಡೋ</string>
     <string name="permission_system_alert_window_description">\"ಪಾಪ್‌ಅಪ್ ತೋರಿಸಿ\" ವೈಶಿಷ್ಟ್ಯವನ್ನು ಸಾಧ್ಯವಾಗಿಸಲು CAPod ಇತರ ಅಪ್ಲಿಕೇಶನ್‌ಗಳ ಮೇಲೆ ಚಿತ್ರಿಸಲು ಅನುಮತಿಸಿ.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">ಕಂಡಾಗ</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">ಕಿವಿಯಲ್ಲಿ</string>
     <string name="pods_dual_left_label">ಎಡ ಪಾಡ್</string>
     <string name="pods_dual_right_label">ಬಲ ಪಾಡ್</string>
-    <string name="pods_dual_left_short_label">ಎ</string>
-    <string name="pods_dual_right_short_label">ಬ</string>
-    <string name="pods_case_label">ಕೇಸ್</string>
     <string name="battery_unavailable_label">ಬ್ಯಾಟರಿ ಲಭ್ಯವಿಲ್ಲ</string>
     <string name="battery_state_low_cd">ಬ್ಯಾಟರಿ ಕಡಿಮೆ</string>
     <string name="battery_state_critical_cd">ಬ್ಯಾಟರಿ ತುಂಬಾ ಕಡಿಮೆ</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">ನೇರ ಸಂಪರ್ಕ ಸಕ್ರಿಯವಾಗಿದೆ</string>
     <string name="signal_indicator_bars_cd">ಸಿಗ್ನಲ್ ಶಕ್ತಿ: 4 ಬಾರ್‌ಗಳಲ್ಲಿ %1$d</string>
     <string name="signal_indicator_disconnected_cd">ಸಿಗ್ನಲ್: ಸಂಪರ್ಕ ಕಡಿತವಾಗಿದೆ</string>
-    <string name="pods_yours">ನಿಮ್ಮದು</string>
     <string name="headset_being_worn_label">ಧರಿಸಲಾಗುತ್ತಿದೆ</string>
     <string name="headset_not_being_worn_label">ಧರಿಸಲಾಗಿಲ್ಲ</string>
     <string name="pods_case_unknown_state">ಅಜ್ಞಾತ ಸ್ಥಿತಿ</string>
-    <string name="last_seen_x">ಕೊನೆಯ ಬಾರಿ ಕಂಡಿದ್ದು: %s</string>
-    <string name="first_seen_x">ಮೊದಲ ಬಾರಿ ಕಂಡಿದ್ದು: %s</string>
     <string name="battery_cached_label">ಕೊನೆಯಾಗಿ ತಿಳಿದಿದ್ದು · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dಘಂ %2$dನಿ</string>
     <string name="battery_time_remaining_format_h">%1$dಘಂ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">ಕನಿಷ್ಠ ಸಿಗ್ನಲ್ ಗುಣಮಟ್ಟ</string>
     <string name="profiles_signal_quality_description">ಈ ಮಿತಿಗಿಂತ ಹೆಚ್ಚಿನ ಸಿಗ್ನಲ್ ಸಾಮರ್ಥ್ಯವಿರುವ ಸಾಧನಗಳನ್ನು ಮಾತ್ರ ಗುರುತಿಸಿ. ಕಡಿಮೆ ಮೌಲ್ಯಗಳು ಗುರುತಿಸುವಿಕೆ ವ್ಯಾಪ್ತಿಯನ್ನು ಹೆಚ್ಚಿಸುತ್ತವೆ ಆದರೆ ತಪ್ಪು ಗುರುತಿಸುವಿಕೆಗಳನ್ನು ಉಂಟುಮಾಡಬಹುದು. ಇದನ್ನು ತುಂಬಾ ಹೆಚ್ಚಿಗೆ ಹೊಂದಿಸಬೇಡಿ - Bluetooth ಸ್ವೀಕರಣವು ಸಾಮಾನ್ಯವಾಗಿ ಕಳಪೆಯಾಗಿರುತ್ತದೆ ಮತ್ತು ದೂರ ಹಾಗೂ ಅಡೆತಡೆಗಳೊಂದಿಗೆ ಬದಲಾಗುತ್ತದೆ.</string>
     <string name="profiles_identitykey_label">ಗುರುತಿನ ಕೀ</string>
-    <string name="profilessettings_maindevice_identitykey_description">ನಿಮ್ಮ ಸಾಧನದ ಗುರುತಿನ ರೆಸಲ್ವಿಂಗ್ ಕೀ (IRK), ಇದು ಹತ್ತಿರದ ಸಾಧನಗಳ ನಡುವೆ CAPod ಅದನ್ನು ಗುರುತಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ಗೌಪ್ಯತೆಗಾಗಿ ತಮ್ಮ Bluetooth ವಿಳಾಸವನ್ನು ಆಗಾಗ ಬದಲಾಯಿಸುತ್ತವೆ. IRK ನಿಮ್ಮ ಸಾಧನವನ್ನು CAPod ಗುರುತಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ. ನಿಮಗೆ ಒಮ್ಮೆ MacBook ಪ್ರವೇಶ ಬೇಕು.</string>
     <string name="profiles_maindevice_encryptionkey_label">ಎನ್‌ಕ್ರಿಪ್ಶನ್ ಕೀ</string>
-    <string name="profiles_maindevice_encryptionkey_description">ನಿಮ್ಮ ಸಾಧನದ ಎನ್‌ಕ್ರಿಪ್ಶನ್ ಕೀ, ಇದು CAPod ಗೆ ವಿವರವಾದ ಸ್ಥಿತಿ ಮಾಹಿತಿಯನ್ನು ಹಿಂಪಡೆಯಲು ಅನುಮತಿಸುತ್ತದೆ.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ಸ್ಥಿತಿ ಸಂದೇಶವನ್ನು ಕಳುಹಿಸುತ್ತವೆ, ಅದರ ಭಾಗವು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಆಗಿರುತ್ತದೆ. ಎನ್‌ಕ್ರಿಪ್ಶನ್ ಕೀ ಪೂರ್ಣ ಸಂದೇಶವನ್ನು CAPod ಡೀಕ್ರಿಪ್ಟ್ ಮಾಡಲು ಅನುಮತಿಸುತ್ತದೆ. ನಿಮಗೆ ಒಮ್ಮೆ MacBook ಪ್ರವೇಶ ಬೇಕು.</string>
     <string name="profiles_key_invalid_format">ಅಮಾನ್ಯ ಕೀ ಸ್ವರೂಪ</string>
     <string name="profiles_key_expected_format">ನಿರೀಕ್ಷಿತ ಸ್ವರೂಪ: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">ನೀವು ಉಳಿಸದ ಬದಲಾವಣೆಗಳನ್ನು ಹೊಂದಿದ್ದೀರಿ. ನೀವು ಏನು ಮಾಡಲು ಬಯಸುತ್ತೀರಿ?</string>
     <string name="general_save_and_exit_action">ಉಳಿಸಿ &amp; ನಿರ್ಗಮಿಸಿ</string>
     <string name="general_discard_action">ತಿರಸ್ಕರಿಸಿ</string>
-    <string name="general_keep_editing_action">ಸಂಪಾದನೆ ಮುಂದುವರಿಸಿ</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ರೆಕಾರ್ಡಿಂಗ್ ತುಂಬಾ ಚಿಕ್ಕದು</string>
     <string name="debug_debuglog_short_recording_message">ಡೀಬಗ್ ಲಾಗ್ ಸಮಸ್ಯೆ ಸಂಭವಿಸುವಾಗ ಅದನ್ನು ಕಾಪ್ಚರ್ ಮಾಡಬೇಕು. ರೆಕಾರ್ಡಿಂಗ್ ಮುಂದುವರಿಸಿ, ಸಮಸ್ಯೆಯನ್ನು ಪುನರಾವರ್ತಿಸಿ, ನಂತರ ರೆಕಾರ್ಡಿಂಗ್ ನಿಲ್ಲಿಸಿ.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ಸಾಧನ ಸೆಟ್ಟಿಂಗ್ಸ್</string>
     <string name="device_settings_subtitle_profile_prefix">ಪ್ರೊಫೈಲ್: %s</string>
-    <string name="device_settings_info_name_label">ಹೆಸರು</string>
     <string name="device_settings_info_bt_name_label">ಬ್ಲೂಟೂತ್ ಸಾಧನ ಲೇಬಲ್</string>
     <string name="device_settings_info_model_label">ಮಾದರಿ</string>
     <string name="device_settings_info_manufacturer_label">ತಯಾರಕ</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">ಬಹುಶಃ ನಂತರ</string>
     <string name="review_app_body">CAPod ಗೆ ವಿಮರ್ಶೆ ನೀಡಲು ನೀವು ಬಯಸುವಿರಾ? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">ಸಾಮಾನ್ಯ</string>
     <string name="device_settings_microphone_mode_label">ಮೈಕ್ರೊಫೋನ್</string>
     <string name="device_settings_microphone_mode_description">ಮೈಕ್ರೊಫೋನ್ ಆಗಿ ಯಾವ ಇಯರ್‌ಬಡ್ ಬಳಸಲಾಗುತ್ತದೆ</string>
     <string name="device_settings_microphone_mode_auto">ಆಟೋ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">공유</string>
     <string name="general_done_action">완료</string>
     <string name="general_cancel_action">취소</string>
-    <string name="general_copy_action">복사</string>
     <string name="general_thank_you_label">감사합니다</string>
     <string name="general_upgrade_action">업그레이드</string>
     <string name="general_retry_action">재시도</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">확인</string>
     <string name="general_close_action">닫기</string>
     <string name="general_dismiss_action">닫기</string>
-    <string name="general_edit_action">수정</string>
     <string name="general_save_action">저장</string>
     <string name="general_guide_action">가이드</string>
     <string name="general_continue_action">계속</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">자동 일시 정지로 멈춘 경우에만 이어팟을 다시 착용하면 음악이 재개됩니다. 직접 일시 정지한 경우(전화, AirPods 스템, 절전)는 그대로 유지됩니다.</string>
     <string name="settings_start_music_on_wear_label">착용 시 음악 시작</string>
     <string name="settings_start_music_on_wear_description">수동으로 일시 정지한 후에도 이어팟을 착용하면 항상 음악 재생을 시도합니다.</string>
-    <string name="settings_eardetection_info_label">착용 감지 알림</string>
     <string name="settings_eardetection_info_description">Apple의 제한으로 착용 감지가 마이크를 이용하는 데 사용되는 한쪽 유닛만 작동할 수 있습니다. Apple 기기에서 다음에 따라 설정할 수 있습니다. 설정 → 블루투스 → Airpods → 마이크</string>
-    <string name="settings_signal_minimum_label">최소 신호 품질</string>
-    <string name="settings_signal_minimum_description">기기가 사용자의 것으로 간주되기 위해 필요한 최소 신호 품질입니다.</string>
     <string name="settings_autoconnect_label">자동 연결</string>
     <string name="settings_autoconnect_description">Android가 자동으로 연결하지 않는다면 앱이 대신 요청할 수 있어요. 이렇게 하면 CAPod가 항상 백그라운드에서 모니터링을 계속해요.</string>
     <string name="settings_autoconnect_info_android12">자동 연결은 Android 12 이상에서 제한하는 시스템 기능에 의존합니다. 기기에서 작동하지 않을 수 있습니다.</string>
     <string name="settings_autoconnect_condition_label">자동 연결 조건</string>
-    <string name="settings_autoconnect_condition_description">언제 기기에 연결을 시도해야 할까요?</string>
     <string name="settings_devices_label">장치</string>
     <string name="settings_devices_description">당신의 장치를 관리하세요.</string>
     <string name="settings_reaction_label">반응</string>
-    <string name="settings_category_yourdevice_label">내 기기</string>
     <string name="settings_category_compatibility_options_title">호환성 옵션</string>
     <string name="settings_category_compatibility_options_description">모든 것이 작동하면 건드리지 마세요 ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">하드웨어 필터링 비활성화</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">시작 중…</string>
     <string name="support_debuglog_label">디버그 로그</string>
     <string name="support_debuglog_desc">앱이 수행하는 모든 작업을 공유할 수 있는 텍스트 파일에 기록합니다.</string>
-    <string name="debug_debuglog_size_label">크기</string>
-    <string name="debug_debuglog_size_compressed_label">압축된 크기</string>
-    <string name="debug_notification_channel_label">디버그 알림</string>
-    <string name="debug_debuglog_file_label">기록된 로그 파일</string>
-    <string name="debug_debuglog_recording_progress">디버그 로그 기록 중</string>
     <string name="debug_debuglog_record_action">디버그 로그 기록</string>
     <string name="debug_debuglog_stop_action">기록 중지</string>
     <string name="debug_debuglog_sensitive_information_message">생성된 파일에는 민감한 정보(예: Bluetooth 기기 세부 정보)가 포함되어 있습니다. 신뢰할 수 있는 당사자와만 공유하십시오.</string>
     <string name="settings_debuglog_explanation">이 기능은 앱이 수행하는 모든 작업을 공유 가능한 파일에 기록합니다. 생성된 파일에는 민감한 정보(예: Bluetooth 기기 세부 정보)가 포함되어 있습니다. 신뢰할 수 있는 당사자(예: 문제를 해결하는 개발자)와만 공유하십시오.</string>
-    <string name="settings_support_installid_label">설치 ID</string>
-    <string name="settings_support_installid_desc">자동 오류 보고서는 익명입니다. 개발자가 오류 보고서를 찾아야 하는 경우 설치 ID를 공유하십시오.</string>
     <string name="settings_support_label">지원</string>
     <string name="settings_support_description">도움이 필요한 경우.</string>
     <string name="settings_wiki_label">위키</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">학습된 데이터를 초기화하시겠습니까?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod가 이 기기의 측정된 방전량, 충전 속도 및 청취 시간을 잊고 정격 배터리 수명부터 다시 시작합니다.</string>
     <string name="settings_acknowledgements_label">감사의 말</string>
-    <string name="settings_debug_autoreports_label">자동 버그 보고서</string>
-    <string name="settings_debug_autoreports_description">앱 충돌에 대한 세부 정보와 같이 문제를 자동으로 보고하여 해결 방법을 파악할 수 있도록 합니다.</string>
-    <string name="settings_compatibility_mode_label">호환성 모드</string>
-    <string name="settings_compatibility_mode_description">호환성을 향상시키려면 최적화를 비활성화합니다. 데이터가 표시되지 않으면 이 옵션을 사용해 보십시오.</string>
     <string name="help_translate_label">번역</string>
     <string name="help_translate_description">이 앱을 즐겨 사용하는 언어로 번역하는 데 도움을 주세요.</string>
     <string name="translators_thanks_title">번역가</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">성공</string>
     <string name="troubleshooter_ble_result_success_body">CAPod에서 BLE 광고 브로드캐스트를 수신하고 있습니다.</string>
     <string name="troubleshooter_ble_result_failure_title">실패</string>
-    <string name="troubleshooter_ble_result_failure_body">문제 해결에 실패했습니다. 호환성 옵션의 어떤 조합도 도움이 되지 않았습니다.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">휴대전화에서 BLE 데이터를 전혀 수신하지 못했습니다. 혼잡한 지역에서 이 테스트를 다시 시도하여 데이터 소스(헤드폰 제외)를 수신할 수 있는지 확인할 수 있습니다. 데이터가 수신되지 않으면 휴대전화 운영 체제에 문제가 있음을 나타냅니다.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">휴대전화에서 BLE 데이터를 수신했지만 데이터가 지원되는 기기에서 오지 않았습니다. 헤드폰이 켜져 있습니까? CAPod가 헤드폰을 지원합니까?</string>
-    <string name="troubleshooter_ble_result_failure_action">다시 시도</string>
-    <string name="troubleshoot_action">문제 해결</string>
     <string name="onboarding_body1">이 앱은 Android에 AirPod 특정 기능에 대한 지원을 추가합니다.</string>
     <string name="onboarding_body2">모든 Android 기기가 추가 AirPod 기능을 완벽하게 지원하는 것은 아닙니다. 운영 체제에는 올바르게 작동하는 Bluetooth Low Energy 구현이 필요합니다.</string>
     <string name="onboarding_body3">CAPod에는 광고가 없으며 데이터를 수집하지 않습니다.</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">기기가 연결되어 있지만 CAPod가 실시간 데이터를 수신하지 못하고 있습니다. 호환성 옵션이 필요할 수 있으며, 문제 해결사가 자동으로 찾아드릴 수 있습니다.</string>
     <string name="overview_troubleshoot_suggestion_action">문제 해결사 실행</string>
     <string name="overview_unmatched_devices_label">일치하지 않는 기기</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d프로필과 일치하지 않는 기기</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">일치하는 프로필이 없는 근처 기기 %d개가 감지되었습니다. 자세한 정보를 보려면 표시하세요. 본인의 기기라면 기기 화면에서 프로필을 추가하여 인식시키세요.</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod는 팝업 띄우기나 자동 연결과 같은 기능을 앱이 꺼져있는 상태에서도 사용할 수 있게 하기 위해 백그라운드 위치 접근 권한을 사용합니다. 백그라운드 위치 접근 권한은 백그라운드에서도 BLE 정보를 받을 수 있게 합니다. CAPod는 이 권한으로 사용자의 위치를 확인하지 않습니다.</string>
     <string name="permission_ignore_battery_optimizations_label">배터리 사용량 최적화 비활성화</string>
     <string name="permission_ignore_battery_optimizations_description">배터리 사용량 최적화는 앱이 백그라운드에서 Bluetooth 신호를 지속적으로 받지 못하게 합니다.</string>
-    <string name="permission_required_title">다음과 같은 권한이 필요합니다:</string>
     <string name="permission_system_alert_window_label">시스템 알림창</string>
     <string name="permission_system_alert_window_description">\"팝업 표시\" 기능을 사용하려면 다른 앱 위에 그리기를 허용해야 합니다.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">앱이 장치를 찾았을때</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">귀에 착용했을 때</string>
     <string name="pods_dual_left_label">왼쪽 유닛</string>
     <string name="pods_dual_right_label">오른쪽 유닛</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">케이스</string>
     <string name="battery_unavailable_label">배터리 사용 불가</string>
     <string name="battery_state_low_cd">배터리 부족</string>
     <string name="battery_state_critical_cd">배터리 극히 부족</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">직접 연결 활성화</string>
     <string name="signal_indicator_bars_cd">신호 강도: 4칸 중 %1$d칸</string>
     <string name="signal_indicator_disconnected_cd">신호: 연결 끊김</string>
-    <string name="pods_yours">내 기기</string>
     <string name="headset_being_worn_label">착용 중</string>
     <string name="headset_not_being_worn_label">착용하지 않음</string>
     <string name="pods_case_unknown_state">알 수 없는 상태</string>
-    <string name="last_seen_x">마지막 업데이트: %s</string>
-    <string name="first_seen_x">처음 업데이트: %s</string>
     <string name="battery_cached_label">마지막으로 확인 · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d시간 %2$d분</string>
     <string name="battery_time_remaining_format_h">%1$d시간</string>
@@ -325,10 +294,8 @@
     <string name="profiles_signal_quality_title">최소 신호 품질</string>
     <string name="profiles_signal_quality_description">이 수치 이상의 신호 세기를 가진 기기만이 감지 됩니다. 낮은 값은 감지 범위를 넓히지만, 오탐을 일으킬 수 있습니다. 너무 높은 값은 블루투스 수신이 거리와 장애물에 민감하기에 권장하지 않습니다.</string>
     <string name="profiles_identitykey_label">ID 키</string>
-    <string name="profilessettings_maindevice_identitykey_description">기기의 ID 확인 키(IRK)로, CAPod가 주변 기기 중에서 해당 기기를 식별하는 데 도움이 됩니다.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods은 개인정보 보호를 위해 자주 Bluetooth 주소를 변경합니다. IRK는 앱이 당신의 기기를 인식하는데 도움이 됩니다. MacBook을 잠깐 사용해야 합니다.</string>
     <string name="profiles_maindevice_encryptionkey_label">암호화 키</string>
-    <string name="profiles_maindevice_encryptionkey_description">당신의 기기의 암호화 키. 앱이 구체적인 상태 정보를 불러올 수 있게 합니다.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods은 일부가 암호화된 상태 메시지를 보냅니다. 암호화 키는 앱이 완전한 메시지를 해독하도록 합니다. MacBook이 잠깐 필요합니다.</string>
     <string name="profiles_key_invalid_format">올바르지 않은 키 형식</string>
     <string name="profiles_key_expected_format">올바른 형식: %1$s</string>
@@ -362,7 +329,6 @@
     <string name="general_unsaved_changes_message">저장되지 않은 변경 사항이 있습니다. 어떻게 하시겠습니까?</string>
     <string name="general_save_and_exit_action">저장 &amp; 종료</string>
     <string name="general_discard_action">무시</string>
-    <string name="general_keep_editing_action">계속 수정하기</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">녹음 너무 짧음</string>
     <string name="debug_debuglog_short_recording_message">디버그 로그는 문제가 발생하는 동안 켜져 있어야 합니다. 녹음을 계속하고 문제를 재현한 다음 녹음을 중지하세요.</string>
@@ -430,7 +396,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">기기 설정</string>
     <string name="device_settings_subtitle_profile_prefix">프로필: %s</string>
-    <string name="device_settings_info_name_label">이름</string>
     <string name="device_settings_info_bt_name_label">블루투스 기기 레이블</string>
     <string name="device_settings_info_model_label">모델</string>
     <string name="device_settings_info_manufacturer_label">제조사</string>
@@ -510,7 +475,6 @@
     <string name="review_app_dismiss_action">다음에 해요</string>
     <string name="review_app_body">CAPod 리뷰를 남겨주시겠어요? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">일반</string>
     <string name="device_settings_microphone_mode_label">마이크</string>
     <string name="device_settings_microphone_mode_description">마이크로 사용할 이어버드</string>
     <string name="device_settings_microphone_mode_auto">자동</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Бөлүшүү</string>
     <string name="general_done_action">Даяр</string>
     <string name="general_cancel_action">Жокко чыгаруу</string>
-    <string name="general_copy_action">Көчүрүү</string>
     <string name="general_thank_you_label">Рахмат</string>
     <string name="general_upgrade_action">Жаңыртуу</string>
     <string name="general_retry_action">Кайтала</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Текшерүү</string>
     <string name="general_close_action">Жабуу</string>
     <string name="general_dismiss_action">Жабуу</string>
-    <string name="general_edit_action">Өзгөртүү</string>
     <string name="general_save_action">Сактоо</string>
     <string name="general_guide_action">Колдонмо</string>
     <string name="general_continue_action">Улантуу</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Подкасттарыңызды кайра кийгенде музыканы улантат, бирок Auto pause токтоткон учурда гана. Өзүңүз токтоткон үзүлүүлөр (телефон, AirPods сабы, уйку) токтоп калат.</string>
     <string name="settings_start_music_on_wear_label">Кийгенде музыканы баштоо</string>
     <string name="settings_start_music_on_wear_description">Подкасттарыңызды кийгенде музыканы ойнотууга аракет кылат, кол менен токтотулгандан кийин да.</string>
-    <string name="settings_eardetection_info_label">Кулак аныктоо эскертмеси</string>
     <string name="settings_eardetection_info_description">Кулак аныктоо бир эле кулакчын үчүн иштесе, бул Apple чектөөсү. Микрофон үчүн колдонулган \"негизги кулакчын\" гана аныкталат. Apple түзмөктөрүндө тууралаңыз: Жөндөөлөр → Bluetooth → AirPods → Микрофон.</string>
-    <string name="settings_signal_minimum_label">Минималдуу сигнал сапаты</string>
-    <string name="settings_signal_minimum_description">Түзмөктүн сиздики деп эсептелиши үчүн талап кылынган минималдуу сигнал сапаты.</string>
     <string name="settings_autoconnect_label">Авто туташуу</string>
     <string name="settings_autoconnect_description">Android автоматтык түрдө туташпаса, биз аны сурай алабыз. Бул CAPod\'дун фондо ар дайым байкоо жүргүзүшүн камсыздайт.</string>
     <string name="settings_autoconnect_info_android12">Автоматтык туташуу Android 12 жана андан жаңыраак версияларда чектелген системалык функцияга таянат. Бул түзмөгүңүздө иштебеши мүмкүн.</string>
     <string name="settings_autoconnect_condition_label">Авто туташуу шарты</string>
-    <string name="settings_autoconnect_condition_description">Түзмөгүңүзгө качан туташууга аракет кылышыбыз керек?</string>
     <string name="settings_devices_label">Түзмөктөр</string>
     <string name="settings_devices_description">Түзмөктөрүңүздү башкаруу.</string>
     <string name="settings_reaction_label">Реакциялар</string>
-    <string name="settings_category_yourdevice_label">Сиздин түзмөгүңүз</string>
     <string name="settings_category_compatibility_options_title">Шайкештик опциялары</string>
     <string name="settings_category_compatibility_options_description">Эгер баары иштесе тийбеңиз ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Аппараттык чыпкалоону өчүрүү</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Баштоодо…</string>
     <string name="support_debuglog_label">Мүчүлүштүктөрдү оңдоо журналы</string>
     <string name="support_debuglog_desc">Колдонмо жасап жаткан бардык нерсени бөлүшө турган текст файлына жазыңыз.</string>
-    <string name="debug_debuglog_size_label">Өлчөмү</string>
-    <string name="debug_debuglog_size_compressed_label">Кысылган өлчөмү</string>
-    <string name="debug_notification_channel_label">Мүчүлүштүктөрдү оңдоо билдирүүлөрү</string>
-    <string name="debug_debuglog_file_label">Жазылган журнал файлы</string>
-    <string name="debug_debuglog_recording_progress">Мүчүлүштүктөрдү оңдоо журналын жазуу</string>
     <string name="debug_debuglog_record_action">Мүчүлүштүктөрдү оңдоо журналын жазуу</string>
     <string name="debug_debuglog_stop_action">Жаздырууну токтотуу</string>
     <string name="debug_debuglog_sensitive_information_message">Түзүлгөн файл купуя маалыматты камтыйт (мис., Bluetooth түзмөгүнүн чоо-жайы). Аны ишенимдүү тараптар менен гана бөлүшүңүз.</string>
     <string name="settings_debuglog_explanation">Бул функция колдонмо жасап жаткан бардык нерсени бөлүшүлүүчү файлга жазат. Түзүлгөн файл купуя маалыматты камтыйт (мис., Bluetooth түзмөгүнүн чоо-жайы). Аны ишенимдүү тараптар менен гана бөлүшүңүз (мис., маселени чечип жаткан иштеп чыгуучу).</string>
-    <string name="settings_support_installid_label">Орнотуу ID</string>
-    <string name="settings_support_installid_desc">Автоматтык ката отчеттору анонимдүү. Эгер иштеп чыгуучуга ката отчетторуңузду табуу керек болсо, орнотуу ID\'ңизди бөлүшүңүз.</string>
     <string name="settings_support_label">Колдоо</string>
     <string name="settings_support_description">Эгер сизге жардам керек болсо.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Үйрөнүлгөн маалыматты тазалообу?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod бул түзүлүштүн өлчөнгөн кубат кетүүсү, зарядтоо ылдамдыгы жана угуу убактысы тууралуу маалыматты унутуп, номиналдык батарея жашоо мөөнөтүнөн кайра баштайт.</string>
     <string name="settings_acknowledgements_label">Ыраазычылыктар</string>
-    <string name="settings_debug_autoreports_label">Автоматтык ката отчеттору</string>
-    <string name="settings_debug_autoreports_description">Маселелерди автоматтык түрдө кабарлайт, мис., колдонмонун бузулушу жөнүндө маалымат, ошентип мен аны кантип оңдоону аныктай алам.</string>
-    <string name="settings_compatibility_mode_label">Шайкештик режими</string>
-    <string name="settings_compatibility_mode_description">Шайкештикти жакшыртуу үчүн оптималдаштырууларды өчүрүңүз. Эгер эч кандай маалымат көрбөсөңүз, муну байкап көрүңүз.</string>
     <string name="help_translate_label">Котормо</string>
     <string name="help_translate_description">Бул колдонмону сүйүктүү тилиңизге которууга жардам бериңиз.</string>
     <string name="translators_thanks_title">Котормочулар</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Ийгиликтүү</string>
     <string name="troubleshooter_ble_result_success_body">BLE жарнамалык уктуруулары CAPod тарабынан кабыл алынууда.</string>
     <string name="troubleshooter_ble_result_failure_title">Ийгиликсиз</string>
-    <string name="troubleshooter_ble_result_failure_body">Кыйынчылыктарды аныктоо ишке ашкан жок. Шайкештик опцияларынын эч бир айкалышы жардам берген жок.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Телефонуңуз эч кандай BLE маалыматын алган жок. Бул тестти эл көп жерде кайталап, маалымат булактары (кулакчындарыңыздан башка) кабыл алынып жатканын текшерсеңиз болот. Эч кандай маалымат алынбаса, бул телефонуңуздун операциялык тутумундагы көйгөйгө ишарат кылат.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Телефонуңуз BLE маалыматын алды, бирок маалымат колдоого алынган эч бир түзмөктөн келген жок. Кулакчындарыңыз күйүп турабы? CAPod сиздин кулакчыныңызды колдойбу?</string>
-    <string name="troubleshooter_ble_result_failure_action">Кайра аракет кылуу</string>
-    <string name="troubleshoot_action">Кыйынчылыктарды аныктоо</string>
     <string name="onboarding_body1">Бул колдонмо Android\'ге AirPod\'го тиешелүү функцияларды колдоону кошот.</string>
     <string name="onboarding_body2">Бардык Android түзмөктөрү AirPod\'дун кошумча функцияларын толук колдобойт. Сиздин операциялык тутумуңуз туура иштеген Bluetooth-Low-Energy ишке ашырылышын талап кылат.</string>
     <string name="onboarding_body3">CAPod жарнамасыз жана сиздин маалыматтарыңызды чогултпайт.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Түзмөгүңүз туташтырылган, бирок CAPod андан жандуу маалымат алып жаткан жок. Телефонуңузга шайкештик параметри керек болушу мүмкүн — кыйынчылыктарды аныктагыч аны автоматтык түрдө тапкыла кыла алат.</string>
     <string name="overview_troubleshoot_suggestion_action">Кыйынчылыктарды аныктагычты иштетүү</string>
     <string name="overview_unmatched_devices_label">Дал келбеген түзмөктөр</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d түзмөк профилсиз</item>
-        <item quantity="other">%d түзмөк профилсиз</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d жакын жайгашкан түзмөк дал келген профилсиз аныкталды. Кеңири маалымат үчүн аны көрсөтүңүз. Эгер ал сизге таандык болсо, аны таануу үчүн Түзмөктөр бөлүмүнөн профиль кошуңуз.</item>
         <item quantity="other">%d жакын жайгашкан түзмөк дал келген профилдерсиз аныкталды. Кеңири маалымат үчүн аларды көрсөтүңүз. Эгер алардын бири сизге таандык болсо, аны таануу үчүн Түзмөктөр бөлүмүнөн профиль кошуңуз.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod колдонмо жабык болгондо \"Калкыма терезе көрсөтүү\" жана \"Авто туташуу\" сыяктуу функцияларды иштетүү үчүн \"фондук жайгашуу\" мүмкүнчүлүгүн колдонот. Фондук жайгашуу колдонмого фондо Bluetooth Low Energy маалыматтарын алууга мүмкүндүк берет. Бул колдонмо Bluetooth маалыматтарын сиздин жайгашуу ордуңузду аныктоо үчүн КОЛДОНБОЙТ.</string>
     <string name="permission_ignore_battery_optimizations_label">Батарея оптималдаштыруусун өчүрүү</string>
     <string name="permission_ignore_battery_optimizations_description">Батарея оптималдаштыруулары бул колдонмонун фондо Bluetooth маалыматтарын ишенимдүү алуусуна тоскоолдук кылат.</string>
-    <string name="permission_required_title">Төмөнкү уруксат талап кылынат:</string>
     <string name="permission_system_alert_window_label">Тутум эскертүү терезеси</string>
     <string name="permission_system_alert_window_description">\"Калкыма терезе көрсөтүү\" функциясын мүмкүн кылуу үчүн CAPod\'го башка колдонмолордун үстүнөн тартууга уруксат бериңиз.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Көрүнгөндө</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Кулакта</string>
     <string name="pods_dual_left_label">Сол кулакчын</string>
     <string name="pods_dual_right_label">Оң кулакчын</string>
-    <string name="pods_dual_left_short_label">Сол</string>
-    <string name="pods_dual_right_short_label">Оң</string>
-    <string name="pods_case_label">Кап</string>
     <string name="battery_unavailable_label">Батарея жеткиликсиз</string>
     <string name="battery_state_low_cd">Батареянын деңгээли төмөн</string>
     <string name="battery_state_critical_cd">Батареянын деңгээли өтө төмөн</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Түз байланыш активдүү</string>
     <string name="signal_indicator_bars_cd">Сигнал күчү: %1$d / 4 тилке</string>
     <string name="signal_indicator_disconnected_cd">Сигнал: ажыратылган</string>
-    <string name="pods_yours">Сиздики</string>
     <string name="headset_being_worn_label">Тагылган</string>
     <string name="headset_not_being_worn_label">Тагылган эмес</string>
     <string name="pods_case_unknown_state">Белгисиз абал</string>
-    <string name="last_seen_x">Акыркы көрүлгөн: %s</string>
-    <string name="first_seen_x">Биринчи көрүлгөн: %s</string>
     <string name="battery_cached_label">Акыркы белгилүү · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dч %2$dмүн</string>
     <string name="battery_time_remaining_format_h">%1$dч</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Минималдуу сигнал сапаты</string>
     <string name="profiles_signal_quality_description">Бул чекиттен жогорку сигнал күчү бар түзмөктөрдү гана аныктаңыз. Төмөн маанилер аныктоо аралыгын жогорулатат, бирок жалган позитивдерди жаратышы мүмкүн. Муну өтө жогору койбоңуз — Bluetooth кабыл алуу жалпысынан начар жана аралыкка жана тоскоолдуктарга жараша өзгөрөт.</string>
     <string name="profiles_identitykey_label">Идентификация ачкычы</string>
-    <string name="profilessettings_maindevice_identitykey_description">Түзмөгүңүздүн Identity Resolving Key (IRK) ачкычы, CAPod\'го аны жакынкы түзмөктөрдүн арасынан аныктоого жардам берет.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods купуялык үчүн Bluetooth дарегин тез-тез өзгөртөт. IRK CAPod\'го түзмөгүңүздү таанууга жардам берет. Сизге MacBook\'ка бир жолку мүмкүнчүлүк керек.</string>
     <string name="profiles_maindevice_encryptionkey_label">Шифрлөө ачкычы</string>
-    <string name="profiles_maindevice_encryptionkey_description">Түзмөгүңүздүн шифрлөө ачкычы, CAPod\'го толук абал маалыматын алууга мүмкүндүк берет.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods абал билдирүүсүн жөнөтөт, анын бир бөлүгү шифрленген. Шифрлөө ачкычы CAPod\'го толук билдирүүнү чечмелөөгө мүмкүндүк берет. Сизге MacBook\'ка бир жолку мүмкүнчүлүк керек.</string>
     <string name="profiles_key_invalid_format">Жараксыз ачкыч форматы</string>
     <string name="profiles_key_expected_format">Күтүлгөн формат: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Сиздин сакталбаган өзгөртүүлөрүңүз бар. Эмне кылгыңыз келет?</string>
     <string name="general_save_and_exit_action">Сактоо &amp; Чыгуу</string>
     <string name="general_discard_action">Жокко чыгаруу</string>
-    <string name="general_keep_editing_action">Түзөтүүнү улантуу</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Жазылуу өтө кыска</string>
     <string name="debug_debuglog_short_recording_message">Мүчүлүштүк жазылмасы ошол болуп жатканда көймөлү жазуу керек. Жазыпты улантырыңыз, каталыкты кайталаңыз, анан жазыпты тохтатыңыз.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Түзмөк жөндөөлөрү</string>
     <string name="device_settings_subtitle_profile_prefix">Профиль: %s</string>
-    <string name="device_settings_info_name_label">Аты</string>
     <string name="device_settings_info_bt_name_label">Bluetooth түзмөгүнүн аталышы</string>
     <string name="device_settings_info_model_label">Модель</string>
     <string name="device_settings_info_manufacturer_label">Өнүмчү</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Кийин</string>
     <string name="review_app_body">CAPod үчүн баалоо берүүнү каалайсызбы? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Жалпы</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
     <string name="device_settings_microphone_mode_description">Кайсы кулакчын микрофон катары колдонулат</string>
     <string name="device_settings_microphone_mode_auto">Авто</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">ແບ່ງປັນ</string>
     <string name="general_done_action">ແລ້ວໆ</string>
     <string name="general_cancel_action">ຍົກເລີກ</string>
-    <string name="general_copy_action">ສຳເນົາ</string>
     <string name="general_thank_you_label">ຂອບໃຈ</string>
     <string name="general_upgrade_action">ອັບເກຣດ</string>
     <string name="general_retry_action">ລອງໃໝ່</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">ກວດສອບ</string>
     <string name="general_close_action">ປິດ</string>
     <string name="general_dismiss_action">ປະຕິເສດ</string>
-    <string name="general_edit_action">ແກ້ໄຂ</string>
     <string name="general_save_action">ບັນທຶກ</string>
     <string name="general_guide_action">ຄູ່ມື</string>
     <string name="general_continue_action">ສືບຕໍ່</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">ຫຼິ້ນດົນຕີຕໍ່ເມື່ອໃສ່ pods ອີກຄັ້ງ, ແຕ່ເທົ່ານັ້ນຖ້າ Auto pause ຢຸດມັນ. ການຢຸດທີ່ທ່ານເຮັດດ້ວຍຕົວເອງ (ໂທລະສັບ, ກ້ານ AirPods, ນອນ) ຍັງຄົງຢຸດຢູ່.</string>
     <string name="settings_start_music_on_wear_label">ເລີ່ມດົນຕີເມື່ອໃສ່</string>
     <string name="settings_start_music_on_wear_description">ພະຍາຍາມຫຼິ້ນດົນຕີທຸກຄັ້ງທີ່ທ່ານໃສ່ pods, ແມ່ນແຕ່ຫຼັງຈາກຢຸດດ້ວຍຕົນເອງ.</string>
-    <string name="settings_eardetection_info_label">ໝາຍເຫດການກວດຈັບຫູ</string>
     <string name="settings_eardetection_info_description">ຖ້າການກວດຈັບຫູເຮັດວຽກສຳລັບພອດດຽວເທົ່ານັ້ນ, ນີ້ແມ່ນຂໍ້ຈຳກັດຂອງ Apple. ສະເພາະ \"ພອດຫຼັກ\" (ໃຊ້ສຳລັບໄມໂຄຣໂຟນ) ເທົ່ານັ້ນທີ່ຖືກກວດຈັບ. ຕັ້ງຄ່າໃນອຸປະກອນ Apple: ການຕັ້ງຄ່າ → Bluetooth → AirPods → ໄມໂຄຣໂຟນ.</string>
-    <string name="settings_signal_minimum_label">ຄຸນນະພາບສັນຍານຂັ້ນຕໍ່າ</string>
-    <string name="settings_signal_minimum_description">ຄຸນນະພາບສັນຍານຂັ້ນຕໍ່າທີ່ອຸປະກອນຕ້ອງມີເພື່ອຖືວ່າເປັນຂອງທ່ານ.</string>
     <string name="settings_autoconnect_label">ເຊື່ອມຕໍ່ອັດຕະໂນມັດ</string>
     <string name="settings_autoconnect_description">ຖ້າ Android ບໍ່ເຊື່ອມຕໍ່ໂດຍອັດຕະໂນມັດ, ພວກເຮົາສາມາດຂໍໃຫ້ມັນເຮັດໄດ້. ອັນນີ້ຈະຮັກສາການຕິດຕາມຂອງ CAPod ໃຫ້ເຮັດວຽກຢູ່ພື້ນຫຼັງຕະຫຼອດເວລາ.</string>
     <string name="settings_autoconnect_info_android12">ການເຊື່ອມຕໍ່ອັດຕະໂນມັດອາໃສຟີເຈີລະບົບທີ່ Android 12 ແລະລຸ້ນໃໝ່ກວ່າຈຳກັດ. ມັນອາດຈະບໍ່ເຮັດວຽກໃນອຸປະກອນຂອງທ່ານ.</string>
     <string name="settings_autoconnect_condition_label">ເງື່ອນໄຂການເຊື່ອມຕໍ່ອັດຕະໂນມັດ</string>
-    <string name="settings_autoconnect_condition_description">ພວກເຮົາຄວນພະຍາຍາມເຊື່ອມຕໍ່ກັບອຸປະກອນຂອງທ່ານເມື່ອໃດ?</string>
     <string name="settings_devices_label">ອຸປະກອນ</string>
     <string name="settings_devices_description">ຈັດການອຸປະກອນຂອງທ່ານ.</string>
     <string name="settings_reaction_label">ປະຕິກິລິຍາ</string>
-    <string name="settings_category_yourdevice_label">ອຸປະກອນຂອງທ່ານ</string>
     <string name="settings_category_compatibility_options_title">ຕົວເລືອກຄວາມເຂົ້າກັນໄດ້</string>
     <string name="settings_category_compatibility_options_description">ຢ່າແຕະຕ້ອງຖ້າທຸກຢ່າງເຮັດວຽກ ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ປິດການກັ່ນຕອງຮາດແວ</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">ກຳລັງເລີ່ມຕົ້ນ…</string>
     <string name="support_debuglog_label">ບັນທຶກດີບັກ</string>
     <string name="support_debuglog_desc">ບັນທຶກທຸກຢ່າງທີ່ແອັບກຳລັງເຮັດໃສ່ໃນໄຟລ໌ຂໍ້ຄວາມທີ່ທ່ານສາມາດແບ່ງປັນໄດ້.</string>
-    <string name="debug_debuglog_size_label">ຂະໜາດ</string>
-    <string name="debug_debuglog_size_compressed_label">ຂະໜາດທີ່ບີບອັດ</string>
-    <string name="debug_notification_channel_label">ການແຈ້ງເຕືອນດີບັກ</string>
-    <string name="debug_debuglog_file_label">ໄຟລ໌ບັນທຶກທີ່ບັນທຶກໄວ້</string>
-    <string name="debug_debuglog_recording_progress">ກໍາລັງບັນທຶກບັນທຶກດີບັກ</string>
     <string name="debug_debuglog_record_action">ບັນທຶກບັນທຶກດີບັກ</string>
     <string name="debug_debuglog_stop_action">ຢຸດການບັນທຶກ</string>
     <string name="debug_debuglog_sensitive_information_message">ໄຟລ໌ທີ່ສ້າງຂຶ້ນມີຂໍ້ມູນທີ່ລະອຽດອ່ອນ (ເຊັ່ນ: ລາຍລະອຽດອຸປະກອນ Bluetooth). ແບ່ງປັນໃຫ້ສະເພາະຜູ້ທີ່ໄວ້ໃຈໄດ້ເທົ່ານັ້ນ.</string>
     <string name="settings_debuglog_explanation">ຟີເຈີນີ້ບັນທຶກທຸກສິ່ງທີ່ແອັບກໍາລັງເຮັດໃສ່ໃນໄຟລ໌ທີ່ແບ່ງປັນໄດ້. ໄຟລ໌ທີ່ສ້າງຂຶ້ນມີຂໍ້ມູນທີ່ລະອຽດອ່ອນ (ເຊັ່ນ: ລາຍລະອຽດອຸປະກອນ Bluetooth). ແບ່ງປັນໃຫ້ສະເພາະຜູ້ທີ່ໄວ້ໃຈໄດ້ (ເຊັ່ນ: ນັກພັດທະນາທີ່ກໍາລັງແກ້ໄຂບັນຫາ) ເທົ່ານັ້ນ.</string>
-    <string name="settings_support_installid_label">ID ການຕິດຕັ້ງ</string>
-    <string name="settings_support_installid_desc">ບົດລາຍງານຂໍ້ຜິດພາດອັດຕະໂນມັດແມ່ນບໍ່ເປີດເຜີຍຊື່. ແບ່ງປັນ ID ຕິດຕັ້ງຂອງທ່ານຖ້າຜູ້ພັດທະນາຕ້ອງການຊອກຫາບົດລາຍງານຂໍ້ຜິດພາດຂອງທ່ານ.</string>
     <string name="settings_support_label">ການຊ່ວຍເຫຼືອ</string>
     <string name="settings_support_description">ຖ້າທ່ານຕ້ອງການການຊ່ວຍເຫຼືອ.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">ຕັ້ງໃໝ່ຂໍ້ມູນທີ່ຮຽນຮູ້ບໍ?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ຈະລືມຂໍ້ມູນການລະບາຍ, ຄວາມໄວໃນການສາກ ແລະ ວລີຟັງຂອງອຸປະກອນນີ້, ແລະ ເລີ່ມຕົ້ນໃໝ່ຈາກອາຍຸແບັດເຕີຣີມາດຕະຖານ</string>
     <string name="settings_acknowledgements_label">ການຮັບຮູ້</string>
-    <string name="settings_debug_autoreports_label">ລາຍງານຂໍ້ບົກພ່ອງອັດຕະໂນມັດ</string>
-    <string name="settings_debug_autoreports_description">ລາຍງານບັນຫາໂດຍອັດຕະໂນມັດ, ຕົວຢ່າງ: ລາຍລະອຽດກ່ຽວກັບການຂັດຂ້ອງຂອງແອັບ ເພື່ອໃຫ້ຂ້ອຍສາມາດຫາວິທີແກ້ໄຂໄດ້.</string>
-    <string name="settings_compatibility_mode_label">ໂໝດຄວາມເຂົ້າກັນໄດ້</string>
-    <string name="settings_compatibility_mode_description">ປິດການປັບແຕ່ງໃຫ້ເໝາະສົມເພື່ອປັບປຸງຄວາມເຂົ້າກັນໄດ້. ລອງໃຊ້ອັນນີ້ຖ້າທ່ານບໍ່ເຫັນຂໍ້ມູນໃດໆ.</string>
     <string name="help_translate_label">ການແປພາສາ</string>
     <string name="help_translate_description">ຊ່ວຍແປແອັບນີ້ເປັນພາສາທີ່ທ່ານມັກ.</string>
     <string name="translators_thanks_title">ຜູ້ແປ</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">ສຳເລັດ</string>
     <string name="troubleshooter_ble_result_success_body">ການອອກອາກາດໂຄສະນາ BLE ກຳລັງຖືກຮັບໂດຍ CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">ບໍ່ສຳເລັດ</string>
-    <string name="troubleshooter_ble_result_failure_body">ການແກ້ໄຂບັນຫາບໍ່ສຳເລັດ. ບໍ່ມີການປະສົມປະສານຕົວເລືອກຄວາມເຂົ້າກັນໄດ້ໃດໆທີ່ຊ່ວຍໄດ້.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">ໂທລະສັບຂອງທ່ານບໍ່ໄດ້ຮັບຂໍ້ມູນ BLE ເລີຍ. ທ່ານສາມາດລອງທົດສອບນີ້ອີກຄັ້ງໃນພື້ນທີ່ແອອັດເພື່ອເບິ່ງວ່າສາມາດຮັບແຫຼ່ງຂໍ້ມູນ (ນອກເໜືອຈາກຫູຟັງຂອງທ່ານ) ໄດ້ຫຼືບໍ່. ການບໍ່ໄດ້ຮັບຂໍ້ມູນໃດໆຊີ້ບອກເຖິງບັນຫາກับລະບົບປະຕິບັດການຂອງໂທລະສັບຂອງທ່ານ.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">ໂທລະສັບຂອງທ່ານໄດ້ຮັບຂໍ້ມູນ BLE, ແຕ່ຂໍ້ມູນບໍ່ໄດ້ມາຈາກອຸປະກອນທີ່ຮອງຮັບໃດໆ. ຫູຟັງຂອງທ່ານເປີດຢູ່ບໍ? CAPod ຮອງຮັບຫູຟັງຂອງທ່ານບໍ?</string>
-    <string name="troubleshooter_ble_result_failure_action">ລອງອີກຄັ້ງ</string>
-    <string name="troubleshoot_action">ແກ້ໄຂບັນຫາ</string>
     <string name="onboarding_body1">ແອັບນີ້ເພີ່ມການຮອງຮັບຄຸນສົມບັດສະເພາະຂອງ AirPod ໃຫ້ກັບ Android.</string>
     <string name="onboarding_body2">ບໍ່ແມ່ນອຸປະກອນ Android ທັງໝົດທີ່ຮອງຮັບຄຸນສົມບັດເພີ່ມເຕີມຂອງ AirPod ຢ່າງເຕັມທີ່. ລະບົບປະຕິບັດການຂອງທ່ານຕ້ອງການການປະຕິບັດ Bluetooth-Low-Energy ທີ່ເຮັດວຽກຢ່າງຖືກຕ້ອງ.</string>
     <string name="onboarding_body3">CAPod ບໍ່ມີໂຄສະນາ ແລະ ບໍ່ເກັບກຳຂໍ້ມູນຂອງທ່ານ.</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">ອຸປະກອນຂອງທ່ານເຊື່ອມຕໍ່ແລ້ວ, ຜູ້ໃດ້ CAPod ບໍ່ໄດ້ຮັບຂໍ້ມູນລິວໃດ້ຈາກມັນ. ໂທລະສັບຂອງທ່ານອາດຕ້ອງການຕົວເລືອກຄວາມເຂົ້າກັນໄດ້ — ຕົວແກ້ໄຂບັນຫາສາມາດພະຍາຍາມຫາຕົວເລືອກທີ່ເຫມາະສະຫມໂດຍອັດຕະໂນມັດ.</string>
     <string name="overview_troubleshoot_suggestion_action">ແລ່ນຕົວແກ້ໄຂບັນຫາ</string>
     <string name="overview_unmatched_devices_label">ອຸປະກອນທີ່ບໍ່ກົງກັນ</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d ອຸປະກອນທີ່ບໍ່ມີໂປຣໄຟລ໌ກົງກັນ</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">ກວດພົບອຸປະກອນໃກ້ຄຽງ %d ໜ່ວຍ ໂດຍບໍ່ມີໂປຣໄຟລ໌ທີ່ກົງກັນ. ສະແດງເພື່ອເບິ່ງລາຍລະອຽດທີ່ມີ. ຖ້າມັນເປັນຂອງທ່ານ, ໃຫ້ເພີ່ມໂປຣໄຟລ໌ຈາກອຸປະກອນເພື່ອຈົດຈຳມັນ.</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod ໃຊ້ \"ເຂົ້າເຖິງທີ່ຕັ້ງໃນພື້ນຫຼັງ\" ເພື່ອເປີດໃຊ້ຄຸນສົມບັດເຊັ່ນ \"ສະແດງປັອບອັບ\" ແລະ \"ເຊື່ອມຕໍ່ອັດຕະໂນມັດ\" ໃນຂະນະທີ່ແອັບປິດຢູ່. ການເຂົ້າເຖິງທີ່ຕັ້ງໃນພື້ນຫຼັງອະນຸຍາດໃຫ້ແອັບຮັບຂໍ້ມູນ Bluetooth Low Energy ໃນພື້ນຫຼັງ. ແອັບນີ້ຈະບໍ່ໃຊ້ຂໍ້ມູນ Bluetooth ເພື່ອກຳນົດທີ່ຕັ້ງຂອງທ່ານ.</string>
     <string name="permission_ignore_battery_optimizations_label">ປິດການປັບແຕ່ງແບັດເຕີລີ້</string>
     <string name="permission_ignore_battery_optimizations_description">ການປັບແຕ່ງແບັດເຕີລີ້ປ້ອງກັນບໍ່ໃຫ້ແອັບນີ້ຮັບຂໍ້ມູນ Bluetooth ຢ່າງໜ້າເຊື່ອຖືໃນຂະນະທີ່ແອັບຢູ່ໃນພື້ນຫຼັງ.</string>
-    <string name="permission_required_title">ຕ້ອງການການອະນຸຍາດຕໍ່ໄປນີ້:</string>
     <string name="permission_system_alert_window_label">ໜ້າຕ່າງການແຈ້ງເຕືອນລະບົບ</string>
     <string name="permission_system_alert_window_description">ອະນຸຍາດໃຫ້ CAPod ແຕ້ມທັບແອັບອື່ນເພື່ອໃຫ້ຄຸນສົມບັດ \"ສະແດງປັອບອັບ\" ເປັນໄປໄດ້.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">ເມື່ອເຫັນ</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">ໃນຫູ</string>
     <string name="pods_dual_left_label">ພອດຊ້າຍ</string>
     <string name="pods_dual_right_label">ພອດຂວາ</string>
-    <string name="pods_dual_left_short_label">ຊ້</string>
-    <string name="pods_dual_right_short_label">ຂວາ</string>
-    <string name="pods_case_label">ເຄສ</string>
     <string name="battery_unavailable_label">ບາດເຕີຣີບໍ່ສາມາດໃຊ້ງານໄດ້</string>
     <string name="battery_state_low_cd">ແບັດເຕີຣີຕໍ່າ</string>
     <string name="battery_state_critical_cd">ແບັດເຕີຣີໃກ້ຈະໝົດ</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">ການເຊື່ອມຕໍ່ໂດຍກົງທີ່ເຄື່ອນໄຫວ</string>
     <string name="signal_indicator_bars_cd">ຄວາມແຮງສັນຍານ: %1$d ຈາກ 4 ຂີດ</string>
     <string name="signal_indicator_disconnected_cd">ສັນຍານ: ຕັດການເຊື່ອມຕໍ່</string>
-    <string name="pods_yours">ຂອງທ່ານ</string>
     <string name="headset_being_worn_label">ກຳລັງໃສ່</string>
     <string name="headset_not_being_worn_label">ບໍ່ໄດ້ໃສ່</string>
     <string name="pods_case_unknown_state">ສະຖານະທີ່ບໍ່ຮູ້ຈັກ</string>
-    <string name="last_seen_x">ເຫັນຫຼ້າສຸດ: %s</string>
-    <string name="first_seen_x">ເຫັນຄັ້ງທຳອິດ: %s</string>
     <string name="battery_cached_label">ຮູ້ຈັກລ່າສຸດ · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">ຄຸນນະພາບສັນຍານຂັ້ນຕໍ່າ</string>
     <string name="profiles_signal_quality_description">ກວດຈັບສະເພາະອຸປະກອນທີ່ມີຄວາມແຮງສັນຍານເກີນເກນນີ້. ຄ່າຕໍ່າກວ່າເພີ່ມຂອບເຂດການກວດຈັບແຕ່ອາດເຮັດໃຫ້ເກີດການກວດຈັບຜິດ. ຢ່າຕັ້ງສູງເກີນໄປ - ການຮັບ Bluetooth ໂດຍທົ່ວໄປແມ່ນບໍ່ດີ ແລະ ແຕກຕ່າງກັນຕາມໄລຍະ ແລະ ສິ່ງກີດຂວາງ.</string>
     <string name="profiles_identitykey_label">ລະຫັດຕົວຕົນ</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) ຂອງອຸປະກອນທ່ານ, ຊຶ່ງຊ່ວຍ CAPod ລະບຸມັນໃນບັນດາອຸປະກອນໃກ້ຄຽງ.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ປ່ຽນທີ່ຢູ່ Bluetooth ເລື້ອຍໆເພື່ອຄວາມເປັນສ່ວນຕົວ. IRK ຊ່ວຍ CAPod ຮັບຮູ້ອຸປະກອນຂອງທ່ານ. ທ່ານຕ້ອງການການເຂົ້າເຖິງ MacBook ຄັ້ງດຽວ.</string>
     <string name="profiles_maindevice_encryptionkey_label">ລະຫັດການເຂົ້າລະຫັດ</string>
-    <string name="profiles_maindevice_encryptionkey_description">ກະແຈເຂົ້າລະຫັດຂອງອຸປະກອນທ່ານ, ຊຶ່ງອະນຸຍາດໃຫ້ CAPod ດຶງຂໍ້ມູນສະຖານະລະອຽດ.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ສົ່ງຂໍ້ຄວາມສະຖານະ, ບາງສ່ວນຂອງມັນຖືກເຂົ້າລະຫັດ. ກະແຈເຂົ້າລະຫັດອະນຸຍາດໃຫ້ CAPod ຖອດລະຫັດຂໍ້ຄວາມທັງໝົດ. ທ່ານຕ້ອງການການເຂົ້າເຖິງ MacBook ຄັ້ງດຽວ.</string>
     <string name="profiles_key_invalid_format">ຮູບແບບກະແຈບໍ່ຖືກຕ້ອງ</string>
     <string name="profiles_key_expected_format">ຮູບແບບທີ່ຄາດໄວ້: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">ທ່ານມີການປ່ຽນແປງທີ່ບໍ່ໄດ້ບັນທຶກ. ທ່ານຕ້ອງການເຮັດຫຍັງ?</string>
     <string name="general_save_and_exit_action">ບັນທຶກ &amp; ອອກ</string>
     <string name="general_discard_action">ຍົກເລີກ</string>
-    <string name="general_keep_editing_action">ສືບຕໍ່ແກ້ໄຂ</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ການບັນທຶກສັ້ນເກີນໄປ</string>
     <string name="debug_debuglog_short_recording_message">ບັນທຶກດີບັກຕ້ອງບັນທຶກບັນຫາໃນຂະນະທີ່ມັນເກີດຂຶ້ນ. ສືບຕໍ່ການບັນທຶກ, ຈາລອງບັນຫາ, ຈາກນັ້ນຊຸດການບັນທຶກ.</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ການຕັ້ງຄ່າອຸປະກອນ</string>
     <string name="device_settings_subtitle_profile_prefix">ໂປຣໄຟລ໌: %s</string>
-    <string name="device_settings_info_name_label">ຊື່</string>
     <string name="device_settings_info_bt_name_label">ຊື່ອຸປະກອນ Bluetooth</string>
     <string name="device_settings_info_model_label">ລຸ້ນ</string>
     <string name="device_settings_info_manufacturer_label">ຜູ້ຜະລິດ</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">ບາງທີພາຍຫຼັງ</string>
     <string name="review_app_body">ທ່ານຢາກໃຫ້ CAPod ຣີວິວບໍ? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">ທົ່ວໄປ</string>
     <string name="device_settings_microphone_mode_label">ໄມໂຄຣໂຟນ</string>
     <string name="device_settings_microphone_mode_description">ຫູຟັງຂ້າງໃດທີ່ໃຊ້ເປັນໄມໂຄໂຟນ</string>
     <string name="device_settings_microphone_mode_auto">ອັດຕະໂນມັດ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Bendrinti</string>
     <string name="general_done_action">Atlikta</string>
     <string name="general_cancel_action">Atšaukti</string>
-    <string name="general_copy_action">Kopijuoti</string>
     <string name="general_thank_you_label">Ačiū</string>
     <string name="general_upgrade_action">Naujinti</string>
     <string name="general_retry_action">Bandyti iš naujo</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Tikrinti</string>
     <string name="general_close_action">Uždaryti</string>
     <string name="general_dismiss_action">Atšaukti</string>
-    <string name="general_edit_action">Redaguoti</string>
     <string name="general_save_action">Išsaugoti</string>
     <string name="general_guide_action">Vadovas</string>
     <string name="general_continue_action">Tęsti</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Tęsti muziką vėl užsidėjus ausines, bet tik jei ją sustabdė automatinis pristabdymas. Pristabdymai, kuriuos inicijavote patys (telefonas, AirPods koteliai, miegas), lieka pristabdyti.</string>
     <string name="settings_start_music_on_wear_label">Pradėti muziką užsidėjus</string>
     <string name="settings_start_music_on_wear_description">Visada bando paleisti muziką, kai užsidedatе ausines, net po rankinio pristabdymo.</string>
-    <string name="settings_eardetection_info_label">Ausies aptikimo pastaba</string>
     <string name="settings_eardetection_info_description">Jei ausies aptikimas veikia tik vienam „pod\", tai yra „Apple\" apribojimas. Aptinkamas tik „pagrindinis pod\" (naudojamas mikrofonui). Konfigūruokite „Apple\" įrenginiuose: Nustatymai → „Bluetooth\" → „AirPods\" → Mikrofonas.</string>
-    <string name="settings_signal_minimum_label">Minimali signalo kokybė</string>
-    <string name="settings_signal_minimum_description">Minimali signalo kokybė, kurią turi turėti įrenginys, kad būtų laikomas jūsų.</string>
     <string name="settings_autoconnect_label">Automatinis prisijungimas</string>
     <string name="settings_autoconnect_description">Jei Android neprijungia automatiškai, galime jį paprašyti. Tai laiko CAPod stebėjimą nuolat fone.</string>
     <string name="settings_autoconnect_info_android12">Automatinis prisijungimas remiasi sistemos funkcija, kurią Android 12 ir naujesnės versijos apriboja. Ji gali neveikti jūsų įrenginyje.</string>
     <string name="settings_autoconnect_condition_label">Automatinio prisijungimo sąlyga</string>
-    <string name="settings_autoconnect_condition_description">Kada turėtume bandyti prisijungti prie jūsų įrenginio?</string>
     <string name="settings_devices_label">Įrenginiai</string>
     <string name="settings_devices_description">Tvarkykite savo įrenginius.</string>
     <string name="settings_reaction_label">Reakcijos</string>
-    <string name="settings_category_yourdevice_label">Jūsų įrenginys</string>
     <string name="settings_category_compatibility_options_title">Suderinamumo parinktys</string>
     <string name="settings_category_compatibility_options_description">Nelieskite, jei viskas veikia ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Išjungti aparatinį filtravimą</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Paleidžiama…</string>
     <string name="support_debuglog_label">Derinimo žurnalas</string>
     <string name="support_debuglog_desc">Įrašykite viską, ką daro programa, į tekstinį failą, kurį galite bendrinti.</string>
-    <string name="debug_debuglog_size_label">Dydis</string>
-    <string name="debug_debuglog_size_compressed_label">Suglaudintas dydis</string>
-    <string name="debug_notification_channel_label">Derinimo pranešimai</string>
-    <string name="debug_debuglog_file_label">Įrašytas žurnalo failas</string>
-    <string name="debug_debuglog_recording_progress">Įrašomas derinimo žurnalas</string>
     <string name="debug_debuglog_record_action">Įrašyti derinimo žurnalą</string>
     <string name="debug_debuglog_stop_action">Stabdyti įrašymą</string>
     <string name="debug_debuglog_sensitive_information_message">Sugeneruotame faile yra slaptos informacijos (pvz., „Bluetooth\" įrenginio informacija). Bendrinkite jį tik su patikimomis šalimis.</string>
     <string name="settings_debuglog_explanation">Ši funkcija įrašo viską, ką daro programa, į bendrinamą failą. Sugeneruotame faile yra slaptos informacijos (pvz., „Bluetooth\" įrenginio informacija). Bendrinkite jį tik su patikimomis šalimis (pvz., kūrėju, kuris sprendžia problemą).</string>
-    <string name="settings_support_installid_label">Diegimo ID</string>
-    <string name="settings_support_installid_desc">Automatinės klaidų ataskaitos yra anoniminės. Pasidalykite savo diegimo ID, jei kūrėjui reikia rasti jūsų klaidų ataskaitas.</string>
     <string name="settings_support_label">Pagalba</string>
     <string name="settings_support_description">Jei jums reikia pagalbos.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Iš naujo nustatyti išmoktus duomenis?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod pamiršs šio įrenginio išmatuotą energijos sąnaudą, įkrovimo greitį ir naudojimosi laiką, ir pradės iš naujo nuo nurodytosios baterijos veikimo trukmės.</string>
     <string name="settings_acknowledgements_label">Padėkos</string>
-    <string name="settings_debug_autoreports_label">Automatinės klaidų ataskaitos</string>
-    <string name="settings_debug_autoreports_description">Automatiškai praneša apie problemas, pvz., išsamią informaciją apie programos strigtį, kad galėčiau išsiaiškinti, kaip ją ištaisyti.</string>
-    <string name="settings_compatibility_mode_label">Suderinamumo režimas</string>
-    <string name="settings_compatibility_mode_description">Išjunkite optimizavimą, kad pagerintumėte suderinamumą. Išbandykite tai, jei nematote jokių duomenų.</string>
     <string name="help_translate_label">Vertimas</string>
     <string name="help_translate_description">Padėkite išversti šią programą į savo mėgstamą kalbą.</string>
     <string name="translators_thanks_title">Vertėjai</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sėkmė</string>
     <string name="troubleshooter_ble_result_success_body">CAPod gauna BLE reklamos transliacijas.</string>
     <string name="troubleshooter_ble_result_failure_title">Nesėkminga</string>
-    <string name="troubleshooter_ble_result_failure_body">Problemų sprendimas nepavyko. Jokia suderinamumo parinkčių kombinacija nepadėjo.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Jūsų telefonas visiškai negavo jokių BLE duomenų. Galite pakartoti šį testą perpildytoje vietoje, kad pamatytumėte, ar galima gauti duomenų šaltinius (išskyrus jūsų ausines). Jokių gautų duomenų nebuvimas rodo problemą su jūsų telefono operacine sistema.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Jūsų telefonas gavo BLE duomenis, tačiau duomenys negaunami iš jokio palaikomo įrenginio. Ar jūsų ausinės įjungtos? Ar CAPod palaiko jūsų ausines?</string>
-    <string name="troubleshooter_ble_result_failure_action">Bandyti vėl</string>
-    <string name="troubleshoot_action">Spręsti problemas</string>
     <string name="onboarding_body1">Ši programa prideda „AirPod\" specifinių funkcijų palaikymą „Android\".</string>
     <string name="onboarding_body2">Ne visi „Android\" įrenginiai visiškai palaiko papildomas „AirPod\" funkcijas. Jūsų operacinei sistemai reikalinga tinkamai veikianti „Bluetooth-Low-Energy\" implementacija.</string>
     <string name="onboarding_body3">CAPod neturi skelbimų ir nerenka jūsų duomenų.</string>
@@ -207,12 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Jūsų įrenginys yra prisijungęs, tačiau CAPod negauna jokių tiesioginių duomenų iš jo. Jūsų telefonui gali reikėti suderinamumo parinkties — problemų sprendiklis gali bandyti ją rasti automatiškai.</string>
     <string name="overview_troubleshoot_suggestion_action">Paleisti problemų sprendiklį</string>
     <string name="overview_unmatched_devices_label">Nesutapę įrenginiai</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d įrenginys be atitinkamo profilio</item>
-        <item quantity="few">%d įrenginiai be atitinkamo profilio</item>
-        <item quantity="many">%d įrenginių be atitinkamo profilio</item>
-        <item quantity="other">%d įrenginių be atitinkamo profilio</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Aptiktas %d netoliese esantis įrenginys be atitinkančio profilio. Rodykite jį, kad pamatytumėte visą informaciją. Jei tai jūsų įrenginys, pridėkite profilį iš skilties „Įrenginiai“, kad jį atpažintų.</item>
         <item quantity="few">Aptikti %d netoliese esantys įrenginiai be atitinkančių profilių. Rodykite juos, kad pamatytumėte visą informaciją. Jei vienas iš jų yra jūsų, pridėkite profilį iš skilties „Įrenginiai“, kad jį atpažintų.</item>
@@ -237,7 +210,6 @@
     <string name="permission_background_location_description">CAPod naudoja „foninę prieigą prie vietos\", kad įjungtų tokias funkcijas kaip „Rodyti iškylantįjį langą\" ir „Automatinis prisijungimas\", kai programa uždaryta. Foninė prieiga prie vietos leidžia programai gauti „Bluetooth Low Energy\" duomenis fone. Ši programa NENAUDOS „Bluetooth\" duomenų jūsų vietai nustatyti.</string>
     <string name="permission_ignore_battery_optimizations_label">Išjungti baterijos optimizavimą</string>
     <string name="permission_ignore_battery_optimizations_description">Baterijos optimizavimas neleidžia šiai programai patikimai gauti „Bluetooth\" duomenų, kai programa veikia fone.</string>
-    <string name="permission_required_title">Reikalingas šis leidimas:</string>
     <string name="permission_system_alert_window_label">Sistemos perspėjimo langas</string>
     <string name="permission_system_alert_window_description">Leiskite CAPod piešti virš kitų programų, kad būtų galima naudoti funkciją „Rodyti iškylantįjį langą\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kai pastebėtas</string>
@@ -245,9 +217,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Ausyje</string>
     <string name="pods_dual_left_label">Kairysis „pod\"</string>
     <string name="pods_dual_right_label">Dešinysis „pod\"</string>
-    <string name="pods_dual_left_short_label">K</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Dėklas</string>
     <string name="battery_unavailable_label">Baterija neprieinama</string>
     <string name="battery_state_low_cd">Baterija žema</string>
     <string name="battery_state_critical_cd">Baterija kritiškai žema</string>
@@ -304,12 +273,9 @@
     <string name="signal_badge_aap_cd">Tiesioginis ryšys aktyvus</string>
     <string name="signal_indicator_bars_cd">Signalo stiprumas: %1$d iš 4 juostų</string>
     <string name="signal_indicator_disconnected_cd">Signalas: atjungta</string>
-    <string name="pods_yours">Jūsų</string>
     <string name="headset_being_worn_label">Dėvimas</string>
     <string name="headset_not_being_worn_label">Nedėvimas</string>
     <string name="pods_case_unknown_state">Nežinoma būsena</string>
-    <string name="last_seen_x">Paskutinį kartą matytas: %s</string>
-    <string name="first_seen_x">Pirmą kartą matytas: %s</string>
     <string name="battery_cached_label">Paskutinis žinomas · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dv %2$dmin</string>
     <string name="battery_time_remaining_format_h">%1$dv</string>
@@ -339,10 +305,8 @@
     <string name="profiles_signal_quality_title">Minimali signalo kokybė</string>
     <string name="profiles_signal_quality_description">Aptikti tik įrenginius, kurių signalo stiprumas viršija šią ribą. Mažesnės vertės padidina aptikimo diapazoną, bet gali sukelti klaidingą aptikimą. Nenustatykite per aukštai – „Bluetooth\" signalas paprastai yra silpnas ir kinta priklausomai nuo atstumo ir kliūčių.</string>
     <string name="profiles_identitykey_label">Tapatybės raktas</string>
-    <string name="profilessettings_maindevice_identitykey_description">Jūsų įrenginio tapatybės sprendimo raktas (IRK), padedantis CAPod jį atpažinti tarp netoliese esančių įrenginių.</string>
     <string name="profiles_maindevice_identitykey_explanation">„AirPods\" dažnai keičia savo „Bluetooth\" adresą dėl privatumo. IRK padeda CAPod atpažinti jūsų įrenginį. Jums reikia vienkartin prieigos prie „MacBook\".</string>
     <string name="profiles_maindevice_encryptionkey_label">Šifravimo raktas</string>
-    <string name="profiles_maindevice_encryptionkey_description">Jūsų įrenginio šifravimo raktas, leidžiantis CAPod gauti išsamią būsenos informaciją.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">„AirPods\" siunčia būsenos pranešimą, kurio dalis yra užšifruota. Šifravimo raktas leidžia CAPod iššifruoti visą pranešimą. Jums reikia vienkartinės prieigos prie „MacBook\".</string>
     <string name="profiles_key_invalid_format">Netinkamas rakto formatas</string>
     <string name="profiles_key_expected_format">Tikėtinas formatas: %1$s</string>
@@ -375,7 +339,6 @@
     <string name="general_unsaved_changes_message">Turite neišsaugotų pakeitimų. Ką norėtumėte daryti?</string>
     <string name="general_save_and_exit_action">Išsaugoti ir išeiti</string>
     <string name="general_discard_action">Atmesti</string>
-    <string name="general_keep_editing_action">Tęsti redagavimą</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Irašas per trumpas</string>
     <string name="debug_debuglog_short_recording_message">Derinimo žurnalas turi užfiksuoti problemą jos metu. Tęskite įrašymą, atkurkite problemą, tada sustabdykite įrašymą.</string>
@@ -452,7 +415,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Įrenginio nustatymai</string>
     <string name="device_settings_subtitle_profile_prefix">Profilis: %s</string>
-    <string name="device_settings_info_name_label">Pavadinimas</string>
     <string name="device_settings_info_bt_name_label">Bluetooth įrenginio žnyma</string>
     <string name="device_settings_info_model_label">Modelis</string>
     <string name="device_settings_info_manufacturer_label">Gamintojas</string>
@@ -532,7 +494,6 @@
     <string name="review_app_dismiss_action">Galbūt vėliau</string>
     <string name="review_app_body">Ar norėtumėte palikti CAPod recenziją? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Bendrieji</string>
     <string name="device_settings_microphone_mode_label">Mikrofonas</string>
     <string name="device_settings_microphone_mode_description">Kuris ausinis naudojamas kaip mikrofonas</string>
     <string name="device_settings_microphone_mode_auto">Automatinis</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Kopīgot</string>
     <string name="general_done_action">Gatavs</string>
     <string name="general_cancel_action">Atcelt</string>
-    <string name="general_copy_action">Ievietot starpliktuvē</string>
     <string name="general_thank_you_label">Paldies</string>
     <string name="general_upgrade_action">Uzlabot</string>
     <string name="general_retry_action">Mēģināt vēlreiz</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Pārbaudīt</string>
     <string name="general_close_action">Aizvērt</string>
     <string name="general_dismiss_action">Noraidīt</string>
-    <string name="general_edit_action">Labot</string>
     <string name="general_save_action">Saglabāt</string>
     <string name="general_guide_action">Ceļvedis</string>
     <string name="general_continue_action">Turpināt</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Atsāk mūziku, kad valkājat savus austiņas atkal, bet tikai tad, ja to apturēja automātiskā pauze. Pauzes, ko aktivizējāt pats (tālrunis, AirPods kāts, miegs), paliek pauzētas.</string>
     <string name="settings_start_music_on_wear_label">Sākt mūziku uzvelkot</string>
     <string name="settings_start_music_on_wear_description">Vienmēr mēģina atskaņot mūziku, kad uzliekat austiņas, pat pēc manuālas pauzes.</string>
-    <string name="settings_eardetection_info_label">Piezīme par auss noteikšanu</string>
     <string name="settings_eardetection_info_description">Ja auss noteikšana darbojas tikai vienai austiņai, tas ir Apple ierobežojums. Tiek noteikta tikai \"galvenā austiņa\" (ko izmanto mikrofonam). Konfigurējiet Apple ierīcēs: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">Minimālā signāla kvalitāte</string>
-    <string name="settings_signal_minimum_description">Minimālā signāla kvalitāte, kādai jābūt ierīcei, lai tā tiktu uzskatīta par jūsu.</string>
     <string name="settings_autoconnect_label">Automātiska savienošana</string>
     <string name="settings_autoconnect_description">Ja Android nepievieno automātiski, mēs tam to varam arī lūgt. Tas notur CAPod darbību fonā visu laiku.</string>
     <string name="settings_autoconnect_info_android12">Automātiskā savienojuma funkcija ir atkarīga no sistēmas funkcijas, ko Android 12 un jaunākas versijas ierobežo. Iespējams, tā nedarbosies jūsu ierīcē.</string>
     <string name="settings_autoconnect_condition_label">Automātiskas savienošanas nosacījums</string>
-    <string name="settings_autoconnect_condition_description">Kad mums vajadzētu mēģināt izveidot savienojumu ar jūsu ierīci?</string>
     <string name="settings_devices_label">Ierīces</string>
     <string name="settings_devices_description">Pārvaldiet savas ierīces.</string>
     <string name="settings_reaction_label">Reakcijas</string>
-    <string name="settings_category_yourdevice_label">Jūsu ierīce</string>
     <string name="settings_category_compatibility_options_title">Saderības opcijas</string>
     <string name="settings_category_compatibility_options_description">Neaiztieciet, ja viss darbojas ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Atspējot aparatūras filtrēšanu</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Uzsākšana…</string>
     <string name="support_debuglog_label">Atkļūdošanas žurnāls</string>
     <string name="support_debuglog_desc">Ierakstiet visu, ko lietotne dara, teksta failā, ko varat kopīgot.</string>
-    <string name="debug_debuglog_size_label">Izmērs</string>
-    <string name="debug_debuglog_size_compressed_label">Saspiests izmērs</string>
-    <string name="debug_notification_channel_label">Atkļūdošanas paziņojumi</string>
-    <string name="debug_debuglog_file_label">Ierakstīts žurnāla fails</string>
-    <string name="debug_debuglog_recording_progress">Notiek atkļūdošanas žurnāla ierakstīšana</string>
     <string name="debug_debuglog_record_action">Ierakstīt atkļūdošanas žurnālu</string>
     <string name="debug_debuglog_stop_action">Pārtraukt ierakstīšanu</string>
     <string name="debug_debuglog_sensitive_information_message">Ģenerētais fails satur sensitīvu informāciju (piem., Bluetooth ierīces informāciju). Kopīgojiet to tikai ar uzticamām pusēm.</string>
     <string name="settings_debuglog_explanation">Šī funkcija ieraksta visu, ko lietotne dara, koplietojamā failā. Ģenerētais fails satur sensitīvu informāciju (piem., Bluetooth ierīces informāciju). Kopīgojiet to tikai ar uzticamām pusēm (piem., izstrādātāju, kas novērš problēmu).</string>
-    <string name="settings_support_installid_label">Instalācijas ID</string>
-    <string name="settings_support_installid_desc">Automātiskie kļūdu ziņojumi ir anonīmi. Kopīgojiet savu instalācijas ID, ja izstrādātājam ir nepieciešams atrast jūsu kļūdu ziņojumus.</string>
     <string name="settings_support_label">Atbalsts</string>
     <string name="settings_support_description">Ja jums nepieciešama palīdzība.</string>
     <string name="settings_wiki_label">Vikipēdija</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Atiestatīt apgūtos datus?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod aizmirsīs šīs ierīces izmērīto baterijas noplūdi, uzlādes ātrumu un klausīšanās laiku, un sāks no jauna ar norādīto baterijas darbības ilgumu.</string>
     <string name="settings_acknowledgements_label">Pateicības</string>
-    <string name="settings_debug_autoreports_label">Automātiski kļūdu ziņojumi</string>
-    <string name="settings_debug_autoreports_description">Automātiski ziņo par problēmām, piem., informāciju par lietotnes avāriju, lai es varētu izdomāt, kā to labot.</string>
-    <string name="settings_compatibility_mode_label">Saderības režīms</string>
-    <string name="settings_compatibility_mode_description">Atspējojiet optimizācijas, lai uzlabotu saderību. Izmēģiniet šo, ja neredzat nekādus datus.</string>
     <string name="help_translate_label">Tulkošana</string>
     <string name="help_translate_description">Palīdziet tulkot šo lietotni savā iecienītajā valodā.</string>
     <string name="translators_thanks_title">Tulkotāji</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Veiksmīgi</string>
     <string name="troubleshooter_ble_result_success_body">CAPod saņem BLE reklāmas pārraides.</string>
     <string name="troubleshooter_ble_result_failure_title">Neveiksmīgi</string>
-    <string name="troubleshooter_ble_result_failure_body">Problēmu risināšana neizdevās. Neviena saderības opciju kombinācija nepalīdzēja.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Jūsu tālrunis vispār nesaņēma nekādus BLE datus. Varat atkārtot šo testu pārpildītā vietā, lai redzētu, vai var saņemt datu avotus (izņemot jūsu austiņas). Datu nesaņemšana norāda uz problēmu ar jūsu tālruņa operētājsistēmu.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Jūsu tālrunis saņēma BLE datus, bet dati nenāk no nevienas atbalstītas ierīces. Vai jūsu austiņas ir ieslēgtas? Vai CAPod atbalsta jūsu austiņas?</string>
-    <string name="troubleshooter_ble_result_failure_action">Mēģiniet vēlreiz</string>
-    <string name="troubleshoot_action">Risināt problēmas</string>
     <string name="onboarding_body1">Šī lietotne pievieno Android ierīcēm AirPod specifisko funkciju atbalstu.</string>
     <string name="onboarding_body2">Ne visas Android ierīces pilnībā atbalsta papildu AirPod funkcijas. Jūsu operētājsistēmai ir nepieciešama pareizi funkcionējoša Bluetooth Low Energy implementācija.</string>
     <string name="onboarding_body3">CAPod nesatur reklāmas un neapkopo jūsu datus.</string>
@@ -207,11 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Jūsu ierīce ir savienota, taču CAPod nesaņem no tās nekādus tiešraides datus. Jūsu tālrunim, iespējams, nepieciešama saderības opcija — problēmu risinātājs var mēģināt to atrast automātiski.</string>
     <string name="overview_troubleshoot_suggestion_action">Palaist problēmu risinātāju</string>
     <string name="overview_unmatched_devices_label">Neatbilstošas ierīces</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="zero">%d ierīce bez atbilstoša profila</item>
-        <item quantity="one">%d ierīces bez atbilstoša profila</item>
-        <item quantity="other">%d ierīces bez atbilstoša profila</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="zero">Tuvumā tika atklāts %d ierīču bez atbilstoša profila. Parādi tās, lai redzētu pieejamo informāciju. Ja kāda no tām ir tava, pievieno profilu sadaļā Ierīces, lai to atpazītu.</item>
         <item quantity="one">Tuvumā tika atklāta %d ierīce bez atbilstoša profila. Parādi to, lai redzētu pieejamo informāciju. Ja tā ir tava, pievieno profilu sadaļā Ierīces, lai to atpazītu.</item>
@@ -234,7 +208,6 @@
     <string name="permission_background_location_description">CAPod izmanto \"atrašanās vietas piekļuvi fonā\", lai iespējotu funkcijas, piemēram, \"Rādīt uznirstošo logu\" un \"Automātiska savienošana\", kamēr lietotne ir aizvērta. Atrašanās vietas piekļuve fonā ļauj lietotnei saņemt Bluetooth Low Energy datus fonā. Šī lietotne NEIZMANTOS Bluetooth datus, lai noteiktu jūsu atrašanās vietu.</string>
     <string name="permission_ignore_battery_optimizations_label">Atspējot baterijas optimizācijas</string>
     <string name="permission_ignore_battery_optimizations_description">Baterijas optimizācijas neļauj šai lietotnei droši saņemt Bluetooth datus, kamēr lietotne ir fonā.</string>
-    <string name="permission_required_title">Nepieciešama šāda atļauja:</string>
     <string name="permission_system_alert_window_label">Sistēmas brīdinājuma logs</string>
     <string name="permission_system_alert_window_description">Atļaujiet CAPod zīmēt virs citām lietotnēm, lai iespējotu funkciju \"Rādīt uznirstošo logu\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kad redzēta</string>
@@ -242,9 +215,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Ausī</string>
     <string name="pods_dual_left_label">Kreisā austiņa</string>
     <string name="pods_dual_right_label">Labā austiņa</string>
-    <string name="pods_dual_left_short_label">K</string>
-    <string name="pods_dual_right_short_label">L</string>
-    <string name="pods_case_label">Korpuss</string>
     <string name="battery_unavailable_label">Akumulātors nav pieejams</string>
     <string name="battery_state_low_cd">Baterija zema</string>
     <string name="battery_state_critical_cd">Baterija kritiski zema</string>
@@ -299,12 +269,9 @@
     <string name="signal_badge_aap_cd">Tiešais savienojums aktīvs</string>
     <string name="signal_indicator_bars_cd">Signāla stiprums: %1$d no 4 joslu</string>
     <string name="signal_indicator_disconnected_cd">Signāls: atvienots</string>
-    <string name="pods_yours">Jūsu</string>
     <string name="headset_being_worn_label">Tiek nēsāta</string>
     <string name="headset_not_being_worn_label">Netiek nēsāta</string>
     <string name="pods_case_unknown_state">Nezināms stāvoklis</string>
-    <string name="last_seen_x">Pēdējoreiz redzēta: %s</string>
-    <string name="first_seen_x">Pirmo reizi redzēta: %s</string>
     <string name="battery_cached_label">Pēdējoreiz zināms · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -334,10 +301,8 @@
     <string name="profiles_signal_quality_title">Minimālā signāla kvalitāte</string>
     <string name="profiles_signal_quality_description">Noteikt tikai ierīces ar signāla stiprumu virs šī sliekšņa. Zemākas vērtības palielina noteikšanas diapazonu, bet var izraisīt viltus pozitīvus rezultātus. Neiestatiet pārāk augstu - Bluetooth uztveršana parasti ir vāja un mainās atkarībā no attāluma un šķēršļiem.</string>
     <string name="profiles_identitykey_label">Identitātes atslēga</string>
-    <string name="profilessettings_maindevice_identitykey_description">Jūsu ierīces Identity Resolving Key (IRK), kas palīdz CAPod to identificēt starp tuvumā esošām ierīcēm.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods bieži maina savu Bluetooth adresi konfidencialitātes nolūkos. IRK palīdz CAPod atpazīt jūsu ierīci. Jums ir nepieciešama vienreizēja piekļuve MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Šifrēšanas atslēga</string>
-    <string name="profiles_maindevice_encryptionkey_description">Jūsu ierīces šifrēšanas atslēga, kas ļauj CAPod iegūt detalizētu statusa informāciju.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods sūta statusa ziņojumu, kura daļa ir šifrēta. Šifrēšanas atslēga ļauj CAPod atšifrēt pilnu ziņojumu. Jums ir nepieciešama vienreizēja piekļuve MacBook.</string>
     <string name="profiles_key_invalid_format">Nederīgs atslēgas formāts</string>
     <string name="profiles_key_expected_format">Gaidāmais formāts: %1$s</string>
@@ -370,7 +335,6 @@
     <string name="general_unsaved_changes_message">Jums ir nesaglabātas izmaiņas. Ko vēlaties darīt?</string>
     <string name="general_save_and_exit_action">Saglabāt &amp; iziet</string>
     <string name="general_discard_action">Atmest</string>
-    <string name="general_keep_editing_action">Turpināt rediģēšanu</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Ieraksts ir pārāk īss</string>
     <string name="debug_debuglog_short_recording_message">Atklāšanas žurnālam jāuztver problēma tās norišanas laikā. Turpiniet ierakstu, reproduciet problēmu un pēc tam apstiediniet ierakstu.</string>
@@ -444,7 +408,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Ierīces iestatījumi</string>
     <string name="device_settings_subtitle_profile_prefix">Profils: %s</string>
-    <string name="device_settings_info_name_label">Nosaukums</string>
     <string name="device_settings_info_bt_name_label">Bluetooth ierīces nosaukums</string>
     <string name="device_settings_info_model_label">Modelis</string>
     <string name="device_settings_info_manufacturer_label">Ražotājs</string>
@@ -524,7 +487,6 @@
     <string name="review_app_dismiss_action">Varbūt vēlāk</string>
     <string name="review_app_body">Vai vēlies atstāt CAPod atsauksmi? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Vispārīgi</string>
     <string name="device_settings_microphone_mode_label">Mikrofons</string>
     <string name="device_settings_microphone_mode_description">Kura austiņa tiek izmantota kā mikrofons</string>
     <string name="device_settings_microphone_mode_auto">Automātiski</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Сподели</string>
     <string name="general_done_action">Готово</string>
     <string name="general_cancel_action">Откажи</string>
-    <string name="general_copy_action">Копирај</string>
     <string name="general_thank_you_label">Ви благодарам</string>
     <string name="general_upgrade_action">Надгради</string>
     <string name="general_retry_action">Повтори</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Провери</string>
     <string name="general_close_action">Затвори</string>
     <string name="general_dismiss_action">Отфрли</string>
-    <string name="general_edit_action">Уредување</string>
     <string name="general_save_action">Зачувај</string>
     <string name="general_guide_action">Водич</string>
     <string name="general_continue_action">Продолжи</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Продолжи со музика кога повторно ги носиш слушалките, но само ако Авто-пауза ја запрела. Паузите кои ги активирал самиот (телефон, стебло на AirPods, спиење) остануваат паузирани.</string>
     <string name="settings_start_music_on_wear_label">Пушти музика при ставање</string>
     <string name="settings_start_music_on_wear_description">Секогаш се обидува да пушти музика кога ги ставаш слушалките, дури и по рачна пауза.</string>
-    <string name="settings_eardetection_info_label">Белешка за детекција на уво</string>
     <string name="settings_eardetection_info_description">Ако детекцијата на увото работи само за еден pod, ова е ограничување на Apple. Се детектира само \"примарниот pod\" (користен за микрофон). Конфигурирајте на Apple уреди: Поставки → Bluetooth → AirPods → Микрофон.</string>
-    <string name="settings_signal_minimum_label">Минимален квалитет на сигналот</string>
-    <string name="settings_signal_minimum_description">Минималниот квалитет на сигналот што уредот мора да го има за да се смета за ваш.</string>
     <string name="settings_autoconnect_label">Автоматско поврзување</string>
     <string name="settings_autoconnect_description">Ако Android не се поврзува автоматски, можеме да го замолиме и ние. Ова го одржува мониторирањето на CAPod во позадина во секое време.</string>
     <string name="settings_autoconnect_info_android12">Автоматското поврзување се потпира на системска функција која Android 12 и понови верзии ја ограничуваат. Може да не работи на вашиот уред.</string>
     <string name="settings_autoconnect_condition_label">Услов за автоматско поврзување</string>
-    <string name="settings_autoconnect_condition_description">Кога треба да се обидеме да се поврземе со вашиот уред?</string>
     <string name="settings_devices_label">Уреди</string>
     <string name="settings_devices_description">Управувајте со вашите уреди.</string>
     <string name="settings_reaction_label">Реакции</string>
-    <string name="settings_category_yourdevice_label">Вашиот уред</string>
     <string name="settings_category_compatibility_options_title">Опции за компатибилност</string>
     <string name="settings_category_compatibility_options_description">Не допирајте ако сè работи ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Оневозможи хардверско филтрирање</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Стартување…</string>
     <string name="support_debuglog_label">Дневник за дебагирање</string>
     <string name="support_debuglog_desc">Снимете сè што прави апликацијата во текстуална датотека што можете да ја споделите.</string>
-    <string name="debug_debuglog_size_label">Големина</string>
-    <string name="debug_debuglog_size_compressed_label">Компресирана големина</string>
-    <string name="debug_notification_channel_label">Известувања за дебагирање</string>
-    <string name="debug_debuglog_file_label">Снимена датотека од дневникот</string>
-    <string name="debug_debuglog_recording_progress">Се снима дневник за дебагирање</string>
     <string name="debug_debuglog_record_action">Сними дневник за дебагирање</string>
     <string name="debug_debuglog_stop_action">Прекини со снимање</string>
     <string name="debug_debuglog_sensitive_information_message">Генерираната датотека содржи чувствителни информации (на пр. детали за Bluetooth уредот). Споделете ја само со доверливи страни.</string>
     <string name="settings_debuglog_explanation">Оваа функција го снима сè што прави апликацијата во датотека што може да се сподели. Генерираната датотека содржи чувствителни информации (на пр. детали за Bluetooth уредот). Споделете ја само со доверливи страни (на пр. развивач кој решава проблем).</string>
-    <string name="settings_support_installid_label">ID на инсталација</string>
-    <string name="settings_support_installid_desc">Автоматските извештаи за грешки се анонимни. Споделете го вашиот ID на инсталација ако развивачот треба да ги најде вашите извештаи за грешки.</string>
     <string name="settings_support_label">Поддршка</string>
     <string name="settings_support_description">Ако ви треба помош.</string>
     <string name="settings_wiki_label">Вики</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Ресетирај научени податоци?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ќе ги заборави измерената потрошња на овој уред, брзината на полнење и времето на слушање, и ќе почне наново од номиналниот век на батеријата.</string>
     <string name="settings_acknowledgements_label">Благодарници</string>
-    <string name="settings_debug_autoreports_label">Автоматски извештаи за грешки</string>
-    <string name="settings_debug_autoreports_description">Автоматски пријавува проблеми, на пр. детали за пад на апликацијата за да можам да откријам како да го поправам.</string>
-    <string name="settings_compatibility_mode_label">Режим на компатибилност</string>
-    <string name="settings_compatibility_mode_description">Оневозможете ги оптимизациите за да ја подобрите компатибилноста. Обидете се со ова ако не гледате никакви податоци.</string>
     <string name="help_translate_label">Превод</string>
     <string name="help_translate_description">Помогнете да ја преведете оваа апликација на вашиот омилен јазик.</string>
     <string name="translators_thanks_title">Преведувачи</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Успех</string>
     <string name="troubleshooter_ble_result_success_body">CAPod прима BLE рекламни емисии.</string>
     <string name="troubleshooter_ble_result_failure_title">Неуспешно</string>
-    <string name="troubleshooter_ble_result_failure_body">Решавањето проблеми не успеа. Ниту една комбинација од опции за компатибилност не помогна.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Вашиот телефон воопшто не прими никакви BLE податоци. Можете повторно да го пробате овој тест на преполно место за да видите дали може да се примат извори на податоци (освен вашите слушалки). Непримањето податоци укажува на проблем со оперативниот систем на вашиот телефон.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Вашиот телефон прими BLE податоци, но податоците не доаѓаат од ниеден поддржан уред. Дали вашите слушалки се вклучени? Дали CAPod ги поддржува вашите слушалки?</string>
-    <string name="troubleshooter_ble_result_failure_action">Обиди се повторно</string>
-    <string name="troubleshoot_action">Реши проблеми</string>
     <string name="onboarding_body1">Оваа апликација додава поддршка за специфични функции на AirPod на Android.</string>
     <string name="onboarding_body2">Не сите Android уреди целосно ги поддржуваат дополнителните функции на AirPod. Вашиот оперативен систем бара правилно функционирачка имплементација на Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod нема реклами и не ги собира вашите податоци.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Уредот е поврзан, но CAPod не прима живи податоци од него. Можеби на телефонот му треба опција за компатибилност — решавањето проблеми може автоматски да пронајде такава.</string>
     <string name="overview_troubleshoot_suggestion_action">Стартувај решавање проблеми</string>
     <string name="overview_unmatched_devices_label">Несовпаднати уреди</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d уред без совпаѓачки профил</item>
-        <item quantity="other">%d уреди без совпаѓачки профил</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Откриен е %d уред во близина без соодветен профил. Прикажи го за достапни детали. Ако е твој, додади профил од Уреди за да го препознаеш.</item>
         <item quantity="other">Откриени се %d уреди во близина без соодветни профили. Прикажи ги за достапни детали. Ако некој е твој, додади профил од Уреди за да го препознаеш.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod користи \"пристап до локација во позадина\" за да овозможи функции како \"Прикажи попап\" и \"Автоматско поврзување\" додека апликацијата е затворена. Пристапот до локација во позадина и овозможува на апликацијата да прима Bluetooth Low Energy податоци додека е во позадина. Оваа апликација НЕМА да користи Bluetooth податоци за одредување на вашата локација.</string>
     <string name="permission_ignore_battery_optimizations_label">Оневозможи оптимизации на батерија</string>
     <string name="permission_ignore_battery_optimizations_description">Оптимизациите на батеријата ја спречуваат оваа апликација да прима сигурно Bluetooth податоци додека апликацијата е во позадина.</string>
-    <string name="permission_required_title">Потребна е следната дозвола:</string>
     <string name="permission_system_alert_window_label">Системски прозорец за предупредување</string>
     <string name="permission_system_alert_window_description">Дозволете CAPod да црта преку други апликации за да ја овозможи функцијата \"Прикажи попап\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Кога е забележан</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Во уво</string>
     <string name="pods_dual_left_label">Лева слушалка</string>
     <string name="pods_dual_right_label">Десна слушалка</string>
-    <string name="pods_dual_left_short_label">Л</string>
-    <string name="pods_dual_right_short_label">Д</string>
-    <string name="pods_case_label">Куќиште</string>
     <string name="battery_unavailable_label">Батеријата не е достапна</string>
     <string name="battery_state_low_cd">Слаба батерија</string>
     <string name="battery_state_critical_cd">Критично слаба батерија</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Директна врска е активна</string>
     <string name="signal_indicator_bars_cd">Јачина на сигнал: %1$d од 4 ленти</string>
     <string name="signal_indicator_disconnected_cd">Сигнал: исклучен</string>
-    <string name="pods_yours">Ваш</string>
     <string name="headset_being_worn_label">Се носи</string>
     <string name="headset_not_being_worn_label">Не се носи</string>
     <string name="pods_case_unknown_state">Непозната состојба</string>
-    <string name="last_seen_x">Последно видено: %s</string>
-    <string name="first_seen_x">Прво видено: %s</string>
     <string name="battery_cached_label">Последно познато · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dч %2$dм</string>
     <string name="battery_time_remaining_format_h">%1$dч</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Минимален квалитет на сигналот</string>
     <string name="profiles_signal_quality_description">Детектирај само уреди со јачина на сигнал над овој праг. Пониските вредности го зголемуваат опсегот на детекција, но може да предизвикаат лажни позитивни резултати. Не го поставувајте ова премногу високо - Bluetooth приемот е генерално слаб и варира со растојанието и пречките.</string>
     <string name="profiles_identitykey_label">Клуч за идентитет</string>
-    <string name="profilessettings_maindevice_identitykey_description">Клучот за решавање на идентитетот (IRK) на вашиот уред, кој му помага на CAPod да го идентификува меѓу блиските уреди.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods честопати ја менуваат нивната Bluetooth адреса за приватност. IRK му помага на CAPod да го препознае вашиот уред. Потребен ви е еднократен пристап до MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Клуч за шифрирање</string>
-    <string name="profiles_maindevice_encryptionkey_description">Клучот за шифрирање на вашиот уред, кој му овозможува на CAPod да добие детални информации за статусот.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods испраќаат порака за статус, дел од која е шифрирана. Клучот за шифрирање му овозможува на CAPod да ја дешифрира целата порака. Потребен ви е еднократен пристап до MacBook.</string>
     <string name="profiles_key_invalid_format">Невалиден формат на клуч</string>
     <string name="profiles_key_expected_format">Очекуван формат: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Имате незачувани промени. Што сакате да направите?</string>
     <string name="general_save_and_exit_action">Зачувај &amp; Излези</string>
     <string name="general_discard_action">Отфрли</string>
-    <string name="general_keep_editing_action">Продолжи со уредување</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Снимањето е прекусо</string>
     <string name="debug_debuglog_short_recording_message">Дневникот за дијагностика треба да го забележи проблемот додека се случува. Продолжете со снимање, репродуцирајте го проблемот, па стопирајте го снимањето.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Поставки на уредот</string>
     <string name="device_settings_subtitle_profile_prefix">Профил: %s</string>
-    <string name="device_settings_info_name_label">Име</string>
     <string name="device_settings_info_bt_name_label">Назив на Блуетут уред</string>
     <string name="device_settings_info_model_label">Модел</string>
     <string name="device_settings_info_manufacturer_label">Производител</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Можеби подоцна</string>
     <string name="review_app_body">Дали сакаш да оставиш рецензија за CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Генерално</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
     <string name="device_settings_microphone_mode_description">Кој слушалец се користи како микрофон</string>
     <string name="device_settings_microphone_mode_auto">Автоматски</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">പങ്കിടുക</string>
     <string name="general_done_action">ചെയ്തു</string>
     <string name="general_cancel_action">റദ്ദാക്കുക</string>
-    <string name="general_copy_action">പകർത്തുക</string>
     <string name="general_thank_you_label">നന്ദി</string>
     <string name="general_upgrade_action">അപ്‌ഗ്രേഡ് ചെയ്യുക</string>
     <string name="general_retry_action">വീണ്ടും ശ്രമിക്കുക</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">പരിശോധിക്കുക</string>
     <string name="general_close_action">അടയ്ക്കുക</string>
     <string name="general_dismiss_action">തള്ളിക്കളയുക</string>
-    <string name="general_edit_action">തിരുത്തുക</string>
     <string name="general_save_action">സേവ് ചെയ്യുക</string>
     <string name="general_guide_action">വഴികാട്ടി</string>
     <string name="general_continue_action">തുടരുക</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">പോഡ്‌സ് വീണ്ടും ധരിക്കുമ്പോൾ സംഗീതം പുനരാരംഭിക്കും, എന്നാൽ ഓട്ടോ പോസ് നിർത്തിയ ഘട്ടത്തിൽ മാത്രം. നിങ്ങൾ സ്വയം ചെയ്ത പോസുകൾ (ഫോൺ, AirPods സ്റ്റെം, ഉറക്കം) പോസ് ആയി തുടരും.</string>
     <string name="settings_start_music_on_wear_label">ധരിക്കുമ്പോൾ സംഗീതം ആരംഭിക്കുക</string>
     <string name="settings_start_music_on_wear_description">പോഡ്‌സ് ഇടുമ്പോൾ സംഗീതം പ്ലേ ചെയ്യാൻ എപ്പോഴും ശ്രമിക്കും, ഒരു മാനുവൽ പോസിന് ശേഷം പോലും.</string>
-    <string name="settings_eardetection_info_label">ഇയർ ഡിറ്റക്ഷൻ കുറിപ്പ്</string>
     <string name="settings_eardetection_info_description">ഇയർ ഡിറ്റക്ഷൻ ഒരു പോഡിന് മാത്രമേ പ്രവർത്തിക്കുകയുള്ളൂവെങ്കിൽ, ഇത് Apple-ന്റെ പരിമിതിയാണ്. \"പ്രൈമറി പോഡ്\" (മൈക്രോഫോണിനായി ഉപയോഗിക്കുന്നത്) മാത്രമേ കണ്ടെത്തുകയുള്ളൂ. Apple ഉപകരണങ്ങളിൽ ക്രമീകരിക്കുക: ക്രമീകരണങ്ങൾ → Bluetooth → AirPods → മൈക്രോഫോൺ.</string>
-    <string name="settings_signal_minimum_label">കുറഞ്ഞ സിഗ്നൽ നിലവാരം</string>
-    <string name="settings_signal_minimum_description">ഒരു ഉപകരണം നിങ്ങളുടേതാണെന്ന് കണക്കാക്കാൻ ആവശ്യമായ ഏറ്റവും കുറഞ്ഞ സിഗ്നൽ നിലവാരം.</string>
     <string name="settings_autoconnect_label">യാന്ത്രികമായി കണക്റ്റുചെയ്യുക</string>
     <string name="settings_autoconnect_description">Android സ്വയമേവ കണക്റ്റ് ചെയ്യുന്നില്ലെങ്കിൽ, നമുക്ക് അത് ചെയ്യാൻ ആവശ്യപ്പെടാം. ഇത് CAPod-നെ എപ്പോഴും പശ്ചാത്തലത്തിൽ നിരീക്ഷിച്ചുകൊണ്ടിരിക്കാൻ സഹായിക്കുന്നു.</string>
     <string name="settings_autoconnect_info_android12">Android 12-ഉം അതിനു ശേഷമുള്ള പതിപ്പുകളും നിയന്ത്രിക്കുന്ന ഒരു സിസ്റ്റം സവിശേഷതയെ ആശ്രയിക്കുന്നതിനാൽ ഓട്ടോ കണക്ട് പ്രവർത്തിക്കണമെന്നില്ല. ഇത് നിങ്ങളുടെ ഡിവൈസിൽ പ്രവർത്തിക്കാതിരിക്കാം.</string>
     <string name="settings_autoconnect_condition_label">യാന്ത്രിക കണക്ഷൻ വ്യവസ്ഥ</string>
-    <string name="settings_autoconnect_condition_description">എപ്പോഴാണ് ഞങ്ങൾ നിങ്ങളുടെ ഉപകരണത്തിലേക്ക് കണക്റ്റുചെയ്യാൻ ശ്രമിക്കേണ്ടത്?</string>
     <string name="settings_devices_label">ഉപകരണങ്ങൾ</string>
     <string name="settings_devices_description">നിങ്ങളുടെ ഉപകരണങ്ങൾ നിയന്ത്രിക്കുക.</string>
     <string name="settings_reaction_label">പ്രতিকകരണങ്ങൾ</string>
-    <string name="settings_category_yourdevice_label">നിങ്ങളുടെ ഉപകരണം</string>
     <string name="settings_category_compatibility_options_title">അനുയോജ്യത ഓപ്ഷനുകൾ</string>
     <string name="settings_category_compatibility_options_description">എല്ലാം ശരിയായി പ്രവർത്തിക്കുന്നുണ്ടെങ്കിൽ തൊടരുത് ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ഹാർഡ്‌വെയർ ഫിൽട്ടറിംഗ് പ്രവർത്തനരഹിതമാക്കുക</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">ആരംഭിച്ചിരിക്കുന്നു…</string>
     <string name="support_debuglog_label">ഡീബഗ് ലോഗ്</string>
     <string name="support_debuglog_desc">ആപ്പ് ചെയ്യുന്നതെല്ലാം നിങ്ങൾക്ക് പങ്കിടാൻ കഴിയുന്ന ഒരു ടെക്സ്റ്റ് ഫയലിൽ റെക്കോർഡ് ചെയ്യുക.</string>
-    <string name="debug_debuglog_size_label">വലുപ്പം</string>
-    <string name="debug_debuglog_size_compressed_label">കംപ്രസ് ചെയ്ത വലുപ്പം</string>
-    <string name="debug_notification_channel_label">ഡീബഗ് അറിയിപ്പുകൾ</string>
-    <string name="debug_debuglog_file_label">റെക്കോർഡ് ചെയ്ത ലോഗ് ഫയൽ</string>
-    <string name="debug_debuglog_recording_progress">ഡീബഗ് ലോഗ് റെക്കോർഡ് ചെയ്യുന്നു</string>
     <string name="debug_debuglog_record_action">ഡീബഗ് ലോഗ് റെക്കോർഡ് ചെയ്യുക</string>
     <string name="debug_debuglog_stop_action">റെക്കോർഡിംഗ് നിർത്തുക</string>
     <string name="debug_debuglog_sensitive_information_message">സൃഷ്ടിച്ച ഫയലിൽ സെൻസിറ്റീവ് വിവരങ്ങൾ അടങ്ങിയിരിക്കുന്നു (ഉദാ. ബ്ലൂടൂത്ത് ഉപകരണ വിശദാംശങ്ങൾ). വിശ്വസ്തരായ കക്ഷികളുമായി മാത്രം ഇത് പങ്കിടുക.</string>
     <string name="settings_debuglog_explanation">ഈ സവിശേഷത ആപ്പ് ചെയ്യുന്നതെല്ലാം പങ്കിടാവുന്ന ഒരു ഫയലിൽ റെക്കോർഡ് ചെയ്യുന്നു. സൃഷ്ടിച്ച ഫയലിൽ സെൻസിറ്റീവ് വിവരങ്ങൾ അടങ്ങിയിരിക്കുന്നു (ഉദാ. ബ്ലൂടൂത്ത് ഉപകരണ വിശദാംശങ്ങൾ). വിശ്വസ്തരായ കക്ഷികളുമായി മാത്രം ഇത് പങ്കിടുക (ഉദാ. ഒരു പ്രശ്നം പരിഹരിക്കുന്ന ഒരു ഡെവലപ്പർ).</string>
-    <string name="settings_support_installid_label">ഇൻസ്റ്റാൾ ഐഡി</string>
-    <string name="settings_support_installid_desc">യാന്ത്രിക പിശക് റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. ഡെവലപ്പർക്ക് നിങ്ങളുടെ പിശക് റിപ്പോർട്ടുകൾ കണ്ടെത്തണമെങ്കിൽ നിങ്ങളുടെ ഇൻസ്റ്റാൾ ഐഡി പങ്കിടുക.</string>
     <string name="settings_support_label">പിന്തുണ</string>
     <string name="settings_support_description">നിങ്ങൾക്ക് എന്തെങ്കിലും സഹായം ആവശ്യമുണ്ടെങ്കിൽ.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">പഠിപ്പിച്ച ഡാറ്റ പുനരാരംഭിക്കണോ?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ഈ ഉപകരണത്തിന്റെ അളന്ന നഷ്ടം, ചാർജിംഗ് വേഗത, കേൾവി സമയം എന്നിവ മറന്ന് നിർദ്ദിഷ്ട ബാറ്ററി കാലാവധിയിൽ നിന്ന് വീണ്ടും ആരംഭിക്കും</string>
     <string name="settings_acknowledgements_label">അംഗീകാരങ്ങൾ</string>
-    <string name="settings_debug_autoreports_label">യാന്ത്രിക ബഗ് റിപ്പോർട്ടുകൾ</string>
-    <string name="settings_debug_autoreports_description">പ്രശ്നങ്ങൾ യാന്ത്രികമായി റിപ്പോർട്ട് ചെയ്യുന്നു, ഉദാ. ആപ്പ് ക്രാഷിനെക്കുറിച്ചുള്ള വിശദാംശങ്ങൾ, അതുവഴി എനിക്കത് എങ്ങനെ പരിഹരിക്കാമെന്ന് കണ്ടെത്താനാകും.</string>
-    <string name="settings_compatibility_mode_label">അനുയോജ്യത മോഡ്</string>
-    <string name="settings_compatibility_mode_description">അനുയോജ്യത മെച്ചപ്പെടുത്താൻ ഒപ്റ്റിമൈസേഷനുകൾ പ്രവർത്തനരഹിതമാക്കുക. നിങ്ങൾക്ക് ഡാറ്റയൊന്നും കാണുന്നില്ലെങ്കിൽ ഇത് പരീക്ഷിക്കുക.</string>
     <string name="help_translate_label">പരിഭാഷ</string>
     <string name="help_translate_description">ഈ ആപ്പ് നിങ്ങളുടെ പ്രിയപ്പെട്ട ഭാഷയിലേക്ക് വിവർത്തനം ചെയ്യാൻ സഹായിക്കുക.</string>
     <string name="translators_thanks_title">പരിഭാഷകർ</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">വിജയം</string>
     <string name="troubleshooter_ble_result_success_body">BLE പരസ്യ പ്രക്ഷേപണങ്ങൾ CAPod സ്വീകരിക്കുന്നു.</string>
     <string name="troubleshooter_ble_result_failure_title">പരാജയപ്പെട്ടു</string>
-    <string name="troubleshooter_ble_result_failure_body">ട്രബിൾഷൂട്ടിംഗ് പരാജയപ്പെട്ടു. അനുയോജ്യത ഓപ്ഷനുകളുടെ ഒരു കോമ്പിനേഷനും സഹായിച്ചില്ല.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">നിങ്ങളുടെ ഫോണിന് BLE ഡാറ്റയൊന്നും ലഭിച്ചില്ല. ഡാറ്റാ ഉറവിടങ്ങൾ (നിങ്ങളുടെ ഹെഡ്‌ഫോണുകൾ ഒഴികെ) സ്വീകരിക്കാൻ കഴിയുമോ എന്നറിയാൻ തിരക്കേറിയ സ്ഥലത്ത് നിങ്ങൾക്ക് ഈ ടെസ്റ്റ് വീണ്ടും ശ്രമിക്കാം. ഡാറ്റയൊന്നും ലഭിക്കാത്തത് നിങ്ങളുടെ ഫോണിന്റെ ഓപ്പറേറ്റിംഗ് സിസ്റ്റത്തിലെ ഒരു പ്രശ്നത്തെ സൂചിപ്പിക്കുന്നു.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">നിങ്ങളുടെ ഫോണിന് BLE ഡാറ്റ ലഭിച്ചു, പക്ഷേ ഡാറ്റ ഏതെങ്കിലും പിന്തുണയ്ക്കുന്ന ഉപകരണത്തിൽ നിന്നല്ല വരുന്നത്. നിങ്ങളുടെ ഹെഡ്‌ഫോണുകൾ ഓണാണോ? CAPod നിങ്ങളുടെ ഹെഡ്‌ഫോണുകളെ പിന്തുണയ്ക്കുന്നുണ്ടോ?</string>
-    <string name="troubleshooter_ble_result_failure_action">വീണ്ടും ശ്രമിക്കുക</string>
-    <string name="troubleshoot_action">ട്രബിൾഷൂട്ട് ചെയ്യുക</string>
     <string name="onboarding_body1">ഈ ആപ്പ് Android-ലേക്ക് AirPod-നിർദ്ദിഷ്ട സവിശേഷതകൾക്കുള്ള പിന്തുണ ചേർക്കുന്നു.</string>
     <string name="onboarding_body2">എല്ലാ Android ഉപകരണങ്ങളും അധിക AirPod സവിശേഷതകളെ പൂർണ്ണമായി പിന്തുണയ്ക്കുന്നില്ല. നിങ്ങളുടെ ഓപ്പറേറ്റിംഗ് സിസ്റ്റത്തിന് ശരിയായി പ്രവർത്തിക്കുന്ന ബ്ലൂടൂത്ത്-ലോ-എനർജി നടപ്പിലാക്കൽ ആവശ്യമാണ്.</string>
     <string name="onboarding_body3">CAPod-ൽ പരസ്യങ്ങളൊന്നുമില്ല, അത് നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കുന്നില്ല.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">നിങ്ങളുടെ ഉപകരണം കണക്‌റ്റ് ചെയ്‌തിരിക്കുന്നു, എന്നാൽ CAPod അതിൽ നിന്ന് തത്സമയ ഡേറ്റ സ്വീകരിക്കുന്നില്ല. നിങ്ങളുടെ ഫോണിന് ഒരു അനുയോജ്യതാ ഓപ്‌ഷൻ ആവശ്യമായി വന്നേക്കാം — ട്രബിൾഷൂട്ടറിന് ഒന്ന് സ്വയംചാലകമായി കണ്ടെത്താൻ ശ്രമിക്കാനാകും.</string>
     <string name="overview_troubleshoot_suggestion_action">ട്രബിൾഷൂട്ടർ പ്രവർത്തിപ്പിക്കുക</string>
     <string name="overview_unmatched_devices_label">പൊരുത്തമില്ലാത്ത ഉപകരണങ്ങൾ</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">പൊരുത്തമുള്ള പ്രൊഫൈൽ ഇല്ലാത്ത %d ഉപകരണം</item>
-        <item quantity="other">പൊരുത്തമുള്ള പ്രൊഫൈൽ ഇല്ലാത്ത %d ഉപകരണങ്ങൾ</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">പൊരുത്തപ്പെടുന്ന പ്രൊഫൈൽ ഇല്ലാത്ത %d സമീപത്തുള്ള ഉപകരണം കണ്ടെത്തി. ലഭ്യമായ വിശദാംശങ്ങൾക്കായി അത് കാണിക്കുക. അത് നിങ്ങളുടേതാണെങ്കിൽ, തിരിച്ചറിയാൻ ഉപകരണങ്ങളിൽ നിന്ന് ഒരു പ്രൊഫൈൽ ചേർക്കുക.</item>
         <item quantity="other">പൊരുത്തപ്പെടുന്ന പ്രൊഫൈലുകൾ ഇല്ലാതെ %d സമീപത്തുള്ള ഉപകരണങ്ങൾ കണ്ടെത്തി. ലഭ്യമായ വിശദാംശങ്ങൾക്കായി അവ കാണിക്കുക. അവയിലൊന്ന് നിങ്ങളുടേതാണെങ്കിൽ, തിരിച്ചറിയാൻ ഉപകരണങ്ങളിൽ നിന്ന് ഒരു പ്രൊഫൈൽ ചേർക്കുക.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">ആപ്പ് അടച്ചിരിക്കുമ്പോൾ \"പോപ്പ്അപ്പ് കാണിക്കുക\", \"യാന്ത്രികമായി കണക്റ്റുചെയ്യുക\" എന്നിവ പോലുള്ള സവിശേഷതകൾ പ്രവർത്തനക്ഷമമാക്കാൻ CAPod \"പശ്ചാത്തല ലൊക്കേഷൻ ആക്സസ്\" ഉപയോഗിക്കുന്നു. പശ്ചാത്തലത്തിൽ ബ്ലൂടൂത്ത് ലോ എനർജി ഡാറ്റ സ്വീകരിക്കാൻ ആപ്പിനെ അനുവദിക്കുന്നു. ഈ ആപ്പ് നിങ്ങളുടെ ലൊക്കേഷൻ നിർണ്ണയിക്കാൻ ബ്ലൂടൂത്ത് ഡാറ്റ ഉപയോഗിക്കില്ല.</string>
     <string name="permission_ignore_battery_optimizations_label">ബാറ്ററി ഒപ്റ്റിമൈസേഷനുകൾ പ്രവർത്തനരഹിതമാക്കുക</string>
     <string name="permission_ignore_battery_optimizations_description">ബാറ്ററി ഒപ്റ്റിമൈസേഷനുകൾ ആപ്പ് പശ്ചാത്തലത്തിലായിരിക്കുമ്പോൾ ബ്ലൂടൂത്ത് ഡാറ്റ വിശ്വസനീയമായി സ്വീകരിക്കുന്നത് തടയുന്നു.</string>
-    <string name="permission_required_title">ഇനിപ്പറയുന്ന അനുമതി ആവശ്യമാണ്:</string>
     <string name="permission_system_alert_window_label">സിസ്റ്റം അലേർട്ട് വിൻഡോ</string>
     <string name="permission_system_alert_window_description">\"പോപ്പ്അപ്പ് കാണിക്കുക\" സവിശേഷത സാധ്യമാക്കാൻ മറ്റ് ആപ്പുകളുടെ മുകളിൽ വരയ്ക്കാൻ CAPod-നെ അനുവദിക്കുക.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">കാണുമ്പോൾ</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">ചെവിയിൽ</string>
     <string name="pods_dual_left_label">ഇടത് പോഡ്</string>
     <string name="pods_dual_right_label">വലത് പോഡ്</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">കേസ്</string>
     <string name="battery_unavailable_label">ബാറ്ററി ലഭ്യമല്ല</string>
     <string name="battery_state_low_cd">ബാറ്ററി കുറവാണ്</string>
     <string name="battery_state_critical_cd">ബാറ്ററി ഗുരുതരമായി കുറവാണ്</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">നേരിട്ടുള്ള കണക്ഷൻ സജീവമാണ്</string>
     <string name="signal_indicator_bars_cd">സിഗ്നൽ ശക്തി: 4-ൽ %1$d ബാർ</string>
     <string name="signal_indicator_disconnected_cd">സിഗ്നൽ: വിച്ഛേദിക്കപ്പെട്ടു</string>
-    <string name="pods_yours">നിങ്ങളുടേത്</string>
     <string name="headset_being_worn_label">ധരിച്ചിരിക്കുന്നു</string>
     <string name="headset_not_being_worn_label">ധരിച്ചിട്ടില്ല</string>
     <string name="pods_case_unknown_state">അജ്ഞാത നില</string>
-    <string name="last_seen_x">അവസാനം കണ്ടത്: %s</string>
-    <string name="first_seen_x">ആദ്യം കണ്ടത്: %s</string>
     <string name="battery_cached_label">അവസാനമായി അറിയപ്പെടുന്നത് · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dമ %2$dമി</string>
     <string name="battery_time_remaining_format_h">%1$dമ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">കുറഞ്ഞ സിഗ്നൽ നിലവാരം</string>
     <string name="profiles_signal_quality_description">ഈ പരിധിക്ക് മുകളിലുള്ള സിഗ്നൽ ശക്തിയുള്ള ഉപകരണങ്ങൾ മാത്രം കണ്ടെത്തുക. കുറഞ്ഞ മൂല്യങ്ങൾ കണ്ടെത്തൽ ശ്രേണി വർദ്ധിപ്പിക്കുന്നു, പക്ഷേ തെറ്റായ പോസിറ്റീവുകൾ ഉണ്ടാക്കിയേക്കാം. ഇത് വളരെ ഉയർന്നതായി സജ്ജമാക്കരുത് - ബ്ലൂടൂത്ത് റിസപ്ഷൻ സാധാരണയായി മോശമാണ്, ദൂരത്തിനും തടസ്സങ്ങൾക്കും അനുസരിച്ച് വ്യത്യാസപ്പെടുന്നു.</string>
     <string name="profiles_identitykey_label">ഐഡന്റിറ്റി കീ</string>
-    <string name="profilessettings_maindevice_identitykey_description">നിങ്ങളുടെ ഉപകരണത്തിന്റെ ഐഡന്റിറ്റി റിസോൾവിംഗ് കീ (IRK), ഇത് സമീപത്തുള്ള ഉപകരണങ്ങൾക്കിടയിൽ CAPod-നെ തിരിച്ചറിയാൻ സഹായിക്കുന്നു.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods സ്വകാര്യതയ്ക്കായി അവയുടെ ബ്ലൂടൂത്ത് വിലാസം ഇടയ്ക്കിടെ മാറ്റുന്നു. IRK നിങ്ങളുടെ ഉപകരണം തിരിച്ചറിയാൻ CAPod-നെ സഹായിക്കുന്നു. നിങ്ങൾക്ക് ഒരു MacBook-ലേക്ക് ഒറ്റത്തവണ ആക്സസ് ആവശ്യമാണ്.</string>
     <string name="profiles_maindevice_encryptionkey_label">എൻക്രിപ്ഷൻ കീ</string>
-    <string name="profiles_maindevice_encryptionkey_description">നിങ്ങളുടെ ഉപകരണത്തിന്റെ എൻക്രിപ്ഷൻ കീ, ഇത് CAPod-നെ വിശദമായ നില വിവരങ്ങൾ വീണ്ടെടുക്കാൻ അനുവദിക്കുന്നു.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ഒരു സ്റ്റാറ്റസ് സന്ദേശം അയയ്ക്കുന്നു, അതിന്റെ ഒരു ഭാഗം എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നു. എൻക്രിപ്ഷൻ കീ CAPod-നെ മുഴുവൻ സന്ദേശവും ഡീക്രിപ്റ്റ് ചെയ്യാൻ അനുവദിക്കുന്നു. നിങ്ങൾക്ക് ഒരു MacBook-ലേക്ക് ഒറ്റത്തവണ ആക്സസ് ആവശ്യമാണ്.</string>
     <string name="profiles_key_invalid_format">അസാധുവായ കീ ഫോർമാറ്റ്</string>
     <string name="profiles_key_expected_format">പ്രതീക്ഷിക്കുന്ന ഫോർമാറ്റ്: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">നിങ്ങൾക്ക് സേവ് ചെയ്യാത്ത മാറ്റങ്ങളുണ്ട്. നിങ്ങൾ എന്ത് ചെയ്യാൻ ആഗ്രഹിക്കുന്നു?</string>
     <string name="general_save_and_exit_action">സേവ് ചെയ്ത് പുറത്തുകടക്കുക</string>
     <string name="general_discard_action">ഉപേക്ഷിക്കുക</string>
-    <string name="general_keep_editing_action">എഡിറ്റിംഗ് തുടരുക</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">റെക്കോർഡിംഗ് വളരെ ചെറുത്</string>
     <string name="debug_debuglog_short_recording_message">ഒരു ഡീബഗ് ലോഗ് പ്രശ്നം നടക്കുമ്പോൾ അത് പകർത്തണം. റെക്കോർഡ് ചെയ്തുകൊണ്ടേ ഇരിക്കൂ, പ്രശ്നം പുനඃസൃഷ്ടിക്കൂ, പിന്നെ റെക്കോർഡിംഗ് നിർത്തൂ.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ഉപകരണ ക്രമീകരണങ്ങൾ</string>
     <string name="device_settings_subtitle_profile_prefix">പ്രൊഫൈൽ: %s</string>
-    <string name="device_settings_info_name_label">പേര്</string>
     <string name="device_settings_info_bt_name_label">ബ്ലൂടൂത്ത് ഡിവൈസ് ലേബൽ</string>
     <string name="device_settings_info_model_label">മോഡൽ</string>
     <string name="device_settings_info_manufacturer_label">നിർമ്മാതാവ്</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">പിന്നീട്</string>
     <string name="review_app_body">CAPod-നെക്കുറിച്ച് നിങ്ങൾ ഒരു റിവ്യൂ നൽകാൻ ആഗ്രഹിക്കുന്നുണ്ടോ? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">പൊതുവായ</string>
     <string name="device_settings_microphone_mode_label">മൈക്രോഫോൺ</string>
     <string name="device_settings_microphone_mode_description">ഏത് ഇയർബഡ് മൈക്രോഫോണായി ഉപയോഗിക്കുന്നു</string>
     <string name="device_settings_microphone_mode_auto">ഓട്ടോ</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Хуваалцах</string>
     <string name="general_done_action">Болсон</string>
     <string name="general_cancel_action">Цуцлах</string>
-    <string name="general_copy_action">Хуулах</string>
     <string name="general_thank_you_label">Баярлалаа</string>
     <string name="general_upgrade_action">Шинэчлэх</string>
     <string name="general_retry_action">Дахин оролдох</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Шалгах</string>
     <string name="general_close_action">Хаах</string>
     <string name="general_dismiss_action">Хаах</string>
-    <string name="general_edit_action">Засах</string>
     <string name="general_save_action">Хадгалах</string>
     <string name="general_guide_action">Удирдамж</string>
     <string name="general_continue_action">Үргэлжлүүлэх</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Pods-аа дахин зүүх үед хөгжмийг үргэлжлүүлнэ, гэхдээ зөвхөн Автомат түр зогсоолт зогсоосон тохиолдолд. Өөрөө идэвхжүүлсэн түр зогсоолтууд (утас, AirPods иш, унтах горим) түр зогсоолтоор үлдэнэ.</string>
     <string name="settings_start_music_on_wear_label">Зүүх үед хөгжим эхлүүлэх</string>
     <string name="settings_start_music_on_wear_description">Pods-аа зүүх үед хөгжмийг тоглуулахыг үргэлж оролдоно, гар аргаар түр зогсоосны дараа ч гэсэн.</string>
-    <string name="settings_eardetection_info_label">Чих илрүүлэлтийн тэмдэглэл</string>
     <string name="settings_eardetection_info_description">Хэрэв чих илрүүлэлт зөвхөн нэг чихэвчинд ажиллаж байвал энэ нь Apple-ийн хязгаарлалт юм. Зөвхөн \"үндсэн чихэвч\" (микрофонд ашигладаг) илрүүлэгдэнэ. Apple төхөөрөмжүүд дээр тохируулах: Тохиргоо → Bluetooth → AirPods → Микрофон.</string>
-    <string name="settings_signal_minimum_label">Дохионы хамгийн бага чанар</string>
-    <string name="settings_signal_minimum_description">Төхөөрөмж таных гэж тооцогдохын тулд байх ёстой дохионы хамгийн бага чанар.</string>
     <string name="settings_autoconnect_label">Автомат холболт</string>
     <string name="settings_autoconnect_description">Хэрэв Android автоматаар холбогдохгүй бол бид үүнийг хийхийг хүсэлт болгож болно. Энэ нь CAPod-ыг үргэлж дэвсгэр горимд ажиллуулж, хянан ажиллуулна.</string>
     <string name="settings_autoconnect_info_android12">Автомат холболт нь Android 12 болон түүнээс хойшхи хувилбарт хязгаарлагдсан системийн функцэд тулгуурладаг. Таны төхөөрөмж дээр ажиллахгүй байж болзошгүй.</string>
     <string name="settings_autoconnect_condition_label">Автомат холболтын нөхцөл</string>
-    <string name="settings_autoconnect_condition_description">Бид таны төхөөрөмжид хэзээ холбогдохыг оролдох ёстой вэ?</string>
     <string name="settings_devices_label">Төхөөрөмжүүд</string>
     <string name="settings_devices_description">Төхөөрөмжүүдээ удирдах.</string>
     <string name="settings_reaction_label">Урвалууд</string>
-    <string name="settings_category_yourdevice_label">Таны төхөөрөмж</string>
     <string name="settings_category_compatibility_options_title">Тохиромжтой байдлын сонголтууд</string>
     <string name="settings_category_compatibility_options_description">Хэрэв бүх зүйл ажиллаж байвал бүү хүр ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Техник хангамжийн шүүлтүүрийг идэвхгүй болгох</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Эхлүүлж байна…</string>
     <string name="support_debuglog_label">Дибаг лог</string>
     <string name="support_debuglog_desc">Апп-н хийж буй бүх зүйлийг хуваалцаж болох текст файлд бүртгэнэ.</string>
-    <string name="debug_debuglog_size_label">Хэмжээ</string>
-    <string name="debug_debuglog_size_compressed_label">Шахсан хэмжээ</string>
-    <string name="debug_notification_channel_label">Дибаг мэдэгдэл</string>
-    <string name="debug_debuglog_file_label">Бүртгэгдсэн лог файл</string>
-    <string name="debug_debuglog_recording_progress">Дибаг лог бүртгэж байна</string>
     <string name="debug_debuglog_record_action">Дибаг лог бүртгэх</string>
     <string name="debug_debuglog_stop_action">Бүртгэлийг зогсоох</string>
     <string name="debug_debuglog_sensitive_information_message">Үүсгэсэн файл нь нууц мэдээлэл агуулсан (жишээ нь, Bluetooth төхөөрөмжийн дэлгэрэнгүй мэдээлэл). Зөвхөн итгэмжлэгдсэн этгээдүүдтэй хуваалцана уу.</string>
     <string name="settings_debuglog_explanation">Энэ функц нь апп-н хийж буй бүх зүйлийг хуваалцаж болох файлд бүртгэдэг. Үүсгэсэн файл нь нууц мэдээлэл агуулсан (жишээ нь, Bluetooth төхөөрөмжийн дэлгэрэнгүй мэдээлэл). Зөвхөн итгэмжлэгдсэн этгээдүүдтэй (жишээ нь, асуудлыг шийдвэрлэж буй хөгжүүлэгчтэй) хуваалцана уу.</string>
-    <string name="settings_support_installid_label">Суулгалтын ID</string>
-    <string name="settings_support_installid_desc">Автомат алдааны тайлангууд нэргүй байна. Хэрэв хөгжүүлэгчид таны алдааны тайланг олох шаардлагатай бол суулгалтын ID-гаа хуваалцана уу.</string>
     <string name="settings_support_label">Дэмжлэг</string>
     <string name="settings_support_description">Хэрэв танд тусламж хэрэгтэй бол.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Сурсан өгөгдлийг сэргээх үү?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod энэ төхөөрөмжийн хэмжсэн цэнэг ашигалт, цэнэглэх хурд болон сонсох цагийг мартаж, үнэлгээтэй батерейны хугацаанаас эхлүүлэх болно.</string>
     <string name="settings_acknowledgements_label">Талархал</string>
-    <string name="settings_debug_autoreports_label">Автомат алдааны тайлан</string>
-    <string name="settings_debug_autoreports_description">Апп-н ослын дэлгэрэнгүй мэдээлэл гэх мэт асуудлуудыг автоматаар мэдээлдэг бөгөөд ингэснээр би түүнийг хэрхэн засахаа олж мэдэх боломжтой.</string>
-    <string name="settings_compatibility_mode_label">Тохиромжтой байдлын горим</string>
-    <string name="settings_compatibility_mode_description">Тохиромжтой байдлыг сайжруулахын тулд оновчлолыг идэвхгүй болгоно. Хэрэв та ямар ч өгөгдөл харахгүй байвал үүнийг туршиж үзнэ үү.</string>
     <string name="help_translate_label">Орчуулга</string>
     <string name="help_translate_description">Энэ апп-г дуртай хэл рүүгээ орчуулахад тусална уу.</string>
     <string name="translators_thanks_title">Орчуулагчид</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Амжилттай</string>
     <string name="troubleshooter_ble_result_success_body">CAPod нь BLE зар сурталчилгааны нэвтрүүлгийг хүлээн авч байна.</string>
     <string name="troubleshooter_ble_result_failure_title">Амжилтгүй</string>
-    <string name="troubleshooter_ble_result_failure_body">Асуудал шийдвэрлэхэд алдаа гарлаа. Тохиромжтой байдлын сонголтуудын аль ч хослол тус болсонгүй.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Таны утас ямар ч BLE өгөгдөл хүлээн авсангүй. Та энэ тестийг хүн ихтэй газар дахин оролдож үзээд өгөгдлийн эх үүсвэрүүдийг (чихэвчнээс бусад) хүлээн авах боломжтой эсэхийг шалгаж болно. Ямар ч өгөгдөл хүлээн аваагүй бол таны утасны үйлдлийн системд асуудал байгааг илтгэнэ.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Таны утас BLE өгөгдөл хүлээн авсан боловч өгөгдөл нь дэмжигдсэн ямар ч төхөөрөмжөөс ирээгүй байна. Таны чихэвч асаалттай байна уу? CAPod таны чихэвчийг дэмждэг үү?</string>
-    <string name="troubleshooter_ble_result_failure_action">Дахин оролдоно уу</string>
-    <string name="troubleshoot_action">Асуудлыг шийдвэрлэх</string>
     <string name="onboarding_body1">Энэхүү аппликейшн нь Android-д AirPod-н тусгай функцуудыг дэмждэг.</string>
     <string name="onboarding_body2">Бүх Android төхөөрөмж AirPod-н нэмэлт функцуудыг бүрэн дэмждэггүй. Таны үйлдлийн системд зөв ажилладаг Bluetooth-Low-Energy-н хэрэгжилт шаардлагатай.</string>
     <string name="onboarding_body3">CAPod-д зар сурталчилгаа байхгүй бөгөөд таны өгөгдлийг цуглуулдаггүй.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Таны төхөөрөмж холбогдсон боловч CAPod түүнээс шууд өгөгдөл хүлээж авахгүй байна. Утас таны нийцтэй байдлын тохиргоо шаардаж болзошгүй — асуудал шийдвэрлэгч автоматаар нэгийг хайж олохыг оролдож чадна.</string>
     <string name="overview_troubleshoot_suggestion_action">Асуудал шийдвэрлэгчийг ажиллуулах</string>
     <string name="overview_unmatched_devices_label">Тохирохгүй төхөөрөмжүүд</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">Тохирох профайлгүй %d төхөөрөмж</item>
-        <item quantity="other">Тохирох профайлгүй %d төхөөрөмж</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d ойролцоох төхөөрөмж тохирох профильгүйгээр илэрлээ. Дэлгэрэнгүй мэдээллийг үзэхийн тулд үзүүлнэ үү. Хэрэв энэ нь тань бол таних боломжтой болгохын тулд Төхөөрөмж хэсгээс профиль нэмнэ үү.</item>
         <item quantity="other">%d ойролцоох төхөөрөмж тохирох профильгүйгээр илэрлээ. Дэлгэрэнгүй мэдээллийг үзэхийн тулд тэдгээрийг үзүүлнэ үү. Хэрэв аль нэг нь тань бол таних боломжтой болгохын тулд Төхөөрөмж хэсгээс профиль нэмнэ үү.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod нь апп хаалттай үед \"Попап харуулах\" болон \"Автомат холболт\" гэх мэт боломжуудыг идэвхжүүлэхийн тулд \"цаана байршилд хандах\" эрхийг ашигладаг. Цаана байршилд хандах нь апп-д цаана ажиллаж байх үед Bluetooth Low Energy өгөгдлийг хүлээн авах боломжийг олгоно. Энэ апп таны байршлыг тодорхойлохын тулд Bluetooth өгөгдлийг АШИГЛАХГҮЙ.</string>
     <string name="permission_ignore_battery_optimizations_label">Батарейн оновчлолыг идэвхгүй болгох</string>
     <string name="permission_ignore_battery_optimizations_description">Батарейн оновчлол нь апп-д цаана ажиллаж байх үед Bluetooth өгөгдлийг найдвартай хүлээн авахад саад болдог.</string>
-    <string name="permission_required_title">Дараах зөвшөөрөл шаардлагатай:</string>
     <string name="permission_system_alert_window_label">Системийн анхааруулгын цонх</string>
     <string name="permission_system_alert_window_description">CAPod-д \"Попап харуулах\" боломжийг ажиллуулахын тулд бусад апп-уудын дээр зурах зөвшөөрөл олгоно уу.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Харагдах үед</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Чихэнд</string>
     <string name="pods_dual_left_label">Зүүн чихэвч</string>
     <string name="pods_dual_right_label">Баруун чихэвч</string>
-    <string name="pods_dual_left_short_label">З</string>
-    <string name="pods_dual_right_short_label">Б</string>
-    <string name="pods_case_label">Кейс</string>
     <string name="battery_unavailable_label">Батарей мэдэгдэхгүй байна</string>
     <string name="battery_state_low_cd">Батерей сулбай байна</string>
     <string name="battery_state_critical_cd">Батерей маш сулбай байна</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Шууд холболт идэвхтэй</string>
     <string name="signal_indicator_bars_cd">Дохионы хүч: 4-ийн %1$d бар</string>
     <string name="signal_indicator_disconnected_cd">Дохио: холболт тасарсан</string>
-    <string name="pods_yours">Таных</string>
     <string name="headset_being_worn_label">Зүүсэн</string>
     <string name="headset_not_being_worn_label">Зүүгээгүй</string>
     <string name="pods_case_unknown_state">Тодорхойгүй төлөв</string>
-    <string name="last_seen_x">Сүүлд харагдсан: %s</string>
-    <string name="first_seen_x">Анх харагдсан: %s</string>
     <string name="battery_cached_label">Сүүлд мэдэгдсэн · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dц %2$dм</string>
     <string name="battery_time_remaining_format_h">%1$dц</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Дохионы хамгийн бага чанар</string>
     <string name="profiles_signal_quality_description">Зөвхөн энэ босгоос дээш дохионы хүчтэй төхөөрөмжүүдийг илрүүлнэ. Бага утга нь илрүүлэлтийн хүрээг нэмэгдүүлэх боловч буруу илрүүлэлтэд хүргэж болно. Үүнийг хэт өндөр болгож бүү тохируулаарай - Bluetooth хүлээн авалт ерөнхийдөө сул бөгөөд зай, саадаас хамааран өөрчлөгддөг.</string>
     <string name="profiles_identitykey_label">Таних түлхүүр</string>
-    <string name="profilessettings_maindevice_identitykey_description">Таны төхөөрөмжийн таних түлхүүр (IRK) нь CAPod-д ойролцоох төхөөрөмжүүдийн дундаас таниулахад тусалдаг.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods нь нууцлалын үүднээс Bluetooth хаягаа байнга өөрчилдөг. IRK нь CAPod-д таны төхөөрөмжийг таниулахад тусалдаг. MacBook-д нэг удаа хандах шаардлагатай.</string>
     <string name="profiles_maindevice_encryptionkey_label">Шифрлэлтийн түлхүүр</string>
-    <string name="profiles_maindevice_encryptionkey_description">Таны төхөөрөмжийн шифрлэлтийн түлхүүр нь CAPod-д дэлгэрэнгүй төлөвийн мэдээллийг авах боломжийг олгодог.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods нь төлөвийн мессеж илгээдэг бөгөөд түүний нэг хэсэг нь шифрлэгдсэн байдаг. Шифрлэлтийн түлхүүр нь CAPod-д бүтэн мессежийг тайлах боломжийг олгодог. MacBook-д нэг удаа хандах шаардлагатай.</string>
     <string name="profiles_key_invalid_format">Түлхүүрийн формат буруу</string>
     <string name="profiles_key_expected_format">Хүлээгдэж буй формат: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Танд хадгалаагүй өөрчлөлтүүд байна. Та юу хийхийг хүсэж байна вэ?</string>
     <string name="general_save_and_exit_action">Хадгалаад гарах</string>
     <string name="general_discard_action">Цуцлах</string>
-    <string name="general_keep_editing_action">Засварлах үргэлжлүүлэх</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Бичлэг хэтэрхий богино</string>
     <string name="debug_debuglog_short_recording_message">Дибаг лог нь асуудал гарах үед бичиж авах ёстой. Бичлэгийг үргэлжүүлж, асуудлыг давтан гаргаад, дараа нь бичлэгийг зогсоо.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Төхөөрөмжийн тохиргоо</string>
     <string name="device_settings_subtitle_profile_prefix">Профайл: %s</string>
-    <string name="device_settings_info_name_label">Нэр</string>
     <string name="device_settings_info_bt_name_label">Bluetooth төхөөрөмжийн нэр</string>
     <string name="device_settings_info_model_label">Загвар</string>
     <string name="device_settings_info_manufacturer_label">Үйлдвэрлэгч</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Дараа нь магадгүй</string>
     <string name="review_app_body">CAPod-д үнэлгээ үлдэхийг хүсч байна уу? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Ерөнхий</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
     <string name="device_settings_microphone_mode_description">Микрофон болгон ашиглах чихэвч</string>
     <string name="device_settings_microphone_mode_auto">Автомат</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">शेअर करा</string>
     <string name="general_done_action">झाले</string>
     <string name="general_cancel_action">रद्द करा</string>
-    <string name="general_copy_action">कॉपी करा</string>
     <string name="general_thank_you_label">धन्यवाद</string>
     <string name="general_upgrade_action">अपग्रेड करा</string>
     <string name="general_retry_action">पुन्हा प्रयत्न करा</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">तपासा</string>
     <string name="general_close_action">बंद करा</string>
     <string name="general_dismiss_action">बंद करा</string>
-    <string name="general_edit_action">संपादित करा</string>
     <string name="general_save_action">सेव्ह करा</string>
     <string name="general_guide_action">मार्गदर्शक</string>
     <string name="general_continue_action">सुरू ठेवा</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">तुम्ही पुन्हा पॉड्स घातल्यावर संगीत पुन्हा सुरू करा, परंतु केवळ तेव्हाच जेव्हा Auto pause ने ते थांबवले असेल. तुम्ही स्वतः थांबवलेले (फोन, AirPods stem, झोप) थांबलेलेच राहतात.</string>
     <string name="settings_start_music_on_wear_label">घातल्यावर संगीत सुरू करा</string>
     <string name="settings_start_music_on_wear_description">तुम्ही पॉड्स घातल्यावर नेहमी संगीत वाजवण्याचा प्रयत्न करतो, अगदी मॅन्युअल पॉजनंतरही.</string>
-    <string name="settings_eardetection_info_label">कान ओळख टीप</string>
     <string name="settings_eardetection_info_description">कान ओळख फक्त एका पॉडसाठी काम करत असल्यास, ही Apple ची मर्यादा आहे. फक्त \"प्राथमिक पॉड\" (मायक्रोफोनसाठी वापरला जातो) ओळखला जातो. Apple डिव्हाइसवर कॉन्फिगर करा: सेटिंग्ज → ब्लूटूथ → AirPods → मायक्रोफोन.</string>
-    <string name="settings_signal_minimum_label">किमान सिग्नल गुणवत्ता</string>
-    <string name="settings_signal_minimum_description">डिव्हाइसला आपले मानण्यासाठी आवश्यक असलेली किमान सिग्नल गुणवत्ता.</string>
     <string name="settings_autoconnect_label">ऑटो-कनेक्ट</string>
     <string name="settings_autoconnect_description">Android आपोआप कनेक्ट होत नसल्यास, आपण त्याला तसे करण्यास सांगू शकतो. यामुळे CAPod नेहमी पार्श्वभूमीत मॉनिटर करत राहते.</string>
     <string name="settings_autoconnect_info_android12">ऑटो कनेक्ट एका सिस्टम वैशिष्ट्यावर अवलंबून आहे जे Android 12 आणि नवीन आवृत्त्या प्रतिबंधित करतात. हे तुमच्या डिव्हाइसवर काम करणार नाही.</string>
     <string name="settings_autoconnect_condition_label">ऑटो-कनेक्ट अट</string>
-    <string name="settings_autoconnect_condition_description">आम्ही आपल्या डिव्हाइसशी कधी कनेक्ट करण्याचा प्रयत्न करावा?</string>
     <string name="settings_devices_label">डिव्हाइस</string>
     <string name="settings_devices_description">आपल्या डिव्हाइसचे व्यवस्थापन करा.</string>
     <string name="settings_reaction_label">प्रतिक्रिया</string>
-    <string name="settings_category_yourdevice_label">तुमचे डिव्हाइस</string>
     <string name="settings_category_compatibility_options_title">सुसंगतता पर्याय</string>
     <string name="settings_category_compatibility_options_description">सर्व काही ठीक चालत असल्यास स्पर्श करू नका ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">हार्डवेअर फिल्टरिंग अक्षम करा</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">सुरुवात होत आहे…</string>
     <string name="support_debuglog_label">डीबग लॉग</string>
     <string name="support_debuglog_desc">अॅप करत असलेल्या प्रत्येक गोष्टीची नोंद तुम्ही शेअर करू शकता अशा टेक्स्ट फाइलमध्ये करा.</string>
-    <string name="debug_debuglog_size_label">आकार</string>
-    <string name="debug_debuglog_size_compressed_label">संकुचित आकार</string>
-    <string name="debug_notification_channel_label">डीबग सूचना</string>
-    <string name="debug_debuglog_file_label">नोंदणीकृत लॉग फाइल</string>
-    <string name="debug_debuglog_recording_progress">डीबग लॉग रेकॉर्ड करत आहे</string>
     <string name="debug_debuglog_record_action">डीबग लॉग रेकॉर्ड करा</string>
     <string name="debug_debuglog_stop_action">रेकॉर्डिंग थांबवा</string>
     <string name="debug_debuglog_sensitive_information_message">तयार केलेल्या फाइलमध्ये संवेदनशील माहिती आहे (उदा. ब्लूटूथ डिव्हाइस तपशील). ती फक्त विश्वासार्ह पक्षांसोबत शेअर करा.</string>
     <string name="settings_debuglog_explanation">हे वैशिष्ट्य अॅप करत असलेल्या प्रत्येक गोष्टीची नोंद शेअर करण्यायोग्य फाइलमध्ये करते. तयार केलेल्या फाइलमध्ये संवेदनशील माहिती आहे (उदा. ब्लूटूथ डिव्हाइस तपशील). ती फक्त विश्वासार्ह पक्षांसोबत शेअर करा (उदा. समस्येचे निवारण करणारा विकसक).</string>
-    <string name="settings_support_installid_label">इंस्टॉल आयडी</string>
-    <string name="settings_support_installid_desc">स्वयंचलित त्रुटी अहवाल अनामिक असतात. विकसकाला तुमच्या त्रुटी अहवाल शोधण्याची आवश्यकता असल्यास तुमचा इंस्टॉल आयडी शेअर करा.</string>
     <string name="settings_support_label">समर्थन</string>
     <string name="settings_support_description">तुम्हाला काही मदत हवी असल्यास.</string>
     <string name="settings_wiki_label">विकी</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">शिकलेला डेटा रीसेट करायचे?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod या डिव्हाइसचा मोजलेला ड्रेन, चार्जिंग गती आणि ऐकण्याचा वेळ विसरून देईल आणि रेट केलेल्या बॅटरी आयुष्यापासून पुन्हा सुरुवात करेल.</string>
     <string name="settings_acknowledgements_label">पोचपावती</string>
-    <string name="settings_debug_autoreports_label">स्वयंचलित बग अहवाल</string>
-    <string name="settings_debug_autoreports_description">समस्या स्वयंचलितपणे नोंदवते, उदा. अॅप क्रॅशबद्दल तपशील जेणेकरून मी ते कसे दुरुस्त करायचे हे शोधू शकेन.</string>
-    <string name="settings_compatibility_mode_label">सुसंगतता मोड</string>
-    <string name="settings_compatibility_mode_description">सुसंगतता सुधारण्यासाठी ऑप्टिमायझेशन अक्षम करा. तुम्हाला कोणताही डेटा दिसत नसल्यास हे वापरून पहा.</string>
     <string name="help_translate_label">भाषांतर</string>
     <string name="help_translate_description">हे अॅप तुमच्या आवडत्या भाषेत भाषांतरित करण्यात मदत करा.</string>
     <string name="translators_thanks_title">भाषांतरकर्ते</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">यश</string>
     <string name="troubleshooter_ble_result_success_body">CAPod द्वारे BLE जाहिरात प्रसारण प्राप्त होत आहेत.</string>
     <string name="troubleshooter_ble_result_failure_title">अयशस्वी</string>
-    <string name="troubleshooter_ble_result_failure_body">समस्या निवारण अयशस्वी झाले. सुसंगतता पर्यायांचे कोणतेही संयोजन मदत करू शकले नाही.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">तुमच्या फोनला कोणतीही BLE डेटा अजिबात मिळाली नाही. डेटा स्रोत (तुमच्या हेडफोन व्यतिरिक्त) प्राप्त होऊ शकतात की नाही हे पाहण्यासाठी तुम्ही गर्दीच्या ठिकाणी हा चाचणी पुन्हा प्रयत्न करू शकता. कोणताही डेटा प्राप्त न होणे तुमच्या फोनच्या ऑपरेटिंग सिस्टममध्ये समस्या दर्शवते.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">तुमच्या फोनला BLE डेटा मिळाला, परंतु डेटा कोणत्याही समर्थित डिव्हाइसवरून येत नाही. तुमचे हेडफोन चालू आहेत का? CAPod तुमच्या हेडफोनला समर्थन देते का?</string>
-    <string name="troubleshooter_ble_result_failure_action">पुन्हा प्रयत्न करा</string>
-    <string name="troubleshoot_action">समस्या सोडवा</string>
     <string name="onboarding_body1">हे अॅप Android साठी AirPod विशिष्ट वैशिष्ट्यांसाठी समर्थन जोडते.</string>
     <string name="onboarding_body2">सर्व Android डिव्हाइस अतिरिक्त AirPod वैशिष्ट्यांना पूर्णपणे समर्थन देत नाहीत. तुमच्या ऑपरेटिंग सिस्टमला योग्यरित्या कार्य करणारे ब्लूटूथ-लो-एनर्जी अंमलबजावणी आवश्यक आहे.</string>
     <string name="onboarding_body3">CAPod मध्ये कोणत्याही जाहिराती नाहीत आणि तुमचा डेटा गोळा करत नाही.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">तुमचे उपकरण जोडलेले आहे, पण CAPod त्याच्याकडून कोणताही थेट डेटा प्राप्त करत नाही. तुमच्या फोनला एका सुसंगतता पर्यायाची आवश्यकता असू शकते — समस्या निवारक आपोआप एक शोधण्याचा प्रयत्न करू शकतो.</string>
     <string name="overview_troubleshoot_suggestion_action">समस्या निवारक चालवा</string>
     <string name="overview_unmatched_devices_label">न जुळणारे डिव्हाइस</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">जुळणारे प्रोफाइल नसलेले %d डिव्हाइस</item>
-        <item quantity="other">जुळणारे प्रोफाइल नसलेले %d डिव्हाइस</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d जवळचे डिव्हाइस जुळणाऱ्या प्रोफाइलशिवाय आढळले. उपलब्ध तपशिलांसाठी ते दाखवा. जर ते तुमचे असेल, तर ते ओळखण्यासाठी डिव्हाइसेसमधून प्रोफाइल जोडा.</item>
         <item quantity="other">%d जवळची डिव्हाइसेस जुळणाऱ्या प्रोफाइल्सशिवाय आढळली. उपलब्ध तपशिलांसाठी ती दाखवा. जर त्यापैकी एक तुमचे असेल, तर ते ओळखण्यासाठी डिव्हाइसेसमधून प्रोफाइल जोडा.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod अॅप बंद असताना \"पॉपअप दर्शवा\" आणि \"ऑटो-कनेक्ट\" सारखी वैशिष्ट्ये सक्षम करण्यासाठी \"पार्श्वभूमी स्थान प्रवेश\" वापरते. पार्श्वभूमी स्थान प्रवेश अॅपला पार्श्वभूमीत असताना ब्लूटूथ लो एनर्जी डेटा प्राप्त करण्याची अनुमती देतो. हे अॅप तुमचे स्थान निर्धारित करण्यासाठी ब्लूटूथ डेटा वापरणार नाही.</string>
     <string name="permission_ignore_battery_optimizations_label">बॅटरी ऑप्टिमायझेशन अक्षम करा</string>
     <string name="permission_ignore_battery_optimizations_description">बॅटरी ऑप्टिमायझेशन या अॅपला पार्श्वभूमीत असताना ब्लूटूथ डेटा विश्वसनीयरित्या प्राप्त करण्यापासून प्रतिबंधित करतात.</string>
-    <string name="permission_required_title">खालील परवानगी आवश्यक आहे:</string>
     <string name="permission_system_alert_window_label">सिस्टम अलर्ट विंडो</string>
     <string name="permission_system_alert_window_description">\"पॉपअप दर्शवा\" वैशिष्ट्य शक्य करण्यासाठी CAPod ला इतर अॅप्सवर चित्रे काढण्याची अनुमती द्या.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">दिसल्यावर</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">कानात</string>
     <string name="pods_dual_left_label">डावा पॉड</string>
     <string name="pods_dual_right_label">उजवा पॉड</string>
-    <string name="pods_dual_left_short_label">डा</string>
-    <string name="pods_dual_right_short_label">उ</string>
-    <string name="pods_case_label">केस</string>
     <string name="battery_unavailable_label">बॅटरी उपलब्ध नाही</string>
     <string name="battery_state_low_cd">बॅटरी कमी</string>
     <string name="battery_state_critical_cd">बॅटरी गंभीरपणे कमी</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">थेट कनेक्शन सक्रिय</string>
     <string name="signal_indicator_bars_cd">सिग्नल शक्ती: %1$d पैकी 4 बार</string>
     <string name="signal_indicator_disconnected_cd">सिग्नल: डिस्कनेक्ट केलेले</string>
-    <string name="pods_yours">तुमचे</string>
     <string name="headset_being_worn_label">घातलेले</string>
     <string name="headset_not_being_worn_label">घातलेले नाही</string>
     <string name="pods_case_unknown_state">अज्ञात स्थिती</string>
-    <string name="last_seen_x">शेवटचे दिसले: %s</string>
-    <string name="first_seen_x">पहिल्यांदा दिसले: %s</string>
     <string name="battery_cached_label">शेवटचे ज्ञात · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dता %2$dमि</string>
     <string name="battery_time_remaining_format_h">%1$dता</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">किमान सिग्नल गुणवत्ता</string>
     <string name="profiles_signal_quality_description">फक्त या मर्यादेपेक्षा जास्त सिग्नल शक्ती असलेले डिव्हाइस शोधा. कमी मूल्ये शोध श्रेणी वाढवतात पण चुकीचे परिणाम देऊ शकतात. हे खूप जास्त सेट करू नका - ब्लूटूथ रिसेप्शन सामान्यतः कमकुवत असते आणि अंतर आणि अडथळ्यांसह बदलते.</string>
     <string name="profiles_identitykey_label">ओळख की</string>
-    <string name="profilessettings_maindevice_identitykey_description">तुमच्या डिव्हाइसची Identity Resolving Key (IRK), जी CAPod ला जवळपासच्या डिव्हाइसमध्ये ते ओळखण्यात मदत करते.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods गोपनीयतेसाठी त्यांचा ब्लूटूथ पत्ता वारंवार बदलतात. IRK CAPod ला तुमचे डिव्हाइस ओळखण्यात मदत करते. तुम्हाला MacBook ला एक-वेळचा प्रवेश आवश्यक आहे.</string>
     <string name="profiles_maindevice_encryptionkey_label">एन्क्रिप्शन की</string>
-    <string name="profiles_maindevice_encryptionkey_description">तुमच्या डिव्हाइसची एन्क्रिप्शन की, जी CAPod ला तपशीलवार स्थिती माहिती प्राप्त करण्यास अनुमती देते.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods एक स्थिती संदेश पाठवतात, ज्याचा एक भाग एन्क्रिप्ट केलेला असतो. एन्क्रिप्शन की CAPod ला पूर्ण संदेश डिक्रिप्ट करण्यास अनुमती देते. तुम्हाला MacBook ला एक-वेळचा प्रवेश आवश्यक आहे.</string>
     <string name="profiles_key_invalid_format">अवैध की स्वरूप</string>
     <string name="profiles_key_expected_format">अपेक्षित स्वरूप: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">तुमच्याकडे सेव्ह न केलेले बदल आहेत. तुम्हाला काय करायचे आहे?</string>
     <string name="general_save_and_exit_action">सेव्ह करा आणि बाहेर पडा</string>
     <string name="general_discard_action">टाकून द्या</string>
-    <string name="general_keep_editing_action">संपादन सुरू ठेवा</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">रेकॉर्डिंग खूप लहान</string>
     <string name="debug_debuglog_short_recording_message">डीबग लॉगने समस्या घडत असताना ती कॅप्चर करणे आवश्यक आहे. रेकॉर्डिंग सुरू ठेवा, समस्या पुनरुत्पादित करा, नंतर रेकॉर्डिंग थांबवा.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">डिव्हाइस सेटिंग्ज</string>
     <string name="device_settings_subtitle_profile_prefix">प्रोफाइल: %s</string>
-    <string name="device_settings_info_name_label">नाव</string>
     <string name="device_settings_info_bt_name_label">ब्लूटूथ डिव्हाइस लेबल</string>
     <string name="device_settings_info_model_label">मॉडेल</string>
     <string name="device_settings_info_manufacturer_label">निर्माता</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">कदाचित नंतर</string>
     <string name="review_app_body">CAPod ला समीक्षा द्यायचे आहे का? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">मायक्रोफोन</string>
     <string name="device_settings_microphone_mode_description">कोणता इअरबड मायक्रोफोन म्हणून वापरला जातो</string>
     <string name="device_settings_microphone_mode_auto">स्वयंचलित</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Kongsi</string>
     <string name="general_done_action">Selesai</string>
     <string name="general_cancel_action">Batal</string>
-    <string name="general_copy_action">Salin</string>
     <string name="general_thank_you_label">Terima kasih</string>
     <string name="general_upgrade_action">Naik taraf</string>
     <string name="general_retry_action">Cuba Semula</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Semak</string>
     <string name="general_close_action">Tutup</string>
     <string name="general_dismiss_action">Tolak</string>
-    <string name="general_edit_action">Edit</string>
     <string name="general_save_action">Simpan</string>
     <string name="general_guide_action">Panduan</string>
     <string name="general_continue_action">Teruskan</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Sambung semula muzik apabila memakai pod anda semula, tetapi hanya jika Jeda Automatik yang menghentikannya. Jeda yang anda picu sendiri (telefon, batang AirPods, tidur) kekal dijeda.</string>
     <string name="settings_start_music_on_wear_label">Mulakan muzik semasa memakai</string>
     <string name="settings_start_music_on_wear_description">Sentiasa cuba memainkan muzik apabila anda memakai pod, walaupun selepas jeda manual.</string>
-    <string name="settings_eardetection_info_label">Nota pengesanan telinga</string>
     <string name="settings_eardetection_info_description">Jika pengesanan telinga hanya berfungsi untuk satu pod, ini adalah had Apple. Hanya \"pod utama\" (digunakan untuk mikrofon) yang dikesan. Konfigurasikan pada peranti Apple: Tetapan → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Kualiti isyarat minimum</string>
-    <string name="settings_signal_minimum_description">Kualiti isyarat minimum yang peranti perlukan untuk dianggap sebagai milik anda.</string>
     <string name="settings_autoconnect_label">Sambung automatik</string>
     <string name="settings_autoconnect_description">Jika Android tidak menyambung secara automatik, kita boleh mintanya juga. Ini memastikan CAPod sentiasa memantau di latar belakang.</string>
     <string name="settings_autoconnect_info_android12">Sambung automatik bergantung pada ciri sistem yang dihadkan oleh Android 12 dan lebih baharu. Ia mungkin tidak berfungsi pada peranti anda.</string>
     <string name="settings_autoconnect_condition_label">Syarat sambungan automatik</string>
-    <string name="settings_autoconnect_condition_description">Bilakah kami patut cuba menyambung ke peranti anda?</string>
     <string name="settings_devices_label">Peranti</string>
     <string name="settings_devices_description">Urus peranti anda.</string>
     <string name="settings_reaction_label">Reaksi</string>
-    <string name="settings_category_yourdevice_label">Peranti anda</string>
     <string name="settings_category_compatibility_options_title">Pilihan keserasian</string>
     <string name="settings_category_compatibility_options_description">Jangan sentuh jika semuanya berfungsi ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Nyahdayakan penapisan perkakasan</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Memulakan…</string>
     <string name="support_debuglog_label">Log nyahpepijat</string>
     <string name="support_debuglog_desc">Rekod semua yang dilakukan oleh apl dalam fail teks yang boleh anda kongsi.</string>
-    <string name="debug_debuglog_size_label">Saiz</string>
-    <string name="debug_debuglog_size_compressed_label">Saiz dimampatkan</string>
-    <string name="debug_notification_channel_label">Pemberitahuan nyahpepijat</string>
-    <string name="debug_debuglog_file_label">Fail log direkodkan</string>
-    <string name="debug_debuglog_recording_progress">Merekod log nyahpepijat</string>
     <string name="debug_debuglog_record_action">Rekod log nyahpepijat</string>
     <string name="debug_debuglog_stop_action">Hentikan rakaman</string>
     <string name="debug_debuglog_sensitive_information_message">Fail yang dijana mengandungi maklumat sensitif (cth. butiran peranti Bluetooth). Kongsi hanya dengan pihak yang dipercayai.</string>
     <string name="settings_debuglog_explanation">Ciri ini merekodkan semua yang dilakukan oleh apl ke dalam fail yang boleh dikongsi. Fail yang dijana mengandungi maklumat sensitif (cth. butiran peranti Bluetooth). Kongsi hanya dengan pihak yang dipercayai (cth. pembangun yang sedang menyelesaikan masalah).</string>
-    <string name="settings_support_installid_label">ID Pemasangan</string>
-    <string name="settings_support_installid_desc">Laporan ralat automatik adalah tanpa nama. Kongsi ID pemasangan anda jika pembangun perlu mencari laporan ralat anda.</string>
     <string name="settings_support_label">Sokongan</string>
     <string name="settings_support_description">Jika anda perlukan bantuan.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Tetapkan semula data yang dipelajari?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod akan melupakan penyusutan terukur peranti ini, kelajuan pengecasan, dan masa mendengar, serta memulakan semula daripada hayat bateri yang dinilai.</string>
     <string name="settings_acknowledgements_label">Penghargaan</string>
-    <string name="settings_debug_autoreports_label">Laporan pepijat automatik</string>
-    <string name="settings_debug_autoreports_description">Melaporkan isu secara automatik, cth. butiran mengenai ranap apl supaya saya boleh memikirkan cara untuk membetulkannya.</string>
-    <string name="settings_compatibility_mode_label">Mod keserasian</string>
-    <string name="settings_compatibility_mode_description">Nyahdayakan pengoptimuman untuk meningkatkan keserasian. Cuba ini jika anda tidak melihat sebarang data.</string>
     <string name="help_translate_label">Terjemahan</string>
     <string name="help_translate_description">Bantu terjemahkan apl ini ke dalam bahasa kegemaran anda.</string>
     <string name="translators_thanks_title">Penterjemah</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Kejayaan</string>
     <string name="troubleshooter_ble_result_success_body">Siaran iklan BLE sedang diterima oleh CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Tidak berjaya</string>
-    <string name="troubleshooter_ble_result_failure_body">Penyelesaian masalah gagal. Tiada gabungan pilihan keserasian dapat membantu.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefon anda tidak menerima sebarang data BLE sama sekali. Anda boleh mencuba semula ujian ini di kawasan yang sesak untuk melihat sama ada sumber data (selain fon kepala anda) boleh diterima. Tiada data yang diterima menunjukkan masalah dengan sistem pengendalian telefon anda.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefon anda menerima data BLE, tetapi data itu tidak datang daripada mana-mana peranti yang disokong. Adakah fon kepala anda dihidupkan? Adakah CAPod menyokong fon kepala anda?</string>
-    <string name="troubleshooter_ble_result_failure_action">Cuba semula</string>
-    <string name="troubleshoot_action">Selesaikan masalah</string>
     <string name="onboarding_body1">Aplikasi ini menambah sokongan untuk ciri khusus AirPod pada Android.</string>
     <string name="onboarding_body2">Tidak semua peranti Android menyokong sepenuhnya ciri AirPod tambahan. Sistem pengendalian anda memerlukan pelaksanaan Bluetooth Tenaga Rendah yang berfungsi dengan betul.</string>
     <string name="onboarding_body3">CAPod tiada iklan dan tidak mengumpul data anda.</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Peranti anda disambungkan, tetapi CAPod tidak menerima sebarang data langsung daripadanya. Telefon anda mungkin memerlukan pilihan keserasian — penyelesai masalah boleh cuba mencari satu secara automatik.</string>
     <string name="overview_troubleshoot_suggestion_action">Jalankan penyelesai masalah</string>
     <string name="overview_unmatched_devices_label">Peranti tidak sepadan</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d peranti tanpa profil yang sepadan</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">%d peranti berdekatan dikesan tanpa profil yang sepadan. Tunjukkan untuk butiran yang tersedia. Jika salah satu daripadanya milik anda, tambah profil daripada Peranti untuk mengenalinya.</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod menggunakan \"akses lokasi latar belakang\" untuk mendayakan ciri seperti \"Tunjukkan pop timbul\" dan \"Sambung automatik\" semasa apl ditutup. Akses lokasi latar belakang membenarkan apl menerima data Bluetooth Low Energy semasa ia berada di latar belakang. Apl ini TIDAK akan menggunakan data Bluetooth untuk menentukan lokasi anda.</string>
     <string name="permission_ignore_battery_optimizations_label">Lumpuhkan pengoptimuman bateri</string>
     <string name="permission_ignore_battery_optimizations_description">Pengoptimuman bateri menghalang apl ini daripada menerima data Bluetooth secara boleh dipercayai semasa apl berada di latar belakang.</string>
-    <string name="permission_required_title">Kebenaran berikut diperlukan:</string>
     <string name="permission_system_alert_window_label">Tetingkap Amaran Sistem</string>
     <string name="permission_system_alert_window_description">Benarkan CAPod melukis di atas apl lain untuk membolehkan ciri \"Tunjukkan pop timbul\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Apabila dilihat</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Dalam telinga</string>
     <string name="pods_dual_left_label">Pod kiri</string>
     <string name="pods_dual_right_label">Pod kanan</string>
-    <string name="pods_dual_left_short_label">K</string>
-    <string name="pods_dual_right_short_label">Ka</string>
-    <string name="pods_case_label">Bekas</string>
     <string name="battery_unavailable_label">Bateri tidak tersedia</string>
     <string name="battery_state_low_cd">Bateri lemah</string>
     <string name="battery_state_critical_cd">Bateri kritikal rendah</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">Sambungan terus aktif</string>
     <string name="signal_indicator_bars_cd">Kekuatan isyarat: %1$d daripada 4 bar</string>
     <string name="signal_indicator_disconnected_cd">Isyarat: terputus</string>
-    <string name="pods_yours">Milik anda</string>
     <string name="headset_being_worn_label">Sedang dipakai</string>
     <string name="headset_not_being_worn_label">Tidak dipakai</string>
     <string name="pods_case_unknown_state">Keadaan tidak diketahui</string>
-    <string name="last_seen_x">Terakhir dilihat: %s</string>
-    <string name="first_seen_x">Pertama kali dilihat: %s</string>
     <string name="battery_cached_label">Terakhir diketahui · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dj %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dj</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">Kualiti Isyarat Minimum</string>
     <string name="profiles_signal_quality_description">Hanya kesan peranti dengan kekuatan isyarat melebihi ambang ini. Nilai yang lebih rendah meningkatkan julat pengesanan tetapi mungkin menyebabkan positif palsu. Jangan tetapkan terlalu tinggi - penerimaan Bluetooth secara amnya lemah dan berbeza mengikut jarak dan halangan.</string>
     <string name="profiles_identitykey_label">Kunci Identiti</string>
-    <string name="profilessettings_maindevice_identitykey_description">Kunci Penyelesaian Identiti (IRK) peranti anda, yang membantu CAPod mengenal pastinya di antara peranti berdekatan.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods kerap menukar alamat Bluetooth mereka untuk privasi. IRK membantu CAPod mengenali peranti anda. Anda memerlukan akses sekali ke MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Kunci Penyulitan</string>
-    <string name="profiles_maindevice_encryptionkey_description">Kunci penyulitan peranti anda, yang membenarkan CAPod mendapatkan maklumat status terperinci.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods menghantar mesej status, sebahagiannya disulitkan. Kunci penyulitan membenarkan CAPod menyahsulit mesej penuh. Anda memerlukan akses sekali ke MacBook.</string>
     <string name="profiles_key_invalid_format">Format kunci tidak sah</string>
     <string name="profiles_key_expected_format">Format yang dijangka: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">Anda mempunyai perubahan yang tidak disimpan. Apa yang anda ingin lakukan?</string>
     <string name="general_save_and_exit_action">Simpan &amp; Keluar</string>
     <string name="general_discard_action">Buang</string>
-    <string name="general_keep_editing_action">Terus Mengedit</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Rakaman terlalu pendek</string>
     <string name="debug_debuglog_short_recording_message">Log debug perlu menangkap isu semasa ia berlaku. Teruskan rakaman, reproduksi masalah, kemudian hentikan rakaman.</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Tetapan Peranti</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Nama</string>
     <string name="device_settings_info_bt_name_label">Label Peranti Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Pengilang</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">Tidak, terima kasih</string>
     <string name="review_app_body">Adakah anda ingin meninggalkan ulasan untuk CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Umum</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Earbud mana yang digunakan sebagai mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">မျှဝေရန်</string>
     <string name="general_done_action">ပြီးပြီ</string>
     <string name="general_cancel_action">ပယ်ဖျက်ရန်</string>
-    <string name="general_copy_action">ကူးယူရန်</string>
     <string name="general_thank_you_label">ကျေးဇူးတင်ပါတယ်</string>
     <string name="general_upgrade_action">အဆင့်မြှင့်တင်ရန်</string>
     <string name="general_retry_action">ထပ်မံစမ်းပါ</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">စစ်ဆေးရန်</string>
     <string name="general_close_action">ပိတ်ရန်</string>
     <string name="general_dismiss_action">ပယ်ဖျက်ပါ</string>
-    <string name="general_edit_action">တည်းဖြတ်ပါ</string>
     <string name="general_save_action">သိမ်းဆည်းရန်</string>
     <string name="general_guide_action">လမ်းညွှန်</string>
     <string name="general_continue_action">ဆက်လုပ်ရန်</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">သင့် pods များကို ပြန်တပ်ဆင်သောအခါ သီချင်းကို ဆက်ဖွင့်သည်၊ သို့သော် Auto pause က ရပ်ထားမှသာ။ သင်ကိုယ်တိုင် ရပ်ထားသော ရပ်ချိန်များ (ဖုန်း၊ AirPods stem၊ အိပ်ချိန်) ကျန်ရှိနေဦးမည်။</string>
     <string name="settings_start_music_on_wear_label">တပ်ဆင်သောအခါ သီချင်းစတင်ဖွင့်မည်</string>
     <string name="settings_start_music_on_wear_description">pods တပ်သောအခါ manual pause ပြီးနောက်ပင် သီချင်းကို ဖွင့်ရန် အမြဲကြိုးစားသည်။</string>
-    <string name="settings_eardetection_info_label">နားအာရုံခံမှုမှတ်ချက်</string>
     <string name="settings_eardetection_info_description">နားအာရုံခံမှုသည် pod တစ်ခုအတွက်သာအလုပ်လုပ်ပါက ၎င်းသည် Apple ကန့်သတ်ချက်ဖြစ်သည်။ \"အဓိက pod\" (မိုက်ခရိုဖုန်းအတွက်အသုံးပြုသော) ကိုသာ ရှာဖွေတွေ့ရှိနိုင်သည်။ Apple စက်ပစ္စည်းများတွင် ပြင်ဆင်ပါ: ဆက်တင်များ → Bluetooth → AirPods → မိုက်ခရိုဖုန်း။</string>
-    <string name="settings_signal_minimum_label">အနိမ့်ဆုံးအချက်ပြအရည်အသွေး</string>
-    <string name="settings_signal_minimum_description">သင့်စက်ပစ္စည်းဟု မှတ်ယူရန် စက်ပစ္စည်းတစ်ခုတွင်ရှိရမည့် အနိမ့်ဆုံးအချက်ပြအရည်အသွေး။</string>
     <string name="settings_autoconnect_label">အလိုအလြှောက်ချိတ်ဆက်ခြင်း</string>
     <string name="settings_autoconnect_description">Android က အလိုအလျောက် ချိတ်ဆက်ပေးမပေးရင် ကျွန်ုပ်တို့ကိုယ်တိုင် တောင်းဆိုပေးနိုင်ပါသည်။ ဒါက CAPod ကို နောက်ခံမှာ အမြဲစောင့်ကြည့်နေစေမည်။</string>
     <string name="settings_autoconnect_info_android12">Android 12 နှင့် အသစ်ပိုမိုထက် မည်သောစနစ်လုပ်ဆောင်ချက်ကို အားကိုးသည့် အလိုအလျောက် ချိတ်ဆက်မှုသည် ကန့်သတ်ချက်ရှိသည်။ သင့်ကိရိယာပေါ်တွင် အလုပ်မလုပ်နိုင်ပေ။</string>
     <string name="settings_autoconnect_condition_label">အလိုအလြှောက်ချိတ်ဆက်ခြင်းအခြေအနေ</string>
-    <string name="settings_autoconnect_condition_description">သင့်စက်ပစ္စည်းသို့ မည်သည့်အချိန်တွင် ချိတ်ဆက်ရန်ကြိုးစားသင့်သနည်း။</string>
     <string name="settings_devices_label">စက်ပစ္စည်းများ</string>
     <string name="settings_devices_description">သင့်စက်ပစ္စည်းများကို စီမံခန့်ခွဲပါ။</string>
     <string name="settings_reaction_label">တုံ့ပြန်မှုများ</string>
-    <string name="settings_category_yourdevice_label">သင့်စက်ပစ္စည်း</string>
     <string name="settings_category_compatibility_options_title">လိုက်ဖက်ညီမှုရွေးချယ်စရာများ</string>
     <string name="settings_category_compatibility_options_description">အရာအားလုံးအဆင်ပြေနေပါက မထိပါနှင့် ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ဟာ့ဒ်ဝဲစစ်ထုတ်ခြင်းကို ပိတ်ပါ</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">စတင်နေသည်…</string>
     <string name="support_debuglog_label">ချွတ်ယွင်းချက်ပြင်ဆင်ခြင်းမှတ်တမ်း</string>
     <string name="support_debuglog_desc">အက်ပ်လုပ်ဆောင်သမျှကို သင်မျှဝေနိုင်သော စာသားဖိုင်တစ်ခုတွင် မှတ်တမ်းတင်ပါ။</string>
-    <string name="debug_debuglog_size_label">အရွယ်အစား</string>
-    <string name="debug_debuglog_size_compressed_label">ချုံ့ထားသောအရွယ်အစား</string>
-    <string name="debug_notification_channel_label">ချွတ်ယွင်းချက်ပြင်ဆင်ခြင်းအသိပေးချက်များ</string>
-    <string name="debug_debuglog_file_label">မှတ်တမ်းတင်ထားသောမှတ်တမ်းဖိုင်</string>
-    <string name="debug_debuglog_recording_progress">ချွတ်ယွင်းချက်ပြင်ဆင်ခြင်းမှတ်တမ်းကို မှတ်တမ်းတင်နေသည်</string>
     <string name="debug_debuglog_record_action">ချွတ်ယွင်းချက်ပြင်ဆင်ခြင်းမှတ်တမ်းကို မှတ်တမ်းတင်ပါ</string>
     <string name="debug_debuglog_stop_action">မှတ်တမ်းတင်ခြင်းကိုရပ်ပါ</string>
     <string name="debug_debuglog_sensitive_information_message">ထုတ်လုပ်လိုက်သောဖိုင်တွင် အရေးကြီးအချက်အလက်များ (ဥပမာ Bluetooth စက်ပစ္စည်းအသေးစိတ်များ) ပါဝင်သည်။ ၎င်းကို ယုံကြည်စိတ်ချရသောသူများနှင့်သာ မျှဝေပါ။</string>
     <string name="settings_debuglog_explanation">ဤအင်္ဂါရပ်သည် အက်ပ်လုပ်ဆောင်သမျှကို မျှဝေနိုင်သောဖိုင်တစ်ခုတွင် မှတ်တမ်းတင်သည်။ ထုတ်လုပ်လိုက်သောဖိုင်တွင် အရေးကြီးအချက်အလက်များ (ဥပမာ Bluetooth စက်ပစ္စည်းအသေးစိတ်များ) ပါဝင်သည်။ ၎င်းကို ယုံကြည်စိတ်ချရသောသူများ (ဥပမာ ပြဿနာဖြေရှင်းနေသော developer) နှင့်သာ မျှဝေပါ။</string>
-    <string name="settings_support_installid_label">ထည့်သွင်းမှု ID</string>
-    <string name="settings_support_installid_desc">အလိုအလြှောက်အမှားအယွင်းအစီရင်ခံစာများသည် အမည်မသိဖြစ်ကြသည်။ developer က သင့်အမှားအယွင်းအစီရင်ခံစာများကို ရှာဖွေရန်လိုအပ်ပါက သင်၏ထည့်သွင်းမှု ID ကိုမျှဝေပါ။</string>
     <string name="settings_support_label">အကူအညီ</string>
     <string name="settings_support_description">သင်အကူအညီအချို့လိုအပ်ပါက။</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">သင်ယူထားသော အချက်အလက်များ ပြန်လည်သတ်မှတ်မည်လား</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod သည် ဤကိရိယာ၏ တိုင်းတာထားသော စွမ်းအားကုန်ဆုံးမှု၊ အားသွင်းနှုန်းနှင့် နားထောင်အချိန်ကို မေ့ပျောက်စေပြီး၊ သတ်မှတ်ထားသော ဘက်ထရီသက်တမ်းမှ အစပြန်စတင်ပါမည်။</string>
     <string name="settings_acknowledgements_label">ကျေးဇူးတင်လွှာ</string>
-    <string name="settings_debug_autoreports_label">အလိုအလြှောက်ချွတ်ယွင်းချက်အစီရင်ခံစာများ</string>
-    <string name="settings_debug_autoreports_description">ပြဿနာများကို အလိုအလြှောက်အစီရင်ခံပါသည်၊ ဥပမာ အက်ပ်ပျက်ကျမှုအကြောင်းအသေးစိတ်များ၊ သို့မှသာ ၎င်းကိုမည်သို့ဖြေရှင်းရမည်ကို ကျွန်ုပ်သိရှိနိုင်မည်ဖြစ်သည်။</string>
-    <string name="settings_compatibility_mode_label">လိုက်ဖက်ညီမှုမုဒ်</string>
-    <string name="settings_compatibility_mode_description">လိုက်ဖက်ညီမှုကိုတိုးတက်စေရန် အကောင်းဆုံးလုပ်ဆောင်မှုများကို ပိတ်ပါ။ သင်ဒေတာတစ်စုံတစ်ရာမတွေ့ပါက ဤအရာကိုစမ်းကြည့်ပါ။</string>
     <string name="help_translate_label">ဘာသာပြန်ဆိုခြင်း</string>
     <string name="help_translate_description">ဤအက်ပ်ကို သင်အကြိုက်ဆုံးဘာသာစကားသို့ ဘာသာပြန်ဆိုရာတွင် ကူညီပါ။</string>
     <string name="translators_thanks_title">ဘာသာပြန်သူများ</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">အောင်မြင်သည်</string>
     <string name="troubleshooter_ble_result_success_body">BLE ကြော်ငြာထုတ်လွှင့်မှုများကို CAPod မှလက်ခံရရှိနေသည်။</string>
     <string name="troubleshooter_ble_result_failure_title">မအောင်မြင်ပါ</string>
-    <string name="troubleshooter_ble_result_failure_body">ပြဿနာဖြေရှင်းခြင်းမအောင်မြင်ပါ။ လိုက်ဖက်ညီမှုရွေးချယ်စရာများ၏ ပေါင်းစပ်မှုတစ်ခုမျှ အထောက်အကူမပြုခဲ့ပါ။</string>
     <string name="troubleshooter_ble_result_failure_phone_body">သင့်ဖုန်းသည် BLE ဒေတာတစ်စုံတစ်ရာလုံးဝမရရှိခဲ့ပါ။ ဒေတာရင်းမြစ်များ (သင့်နားကြပ်များမှလွဲ၍) လက်ခံရရှိနိုင်ခြင်းရှိမရှိကြည့်ရှုရန် လူစည်ကားသောနေရာတွင် ဤစမ်းသပ်မှုကို ထပ်မံကြိုးစားနိုင်သည်။ ဒေတာတစ်စုံတစ်ရာမရရှိခြင်းသည် သင့်ဖုန်း၏လည်ပတ်မှုစနစ်နှင့်ပတ်သက်သော ပြဿနာတစ်ခုကိုညွှန်ပြသည်။</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">သင့်ဖုန်းသည် BLE ဒေတာကိုလက်ခံရရှိခဲ့သော်လည်း ဒေတာသည် ပံ့ပိုးထားသောမည်သည့်စက်ပစ္စည်းမှမလာပါ။ သင့်နားကြပ်များဖွင့်ထားပါသလား။ CAPod သည် သင့်နားကြပ်များကိုပံ့ပိုးပါသလား။</string>
-    <string name="troubleshooter_ble_result_failure_action">ထပ်ကြိုးစားပါ</string>
-    <string name="troubleshoot_action">ပြဿနာဖြေရှင်းပါ</string>
     <string name="onboarding_body1">ဤအက်ပ်သည် Android သို့ AirPod အင်္ဂါရပ်များအတွက် အထောက်အပံ့ကိုထည့်သွင်းသည်။</string>
     <string name="onboarding_body2">Android စက်ပစ္စည်းအားလုံးသည် အပို AirPod အင်္ဂါရပ်များကို အပြည့်အဝမပံ့ပိုးပါ။ သင့်လည်ပတ်မှုစနစ်သည် မှန်ကန်စွာအလုပ်လုပ်သော Bluetooth-Low-Energy အကောင်အထည်ဖော်မှုတစ်ခုလိုအပ်သည်။</string>
     <string name="onboarding_body3">CAPod တွင် ကြော်ငြာများမရှိပါ၊ ၎င်းသည် သင့်ဒေတာကိုမစုဆောင်းပါ။</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">သင့်ကိရိယာ ချိတ်ဆက်ထားသော်လည်း CAPod မှ ၎င်းထံမှ တိုက်ရိုက်ဒေတာ မရရှိပါ။ သင့်ဖုန်းသည် တွဲဖက်သုံးနိုင်မှု ရွေးချယ်မှုတစ်ခု လိုအပ်နိုင်သည် — ပြဿနာဖြေရှင်းသူက အလိုအလျောက် ရှာဖွေကြည့်နိုင်သည်။</string>
     <string name="overview_troubleshoot_suggestion_action">ပြဿနာဖြေရှင်းသူ စတင်ရန်</string>
     <string name="overview_unmatched_devices_label">တိုက်ဆိုင်မှုမရှိသော စက်ပစ္စည်းများ</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">ကိုက်ညီသောပရိုဖိုင်မရှိသော စက်ပစ္စည်း %d ခု</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">အနီးအနားရှိ စက်ပစ္စည်း %d ခုကို ကိုက်ညီသည့်ပရိုဖိုင်းမရှိဘဲ တွေ့ရှိခဲ့ပါသည်။ အသေးစိတ်အချက်အလက်များအတွက် ၎င်းတို့ကို ကြည့်ရှုပါ။ တစ်ခုသည် သင့်ပစ္စည်းဖြစ်ပါက ၎င်းကို မှတ်မိစေရန် စက်ပစ္စည်းများမှ ပရိုဖိုင်းတစ်ခု ထည့်သွင်းပါ။</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod သည် အက်ပ်ပိတ်ထားစဉ် \"ပြတင်းပေါက်ပြသခြင်း\" နှင့် \"အလိုအလြှောက်ချိတ်ဆက်ခြင်း\" ကဲ့သို့သော အင်္ဂါရပ်များကိုဖွင့်ရန် \"နောက်ခံတည်နေရာအသုံးပြုခွင့်\" ကိုအသုံးပြုသည်။ နောက်ခံတည်နေရာအသုံးပြုခွင့်သည် အက်ပ်အား နောက်ခံတွင်ရှိစဉ် Bluetooth Low Energy ဒေတာကို လက်ခံရန်ခွင့်ပြုသည်။ ဤအက်ပ်သည် သင့်တည်နေရာကို ဆုံးဖြတ်ရန် Bluetooth ဒေတာကို အသုံးပြုမည်မဟုတ်ပါ။</string>
     <string name="permission_ignore_battery_optimizations_label">ဘက်ထရီအကောင်းဆုံးလုပ်ဆောင်မှုများကို ပိတ်ပါ</string>
     <string name="permission_ignore_battery_optimizations_description">ဘက်ထရီအကောင်းဆုံးလုပ်ဆောင်မှုများသည် အက်ပ်နောက်ခံတွင်ရှိစဉ် Bluetooth ဒေတာကို ယုံကြည်စိတ်ချစွာ လက်ခံခြင်းမှ ဤအက်ပ်ကို တားဆီးသည်။</string>
-    <string name="permission_required_title">အောက်ပါခွင့်ပြုချက်လိုအပ်သည်:</string>
     <string name="permission_system_alert_window_label">စနစ်သတိပေးချက်ပြတင်းပေါက်</string>
     <string name="permission_system_alert_window_description">\"ပြတင်းပေါက်ပြသခြင်း\" အင်္ဂါရပ်ကိုဖြစ်နိုင်စေရန် CAPod အား အခြားအက်ပ်များပေါ်တွင် ပုံဆွဲခွင့်ပြုပါ။</string>
     <string name="settings_reaction_autoconnect_whenseen_label">တွေ့မြင်သောအခါ</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">နားထဲတွင်</string>
     <string name="pods_dual_left_label">ဘယ်ဘက်နားကြပ်</string>
     <string name="pods_dual_right_label">ညာဘက်နားကြပ်</string>
-    <string name="pods_dual_left_short_label">ဘ</string>
-    <string name="pods_dual_right_short_label">ည</string>
-    <string name="pods_case_label">အိတ်</string>
     <string name="battery_unavailable_label">ဘက်ထရီ မရနိုင်ပါ</string>
     <string name="battery_state_low_cd">ဘက်ထရီ နည်း</string>
     <string name="battery_state_critical_cd">ဘက်ထရီ အလွန်နည်း</string>
@@ -288,12 +260,9 @@
     <string name="signal_badge_aap_cd">တိုက်ရိုက်ချိတ်ဆက်မှု တက်ကြွနေသည်</string>
     <string name="signal_indicator_bars_cd">လိုင်းကြောင်းအားသန်မာမှု: %1$d / ၄ ဘား</string>
     <string name="signal_indicator_disconnected_cd">လိုင်းကြောင်း: ချိတ်ဆက်မှုပြတ်တောက်</string>
-    <string name="pods_yours">သင့်ဟာ</string>
     <string name="headset_being_worn_label">တပ်ဆင်ထားသည်</string>
     <string name="headset_not_being_worn_label">တပ်ဆင်မထားပါ</string>
     <string name="pods_case_unknown_state">မသိသောအခြေအနေ</string>
-    <string name="last_seen_x">နောက်ဆုံးတွေ့ရှိချိန်: %s</string>
-    <string name="first_seen_x">ပထမဆုံးတွေ့ရှိချိန်: %s</string>
     <string name="battery_cached_label">နောက်ဆုံးသိသည် · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dနာရီ %2$dမိနစ်</string>
     <string name="battery_time_remaining_format_h">%1$dနာရီ</string>
@@ -323,10 +292,8 @@
     <string name="profiles_signal_quality_title">အနိမ့်ဆုံးအချက်ပြအရည်အသွေး</string>
     <string name="profiles_signal_quality_description">ဤအဆင့်ထက်ပိုသော အချက်ပြအားကောင်းမှုရှိသော စက်ပစ္စည်းများကိုသာ ရှာဖွေပါ။ နိမ့်သောတန်ဖိုးများသည် ရှာဖွေမှုအကွာအဝေးကို တိုးမြှင့်သော်လည်း မှားယွင်းသောရလဒ်များ ဖြစ်နိုင်သည်။ အလွန်မြင့်မားစွာ မသတ်မှတ်ပါနှင့် - Bluetooth လက်ခံမှုသည် ယေဘုယျအားဖြင့် အားနည်းပြီး အကွာအဝေးနှင့် အတားအဆီးများအပေါ် မူတည်၍ ကွဲပြားသည်။</string>
     <string name="profiles_identitykey_label">အထောက်အထားသော့</string>
-    <string name="profilessettings_maindevice_identitykey_description">သင့်စက်ပစ္စည်း၏ Identity Resolving Key (IRK) သည် CAPod ကို အနီးအနားရှိ စက်ပစ္စည်းများကြားတွင် ၎င်းကို ခွဲခြားသိရှိရန် ကူညီသည်။</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods သည် ကိုယ်ရေးကိုယ်တာအတွက် ၎င်းတို့၏ Bluetooth လိပ်စာကို မကြာခဏပြောင်းလဲသည်။ IRK သည် CAPod ကို သင့်စက်ပစ္စည်းကို မှတ်မိရန် ကူညီသည်။ MacBook သို့ တစ်ကြိမ်တည်းဝင်ရောက်ခွင့် လိုအပ်သည်။</string>
     <string name="profiles_maindevice_encryptionkey_label">ကုဒ်ဝှက်သော့</string>
-    <string name="profiles_maindevice_encryptionkey_description">သင့်စက်ပစ္စည်း၏ ကုဒ်ဝှက်သော့သည် CAPod ကို အသေးစိတ်အခြေအနေအချက်အလက်များ ရယူခွင့်ပေးသည်။</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods သည် အခြေအနေမက်ဆေ့ချ်တစ်ခုပို့သည်၊ ၎င်း၏အစိတ်အပိုင်းတစ်ခုသည် ကုဒ်ဝှက်ထားသည်။ ကုဒ်ဝှက်သော့သည် CAPod ကို မက်ဆေ့ချ်အပြည့်အစုံကို ကုဒ်ဖြည်ခွင့်ပေးသည်။ MacBook သို့ တစ်ကြိမ်တည်းဝင်ရောက်ခွင့် လိုအပ်သည်။</string>
     <string name="profiles_key_invalid_format">သော့ပုံစံမမှန်ပါ</string>
     <string name="profiles_key_expected_format">မျှော်မှန်းထားသောပုံစံ: %1$s</string>
@@ -359,7 +326,6 @@
     <string name="general_unsaved_changes_message">သင့်တွင် မသိမ်းဆည်းရသေးသော ပြောင်းလဲမှုများရှိသည်။ ဘာလုပ်လိုပါသလဲ။</string>
     <string name="general_save_and_exit_action">သိမ်းဆည်းပြီး ထွက်ရန်</string>
     <string name="general_discard_action">စွန့်ပစ်ရန်</string>
-    <string name="general_keep_editing_action">ဆက်လက်တည်းဖြတ်ရန်</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ကောက်ယူမှု တိုလွန်းသည်</string>
     <string name="debug_debuglog_short_recording_message">ချွတ်ယွင်းချက် မှတ်တမ်းသည် ဖြစ်ပွားနေသည်ကို ဖမ်မတ်ရန် လိုအပ်သည်။ မှတ်တမ်းကို ဆက်လက်ပြုလုပါ၊ ပြပညမာကို ပြန်ဖြစ်အောင်လုပါ၊ ထိတ်နောက် မှတ်တမ်းကို ရပ်တန့်ပါ။</string>
@@ -427,7 +393,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ကိရိယာ ဆက်တင်များ</string>
     <string name="device_settings_subtitle_profile_prefix">ပရိုဖိုင်: %s</string>
-    <string name="device_settings_info_name_label">အမည်</string>
     <string name="device_settings_info_bt_name_label">Bluetooth ကိရိယာ အညွှန်း</string>
     <string name="device_settings_info_model_label">မော်ဒယ်</string>
     <string name="device_settings_info_manufacturer_label">ထုတ်လုပ်သူ</string>
@@ -505,7 +470,6 @@
     <string name="review_app_dismiss_action">နောက်ပိုင်းမှ</string>
     <string name="review_app_body">CAPod အတွက် သုံးသပ်ချက် ချန်ထားလိုပါသလား။ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">ယေဘူယျ</string>
     <string name="device_settings_microphone_mode_label">မိုက်ခရိုဖုန်း</string>
     <string name="device_settings_microphone_mode_description">မည်သည့် earbud ကို မိုက်ခရိုဖုန်းအဖြစ် အသုံးပြုသနည်း</string>
     <string name="device_settings_microphone_mode_auto">အလိုအလျောက်</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Del</string>
     <string name="general_done_action">Ferdig</string>
     <string name="general_cancel_action">Avbryt</string>
-    <string name="general_copy_action">Kopier</string>
     <string name="general_thank_you_label">Tusen takk</string>
     <string name="general_upgrade_action">Oppgrader</string>
     <string name="general_retry_action">Prøv igjen</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Sjekk</string>
     <string name="general_close_action">Lukk</string>
     <string name="general_dismiss_action">Lukk</string>
-    <string name="general_edit_action">Rediger</string>
     <string name="general_save_action">Lagre</string>
     <string name="general_guide_action">Veiledning</string>
     <string name="general_continue_action">Fortsett</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Fortsett musikken når du tar på deg podene igjen, men bare hvis Auto-pause stoppet den. Pauser du utløste selv (telefon, AirPods-stilk, søvn) forblir pauset.</string>
     <string name="settings_start_music_on_wear_label">Start musikk ved påsetting</string>
     <string name="settings_start_music_on_wear_description">Prøver alltid å spille musikk når du setter på podene, selv etter en manuell pause.</string>
-    <string name="settings_eardetection_info_label">Merknad om øredeteksjon</string>
     <string name="settings_eardetection_info_description">Hvis øredeteksjon bare fungerer for den ene poden, er dette en Apple-begrensning. Bare den \"primære poden\" (brukt til mikrofon) oppdages. Konfigurer på Apple-enheter: Innstillinger → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimum signalkvalitet</string>
-    <string name="settings_signal_minimum_description">Minimumssignalkvaliteten som en enhet må ha for å anses som din.</string>
     <string name="settings_autoconnect_label">Autotilkobling</string>
     <string name="settings_autoconnect_description">Hvis Android ikke kobler til automatisk, kan vi be om det også. Dette gjør at CAPod fortsetter å overvåke i bakgrunnen hele tiden.</string>
     <string name="settings_autoconnect_info_android12">Automatisk tilkobling er avhengig av en systemfunksjon som Android 12 og nyere begrenser. Det fungerer kanskje ikke på enheten din.</string>
     <string name="settings_autoconnect_condition_label">Betingelse for autotilkobling</string>
-    <string name="settings_autoconnect_condition_description">Når skal vi prøve å koble til enheten din?</string>
     <string name="settings_devices_label">Enheter</string>
     <string name="settings_devices_description">Administrer enhetene dine.</string>
     <string name="settings_reaction_label">Reaksjoner</string>
-    <string name="settings_category_yourdevice_label">Enheten din</string>
     <string name="settings_category_compatibility_options_title">Kompatibilitets-alternativer</string>
     <string name="settings_category_compatibility_options_description">Ikke rør hvis alt virker ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Deaktiver maskinvarefiltrering</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Starter opp…</string>
     <string name="support_debuglog_label">Feilsøkingslogg</string>
     <string name="support_debuglog_desc">Registrer alt appen gjør i en tekstfil som du kan dele.</string>
-    <string name="debug_debuglog_size_label">Størrelse</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimert størrelse</string>
-    <string name="debug_notification_channel_label">Feilsøkingsvarslinger</string>
-    <string name="debug_debuglog_file_label">Fil med registrert logg</string>
-    <string name="debug_debuglog_recording_progress">Registrerer feilsøkingslogg</string>
     <string name="debug_debuglog_record_action">Registrer feilsøkingslogg</string>
     <string name="debug_debuglog_stop_action">Stopp opptak</string>
     <string name="debug_debuglog_sensitive_information_message">Den genererte filen inneholder sensitiv informasjon (f.eks. detaljer om Bluetooth-enhet). Bare del den med parter du stoler på.</string>
     <string name="settings_debuglog_explanation">Denne funksjonen registrerer alt appen gjør i en fil som kan deles. Den genererte filen inneholder sensitiv informasjon (f.eks. detaljer om Bluetooth-enhet). Bare del den med parter du stoler på (f.eks. en utvikler som feilsøker et problem).</string>
-    <string name="settings_support_installid_label">Installasjons-ID</string>
-    <string name="settings_support_installid_desc">Automatiske feilrapporter er anonyme. Del installasjons-ID-en din hvis utvikleren skal finne feilrapportene dine.</string>
     <string name="settings_support_label">Brukerstøtte</string>
     <string name="settings_support_description">Hvis du trenger hjelp med noe.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Nullstill lærte data?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod vil glemme denne enhetens målte drenering, ladefart og lyttetid, og starte på nytt fra batteriets angitte levetid.</string>
     <string name="settings_acknowledgements_label">Anerkjennelser</string>
-    <string name="settings_debug_autoreports_label">Automatiske feilrapporter</string>
-    <string name="settings_debug_autoreports_description">Rapporterer problemer automatisk, f.eks. detaljer om en appkrasj slik at jeg kan finne ut hvordan jeg kan fikse det.</string>
-    <string name="settings_compatibility_mode_label">Kompatibilitetsmodus</string>
-    <string name="settings_compatibility_mode_description">Deaktiver optimaliseringer for å forbedre kompatibiliteten. Prøv dette hvis du ikke ser noen data.</string>
     <string name="help_translate_label">Oversettelse</string>
     <string name="help_translate_description">Hjelp til med å oversette denne appen til ditt favorittspråk.</string>
     <string name="translators_thanks_title">Oversettere</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Vellykket</string>
     <string name="troubleshooter_ble_result_success_body">BLE advertisement kringkastinger blir mottatt av CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Mislykket</string>
-    <string name="troubleshooter_ble_result_failure_body">Feilsøking mislyktes. Ingen kombinasjoner av kompatibilitets-alternativer fungerte.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefonen din mottok ingen BLE-data i det hele tatt. Du kan prøve denne testen på nytt i et folksomt område for å se om datakilder (annet enn hodetelefonene dine) kan mottas. Ingen data mottatt peker mot et problem med telefonens operativsystem.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefonen din mottok BLE-data, men dataene kommer ikke fra en støttet enhet. Er hodetelefonene dine slått på? Støtter CAPod din type hodetelefoner?</string>
-    <string name="troubleshooter_ble_result_failure_action">Prøv igjen</string>
-    <string name="troubleshoot_action">Feilsøk</string>
     <string name="onboarding_body1">Denne appen legger til støtte for AirPod-spesifikke funksjoner til Android.</string>
     <string name="onboarding_body2">Ikke alle Android-enheter støtter de ekstra AirPod-funksjonene fullt ut. Operativsystemet ditt krever en fungerende Bluetooth-Low-Energy-implementering.</string>
     <string name="onboarding_body3">CAPod har ingen annonser og samler ikke inn dataene dine.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Enheten din er tilkoblet, men CAPod mottar ikke live-data fra den. Telefonen din kan trenge et kompatibilitetsalternativ — feilsøkeren kan prøve å finne ett automatisk.</string>
     <string name="overview_troubleshoot_suggestion_action">Kjør feilsøker</string>
     <string name="overview_unmatched_devices_label">Ikke-matchede enheter</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d enhet uten matchende profil</item>
-        <item quantity="other">%d enheter uten matchende profil</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d enhet i nærheten ble oppdaget uten en matchende profil. Vis den for tilgjengelige detaljer. Hvis den er din, kan du legge til en profil fra Enheter for å gjenkjenne den.</item>
         <item quantity="other">%d enheter i nærheten ble oppdaget uten matchende profiler. Vis dem for tilgjengelige detaljer. Hvis en av dem er din, kan du legge til en profil fra Enheter for å gjenkjenne den.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod bruker \"bakgrunnsposisjonstilgang\" for å aktivere funksjoner som \"Vis popup\" og \"Autotilkobling\" mens appen er lukket. Bakgrunnsposisjonstilgang lar appen motta Bluetooth Low Energy-data mens den er i bakgrunnen. Denne appen vil IKKE bruke Bluetooth-data til å bestemme posisjonen din.</string>
     <string name="permission_ignore_battery_optimizations_label">Deaktiver batterioptimalisering</string>
     <string name="permission_ignore_battery_optimizations_description">Batterioptimalisering forhindrer denne appen fra å pålitelig motta Bluetooth-data mens appen er i bakgrunnen.</string>
-    <string name="permission_required_title">Følgende tillatelse er påkrevd:</string>
     <string name="permission_system_alert_window_label">Systemvarslingsvindu</string>
     <string name="permission_system_alert_window_description">Tillat CAPod å tegne over andre apper for å gjøre funksjonen \"Vis popup\" mulig.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Når sett</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">I øret</string>
     <string name="pods_dual_left_label">Venstre pod</string>
     <string name="pods_dual_right_label">Høyre pod</string>
-    <string name="pods_dual_left_short_label">V</string>
-    <string name="pods_dual_right_short_label">H</string>
-    <string name="pods_case_label">Etui</string>
     <string name="battery_unavailable_label">Batteri ikke tilgjengelig</string>
     <string name="battery_state_low_cd">Lavt batterinivå</string>
     <string name="battery_state_critical_cd">Kritisk lavt batterinivå</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Direktetilkobling aktiv</string>
     <string name="signal_indicator_bars_cd">Signalstyrke: %1$d av 4 streker</string>
     <string name="signal_indicator_disconnected_cd">Signal: frakoblet</string>
-    <string name="pods_yours">Din</string>
     <string name="headset_being_worn_label">Brukes</string>
     <string name="headset_not_being_worn_label">Brukes ikke</string>
     <string name="pods_case_unknown_state">Ukjent tilstand</string>
-    <string name="last_seen_x">Sist sett: %s</string>
-    <string name="first_seen_x">Først sett: %s</string>
     <string name="battery_cached_label">Sist kjent · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dt %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dt</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimum signalkvalitet</string>
     <string name="profiles_signal_quality_description">Oppdage bare enheter med signalstyrke over denne terskelen. Lavere verdier øker deteksjonsrekkevidden, men kan forårsake falske positive. Ikke sett denne for høyt - Bluetooth-mottak er generelt dårlig og varierer med avstand og hindringer.</string>
     <string name="profiles_identitykey_label">Identitetsnøkkel</string>
-    <string name="profilessettings_maindevice_identitykey_description">Enhetens identitetsløsingsnøkkel (IRK), som hjelper CAPod med å identifisere den blant enheter i nærheten.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods endrer ofte Bluetooth-adressen sin for personvern. IRK hjelper CAPod med å gjenkjenne enheten din. Du trenger engangs tilgang til en MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Krypteringsnøkkel</string>
-    <string name="profiles_maindevice_encryptionkey_description">Enhetens krypteringsnøkkel, som lar CAPod hente detaljert statusinformasjon.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods sender en statusmelding der en del er kryptert. Krypteringsnøkkelen lar CAPod dekryptere hele meldingen. Du trenger engangs tilgang til en MacBook.</string>
     <string name="profiles_key_invalid_format">Ugyldig nøkkelformat</string>
     <string name="profiles_key_expected_format">Forventet format: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Du har ulagrede endringer. Hva vil du gjøre?</string>
     <string name="general_save_and_exit_action">Lagre og avslutt</string>
     <string name="general_discard_action">Forkast</string>
-    <string name="general_keep_editing_action">Fortsett redigering</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Opptak for kort</string>
     <string name="debug_debuglog_short_recording_message">En feillogg må fange opp problemet mens det skjer. Fortsett opptaket, reproduser problemet, og stopp deretter opptaket.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Enhetsinnstillinger</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Navn</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-enhetsnavn</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Produsent</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Kanskje senere</string>
     <string name="review_app_body">Vil du gi CAPod en anmeldelse? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Generelt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Hvilken ørepropp som brukes som mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">सेयर गर्नुहोस्</string>
     <string name="general_done_action">भयो</string>
     <string name="general_cancel_action">रद्द गर्नुहोस्</string>
-    <string name="general_copy_action">प्रतिलिपि गर्नुहोस्</string>
     <string name="general_thank_you_label">धन्यवाद</string>
     <string name="general_upgrade_action">अपग्रेड गर्नुहोस्</string>
     <string name="general_retry_action">पुनः प्रयास</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">जाँच गर्नुहोस्</string>
     <string name="general_close_action">बन्द गर्नुहोस्</string>
     <string name="general_dismiss_action">बन्द गर्नुहोस्</string>
-    <string name="general_edit_action">सम्पादन गर्नुहोस्</string>
     <string name="general_save_action"> सुरक्षित गर्नुहोस्</string>
     <string name="general_guide_action">मार्गनिर्देशन</string>
     <string name="general_continue_action">जारी राख्नुहोस्</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">तपाईंले आफ्नो पड्स फेरि लगाउँदा सङ्गीत फेरि सुरु गर्नुहोस्, तर केवल यदि अटो पज ले रोकेको थियो भने। तपाईंले आफैं रोकेका पज (फोन, AirPods स्टेम, निद्रा) रोकिएकै रहन्छन्।</string>
     <string name="settings_start_music_on_wear_label">लगाउँदा सङ्गीत सुरु गर्नुहोस्</string>
     <string name="settings_start_music_on_wear_description">तपाईंले आफ्नो पड्स लगाउँदा सधैं सङ्गीत बजाउने कोशिश गर्छ, म्यानुअल पज पछि पनि।</string>
-    <string name="settings_eardetection_info_label">कान पत्ता लगाउने नोट</string>
     <string name="settings_eardetection_info_description">यदि कान पत्ता लगाउने सुविधा एक पोडको लागि मात्र काम गर्छ भने, यो Apple सीमितता हो। माइक्रोफोनको लागि प्रयोग हुने \"प्राथमिक पोड\" मात्र पत्ता लगाइन्छ। Apple उपकरणहरूमा कन्फिगर गर्नुहोस्: सेटिङ → Bluetooth → AirPods → माइक्रोफोन।</string>
-    <string name="settings_signal_minimum_label">न्यूनतम सिग्नल गुणस्तर</string>
-    <string name="settings_signal_minimum_description">उपकरणलाई तपाइँको मान्नको लागि आवश्यक पर्ने न्यूनतम सिग्नल गुणस्तर।</string>
     <string name="settings_autoconnect_label">स्वत: जडान</string>
     <string name="settings_autoconnect_description">यदि Android स्वचालित रूपमा जोडिँदैन भने, हामी पनि यसलाई अनुरोध गर्न सक्छौं। यसले CAPod लाई सधैं पृष्ठभूमिमा अनुगमन गरिरहन मद्दत गर्छ।</string>
     <string name="settings_autoconnect_info_android12">स्वतः जडान Android 12 र त्यसभन्दा नयाँले प्रतिबन्धित गरेको एउटा प्रणाली सुविधामा निर्भर छ। यो तपाईंको उपकरणमा काम नगर्न सक्छ।</string>
     <string name="settings_autoconnect_condition_label">स्वत: जडान अवस्था</string>
-    <string name="settings_autoconnect_condition_description">हामीले कहिले तपाइँको उपकरणमा जडान गर्ने प्रयास गर्नुपर्छ?</string>
     <string name="settings_devices_label">उपकरणहरू</string>
     <string name="settings_devices_description">आफ्ना उपकरणहरू व्यवस्थापन गर्नुहोस्।</string>
     <string name="settings_reaction_label">प्रतिक्रियाहरू</string>
-    <string name="settings_category_yourdevice_label">तपाईंको उपकरण</string>
     <string name="settings_category_compatibility_options_title">अनुकूलता विकल्पहरू</string>
     <string name="settings_category_compatibility_options_description">सबै कुरा ठीकठाक चलिरहेको छ भने नचलाउनुहोस् ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">हार्डवेयर फिल्टरिङ असक्षम गर्नुहोस्</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">सुरु भइरहेको छ…</string>
     <string name="support_debuglog_label">डिबग लग</string>
     <string name="support_debuglog_desc">एपले गर्ने सबै कुरालाई तपाईंले साझेदारी गर्न सक्ने टेक्स्ट फाइलमा रेकर्ड गर्नुहोस्।</string>
-    <string name="debug_debuglog_size_label">आकार</string>
-    <string name="debug_debuglog_size_compressed_label">संकुचित आकार</string>
-    <string name="debug_notification_channel_label">डिबग सूचनाहरू</string>
-    <string name="debug_debuglog_file_label">रेकर्ड गरिएको लग फाइल</string>
-    <string name="debug_debuglog_recording_progress">डिबग लग रेकर्ड गर्दै</string>
     <string name="debug_debuglog_record_action">डिबग लग रेकर्ड गर्नुहोस्</string>
     <string name="debug_debuglog_stop_action">रेकर्डिङ रोक्नुहोस्</string>
     <string name="debug_debuglog_sensitive_information_message">उत्पन्न गरिएको फाइलमा संवेदनशील जानकारी (जस्तै ब्लुटुथ उपकरण विवरणहरू) समावेश छ। यसलाई विश्वसनीय पक्षहरूसँग मात्र साझेदारी गर्नुहोस्।</string>
     <string name="settings_debuglog_explanation">यो सुविधाले एपले गर्ने सबै कुरालाई साझेदारी गर्न मिल्ने फाइलमा रेकर्ड गर्छ। उत्पन्न गरिएको फाइलमा संवेदनशील जानकारी (जस्तै ब्लुटुथ उपकरण विवरणहरू) समावेश छ। यसलाई विश्वसनीय पक्षहरूसँग मात्र साझेदारी गर्नुहोस् (जस्तै समस्या निवारण गरिरहेको विकासकर्ता)।</string>
-    <string name="settings_support_installid_label">स्थापना आईडी</string>
-    <string name="settings_support_installid_desc">स्वचालित त्रुटि रिपोर्टहरू गुमनाम छन्। यदि विकासकर्तालाई तपाईंको त्रुटि रिपोर्टहरू फेला पार्न आवश्यक छ भने आफ्नो स्थापना आईडी साझेदारी गर्नुहोस्।</string>
     <string name="settings_support_label">समर्थन</string>
     <string name="settings_support_description">यदि तपाईंलाई केही मद्दत चाहिन्छ भने।</string>
     <string name="settings_wiki_label">विकि</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">सिखेको डेटा रिसेट गर्नुहोस्?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ले यो उपकरणको मापन गरिएको ड्रेन, चार्जिङ गति र सुन्ने समय भुल्नेछ, र रेट गरिएको ब्याटरी आयुबाट फेरि सुरु गर्नेछ।</string>
     <string name="settings_acknowledgements_label">स्वीकृतिहरू</string>
-    <string name="settings_debug_autoreports_label">स्वचालित बग रिपोर्टहरू</string>
-    <string name="settings_debug_autoreports_description">समस्याहरू स्वचालित रूपमा रिपोर्ट गर्दछ, उदाहरणका लागि एप क्र्यास बारे विवरणहरू ताकि म यसलाई कसरी समाधान गर्ने भनेर पत्ता लगाउन सकूँ।</string>
-    <string name="settings_compatibility_mode_label">अनुकूलता मोड</string>
-    <string name="settings_compatibility_mode_description">अनुकूलता सुधार गर्न अप्टिमाइजेसनहरू असक्षम गर्नुहोस्। यदि तपाईंले कुनै डाटा देख्नुभएन भने यो प्रयास गर्नुहोस्।</string>
     <string name="help_translate_label">अनुवाद</string>
     <string name="help_translate_description">यो एपलाई आफ्नो मनपर्ने भाषामा अनुवाद गर्न मद्दत गर्नुहोस्।</string>
     <string name="translators_thanks_title">अनुवादकहरू</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">सफलता</string>
     <string name="troubleshooter_ble_result_success_body">CAPod द्वारा BLE विज्ञापन प्रसारणहरू प्राप्त भइरहेका छन्।</string>
     <string name="troubleshooter_ble_result_failure_title">असफल</string>
-    <string name="troubleshooter_ble_result_failure_body">समस्या निवारण असफल भयो। अनुकूलता विकल्पहरूको कुनै पनि संयोजनले मद्दत गरेन।</string>
     <string name="troubleshooter_ble_result_failure_phone_body">तपाईंको फोनले कुनै पनि BLE डाटा प्राप्त गरेन। डाटा स्रोतहरू (तपाईंको हेडफोन बाहेक) प्राप्त गर्न सकिन्छ कि भनेर हेर्न तपाईं यो परीक्षण भीडभाड भएको क्षेत्रमा पुन: प्रयास गर्न सक्नुहुन्छ। कुनै डाटा प्राप्त नहुनुले तपाईंको फोनको अपरेटिङ सिस्टममा समस्या भएको सङ्केत गर्छ।</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">तपाईंको फोनले BLE डाटा प्राप्त गर्‍यो, तर डाटा कुनै पनि समर्थित उपकरणबाट आएको छैन। तपाईंको हेडफोनहरू सक्रिय छन्? CAPod ले तपाईंको हेडफोनलाई समर्थन गर्छ?</string>
-    <string name="troubleshooter_ble_result_failure_action">फेरि प्रयास गर्नुहोस्</string>
-    <string name="troubleshoot_action">समस्या समाधान गर्नुहोस्</string>
     <string name="onboarding_body1">यो एपले एन्ड्रोइडमा AirPod विशेष सुविधाहरूको लागि समर्थन थप्छ।</string>
     <string name="onboarding_body2">सबै एन्ड्रोइड उपकरणहरूले अतिरिक्त AirPod सुविधाहरूलाई पूर्ण रूपमा समर्थन गर्दैनन्। तपाईंको अपरेटिङ सिस्टमलाई सही रूपमा काम गर्ने ब्लुटुथ-कम-ऊर्जा कार्यान्वयन आवश्यक छ।</string>
     <string name="onboarding_body3">CAPod मा कुनै विज्ञापन छैन र तपाईंको डाटा सङ्कलन गर्दैन।</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">तपाईंको यन्त्र जोडिएको छ, तर CAPod ले यसबाट कुनै लाइभ डेटा प्राप्त गरिरहेको छैन। तपाईंको फोनलाई अनुकूलता विकल्पको आवश्यकता पर्न सक्छ — समस्या निवारकले स्वतः एउटा खोज्ने प्रयास गर्न सक्छ।</string>
     <string name="overview_troubleshoot_suggestion_action">समस्या निवारक चलाउनुस्</string>
     <string name="overview_unmatched_devices_label">मेल नखाएका उपकरणहरू</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">मेल खाने प्रोफाइल नभएको %d उपकरण</item>
-        <item quantity="other">मेल खाने प्रोफाइल नभएका %d उपकरणहरू</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d नजिकैको यन्त्र मिल्दो प्रोफाइल बिना पत्ता लाग्यो। उपलब्ध विवरणहरूका लागि यसलाई देखाउनुहोस्। यदि यो तपाईंको हो भने, यसलाई चिन्नका लागि यन्त्रहरूबाट प्रोफाइल थप्नुहोस्।</item>
         <item quantity="other">%d नजिकैका यन्त्रहरू मिल्दो प्रोफाइलहरू बिना पत्ता लागे। उपलब्ध विवरणहरूका लागि तिनीहरूलाई देखाउनुहोस्। यदि तिनीहरूमध्ये एउटा तपाईंको हो भने, यसलाई चिन्नका लागि यन्त्रहरूबाट प्रोफाइल थप्नुहोस्।</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod ले एप बन्द हुँदा \"पपअप देखाउनुहोस्\" र \"स्वत: जडान\" जस्ता सुविधाहरू सक्षम गर्न \"पृष्ठभूमि स्थान पहुँच\" प्रयोग गर्छ। पृष्ठभूमि स्थान पहुँचले एपलाई पृष्ठभूमिमा हुँदा Bluetooth Low Energy डाटा प्राप्त गर्न अनुमति दिन्छ। यो एपले तपाईंको स्थान निर्धारण गर्न Bluetooth डाटा प्रयोग गर्दैन।</string>
     <string name="permission_ignore_battery_optimizations_label">ब्याट्री अप्टिमाइजेसन असक्षम गर्नुहोस्</string>
     <string name="permission_ignore_battery_optimizations_description">ब्याट्री अप्टिमाइजेसनले यो एपलाई पृष्ठभूमिमा हुँदा Bluetooth डाटा भरपर्दो रूपमा प्राप्त गर्नबाट रोक्छ।</string>
-    <string name="permission_required_title">निम्न अनुमति आवश्यक छ:</string>
     <string name="permission_system_alert_window_label">प्रणाली अलर्ट विन्डो</string>
     <string name="permission_system_alert_window_description">\"पपअप देखाउनुहोस्\" सुविधा सम्भव बनाउन CAPod लाई अन्य एपहरूमाथि कोर्न अनुमति दिनुहोस्।</string>
     <string name="settings_reaction_autoconnect_whenseen_label">देखिएमा</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">कानमा</string>
     <string name="pods_dual_left_label">बायाँ पोड</string>
     <string name="pods_dual_right_label">दायाँ पोड</string>
-    <string name="pods_dual_left_short_label">बा</string>
-    <string name="pods_dual_right_short_label">दा</string>
-    <string name="pods_case_label">केस</string>
     <string name="battery_unavailable_label">ब्याट्री उपलब्ध छैन</string>
     <string name="battery_state_low_cd">ब्याटरी कम</string>
     <string name="battery_state_critical_cd">ब्याटरी अत्यन्त कम</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">प्रत्यक्ष जडान सक्रिय</string>
     <string name="signal_indicator_bars_cd">सिग्नल शक्ति: ४ मध्ये %1$d बार</string>
     <string name="signal_indicator_disconnected_cd">सिग्नल: विच्छेदित</string>
-    <string name="pods_yours">तपाईंको</string>
     <string name="headset_being_worn_label">लगाइएको छ</string>
     <string name="headset_not_being_worn_label">लगाइएको छैन</string>
     <string name="pods_case_unknown_state">अज्ञात स्थिति</string>
-    <string name="last_seen_x">अन्तिम देखिएको: %s</string>
-    <string name="first_seen_x">पहिलो पटक देखिएको: %s</string>
     <string name="battery_cached_label">अन्तिम थाहा · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dघ %2$dमि</string>
     <string name="battery_time_remaining_format_h">%1$dघ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">न्यूनतम सिग्नल गुणस्तर</string>
     <string name="profiles_signal_quality_description">यो थ्रेसहोल्डभन्दा माथिको सिग्नल शक्ति भएका उपकरणहरू मात्र पत्ता लगाउनुहोस्। कम मानहरूले पत्ता लगाउने दायरा बढाउँछ तर गलत सकारात्मक निम्त्याउन सक्छ। यसलाई धेरै उच्च नराख्नुहोस् — Bluetooth रिसेप्सन सामान्यतया कमजोर हुन्छ र दूरी र बाधाहरूसँग भिन्न हुन्छ।</string>
     <string name="profiles_identitykey_label">पहिचान कुञ्जी</string>
-    <string name="profilessettings_maindevice_identitykey_description">तपाईंको उपकरणको Identity Resolving Key (IRK), जसले CAPod लाई नजिकका उपकरणहरूमध्ये यसलाई पहिचान गर्न मद्दत गर्छ।</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ले गोपनीयताको लागि आफ्नो Bluetooth ठेगाना बारम्बार परिवर्तन गर्छ। IRK ले CAPod लाई तपाईंको उपकरण चिन्न मद्दत गर्छ। तपाईंलाई MacBook मा एक पटक पहुँच चाहिन्छ।</string>
     <string name="profiles_maindevice_encryptionkey_label">इन्क्रिप्शन कुञ्जी</string>
-    <string name="profiles_maindevice_encryptionkey_description">तपाईंको उपकरणको इन्क्रिप्शन कुञ्जी, जसले CAPod लाई विस्तृत स्थिति जानकारी प्राप्त गर्न अनुमति दिन्छ।</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ले स्थिति सन्देश पठाउँछ, जसको एक भाग इन्क्रिप्टेड हुन्छ। इन्क्रिप्शन कुञ्जीले CAPod लाई पूर्ण सन्देश डिक्रिप्ट गर्न अनुमति दिन्छ। तपाईंलाई MacBook मा एक पटक पहुँच चाहिन्छ।</string>
     <string name="profiles_key_invalid_format">अमान्य कुञ्जी ढाँचा</string>
     <string name="profiles_key_expected_format">अपेक्षित ढाँचा: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">तपाईंसँग नसुरक्षित परिवर्तनहरू छन्। तपाईं के गर्न चाहनुहुन्छ?</string>
     <string name="general_save_and_exit_action">सुरक्षित गर्नुहोस् &amp; बाहिर जानुहोस्</string>
     <string name="general_discard_action">खारेज गर्नुहोस्</string>
-    <string name="general_keep_editing_action">सम्पादन जारी राख्नुहोस्</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">रेकर्डिङ धेरै छोटो छ</string>
     <string name="debug_debuglog_short_recording_message">डिबग लगले समस्या हुँदाकै क्याप्चर गर्नु पर्दछ। रेकर्डिङ चालू राख्नुहोस्, समस्या पुनरुत्पादन गर्नुहोस्, त्यसपछि रेकर्डिङ बन्द गर्नुहोस्।</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">उपकरण सेटिङहरू</string>
     <string name="device_settings_subtitle_profile_prefix">प्रोफाइल: %s</string>
-    <string name="device_settings_info_name_label">नाम</string>
     <string name="device_settings_info_bt_name_label">ब्लुटुथ उपकरण लेबल</string>
     <string name="device_settings_info_model_label">मोडेल</string>
     <string name="device_settings_info_manufacturer_label">निर्माता</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">पछि गर्ने</string>
     <string name="review_app_body">के तपाई CAPod को लागि एक समीक्षा दिन चाहनुहुन्छ? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">सामान्य</string>
     <string name="device_settings_microphone_mode_label">माइक्रोफोन</string>
     <string name="device_settings_microphone_mode_description">कुन इयरबड माइक्रोफोनको रूपमा प्रयोग गरिन्छ</string>
     <string name="device_settings_microphone_mode_auto">स्वतः</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Delen</string>
     <string name="general_done_action">Klaar</string>
     <string name="general_cancel_action">Annuleren</string>
-    <string name="general_copy_action">Kopiëren</string>
     <string name="general_thank_you_label">Bedankt</string>
     <string name="general_upgrade_action">Upgraden</string>
     <string name="general_retry_action">Opnieuw proberen</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Controleren</string>
     <string name="general_close_action">Sluiten</string>
     <string name="general_dismiss_action">Afwijzen</string>
-    <string name="general_edit_action">Bewerken</string>
     <string name="general_save_action">Opslaan</string>
     <string name="general_guide_action">Handleiding</string>
     <string name="general_continue_action">Doorgaan</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Hervat muziek wanneer je je pods weer opdoet, maar alleen als Automatisch pauzeren dit heeft gestopt. Pauzes die je zelf hebt geactiveerd (telefoon, AirPods-steel, slaap) blijven gepauzeerd.</string>
     <string name="settings_start_music_on_wear_label">Muziek starten bij dragen</string>
     <string name="settings_start_music_on_wear_description">Probeert altijd muziek af te spelen wanneer je je pods opdoet, zelfs na een handmatige pauze.</string>
-    <string name="settings_eardetection_info_label">Oordetectienotitie</string>
     <string name="settings_eardetection_info_description">Als oordetectie slechts voor één pod werkt, is dit een beperking van Apple. Alleen de \"primaire pod\" (gebruikt voor de microfoon) wordt gedetecteerd. Configureer op Apple-apparaten: Instellingen → Bluetooth → AirPods → Microfoon.</string>
-    <string name="settings_signal_minimum_label">Minimale signaalkwaliteit</string>
-    <string name="settings_signal_minimum_description">De minimale signaalkwaliteit die een apparaat nodig heeft om als je apparaat te worden beschouwd.</string>
     <string name="settings_autoconnect_label">Automatisch verbinden</string>
     <string name="settings_autoconnect_description">Als Android niet automatisch verbinding maakt, kunnen we het ook vragen. Hierdoor blijft CAPod voortdurend op de achtergrond controleren.</string>
     <string name="settings_autoconnect_info_android12">Automatisch verbinden is afhankelijk van een systeemfunctie die beperkt wordt door Android 12 en nieuwer. Het werkt mogelijk niet op je apparaat.</string>
     <string name="settings_autoconnect_condition_label">Auto verbindingsvoorwaarde</string>
-    <string name="settings_autoconnect_condition_description">Wanneer moeten we proberen verbinding te maken met je apparaat?</string>
     <string name="settings_devices_label">Apparaten</string>
     <string name="settings_devices_description">Beheer je apparaten.</string>
     <string name="settings_reaction_label">Reacties</string>
-    <string name="settings_category_yourdevice_label">Je apparaat</string>
     <string name="settings_category_compatibility_options_title">Compatibiliteitsopties</string>
     <string name="settings_category_compatibility_options_description">Niet aanraken als alles werkt ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Hardware filtering uitzetten</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Aan de slag…</string>
     <string name="support_debuglog_label">Foutopsporingslogboek</string>
     <string name="support_debuglog_desc">Registreer alles wat de app doet in een tekstbestand dat je kunt delen.</string>
-    <string name="debug_debuglog_size_label">Grootte</string>
-    <string name="debug_debuglog_size_compressed_label">Gecomprimeerde grootte</string>
-    <string name="debug_notification_channel_label">Foutopsporingsmeldingen</string>
-    <string name="debug_debuglog_file_label">Opgenomen logbestand</string>
-    <string name="debug_debuglog_recording_progress">Opnemen van foutopsporingslogboek</string>
     <string name="debug_debuglog_record_action">Foutopsporingslogboek opnemen</string>
     <string name="debug_debuglog_stop_action">Stop met opnemen</string>
     <string name="debug_debuglog_sensitive_information_message">Het gegenereerde bestand bevat gevoelige informatie (bijv. Bluetooth-apparaatdetails). Deel het alleen met vertrouwde partijen.</string>
     <string name="settings_debuglog_explanation">Deze functie slaat alles op wat de app doet in een deelbaar bestand. Het gegenereerde bestand bevat gevoelige informatie (bijvoorbeeld. Bluetooth apparaat details). Deel het alleen met vertrouwde partijen (bijv. een ontwikkelaar die problemen oplost).</string>
-    <string name="settings_support_installid_label">Installatie-ID</string>
-    <string name="settings_support_installid_desc">Automatische foutmeldingen zijn anoniem. Deel je installatie-ID als de ontwikkelaar kje foutmeldingen moet kunnen inzien.</string>
     <string name="settings_support_label">Ondersteuning</string>
     <string name="settings_support_description">Als je hulp nodig hebt.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Leergegevens wissen?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod zal het verbruik, de oplaadsnelheid en luisterduur van dit apparaat vergeten en opnieuw met de nominale batterijduur beginnen.</string>
     <string name="settings_acknowledgements_label">Dankbetuigingen</string>
-    <string name="settings_debug_autoreports_label">Automatische bugrapporten</string>
-    <string name="settings_debug_autoreports_description">Rapporteert automatisch problemen, b.v. details over een app-crash, zodat ik kan uitzoeken hoe ik dit kan oplossen.</string>
-    <string name="settings_compatibility_mode_label">Compatibiliteitsmodus</string>
-    <string name="settings_compatibility_mode_description">Schakel optimalisaties uit om de compatibiliteit te verbeteren. Probeer dit als je geen gegevens ziet.</string>
     <string name="help_translate_label">Vertaling</string>
     <string name="help_translate_description">Help deze app te vertalen in je favoriete taal.</string>
     <string name="translators_thanks_title">Vertalers</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Gelukt</string>
     <string name="troubleshooter_ble_result_success_body">BLE-advertentie-uitzendingen worden door CAPod ontvangen.</string>
     <string name="troubleshooter_ble_result_failure_title">Mislukt</string>
-    <string name="troubleshooter_ble_result_failure_body">Problemen oplossen mislukt. Geen enkele combinatie van compatibiliteitsopties heeft geholpen.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Je telefoon heeft helemaal geen BLE-gegevens ontvangen. Je kunt deze test herhalen in een drukke omgeving om te zien of er wel gegevensbronnen (anders dan je koptelefoon) worden ontvangen. Als er geen gegevens worden ontvangen, wijst dit op een probleem met het besturingssysteem van je telefoon.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Je telefoon heeft BLE-gegevens ontvangen, maar de gegevens zijn niet afkomstig van een ondersteund apparaat. Staat je koptelefoon aan? Ondersteunt CAPod je koptelefoon?</string>
-    <string name="troubleshooter_ble_result_failure_action">Probeer opnieuw</string>
-    <string name="troubleshoot_action">Problemen oplossen</string>
     <string name="onboarding_body1">Deze app voegt ondersteuning voor AirPod-specifieke functies toe aan Android.</string>
     <string name="onboarding_body2">Niet alle Android-apparaten ondersteunen de extra AirPod-functies volledig. Je besturingssysteem vereist een correct werkende Bluetooth-Low-Energy implementatie.</string>
     <string name="onboarding_body3">CAPod heeft geen advertenties en verzamelt je gegevens niet.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Je apparaat is verbonden, maar CAPod ontvangt geen live gegevens. Je telefoon heeft mogelijk een compatibiliteitsoptie nodig — de probleemoplosser kan er automatisch een zoeken.</string>
     <string name="overview_troubleshoot_suggestion_action">Probleemoplosser starten</string>
     <string name="overview_unmatched_devices_label">Niet overeenkomende apparaten</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d apparaat zonder overeenkomend profiel</item>
-        <item quantity="other">%d apparaten zonder overeenkomend profiel</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Er is %d apparaat in de buurt gedetecteerd zonder bijbehorend profiel. Bekijk het voor beschikbare details. Als het van jou is, voeg dan een profiel toe via Apparaten om het te herkennen.</item>
         <item quantity="other">Er zijn %d apparaten in de buurt gedetecteerd zonder bijbehorende profielen. Bekijk ze voor beschikbare details. Als een ervan van jou is, voeg dan een profiel toe via Apparaten om het te herkennen.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod gebruikt \'locatietoegang op de achtergrond\' om functies zoals \'Pop-up weergeven\' en \'Automatisch verbinden\' in te schakelen terwijl de app gesloten is. Met locatietoegang op de achtergrond kan de app Bluetooth Low Energy-gegevens ontvangen terwijl deze op de achtergrond actief is. Deze app gebruikt GEEN Bluetooth-gegevens om je locatie te bepalen.</string>
     <string name="permission_ignore_battery_optimizations_label">Batterij-optimalisaties uitschakelen</string>
     <string name="permission_ignore_battery_optimizations_description">Door batterijoptimalisatie kan deze app geen betrouwbare Bluetooth-gegevens ontvangen zolang de app op de achtergrond draait.</string>
-    <string name="permission_required_title">De volgende toestemming is vereist:</string>
     <string name="permission_system_alert_window_label">Systeemwaarschuwingsvenster</string>
     <string name="permission_system_alert_window_description">Geef CAPod de mogelijkheid om over andere apps heen te tekenen, zodat de functie \"Pop-up weergeven\" mogelijk is.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Wanneer gezien</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">In oor</string>
     <string name="pods_dual_left_label">Linker pod</string>
     <string name="pods_dual_right_label">Rechter pod</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">Geval</string>
     <string name="battery_unavailable_label">Batterij niet beschikbaar</string>
     <string name="battery_state_low_cd">Batterij laag</string>
     <string name="battery_state_critical_cd">Batterij kritiek leeg</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Directe verbinding actief</string>
     <string name="signal_indicator_bars_cd">Signaalsterkte: %1$d van 4 balken</string>
     <string name="signal_indicator_disconnected_cd">Signaal: verbroken verbinding</string>
-    <string name="pods_yours">Jouw</string>
     <string name="headset_being_worn_label">Wordt gedragen</string>
     <string name="headset_not_being_worn_label">Wordt niet gedragen</string>
     <string name="pods_case_unknown_state">Onbekende status</string>
-    <string name="last_seen_x">Laatst gezien: %s</string>
-    <string name="first_seen_x">Voor het eerst gezien: %s</string>
     <string name="battery_cached_label">Laatst bekend \u00B7 %s</string>
     <string name="battery_time_remaining_format_hm">%1$du %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$du</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimale Signaalkwaliteit</string>
     <string name="profiles_signal_quality_description">Detecteer alleen apparaten met een signaalsterkte boven deze drempelwaarde. Lagere waarden vergroten het detectiebereik, maar kunnen valse positieven veroorzaken. Stel deze waarde niet te hoog in - Bluetooth-ontvangst is over het algemeen slecht en varieert met de afstand en obstakels.</string>
     <string name="profiles_identitykey_label">Identiteitssleutel</string>
-    <string name="profilessettings_maindevice_identitykey_description">De Identity Resolving Key (IRK) van je apparaat, waarmee CAPod je apparaat kan identificeren tussen apparaten in de buurt.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods veranderen regelmatig hun Bluetooth-adres om privacyredenen. De IRK helpt CAPod je apparaat te herkennen. Je hebt eenmalig toegang tot een MacBook nodig.</string>
     <string name="profiles_maindevice_encryptionkey_label">Encryptiesleutel</string>
-    <string name="profiles_maindevice_encryptionkey_description">De encryptiesleutel van je apparaat, waarmee CAPod gedetailleerde statusinformatie kan ophalen.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods sturen een statusbericht, waarvan een deel versleuteld is. De encryptiesleutel stelt CAPod in staat het volledige bericht te ontsleutelen. Je hebt hiervoor eenmalige toegang tot een MacBook nodig.</string>
     <string name="profiles_key_invalid_format">Ongeldig sleutelformaat</string>
     <string name="profiles_key_expected_format">Verwacht formaat: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Je hebt niet-opgeslagen wijzigingen. Wat wil je ermee doen?</string>
     <string name="general_save_and_exit_action">Opslaan &amp; afsluiten</string>
     <string name="general_discard_action">Weggooien</string>
-    <string name="general_keep_editing_action">Blijf Bewerken</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Opname te kort</string>
     <string name="debug_debuglog_short_recording_message">Een debuglogboek moet het probleem vastleggen terwijl het zich voordoet. Blijf opnemen, reproduceer het probleem en stop dan de opname.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Apparaatinstellingen</string>
     <string name="device_settings_subtitle_profile_prefix">Profiel: %s</string>
-    <string name="device_settings_info_name_label">Naam</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-apparaatlabel</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Fabrikant</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Misschien later</string>
     <string name="review_app_body">Wil je CAPod een beoordeling achterlaten? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Algemeen</string>
     <string name="device_settings_microphone_mode_label">Microfoon</string>
     <string name="device_settings_microphone_mode_description">Welk oordopje wordt gebruikt als microfoon</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Udostępnij</string>
     <string name="general_done_action">Gotowe</string>
     <string name="general_cancel_action">Anuluj</string>
-    <string name="general_copy_action">Kopiuj</string>
     <string name="general_thank_you_label">Dziękuję ci</string>
     <string name="general_upgrade_action">Uaktualnij</string>
     <string name="general_retry_action">Ponów</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Sprawdź</string>
     <string name="general_close_action">Zamknij</string>
     <string name="general_dismiss_action">Zamknij</string>
-    <string name="general_edit_action">Edytuj</string>
     <string name="general_save_action">Zapisz</string>
     <string name="general_guide_action">Poradnik</string>
     <string name="general_continue_action">Kontynuuj</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Wznów odtwarzanie muzyki po ponownym założeniu słuchawek, ale tylko wtedy, gdy funkcja automatycznej pauzy ją wyłączyła. Pauzy, które sam uruchomiłeś (telefon, słuchawka AirPods, sen), pozostają wstrzymane.</string>
     <string name="settings_start_music_on_wear_label">Włącz muzykę po założeniu</string>
     <string name="settings_start_music_on_wear_description">Zawsze próbuj odtwarzać muzykę po włożeniu słuchawek, nawet po ręcznym wstrzymaniu.</string>
-    <string name="settings_eardetection_info_label">Informacja o wykryciu ucha</string>
     <string name="settings_eardetection_info_description">Jeśli wykrywanie w uchu działa tylko dla jednej słuchawki, jest to ograniczenie Apple. Wykrywana jest tylko „główna słuchawka” (używana do mikrofonu). Skonfiguruj na urządzeniach Apple: Ustawienia → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimalna jakość sygnału</string>
-    <string name="settings_signal_minimum_description">Minimalna jakość sygnału, wymagana od urządzenia, aby zostało uznanym za twoje.</string>
     <string name="settings_autoconnect_label">Automatyczne połączenie</string>
     <string name="settings_autoconnect_description">Jeśli Android nie połączy się automatycznie, możemy również o to poprosić. Dzięki temu CAPod będzie stale monitorował system w tle.</string>
     <string name="settings_autoconnect_info_android12">Automatyczne łączenie opiera się na funkcji systemowej, którą ograniczają systemy Android 12 i nowsze. Funkcja ta może nie działać na twoim urządzeniu.</string>
     <string name="settings_autoconnect_condition_label">Warunek automatycznego połączenia</string>
-    <string name="settings_autoconnect_condition_description">Kiedy należy połączyć się z twoim urządzeniem?</string>
     <string name="settings_devices_label">Urządzenia</string>
     <string name="settings_devices_description">Zarządzaj swoimi urządzeniami.</string>
     <string name="settings_reaction_label">Reakcje</string>
-    <string name="settings_category_yourdevice_label">Twoje urządzenie</string>
     <string name="settings_category_compatibility_options_title">Opcje kompatybilności</string>
     <string name="settings_category_compatibility_options_description">Nie dotykaj, jeżeli wszystko działa ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Wyłącz sprzętowe filtrowanie</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Uruchamianie…</string>
     <string name="support_debuglog_label">Dziennik debugowania</string>
     <string name="support_debuglog_desc">Rejestruj wszystko, co robi aplikacja do pliku tekstowego, który możesz udostępnić.</string>
-    <string name="debug_debuglog_size_label">Rozmiar</string>
-    <string name="debug_debuglog_size_compressed_label">Rozmiar skompresowany</string>
-    <string name="debug_notification_channel_label">Powiadomienia debugowania</string>
-    <string name="debug_debuglog_file_label">Zapisany plik dziennika</string>
-    <string name="debug_debuglog_recording_progress">Rejestrowanie dziennika debugowania</string>
     <string name="debug_debuglog_record_action">Rejestruj dziennik debugowania</string>
     <string name="debug_debuglog_stop_action">Zatrzymaj rejestrowanie</string>
     <string name="debug_debuglog_sensitive_information_message">Wygenerowany plik zawiera poufne informacje (np. dane urządzenia Bluetooth). Udostępniaj go tylko zaufanym podmiotom.</string>
     <string name="settings_debuglog_explanation">Ta funkcja rejestruje wszystkie działania aplikacji w pliku, który można udostępniać. Wygenerowany plik zawiera poufne informacje (np. dane urządzenia Bluetooth). Udostępniaj go tylko zaufanym podmiotom (np. programistom rozwiązującym problem).</string>
-    <string name="settings_support_installid_label">ID instalacji</string>
-    <string name="settings_support_installid_desc">Automatyczne raporty błędów są anonimowe. Udostępni swoje ID instalacji, aby autor mógł znaleźć twój raport błędu.</string>
     <string name="settings_support_label">Wsparcie</string>
     <string name="settings_support_description">Jeśli potrzebujesz pomocy.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Zresetować zapamiętane dane?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod zapomni o zmierzonej szybkości rozładowania, szybkości ładowania i czasie pracy tego urządzenia i zacznie od nowa od podanego czasu pracy baterii.</string>
     <string name="settings_acknowledgements_label">Podziękowania</string>
-    <string name="settings_debug_autoreports_label">Automatyczne raportowanie błędów</string>
-    <string name="settings_debug_autoreports_description">Automatyczne raportowanie problemów, na przykład w przypadku awarii aplikacji, tak aby można było łatwo ją naprawić.</string>
-    <string name="settings_compatibility_mode_label">Tryb kompatybilności</string>
-    <string name="settings_compatibility_mode_description">Wyłącza optymalizacje, aby poprawić kompatybilność. Wypróbuj, jeśli nie widzisz żadnych danych.</string>
     <string name="help_translate_label">Tłumaczenie</string>
     <string name="help_translate_description">Pomóż przetłumaczyć aplikację na twój ulubiony język.</string>
     <string name="translators_thanks_title">Tłumacze</string>
@@ -175,11 +157,8 @@ K4r0lSz;</string>
     <string name="troubleshooter_ble_result_success_title">Sukces</string>
     <string name="troubleshooter_ble_result_success_body">Audycje reklamowe BLE są odbierane przez CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Niepowodzenie</string>
-    <string name="troubleshooter_ble_result_failure_body">Rozwiązywanie problemów się nie powiodło. Nie pomogła żadna kombinacja opcji kompatybilności.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Twój telefon w ogóle nie odebrał danych BLE. Możesz powtórzyć test w zatłoczonym miejscu, aby sprawdzić, czy można odebrać dane ze źródeł innych niż słuchawki. Brak odbioru danych wskazuje na problem z systemem operacyjnym telefonu.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Twój telefon odebrał dane BLE, jednak nie pochodzą one z obsługiwanego urządzenia. Czy twoje słuchawki są włączone? Czy CAPod obsługuje twoje słuchawki?</string>
-    <string name="troubleshooter_ble_result_failure_action">Spróbuj ponownie</string>
-    <string name="troubleshoot_action">Rozwiązywanie problemów</string>
     <string name="onboarding_body1">Ta aplikacja dodaje wsparcie dla funkcji AirPods na Androidzie.</string>
     <string name="onboarding_body2">Nie wszystkie urządzenia z Androidem w pełni wspierają dodatkowe funkcje AirPods. Twój system operacyjny wymaga dobrze działającej implementacji Bluetooth Low Energy.</string>
     <string name="onboarding_body3">CAPod nie wyświetla reklam i nie zbiera twoich danych.</string>
@@ -209,12 +188,6 @@ K4r0lSz;</string>
     <string name="overview_troubleshoot_suggestion_description">Twoje urządzenie jest połączone, ale CAPod nie odbiera żadnych danych na żywo. Twój telefon może potrzebować opcji zgodności — narzędzie do rozwiązywania problemów może spróbować znaleźć ją automatycznie.</string>
     <string name="overview_troubleshoot_suggestion_action">Uruchom narzędzie do rozwiązywania problemów</string>
     <string name="overview_unmatched_devices_label">Niedopasowane urządzenia</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d urządzenie bez pasującego profilu</item>
-        <item quantity="few">%d urządzenia bez pasującego profilu</item>
-        <item quantity="many">%d urządzeń bez pasującego profilu</item>
-        <item quantity="other">%d urządzeń bez pasującego profilu</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Wykryto %d pobliskie urządzenie bez pasującego profilu. Pokaż je, aby zobaczyć dostępne szczegóły. Jeśli jest twoje, dodaj profil w Urządzeniach, aby je rozpoznać.</item>
         <item quantity="few">Wykryto %d pobliskie urządzenia bez pasujących profili. Pokaż je, aby zobaczyć dostępne szczegóły. Jeśli jedno z nich jest twoje, dodaj profil w Urządzeniach, aby je rozpoznać.</item>
@@ -239,7 +212,6 @@ K4r0lSz;</string>
     <string name="permission_background_location_description">CAPdo używa dostępu do lokalizacji w tle, aby skorzystać z funkcjonalności takich jak \"Wyświetl okienko\" lub \"Automatycznie połącz\", gdy aplikacja jest zamknięta. Dostęp do lokalizacji w tle pozwala aplikacji na odbieranie danych Bluetooth Low Energy, gdy aplikacja działa w tle. Aplikacja nie będzie korzystać z danych Bluetooth do ustalenia twojego położenia.</string>
     <string name="permission_ignore_battery_optimizations_label">Wyłącz optymalizację baterii</string>
     <string name="permission_ignore_battery_optimizations_description">Optymalizacja baterii zapobiega przed niezawodnym odbieraniem danych Bluetooth, gdy aplikacja działa w tle.</string>
-    <string name="permission_required_title">Następujące uprawnienie jest wymagane:</string>
     <string name="permission_system_alert_window_label">Okna alertów systemowych</string>
     <string name="permission_system_alert_window_description">Zezwól na wyświetlanie CAPod nad innymi aplikacjami, aby aktywować funkcję \"Wyświetlanie informacji\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kiedy widoczne</string>
@@ -247,9 +219,6 @@ K4r0lSz;</string>
     <string name="settings_reaction_autoconnect_inear_label">W uszach</string>
     <string name="pods_dual_left_label">Lewa słuchawka</string>
     <string name="pods_dual_right_label">Prawa słuchawka</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">P</string>
-    <string name="pods_case_label">Etui</string>
     <string name="battery_unavailable_label">Bateria niedostępna</string>
     <string name="battery_state_low_cd">Bateria słaba</string>
     <string name="battery_state_critical_cd">Bateria krytycznie słaba</string>
@@ -306,12 +275,9 @@ K4r0lSz;</string>
     <string name="signal_badge_aap_cd">Połączenie bezpośrednie aktywne</string>
     <string name="signal_indicator_bars_cd">Siła sygnału: %1$d z 4 kresek</string>
     <string name="signal_indicator_disconnected_cd">Sygnał: rozłączony</string>
-    <string name="pods_yours">Twoje</string>
     <string name="headset_being_worn_label">Założone</string>
     <string name="headset_not_being_worn_label">Nie założone</string>
     <string name="pods_case_unknown_state">Nieznany stan</string>
-    <string name="last_seen_x">Ostatnio widziane: %s</string>
-    <string name="first_seen_x">Widziane pierwszy raz: %s</string>
     <string name="battery_cached_label">Ostatnio znane · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dg %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dg</string>
@@ -341,10 +307,8 @@ K4r0lSz;</string>
     <string name="profiles_signal_quality_title">Minimalna jakość sygnału</string>
     <string name="profiles_signal_quality_description">Wykrywa tylko urządzenia o sile sygnału powyżej tego progu. Niższe wartości zwiększają zasięg wykrywania, ale mogą powodować fałszywe alarmy. Nie ustawiaj zbyt wysokiego poziomu – odbiór Bluetooth jest zazwyczaj słaby i zmienia się w zależności od odległości i przeszkód.</string>
     <string name="profiles_identitykey_label">Klucz identyfikacyjny</string>
-    <string name="profilessettings_maindevice_identitykey_description">Klucz identyfikacyjny (IRK) twojego urządzenia, który pomaga CAPod zidentyfikować je wśród pobliskich urządzeń.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods często zmienia swój adres Bluetooth dla prywatności. IRK pomaga CAPod rozpoznawać twoje urządzenie. Potrzebujesz jednorazowego dostępu do MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Klucz szyfrowania</string>
-    <string name="profiles_maindevice_encryptionkey_description">Klucz szyfrowania twojego urządzenia, który umożliwia CAPod pobieranie szczegółowych informacji o statusie.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods wysyła wiadomość o statusie, której część jest zaszyfrowana. Klucz szyfrowania pozwala CAPod odszyfrować całą wiadomość. Potrzebujesz jednorazowego dostępu do MacBook.</string>
     <string name="profiles_key_invalid_format">Nieprawidłowy format klucza</string>
     <string name="profiles_key_expected_format">Oczekiwany format: %1$s</string>
@@ -377,7 +341,6 @@ K4r0lSz;</string>
     <string name="general_unsaved_changes_message">Masz niezapisane zmiany. Co chcesz zrobić?</string>
     <string name="general_save_and_exit_action">Zapisz i wyjdź</string>
     <string name="general_discard_action">Odrzuć</string>
-    <string name="general_keep_editing_action">Kontynuuj edytowanie</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Nagranie zbyt krótkie</string>
     <string name="debug_debuglog_short_recording_message">Dziennik debugowania musi przechwycić problem w momencie jego wystąpienia. Kontynuuj nagrywanie, odtwórz problem, a następnie zatrzymaj nagrywanie.</string>
@@ -454,7 +417,6 @@ K4r0lSz;</string>
     <!-- Device Settings -->
     <string name="device_settings_title">Ustawienia urządzenia</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Nazwa</string>
     <string name="device_settings_info_bt_name_label">Etykieta urządzenia Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producent</string>
@@ -534,7 +496,6 @@ K4r0lSz;</string>
     <string name="review_app_dismiss_action">Może później</string>
     <string name="review_app_body">Wystawisz opinię dla CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Ogólne</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Która słuchawka jest używana jako mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Compartilhar</string>
     <string name="general_done_action">Pronto</string>
     <string name="general_cancel_action">Cancelar</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Obrigado</string>
     <string name="general_upgrade_action">Atualizar</string>
     <string name="general_retry_action">Repetir</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Fechar</string>
     <string name="general_dismiss_action">Dispensar</string>
-    <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Salvar</string>
     <string name="general_guide_action">Guia</string>
     <string name="general_continue_action">Continuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Retoma a música quando você colocar os fones novamente, mas somente se a Pausa automática a tiver pausado. Pausas feitas por você (telefone, haste do AirPods, suspensão) continuam pausadas.</string>
     <string name="settings_start_music_on_wear_label">Iniciar música ao usar</string>
     <string name="settings_start_music_on_wear_description">Sempre tenta reproduzir música quando você coloca os fones, mesmo após uma pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota sobre detecção auricular</string>
     <string name="settings_eardetection_info_description">Se a detecção auricular funcionar apenas para um fone, essa é uma limitação da Apple. Apenas o \"fone principal\" (usado para o microfone) é detectado. Configure em dispositivos Apple: Ajustes → Bluetooth → AirPods → Microfone.</string>
-    <string name="settings_signal_minimum_label">Qualidade mínima do sinal</string>
-    <string name="settings_signal_minimum_description">A qualidade mínima do sinal que um dispositivo precisa ter para ser considerado seu.</string>
     <string name="settings_autoconnect_label">Conexão automática</string>
     <string name="settings_autoconnect_description">Se o Android não conectar automaticamente, podemos pedir também. Isso mantém o CAPod monitorando em segundo plano o tempo todo.</string>
     <string name="settings_autoconnect_info_android12">A conexão automática depende de um recurso do sistema restrito pelo Android 12 e versões mais recentes. Pode não funcionar no seu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condição de conexão automática</string>
-    <string name="settings_autoconnect_condition_description">Quando devemos tentar nos conectar ao seu dispositivo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Gerenciar seus dispositivos</string>
     <string name="settings_reaction_label">Reações</string>
-    <string name="settings_category_yourdevice_label">Seu dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opções de compatibilidade</string>
     <string name="settings_category_compatibility_options_description">Não toque se tudo funcionar ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desativar filtragem de hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Log de depuração</string>
     <string name="support_debuglog_desc">Registre tudo o que o aplicativo faz em um arquivo de texto que você pode compartilhar.</string>
-    <string name="debug_debuglog_size_label">Tamanho</string>
-    <string name="debug_debuglog_size_compressed_label">Tamanho compactado</string>
-    <string name="debug_notification_channel_label">Notificações de depuração</string>
-    <string name="debug_debuglog_file_label">Arquivo de log gravado</string>
-    <string name="debug_debuglog_recording_progress">Gravando log de depuração</string>
     <string name="debug_debuglog_record_action">Gravar log de depuração</string>
     <string name="debug_debuglog_stop_action">Parar gravação</string>
     <string name="debug_debuglog_sensitive_information_message">O arquivo gerado contém informações confidenciais (por exemplo, detalhes do dispositivo Bluetooth). Compartilhe-o apenas com partes confiáveis.</string>
     <string name="settings_debuglog_explanation">Este recurso registra tudo o que o aplicativo faz em um arquivo compartilhável. O arquivo gerado contém informações confidenciais (por exemplo, detalhes do dispositivo Bluetooth). Compartilhe-o apenas com partes confiáveis (por exemplo, um desenvolvedor que está solucionando um problema).</string>
-    <string name="settings_support_installid_label">ID de instalação</string>
-    <string name="settings_support_installid_desc">Os relatórios automáticos de erros são anônimos. Compartilhe seu ID de instalação se o desenvolvedor precisar encontrar seus relatórios de erros.</string>
     <string name="settings_support_label">Suporte</string>
     <string name="settings_support_description">Se você precisar de alguma ajuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Redefinir dados aprendidos?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod esquecerá a drenagem medida deste dispositivo, velocidade de carregamento e tempo de escuta, e começará novamente com a vida útil nominal da bateria.</string>
     <string name="settings_acknowledgements_label">Agradecimentos</string>
-    <string name="settings_debug_autoreports_label">Relatórios automáticos de bugs</string>
-    <string name="settings_debug_autoreports_description">Relata problemas automaticamente, por exemplo. detalhes sobre uma falha de aplicativo para que eu possa descobrir como corrigi-lo.</string>
-    <string name="settings_compatibility_mode_label">Modo de compatibilidade</string>
-    <string name="settings_compatibility_mode_description">Desative as otimizações para melhorar a compatibilidade. Tente isto se você não estiver vendo nenhum dado.</string>
     <string name="help_translate_label">Tradução</string>
     <string name="help_translate_description">Ajude a traduzir este aplicativo para seu idioma favorito.</string>
     <string name="translators_thanks_title">Tradutores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sucesso</string>
     <string name="troubleshooter_ble_result_success_body">As transmissões de anúncios BLE estão sendo recebidas pelo CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Sem sucesso</string>
-    <string name="troubleshooter_ble_result_failure_body">A solução de problemas falhou. Nenhuma combinação de opções de compatibilidade ajudou.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Seu telefone não recebeu nenhum dado BLE. Você pode tentar novamente este teste em uma área lotada para ver se fontes de dados (além dos fones de ouvido) podem ser recebidas. Nenhum dado recebido indica um problema no sistema operacional do seu telefone.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Seu telefone recebeu dados BLE, mas os dados não vêm de nenhum dispositivo compatível. Seus fones de ouvido estão ligados? O CAPod suporta seu fone de ouvido?</string>
-    <string name="troubleshooter_ble_result_failure_action">Tentar novamente</string>
-    <string name="troubleshoot_action">Solucionar problemas</string>
     <string name="onboarding_body1">Este aplicativo adiciona suporte para recursos específicos do AirPod ao Android.</string>
     <string name="onboarding_body2">Nem todos os dispositivos Android oferecem suporte total aos recursos extras do AirPod. Seu sistema operacional requer uma implementação de Bluetooth de Baixo Consumo de Energia que funcione corretamente.</string>
     <string name="onboarding_body3">O CAPod não possui anúncios e não coleta seus dados.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Seu dispositivo está conectado, mas o CAPod não está recebendo dados em tempo real dele. Seu telefone pode precisar de uma opção de compatibilidade — o solucionador de problemas pode tentar encontrar uma automaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Executar solucionador de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos sem correspondência</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo sem perfil correspondente</item>
-        <item quantity="other">%d dispositivos sem perfil correspondente</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d dispositivo próximo foi detectado sem um perfil correspondente. Exiba-o para ver os detalhes disponíveis. Se for seu, adicione um perfil em Dispositivos para reconhecê-lo.</item>
         <item quantity="other">%d dispositivos próximos foram detectados sem perfis correspondentes. Exiba-os para ver os detalhes disponíveis. Se algum deles for seu, adicione um perfil em Dispositivos para reconhecê-lo.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">O CAPod usa o \"Acesso à localização em segundo plano\" para habilitar recursos como \"Mostrar popup\" e \"Conexão automática\" quando o aplicativo está fechado. O acesso à localização em segundo plano permite que o aplicativo receba dados Bluetooth de Baixo Consumo de Energia em segundo plano. Este aplicativo NÃO usará dados Bluetooth para determinar sua localização.</string>
     <string name="permission_ignore_battery_optimizations_label">Desativar otimizações de bateria</string>
     <string name="permission_ignore_battery_optimizations_description">As otimizações de bateria impedem este aplicativo de receber dados Bluetooth de forma confiável quando está em segundo plano.</string>
-    <string name="permission_required_title">A seguinte permissão é necessária:</string>
     <string name="permission_system_alert_window_label">Janela de Alerta do Sistema</string>
     <string name="permission_system_alert_window_description">Permitir que o CAPod desenhe sobre outros aplicativos para tornar possível o recurso \"Mostrar PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Quando visto</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">No ouvido</string>
     <string name="pods_dual_left_label">Fone esquerdo</string>
     <string name="pods_dual_right_label">Fone direito</string>
-    <string name="pods_dual_left_short_label">E</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Estojo</string>
     <string name="battery_unavailable_label">Bateria indisponível</string>
     <string name="battery_state_low_cd">Bateria baixa</string>
     <string name="battery_state_critical_cd">Bateria crítica</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Conexão direta ativa</string>
     <string name="signal_indicator_bars_cd">Intensidade do sinal: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Sinal: desconectado</string>
-    <string name="pods_yours">Seu</string>
     <string name="headset_being_worn_label">Sendo usado</string>
     <string name="headset_not_being_worn_label">Não está sendo usado</string>
     <string name="pods_case_unknown_state">Estado desconhecido</string>
-    <string name="last_seen_x">Visto por último: %s</string>
-    <string name="first_seen_x">Visto pela primeira vez: %s</string>
     <string name="battery_cached_label">Visto por último · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Qualidade Mínima do Sinal</string>
     <string name="profiles_signal_quality_description">Detectar apenas dispositivos com intensidade de sinal acima deste limite. Valores mais baixos aumentam o alcance de detecção, mas podem causar falsos positivos. Não defina isso muito alto - a recepção Bluetooth geralmente é fraca e varia com a distância e obstáculos.</string>
     <string name="profiles_identitykey_label">Chave de Identidade</string>
-    <string name="profilessettings_maindevice_identitykey_description">A Chave de Resolução de Identidade (IRK) do seu dispositivo, que ajuda o CAPod a identificá-lo entre dispositivos próximos.</string>
     <string name="profiles_maindevice_identitykey_explanation">Os AirPods mudam frequentemente o endereço Bluetooth para privacidade. A IRK ajuda o CAPod a reconhecer seu dispositivo. Você precisa de acesso único a um MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Chave de Criptografia</string>
-    <string name="profiles_maindevice_encryptionkey_description">A chave de criptografia do seu dispositivo, que permite ao CAPod obter informações detalhadas de status.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Os AirPods enviam uma mensagem de status, parte da qual é criptografada. A chave de criptografia permite ao CAPod descriptografar a mensagem completa. Você precisa de acesso único a um MacBook.</string>
     <string name="profiles_key_invalid_format">Formato de chave inválido</string>
     <string name="profiles_key_expected_format">Formato esperado: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Você tem alterações não salvas. O que gostaria de fazer?</string>
     <string name="general_save_and_exit_action">Salvar &amp; Sair</string>
     <string name="general_discard_action">Descartar</string>
-    <string name="general_keep_editing_action">Continuar Editando</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Gravação muito curta</string>
     <string name="debug_debuglog_short_recording_message">Um log de depuração precisa capturar o problema enquanto ele acontece. Continue gravando, reproduza o problema e depois pare a gravação.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Configurações do dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nome</string>
     <string name="device_settings_info_bt_name_label">Rótulo do dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Talvez depois</string>
     <string name="review_app_body">Você gostaria de deixar uma avaliação do CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Gerais</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>
     <string name="device_settings_microphone_mode_description">Qual fone é usado como microfone</string>
     <string name="device_settings_microphone_mode_auto">Automático</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Partilhar</string>
     <string name="general_done_action">Concluído</string>
     <string name="general_cancel_action">Cancelar</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Obrigado</string>
     <string name="general_upgrade_action">Atualizar</string>
     <string name="general_retry_action">Tentar novamente</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Verificar</string>
     <string name="general_close_action">Fechar</string>
     <string name="general_dismiss_action">Dispensar</string>
-    <string name="general_edit_action">Editar</string>
     <string name="general_save_action">Guardar</string>
     <string name="general_guide_action">Guia</string>
     <string name="general_continue_action">Continuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Retoma a música ao colocar os auriculares novamente, mas apenas se a pausa automática a tiver interrompido. As pausas que acionaste tu próprio (telefone, haste dos AirPods, suspensão) permanecem pausadas.</string>
     <string name="settings_start_music_on_wear_label">Iniciar música ao colocar</string>
     <string name="settings_start_music_on_wear_description">Tenta sempre reproduzir música quando colocas os auriculares, mesmo após uma pausa manual.</string>
-    <string name="settings_eardetection_info_label">Nota sobre deteção de ouvido</string>
     <string name="settings_eardetection_info_description">Se a deteção de ouvido funcionar apenas para um auricular, é uma limitação da Apple. Apenas o \"auricular principal\" (utilizado para o microfone) é detetado. Configure em dispositivos Apple: Definições → Bluetooth → AirPods → Microfone.</string>
-    <string name="settings_signal_minimum_label">Qualidade mínima do sinal</string>
-    <string name="settings_signal_minimum_description">A qualidade mínima do sinal que um dispositivo tem de ter para ser considerado seu.</string>
     <string name="settings_autoconnect_label">Ligar automaticamente</string>
     <string name="settings_autoconnect_description">Se o Android não se ligar automaticamente, podemos pedir-lhe para o fazer. Isto mantém o CAPod a monitorizar em segundo plano o tempo todo.</string>
     <string name="settings_autoconnect_info_android12">A ligação automática depende de uma funcionalidade do sistema que o Android 12 e versões mais recentes restringem. Pode não funcionar no seu dispositivo.</string>
     <string name="settings_autoconnect_condition_label">Condição de ligação automática</string>
-    <string name="settings_autoconnect_condition_description">Quando é que devemos tentar ligar ao seu dispositivo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Gerir os seus dispositivos.</string>
     <string name="settings_reaction_label">Reações</string>
-    <string name="settings_category_yourdevice_label">O seu dispositivo</string>
     <string name="settings_category_compatibility_options_title">Opções de compatibilidade</string>
     <string name="settings_category_compatibility_options_description">Não mexa se tudo estiver a funcionar ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Desativar filtragem por hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="support_debuglog_label">Registo de depuração</string>
     <string name="support_debuglog_desc">Registe tudo o que a aplicação faz num ficheiro de texto que pode partilhar.</string>
-    <string name="debug_debuglog_size_label">Tamanho</string>
-    <string name="debug_debuglog_size_compressed_label">Tamanho comprimido</string>
-    <string name="debug_notification_channel_label">Notificações de depuração</string>
-    <string name="debug_debuglog_file_label">Ficheiro de registo gravado</string>
-    <string name="debug_debuglog_recording_progress">A gravar registo de depuração</string>
     <string name="debug_debuglog_record_action">Gravar registo de depuração</string>
     <string name="debug_debuglog_stop_action">Parar gravação</string>
     <string name="debug_debuglog_sensitive_information_message">O ficheiro gerado contém informações sensíveis (p. ex., detalhes do dispositivo Bluetooth). Partilhe-o apenas com entidades fidedignas.</string>
     <string name="settings_debuglog_explanation">Esta funcionalidade regista tudo o que a aplicação faz num ficheiro partilhável. O ficheiro gerado contém informações sensíveis (p. ex., detalhes do dispositivo Bluetooth). Partilhe-o apenas com entidades fidedignas (p. ex., um programador que esteja a resolver um problema).</string>
-    <string name="settings_support_installid_label">ID de instalação</string>
-    <string name="settings_support_installid_desc">Os relatórios de erros automáticos são anónimos. Partilhe o seu ID de instalação se o programador precisar de encontrar os seus relatórios de erros.</string>
     <string name="settings_support_label">Suporte</string>
     <string name="settings_support_description">Se precisar de ajuda.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Repor dados aprendidos?</string>
     <string name="device_battery_estimate_reset_confirm_message">O CAPod esquecerá o consumo medido, velocidade de carregamento e tempo de escuta deste dispositivo, e recomeçará a partir da duração da bateria nominal.</string>
     <string name="settings_acknowledgements_label">Agradecimentos</string>
-    <string name="settings_debug_autoreports_label">Relatórios de erros automáticos</string>
-    <string name="settings_debug_autoreports_description">Relata problemas automaticamente, p. ex., detalhes sobre uma falha da aplicação para que eu possa descobrir como corrigi-la.</string>
-    <string name="settings_compatibility_mode_label">Modo de compatibilidade</string>
-    <string name="settings_compatibility_mode_description">Desative as otimizações para melhorar a compatibilidade. Tente isto se não estiver a ver nenhuns dados.</string>
     <string name="help_translate_label">Tradução</string>
     <string name="help_translate_description">Ajude a traduzir esta aplicação para o seu idioma favorito.</string>
     <string name="translators_thanks_title">Tradutores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sucesso</string>
     <string name="troubleshooter_ble_result_success_body">As transmissões de anúncios BLE estão a ser recebidas pelo CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Sem êxito</string>
-    <string name="troubleshooter_ble_result_failure_body">A resolução de problemas falhou. Nenhuma combinação de opções de compatibilidade ajudou.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">O seu telemóvel não recebeu nenhuns dados BLE. Pode tentar este teste novamente numa área movimentada para ver se as fontes de dados (para além dos seus auscultadores) podem ser recebidas. Nenhuns dados recebidos apontam para um problema com o sistema operativo do seu telemóvel.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">O seu telemóvel recebeu dados BLE, mas os dados não vêm de nenhum dispositivo suportado. Os seus auscultadores estão ligados? O CAPod suporta os seus auscultadores?</string>
-    <string name="troubleshooter_ble_result_failure_action">Tentar novamente</string>
-    <string name="troubleshoot_action">Resolver problemas</string>
     <string name="onboarding_body1">Esta aplicação adiciona suporte para funcionalidades específicas dos AirPods ao Android.</string>
     <string name="onboarding_body2">Nem todos os dispositivos Android suportam totalmente as funcionalidades adicionais dos AirPods. O seu sistema operativo requer uma implementação de Bluetooth de Baixo Consumo de Energia que funcione corretamente.</string>
     <string name="onboarding_body3">O CAPod não tem anúncios e não recolhe os seus dados.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">O teu dispositivo está ligado, mas o CAPod não está a receber dados em tempo real. O teu telefone pode precisar de uma opção de compatibilidade — o solucionador de problemas pode tentar encontrar uma automaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Executar solucionador de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos sem correspondência</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivo sem perfil correspondente</item>
-        <item quantity="other">%d dispositivos sem perfil correspondente</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Foi detetado %d dispositivo próximo sem um perfil correspondente. Mostra-o para ver os detalhes disponíveis. Se for teu, adiciona um perfil em Dispositivos para o reconhecer.</item>
         <item quantity="other">Foram detetados %d dispositivos próximos sem perfis correspondentes. Mostra-os para ver os detalhes disponíveis. Se algum for teu, adiciona um perfil em Dispositivos para o reconhecer.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">O CAPod utiliza o \"Acesso à localização em segundo plano\" para ativar funcionalidades como \"Mostrar popup\" e \"Ligação automática\" quando a aplicação está fechada. O acesso à localização em segundo plano permite que a aplicação receba dados Bluetooth de Baixo Consumo de Energia em segundo plano. Esta aplicação NÃO utilizará dados Bluetooth para determinar a sua localização.</string>
     <string name="permission_ignore_battery_optimizations_label">Desativar otimizações de bateria</string>
     <string name="permission_ignore_battery_optimizations_description">As otimizações de bateria impedem esta aplicação de receber dados Bluetooth de forma fiável quando a aplicação está em segundo plano.</string>
-    <string name="permission_required_title">A seguinte permissão é necessária:</string>
     <string name="permission_system_alert_window_label">Janela de alerta do sistema</string>
     <string name="permission_system_alert_window_description">Permitir que o CAPod desenhe sobre outras aplicações para tornar possível a funcionalidade \"Mostrar PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Quando visto</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">No ouvido</string>
     <string name="pods_dual_left_label">Auricular esquerdo</string>
     <string name="pods_dual_right_label">Auricular direito</string>
-    <string name="pods_dual_left_short_label">E</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Caixa</string>
     <string name="battery_unavailable_label">Bateria indisponível</string>
     <string name="battery_state_low_cd">Bateria baixa</string>
     <string name="battery_state_critical_cd">Bateria criticamente baixa</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Ligação direta ativa</string>
     <string name="signal_indicator_bars_cd">Intensidade do sinal: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Sinal: desconectado</string>
-    <string name="pods_yours">Seu</string>
     <string name="headset_being_worn_label">A ser usado</string>
     <string name="headset_not_being_worn_label">Não está a ser usado</string>
     <string name="pods_case_unknown_state">Estado desconhecido</string>
-    <string name="last_seen_x">Visto pela última vez: %s</string>
-    <string name="first_seen_x">Visto pela primeira vez: %s</string>
     <string name="battery_cached_label">Último conhecido · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Qualidade Mínima do Sinal</string>
     <string name="profiles_signal_quality_description">Detetar apenas dispositivos com intensidade de sinal acima deste limiar. Valores mais baixos aumentam o alcance de deteção, mas podem causar falsos positivos. Não defina isto demasiado alto - a receção Bluetooth é geralmente fraca e varia com a distância e obstáculos.</string>
     <string name="profiles_identitykey_label">Chave de Identidade</string>
-    <string name="profilessettings_maindevice_identitykey_description">A Chave de Resolução de Identidade (IRK) do seu dispositivo, que ajuda o CAPod a identificá-lo entre dispositivos próximos.</string>
     <string name="profiles_maindevice_identitykey_explanation">Os AirPods mudam frequentemente o endereço Bluetooth para privacidade. A IRK ajuda o CAPod a reconhecer o seu dispositivo. Necessita de acesso único a um MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Chave de Encriptação</string>
-    <string name="profiles_maindevice_encryptionkey_description">A chave de encriptação do seu dispositivo, que permite ao CAPod obter informações detalhadas de estado.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Os AirPods enviam uma mensagem de estado, parte da qual é encriptada. A chave de encriptação permite ao CAPod desencriptar a mensagem completa. Necessita de acesso único a um MacBook.</string>
     <string name="profiles_key_invalid_format">Formato de chave inválido</string>
     <string name="profiles_key_expected_format">Formato esperado: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Tem alterações não guardadas. O que gostaria de fazer?</string>
     <string name="general_save_and_exit_action">Guardar &amp; Sair</string>
     <string name="general_discard_action">Descartar</string>
-    <string name="general_keep_editing_action">Continuar a Editar</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Gravação demasiado curta</string>
     <string name="debug_debuglog_short_recording_message">Um registo de depuração precisa de capturar o problema enquanto ele acontece. Continue a gravar, reproduza o problema e depois pare a gravação.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Definições do dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Perfil: %s</string>
-    <string name="device_settings_info_name_label">Nome</string>
     <string name="device_settings_info_bt_name_label">Etiqueta do Dispositivo Bluetooth</string>
     <string name="device_settings_info_model_label">Modelo</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Talvez mais tarde</string>
     <string name="review_app_body">Gostaria de avaliar o CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Geral</string>
     <string name="device_settings_microphone_mode_label">Microfone</string>
     <string name="device_settings_microphone_mode_description">Qual o auricular utilizado como microfone</string>
     <string name="device_settings_microphone_mode_auto">Automático</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Partir</string>
     <string name="general_done_action">Terminà</string>
     <string name="general_cancel_action">Interrumper</string>
-    <string name="general_copy_action">Copiar</string>
     <string name="general_thank_you_label">Engraziel</string>
     <string name="general_upgrade_action">Actualisar</string>
     <string name="general_retry_action">Reprovescha</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Controllar</string>
     <string name="general_close_action">Serrar</string>
     <string name="general_dismiss_action">Dimitter</string>
-    <string name="general_edit_action">Modifitgar</string>
     <string name="general_save_action">Memorisar</string>
     <string name="general_guide_action">Guida</string>
     <string name="general_continue_action">Cuntinuar</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Reprend la musica cur che ti mets danovamain ils tuts, ma mo sche la pausa automatica l\'ha stoppada. Pausas che ti hast fatg (telefon, tulpa AirPods, sonns) restan en pausa.</string>
     <string name="settings_start_music_on_wear_label">Cumenza musica cur che ti mets ils tuts</string>
     <string name="settings_start_music_on_wear_description">Emprova adina da reprudar la musica cur che ti mets ils tuts, era suenter ina pausa manuala.</string>
-    <string name="settings_eardetection_info_label">Remartga davart la recugnoschientscha da l\'ureglia</string>
     <string name="settings_eardetection_info_description">Sche la recugnoschientscha da l\'ureglia funcziuna be per in singul pod, è quai ina restricziun dad Apple. Be il \"pod principal\" (duvrà per il microfon) vegn recugnuschì. Configurar sin apparats Apple: Configuraziun → Bluetooth → AirPods → Microfon.</string>
-    <string name="settings_signal_minimum_label">Qualitad minimala dal signal</string>
-    <string name="settings_signal_minimum_description">La qualitad minimala dal signal che in apparat sto avair per vegnir considerà sco Voss.</string>
     <string name="settings_autoconnect_label">Connectar automaticamain</string>
     <string name="settings_autoconnect_description">Sche Android na sa connectescha betg automaticamain, dumandain nus lez da far quai. Uschia resta CAPod adina activ en il fund per la surveglianza.</string>
     <string name="settings_autoconnect_info_android12">La connexiun automatica sa basa sin ina funcziun dal sistem che Android 12 e pli nov limita. Eventualmain che questa funcziun na funcziuna betg sin voss apparat.</string>
     <string name="settings_autoconnect_condition_label">Cundiziun per connectar automaticamain</string>
-    <string name="settings_autoconnect_condition_description">Cura duain nus empruvar da connectar cun Voss apparat?</string>
     <string name="settings_devices_label">Apparats</string>
     <string name="settings_devices_description">Administrar Voss apparats.</string>
     <string name="settings_reaction_label">Reacziuns</string>
-    <string name="settings_category_yourdevice_label">Voss apparat</string>
     <string name="settings_category_compatibility_options_title">Opziuns da cumpatibilitad</string>
     <string name="settings_category_compatibility_options_description">Betg tuccar sche tut funcziuna ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Deactivar la filtraziun hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">A startar…</string>
     <string name="support_debuglog_label">Protocol da debugging</string>
     <string name="support_debuglog_desc">Registrar tut quai che l\'app fa en in datotec text che Vus pudais partir.</string>
-    <string name="debug_debuglog_size_label">Grondezza</string>
-    <string name="debug_debuglog_size_compressed_label">Grondezza cumprimida</string>
-    <string name="debug_notification_channel_label">Notificaziuns da debugging</string>
-    <string name="debug_debuglog_file_label">Datotec da protocol registrà</string>
-    <string name="debug_debuglog_recording_progress">Registrar il protocol da debugging</string>
     <string name="debug_debuglog_record_action">Registrar il protocol da debugging</string>
     <string name="debug_debuglog_stop_action">Finir la registraziun</string>
     <string name="debug_debuglog_sensitive_information_message">Il datotec generà cuntegn infurmaziuns sensiblas (p.ex. detagls da l\'apparat Bluetooth). Partir el be cun terzas persunas fidadas.</string>
     <string name="settings_debuglog_explanation">Questa funcziun registrescha tut quai che l\'app fa en in datotec che sa lascha partir. Il datotec generà cuntegn infurmaziuns sensiblas (p.ex. detagls da l\'apparat Bluetooth). Partir el be cun terzas persunas fidadas (p.ex. in sviluppader che tracta in problem).</string>
-    <string name="settings_support_installid_label">ID d\'installaziun</string>
-    <string name="settings_support_installid_desc">Raports d\'errur automatics èn anonims. Partir Voss ID d\'installaziun sche il sviluppader dovra da chattar Voss rapports d\'errur.</string>
     <string name="settings_support_label">Agid</string>
     <string name="settings_support_description">Sche Vus avais basegn d\'agid.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Redatg da datas appresas?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod vegn a scerder il consumo mesirà, la velocitad da chargia e la temp d\'audiziun da quest apparat, e vegn a recomenzar da la vita da bateria valitada.</string>
     <string name="settings_acknowledgements_label">Remerciaments</string>
-    <string name="settings_debug_autoreports_label">Raports da bugs automatics</string>
-    <string name="settings_debug_autoreports_description">Raporta automaticamain problems, p.ex. detagls davart in crash da l\'app, uschia che jau poss chapir co reparar quai.</string>
-    <string name="settings_compatibility_mode_label">Modus da cumpatibilitad</string>
-    <string name="settings_compatibility_mode_description">Deactivar optimaziuns per meglierar la cumpatibilitad. Empruvai quai sche Vus na visais naginas datas.</string>
     <string name="help_translate_label">Translaziun</string>
     <string name="help_translate_description">Gidar a translatar questa app en Vossa lingua preferida.</string>
     <string name="translators_thanks_title">Translataders</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Reussì</string>
     <string name="troubleshooter_ble_result_success_body">Emissiuns da reclama BLE vegnan retschavidas da CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Senza success</string>
-    <string name="troubleshooter_ble_result_failure_body">La schliaziun da problems ha fatg fiasco. Nagina cumbinaziun d\'opziuns da cumpatibilitad ha gidà.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Voss telefonin n\'ha retschavì naginas datas BLE. Vus pudais repeter quest test en in lieu cun blera glieud per vesair sche funtaunas da datas (autras che Voss cularins) pon vegnir retschavidas. Naginas datas retschavidas inditgeschan in problem cun il sistem operativ da Voss telefonin.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Voss telefonin ha retschavì datas BLE, ma las datas na derivan da nagin apparat sustegnì. Èn Voss cularins empits? Sustegn CAPod Voss cularin?</string>
-    <string name="troubleshooter_ble_result_failure_action">Empruvar anc ina giada</string>
-    <string name="troubleshoot_action">Schliar problems</string>
     <string name="onboarding_body1">Questa app agiunta support per funcziuns specificas dad AirPods ad Android.</string>
     <string name="onboarding_body2">Betg tut ils apparats Android sustegnan cumplainamain las funcziuns supplementaras dad AirPods. Voss sistem operativ dovra in\'implementaziun da Bluetooth-Low-Energy che funcziuna correctamain.</string>
     <string name="onboarding_body3">CAPod n\'ha nagina reclama e na collecziunescha betg Vossas datas.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tieu apparat è connectà, ma CAPod na retschaiva naginas datas en diretta. Tiu telefon sto eventualmain ina opziun da cumpatibilitad — il schliader da problems po emprovar da chattar ina automaticamain.</string>
     <string name="overview_troubleshoot_suggestion_action">Aviar il schliader da problems</string>
     <string name="overview_unmatched_devices_label">Apparats senza correspondenza</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d apparat senza profil correspundent</item>
-        <item quantity="other">%d apparats senza profil correspundent</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d apparat en vicinanza è stà scuvrì senza in profil correspundent. Mussa el per vesair ils detagls disponibels. Sche el t\'appartegna, agiundscha in profil en Apparats per al renconuscher.</item>
         <item quantity="other">%d apparats en vicinanza èn stads scuvrids senza profils correspundents. Mussa els per vesair ils detagls disponibels. Sche in t\'appartegna, agiundscha in profil en Apparats per al renconuscher.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod dovra l\'\"Access a la posiziun en il fund davos\" per activar funcziuns sco \"Mussar popup\" e \"Connectar automaticamain\" cura che l\'app è serrada. L\'access a la posiziun en il fund davos permetta a l\'app da retschaiver datas Bluetooth Low Energy en il fund davos. Questa app NA vegn BETG a duvrar datas Bluetooth per determinar Vossa posiziun.</string>
     <string name="permission_ignore_battery_optimizations_label">Deactivar optimaziuns da battaria</string>
     <string name="permission_ignore_battery_optimizations_description">Optimaziuns da battaria impedeschan questa app da retschaiver datas Bluetooth a moda fidabla cura che l\'app è en il fund davos.</string>
-    <string name="permission_required_title">La suandanta permissiun è necessaria:</string>
     <string name="permission_system_alert_window_label">Fanestra d\'avis dal sistem</string>
     <string name="permission_system_alert_window_description">Permetter a CAPod da dessegnar sur autras apps per render pussaivla la funcziun \"Mussar PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Cura che vis</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">En l\'ureglia</string>
     <string name="pods_dual_left_label">Pod seniester</string>
     <string name="pods_dual_right_label">Pod dretg</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Scatla</string>
     <string name="battery_unavailable_label">Battaria betg disponibla</string>
     <string name="battery_state_low_cd">Bateria bassa</string>
     <string name="battery_state_critical_cd">Bateria criticamain bassa</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Connexiun directa activa</string>
     <string name="signal_indicator_bars_cd">Forza dal signal: %1$d da 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Signal: disconnect</string>
-    <string name="pods_yours">Voss</string>
     <string name="headset_being_worn_label">Vegn purtà</string>
     <string name="headset_not_being_worn_label">Na vegn betg purtà</string>
     <string name="pods_case_unknown_state">Stadi nunenconuschent</string>
-    <string name="last_seen_x">Vis l\'ultima giada: %s</string>
-    <string name="first_seen_x">Vis l\'emprima giada: %s</string>
     <string name="battery_cached_label">Ultim enconuschent · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Qualitad minimala dal signal</string>
     <string name="profiles_signal_quality_description">Be chattar apparats cun intensitad da signal sur quest limitscha. Valurs pli bass augmentan il radius da detecziun ma pon chaschunair fos positivas. Betg metter quai memia aut - la recepziun Bluetooth è generalmain debla e variescha cun la distanza e cun obstacles.</string>
     <string name="profiles_identitykey_label">Clav d\'identitad</string>
-    <string name="profilessettings_maindevice_identitykey_description">La Clav da Resoluziun d\'Identitad (IRK) da Voss apparat che gida CAPod ad al identifitgar tranter apparats datiers.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods midan savens lur adressa Bluetooth per la protecziun da datas. L\'IRK gida CAPod a recugnuoscher Voss apparat. Vus basegnais in access unic ad in MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Clav da criptaziun</string>
-    <string name="profiles_maindevice_encryptionkey_description">La clav da criptaziun da Voss apparat che permetta a CAPod da retschaiver infurmaziuns detagliadas davart il stadi.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods tramettian in messadi da stadi, in\'part dal qual è criptà. La clav da criptaziun permetta a CAPod da decriptar il messadi cumplet. Vus basegnais in access unic ad in MacBook.</string>
     <string name="profiles_key_invalid_format">Format da clav nunvalid</string>
     <string name="profiles_key_expected_format">Format spetgà: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Vus avais midadas betg memorisadas. Tge vulais Vus far?</string>
     <string name="general_save_and_exit_action">Memorisar &amp; Serrar</string>
     <string name="general_discard_action">Bandunar</string>
-    <string name="general_keep_editing_action">Cuntinuar a modifitgar</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Registraziun memia curta</string>
     <string name="debug_debuglog_short_recording_message">In protocol da debug sto captar il problem durant che el occorra. Cuntinuescha la registraziun, repruduescha il problem, lur stoppa la registraziun.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Parameters da l\'apparat</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Num</string>
     <string name="device_settings_info_bt_name_label">Designaziun da l\'apparat Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producent</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Forsa pli tard</string>
     <string name="review_app_body">Vuless ti laschar ina recenziun per CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
     <string name="device_settings_microphone_mode_description">Tge tschappin è utilisà sco microfon</string>
     <string name="device_settings_microphone_mode_auto">Automatic</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Distribuie</string>
     <string name="general_done_action">Efectuat</string>
     <string name="general_cancel_action">Anulare</string>
-    <string name="general_copy_action">Copiază</string>
     <string name="general_thank_you_label">Mulțumesc</string>
     <string name="general_upgrade_action">Actualizare</string>
     <string name="general_retry_action">Reîncearcă</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Verifică</string>
     <string name="general_close_action">Închide</string>
     <string name="general_dismiss_action">Respinge</string>
-    <string name="general_edit_action">Editează</string>
     <string name="general_save_action">Salvare</string>
     <string name="general_guide_action">Ghid</string>
     <string name="general_continue_action">Continuă</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Reia muzica când porți din nou căștile, dar numai dacă Auto pauză a oprit-o. Pauzele pe care le-ai declanșat tu (telefon, tijă AirPods, somn) rămân în pauză.</string>
     <string name="settings_start_music_on_wear_label">Pornește muzica la purtare</string>
     <string name="settings_start_music_on_wear_description">Încearcă întotdeauna să redea muzica când îți pui căștile, chiar și după o pauză manuală.</string>
-    <string name="settings_eardetection_info_label">Notă despre detectarea urechii</string>
     <string name="settings_eardetection_info_description">Dacă detectarea urechii funcționează doar pentru o cască, aceasta este o limitare Apple. Doar \"căștile principale\" (folosite pentru microfon) sunt detectate. Configurați pe dispozitivele Apple: Setări → Bluetooth → AirPods → Microfon.</string>
-    <string name="settings_signal_minimum_label">Calitatea minimă a semnalului</string>
-    <string name="settings_signal_minimum_description">Calitatea minimă a semnalului pe care trebuie să o aibă un dispozitiv trebuie să fie considerată a dvs.</string>
     <string name="settings_autoconnect_label">Conectare automată</string>
     <string name="settings_autoconnect_description">Dacă Android nu se conectează automat, îi putem cere și noi. Aceasta menține monitorizarea CAPod în fundal în permanență.</string>
     <string name="settings_autoconnect_info_android12">Conectarea automată se bazează pe o funcție de sistem restricționată în Android 12 și versiunile mai noi. Este posibil să nu funcționeze pe dispozitivul tău.</string>
     <string name="settings_autoconnect_condition_label">Condiția de conectare automată</string>
-    <string name="settings_autoconnect_condition_description">Când ar trebui să încercăm să ne conectăm la dispozitivul dvs.?</string>
     <string name="settings_devices_label">Dispozitive</string>
     <string name="settings_devices_description">Gestionați dispozitivele dvs.</string>
     <string name="settings_reaction_label">Reacții</string>
-    <string name="settings_category_yourdevice_label">Dispozitivul tău</string>
     <string name="settings_category_compatibility_options_title">Opțiuni de compatibilitate</string>
     <string name="settings_category_compatibility_options_description">Nu atingeți dacă totul funcționează ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Dezactivați filtrarea hardware-ului</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Se inițiază…</string>
     <string name="support_debuglog_label">Jurnal de depanare</string>
     <string name="support_debuglog_desc">Înregistrați tot ce face aplicația într-un fișier text pe care îl puteți partaja.</string>
-    <string name="debug_debuglog_size_label">Dimensiune</string>
-    <string name="debug_debuglog_size_compressed_label">Dimensiune comprimată</string>
-    <string name="debug_notification_channel_label">Notificări de depanare</string>
-    <string name="debug_debuglog_file_label">Fișier jurnal înregistrat</string>
-    <string name="debug_debuglog_recording_progress">Înregistrare jurnal de depanare</string>
     <string name="debug_debuglog_record_action">Înregistrare jurnal de depanare</string>
     <string name="debug_debuglog_stop_action">Oprire înregistrare</string>
     <string name="debug_debuglog_sensitive_information_message">Fișierul generat conține informații sensibile (de exemplu, detalii despre dispozitivul Bluetooth). Partajați-l numai cu terți de încredere.</string>
     <string name="settings_debuglog_explanation">Această funcție înregistrează tot ce face aplicația într-un fișier partajabil. Fișierul generat conține informații sensibile (de exemplu, detalii despre dispozitivul Bluetooth). Partajați-l numai cu terți de încredere (de exemplu, un dezvoltator care depanează o problemă).</string>
-    <string name="settings_support_installid_label">ID de instalare</string>
-    <string name="settings_support_installid_desc">Rapoartele automate de eroare sunt anonime. Partajați ID-ul de instalare dacă dezvoltatorul trebuie să vă găsească rapoartele de eroare.</string>
     <string name="settings_support_label">Suport</string>
     <string name="settings_support_description">Dacă ai nevoie de ajutor.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Resetezi datele învățate?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod va uita consumul măsurat al acestui dispozitiv, viteza de încărcare și timpul de ascultare, și va porni din nou de la durata de viață a bateriei nominale.</string>
     <string name="settings_acknowledgements_label">Mulțumiri</string>
-    <string name="settings_debug_autoreports_label">Rapoarte automate de erori</string>
-    <string name="settings_debug_autoreports_description">Raportează automat probleme, ex: detalii despre o blocare a aplicației, astfel încât să îmi dau seama cum să o rezolv.</string>
-    <string name="settings_compatibility_mode_label">Mod de compatibilitate</string>
-    <string name="settings_compatibility_mode_description">Dezactivați optimizările pentru a îmbunătăți compatibilitatea. Încercați acest lucru dacă nu vedeți nicio dată.</string>
     <string name="help_translate_label">Traducere</string>
     <string name="help_translate_description">Ajută la traducerea acestei aplicații în limba ta preferată.</string>
     <string name="translators_thanks_title">Traducători</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Succes</string>
     <string name="troubleshooter_ble_result_success_body">Emisiunile de reclame BLE sunt recepționate de CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Eșuat</string>
-    <string name="troubleshooter_ble_result_failure_body">Depanarea eșuată. Nici una din opțiunile de compatibilitate, nu a ajutat.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefonul dvs. nu a primit deloc date BLE. Puteți reîncerca acest test într-o zonă aglomerată pentru a vedea dacă sursele de date (altele decât căștile) pot fi recepționate. Nicio dată primită indică o problemă cu sistemul de operare al telefonului dvs.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefonul dvs. a recepționat date BLE, dar datele nu provin de la niciun dispozitiv suportat. Căștile tale sunt pornite? CAPod suportă căștile dvs.?</string>
-    <string name="troubleshooter_ble_result_failure_action">Încearcă din nou</string>
-    <string name="troubleshoot_action">Depanare</string>
     <string name="onboarding_body1">Această aplicație adaugă suport pentru caracteristicile specifice AirPod pentru Android.</string>
     <string name="onboarding_body2">Nu toate dispozitivele Android acceptă pe deplin funcțiile suplimentare AirPod. Sistemul dvs. de operare necesită o implementare Bluetooth Energie Scăzută (BLE) care funcționează corect.</string>
     <string name="onboarding_body3">CAPod nu conține reclame și nu colectează datele dumneavoastră.</string>
@@ -207,11 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Dispozitivul tău este conectat, dar CAPod nu primește date în timp real de la acesta. Este posibil ca telefonul tău să aibă nevoie de o opțiune de compatibilitate — depuratorul poate încerca să găsească una automat.</string>
     <string name="overview_troubleshoot_suggestion_action">Rulează depuratorul</string>
     <string name="overview_unmatched_devices_label">Dispozitive fără corespondență</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispozitiv fără profil corespunzător</item>
-        <item quantity="few">%d dispozitive fără profil corespunzător</item>
-        <item quantity="other">%d de dispozitive fără profil corespunzător</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">A fost detectat %d dispozitiv din apropiere fără un profil corespunzător. Afișează-l pentru detalii disponibile. Dacă este al tău, adaugă un profil din Dispozitive pentru a-l recunoaște.</item>
         <item quantity="few">Au fost detectate %d dispozitive din apropiere fără profiluri corespunzătoare. Afișează-le pentru detalii disponibile. Dacă unul este al tău, adaugă un profil din Dispozitive pentru a-l recunoaște.</item>
@@ -234,7 +208,6 @@
     <string name="permission_background_location_description">CAPod folosește \"Accesul la locația în fundal\" pentru a activa funcții precum \"Afișare popup\" și \"Conectare automată\" când aplicația este închisă. Accesul la locația în fundal permite aplicației să primească date Bluetooth Energie Scăzută în fundal. Această aplicație NU va folosi datele Bluetooth pentru a vă determina locația.</string>
     <string name="permission_ignore_battery_optimizations_label">Dezactivare optimizări baterie</string>
     <string name="permission_ignore_battery_optimizations_description">Optimizările bateriei împiedică această aplicație să primească în mod fiabil date Bluetooth când aplicația este în fundal.</string>
-    <string name="permission_required_title">Următoarea permisiune este necesară:</string>
     <string name="permission_system_alert_window_label">Fereastră alertă sistem</string>
     <string name="permission_system_alert_window_description">Permiteți CAPod să deseneze peste alte aplicații pentru a face posibilă funcția \"Afișare PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Când este detectat</string>
@@ -242,9 +215,6 @@
     <string name="settings_reaction_autoconnect_inear_label">În ureche</string>
     <string name="pods_dual_left_label">Cască stângă</string>
     <string name="pods_dual_right_label">Cască dreaptă</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Carcasă</string>
     <string name="battery_unavailable_label">Baterie indisponibilă</string>
     <string name="battery_state_low_cd">Baterie scăzută</string>
     <string name="battery_state_critical_cd">Baterie critic de scăzută</string>
@@ -299,12 +269,9 @@
     <string name="signal_badge_aap_cd">Conexiune directă activă</string>
     <string name="signal_indicator_bars_cd">Putere semnal: %1$d din 4 bare</string>
     <string name="signal_indicator_disconnected_cd">Semnal: deconectat</string>
-    <string name="pods_yours">Al tău</string>
     <string name="headset_being_worn_label">Este purtat</string>
     <string name="headset_not_being_worn_label">Nu este purtat</string>
     <string name="pods_case_unknown_state">Stare necunoscută</string>
-    <string name="last_seen_x">Ultima detectare: %s</string>
-    <string name="first_seen_x">Prima detectare: %s</string>
     <string name="battery_cached_label">Ultimul cunoscut · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -334,10 +301,8 @@
     <string name="profiles_signal_quality_title">Calitate Minimă a Semnalului</string>
     <string name="profiles_signal_quality_description">Detectați doar dispozitivele cu puterea semnalului peste acest prag. Valorile mai mici cresc raza de detectare, dar pot cauza fals pozitive. Nu setați prea mare - recepția Bluetooth este în general slabă și variază în funcție de distanță și obstacole.</string>
     <string name="profiles_identitykey_label">Cheie de Identitate</string>
-    <string name="profilessettings_maindevice_identitykey_description">Cheia de Rezolvare a Identității (IRK) a dispozitivului dvs., care ajută CAPod să-l identifice printre dispozitivele din apropiere.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods-urile își schimbă frecvent adresa Bluetooth pentru confidențialitate. IRK-ul ajută CAPod să recunoască dispozitivul dvs. Aveți nevoie de acces unic la un MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Cheie de Criptare</string>
-    <string name="profiles_maindevice_encryptionkey_description">Cheia de criptare a dispozitivului dvs., care permite CAPod să obțină informații detaliate despre stare.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods-urile trimit un mesaj de stare, o parte din care este criptat. Cheia de criptare permite CAPod să decripteze mesajul complet. Aveți nevoie de acces unic la un MacBook.</string>
     <string name="profiles_key_invalid_format">Format cheie invalid</string>
     <string name="profiles_key_expected_format">Format așteptat: %1$s</string>
@@ -370,7 +335,6 @@
     <string name="general_unsaved_changes_message">Aveți modificări nesalvate. Ce doriți să faceți?</string>
     <string name="general_save_and_exit_action">Salvare &amp; Ieșire</string>
     <string name="general_discard_action">Renunță</string>
-    <string name="general_keep_editing_action">Continuă Editarea</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Înregistrare prea scurtă</string>
     <string name="debug_debuglog_short_recording_message">Un jurnal de depanare trebuie să surprindă problema în timp ce apare. Continuați înregistrarea, reproduceți problema, apoi opriți înregistrarea.</string>
@@ -444,7 +408,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Setări dispozitiv</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Nume</string>
     <string name="device_settings_info_bt_name_label">Etichetă dispozitiv Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Producător</string>
@@ -524,7 +487,6 @@
     <string name="review_app_dismiss_action">Poate mai târziu</string>
     <string name="review_app_body">Ți-ar plăcea să lași o recenzie pentru CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
     <string name="device_settings_microphone_mode_description">Care cășcă este folosită ca microfon</string>
     <string name="device_settings_microphone_mode_auto">Automat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Поделиться</string>
     <string name="general_done_action">Готово</string>
     <string name="general_cancel_action">Отмена</string>
-    <string name="general_copy_action">Копировать</string>
     <string name="general_thank_you_label">Спасибо</string>
     <string name="general_upgrade_action">Улучшить</string>
     <string name="general_retry_action">Повторить</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Проверить</string>
     <string name="general_close_action">Закрыть</string>
     <string name="general_dismiss_action">Отклонить</string>
-    <string name="general_edit_action">Редактировать</string>
     <string name="general_save_action">Сохранить</string>
     <string name="general_guide_action">Руководство</string>
     <string name="general_continue_action">Продолжить</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Возобновите музыку, когда снова надеваете наушники, но только если воспроизведение было остановлено функцией «Автопауза». Паузы, которые Вы поставили вручную (с телефона, AirPods или по таймеру сна), сохраняются.</string>
     <string name="settings_start_music_on_wear_label">Запускать музыку при надевании</string>
     <string name="settings_start_music_on_wear_description">Всегда пытается воспроизвести музыку, когда Вы надеваете наушники, даже после ручной паузы.</string>
-    <string name="settings_eardetection_info_label">Уведомление об обнаружении уха</string>
     <string name="settings_eardetection_info_description">Если обнаружение уха работает только для одного наушника, это ограничение Apple. Обнаруживается только \"основной наушник\" (используемый для микрофона). Настроить на устройствах Apple: Настройки → Bluetooth → AirPods → Микрофон.</string>
-    <string name="settings_signal_minimum_label">Минимальное качество сигнала</string>
-    <string name="settings_signal_minimum_description">Минимальное качество сигнала, необходимое устройству, чтобы оно опознавалось как Ваше.</string>
     <string name="settings_autoconnect_label">Автоподключение</string>
     <string name="settings_autoconnect_description">Если Android не подключается автоматически, мы можем попросить его об этом. Благодаря этому CAPod постоянно следит за устройством в фоновом режиме.</string>
     <string name="settings_autoconnect_info_android12">Автоподключение использует системную функцию, ограниченную в Android 12 и новее. Может не работать на Вашем устройстве.</string>
     <string name="settings_autoconnect_condition_label">Условия автоподключения</string>
-    <string name="settings_autoconnect_condition_description">Когда мы должны пытаться подключить Ваше устройство?</string>
     <string name="settings_devices_label">Устройства</string>
     <string name="settings_devices_description">Управление устройствами.</string>
     <string name="settings_reaction_label">Реакции</string>
-    <string name="settings_category_yourdevice_label">Ваше устройство</string>
     <string name="settings_category_compatibility_options_title">Настройки совместимости</string>
     <string name="settings_category_compatibility_options_description">Не трогать, если всё работает :)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Отключить аппаратную фильтрацию</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Запуск…</string>
     <string name="support_debuglog_label">Журнал отладки</string>
     <string name="support_debuglog_desc">Запись всего, что делает приложение, в текстовый файл, которым можно поделиться.</string>
-    <string name="debug_debuglog_size_label">Размер</string>
-    <string name="debug_debuglog_size_compressed_label">Сжатый размер</string>
-    <string name="debug_notification_channel_label">Уведомления отладки</string>
-    <string name="debug_debuglog_file_label">Записанный файл журнала</string>
-    <string name="debug_debuglog_recording_progress">Запись журнала отладки</string>
     <string name="debug_debuglog_record_action">Записать журнал отладки</string>
     <string name="debug_debuglog_stop_action">Остановить запись</string>
     <string name="debug_debuglog_sensitive_information_message">Созданный файл содержит конфиденциальную информацию (например, сведения об устройстве Bluetooth). Передавайте его только доверенным лицам.</string>
     <string name="settings_debuglog_explanation">Эта функция записывает все, что делает приложение, в общий файл. Созданный файл содержит конфиденциальную информацию (например, сведения об устройстве Bluetooth). Делитесь им только с доверенными сторонами (например, разработчиком, который устраняет проблему).</string>
-    <string name="settings_support_installid_label">ID установки</string>
-    <string name="settings_support_installid_desc">Автоматические отчёты об ошибках анонимны. Поделитесь Вашим ID установки, если разработчику нужен доступ к Вашим отчётам об ошибках.</string>
     <string name="settings_support_label">Поддержка</string>
     <string name="settings_support_description">Если нужна помощь.</string>
     <string name="settings_wiki_label">Вики</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Сбросить собранные данные?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod забудет измеренный расход, скорость зарядки и время прослушивания этого устройства и начнет заново с номинального времени батареи.</string>
     <string name="settings_acknowledgements_label">Благодарности</string>
-    <string name="settings_debug_autoreports_label">Автоматические отчёты об ошибках</string>
-    <string name="settings_debug_autoreports_description">Автоматические отчёты об ошибках, например, детали сбоя приложения, которые могут помочь решению проблемы.</string>
-    <string name="settings_compatibility_mode_label">Режим совместимости</string>
-    <string name="settings_compatibility_mode_description">Отключите оптимизацию для улучшения совместимости. Попробуйте это, если не видите данных.</string>
     <string name="help_translate_label">Перевод</string>
     <string name="help_translate_description">Помогите перевести приложение на Ваш язык.</string>
     <string name="translators_thanks_title">Переводчики</string>
@@ -174,11 +156,8 @@ AL_Cool_T</string>
     <string name="troubleshooter_ble_result_success_title">Успешно</string>
     <string name="troubleshooter_ble_result_success_body">BLE рекламные трансляции принимаются на CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Ошибка</string>
-    <string name="troubleshooter_ble_result_failure_body">Не удалось устранить неполадки. Ни одна комбинация параметров совместимости не помогла.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ваш телефон не получал никаких BLE данных. Вы можете повторить этот тест в людном месте, чтобы проверить, могут ли быть получены данные (c других источников кроме наушников). Отсутствие полученных данных указывает на проблему с операционной системой Вашего телефона.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Ваш телефон получил BLE данные, но данные не поступают ни с одного поддерживаемого устройства. Ваши наушники включены? Поддерживает ли CAPod ваши наушники?</string>
-    <string name="troubleshooter_ble_result_failure_action">Попробуйте еще раз</string>
-    <string name="troubleshoot_action">Устранение неполадок</string>
     <string name="onboarding_body1">Приложение обеспечивает поддержку специфичных функций AirPod на Android.</string>
     <string name="onboarding_body2">Не все устройства Android полностью поддерживают дополнительные функции AirPod. Вашей операционной системе требуется корректно работающая версия Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod не содержит рекламы и не собирает Ваши данные.</string>
@@ -208,12 +187,6 @@ AL_Cool_T</string>
     <string name="overview_troubleshoot_suggestion_description">Устройство подключено, но CAPod не получает от него данных в режиме реального времени. Возможно, твоему телефону нужна опция совместимости — помощник может попытаться найти её автоматически.</string>
     <string name="overview_troubleshoot_suggestion_action">Запустить помощник</string>
     <string name="overview_unmatched_devices_label">Несопряжённые устройства</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d устройство без соответствующего профиля</item>
-        <item quantity="few">%d устр. без соответствующего профиля</item>
-        <item quantity="many">%d устр. без соответствующего профиля</item>
-        <item quantity="other">%d устр. без соответствующего профиля</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Обнаружено %d устройство поблизости без подходящего профиля. Откройте его, чтобы увидеть доступные сведения. Если это Ваше устройство, добавьте профиль из раздела «Устройства», чтобы его распознать.</item>
         <item quantity="few">Обнаружено устройств поблизости без подходящего профиля: %d. Откройте их, чтобы увидеть доступные сведения. Если это Ваши устройства, добавьте профиль из раздела «Устройства», чтобы их распознать.</item>
@@ -238,7 +211,6 @@ AL_Cool_T</string>
     <string name="permission_background_location_description">CAPod использует разрешение \"Доступ к местоположению в фоне\" для включения таких функций, как \"Всплывающие окна\" и \"Автоподключение\", когда приложение закрыто. Фоновый доступ к местоположению позволяет приложению получать данные Bluetooth Low Energy в фоне. Это приложение НЕ будет использовать данные Bluetooth для определения Вашего местоположения.</string>
     <string name="permission_ignore_battery_optimizations_label">Отключить оптимизацию батареи</string>
     <string name="permission_ignore_battery_optimizations_description">Оптимизация батареи не позволяет приложению должным образом получать данные Bluetooth, когда приложение работает в фоне.</string>
-    <string name="permission_required_title">Требуется следующее разрешение:</string>
     <string name="permission_system_alert_window_label">Окно системных предупреждений</string>
     <string name="permission_system_alert_window_description">Позволить CAPod наложение поверх других приложений для работы функции \"Всплывающие сообщения\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">При обнаружении</string>
@@ -246,9 +218,6 @@ AL_Cool_T</string>
     <string name="settings_reaction_autoconnect_inear_label">В ухе</string>
     <string name="pods_dual_left_label">Левый наушник</string>
     <string name="pods_dual_right_label">Правый наушник</string>
-    <string name="pods_dual_left_short_label">Л</string>
-    <string name="pods_dual_right_short_label">П</string>
-    <string name="pods_case_label">Футляр</string>
     <string name="battery_unavailable_label">Заряд недоступен</string>
     <string name="battery_state_low_cd">Низкий уровень батареи</string>
     <string name="battery_state_critical_cd">Критически низкий уровень батареи</string>
@@ -305,12 +274,9 @@ AL_Cool_T</string>
     <string name="signal_badge_aap_cd">Прямое соединение активно</string>
     <string name="signal_indicator_bars_cd">Уровень сигнала: %1$d из 4 делений</string>
     <string name="signal_indicator_disconnected_cd">Сигнал: отключено</string>
-    <string name="pods_yours">Ваше</string>
     <string name="headset_being_worn_label">Надеты</string>
     <string name="headset_not_being_worn_label">Не надеты</string>
     <string name="pods_case_unknown_state">Неизвестное состояние</string>
-    <string name="last_seen_x">Последние: %s</string>
-    <string name="first_seen_x">Первые: %s</string>
     <string name="battery_cached_label">Последнее известное · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d ч %2$d мин</string>
     <string name="battery_time_remaining_format_h">%1$d ч</string>
@@ -340,10 +306,8 @@ AL_Cool_T</string>
     <string name="profiles_signal_quality_title">Минимальное качество сигнала</string>
     <string name="profiles_signal_quality_description">Определять только устройства с сигналом выше этого порога. Низкие значения увеличивают диапазон детекции, но могут привести к ложному срабатыванию. Не устанавливайте слишком высокое значение - приём Bluetooth обычно слабый и варьируется в зависимости от расстояния и препятствий.</string>
     <string name="profiles_identitykey_label">Ключ идентификации</string>
-    <string name="profilessettings_maindevice_identitykey_description">Идентификационный ключ (IRK), который помогает CAPod идентифицировать его между близлежащими устройствами.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods часто меняют Bluetooth-адрес для приватности. IRK помогает CAPod распознать Ваше устройство. Вам нужен одноразовый доступ к MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ключ шифрования</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ключ шифрования Вашего устройства, который позволяет CAPod получать подробную информацию.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods отправляет сообщение о состоянии, часть которого зашифрована. Ключ шифрования позволяет CAPod расшифровать полное сообщение. Вам нужен одноразовый доступ к MacBook.</string>
     <string name="profiles_key_invalid_format">Неверный формат ключа</string>
     <string name="profiles_key_expected_format">Правильный формат: %1$s</string>
@@ -376,7 +340,6 @@ AL_Cool_T</string>
     <string name="general_unsaved_changes_message">У вас есть несохранённые изменения. Что вы хотите сделать?</string>
     <string name="general_save_and_exit_action">Сохранить и выйти</string>
     <string name="general_discard_action">Отменить</string>
-    <string name="general_keep_editing_action">Продолжить редактирование</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Запись слишком короткая</string>
     <string name="debug_debuglog_short_recording_message">Для захвата проблемы журнал отладки должен фиксировать её в момент возникновения. Продолжайте запись, воспроизведите проблему, затем остановите запись.</string>
@@ -453,7 +416,6 @@ AL_Cool_T</string>
     <!-- Device Settings -->
     <string name="device_settings_title">Настройки устройства</string>
     <string name="device_settings_subtitle_profile_prefix">Профиль: %s</string>
-    <string name="device_settings_info_name_label">Название</string>
     <string name="device_settings_info_bt_name_label">Название Bluetooth-устройства</string>
     <string name="device_settings_info_model_label">Модель</string>
     <string name="device_settings_info_manufacturer_label">Производитель</string>
@@ -533,7 +495,6 @@ AL_Cool_T</string>
     <string name="review_app_dismiss_action">Возможно, позже</string>
     <string name="review_app_body">Хочешь оставить отзыв для CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Общее</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
     <string name="device_settings_microphone_mode_description">Какой наушник используется как микрофон</string>
     <string name="device_settings_microphone_mode_auto">Авто</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Cumpartzi</string>
     <string name="general_done_action">Fatu</string>
     <string name="general_cancel_action">Annulla</string>
-    <string name="general_copy_action">Còpia</string>
     <string name="general_thank_you_label">Gràtzias</string>
     <string name="general_upgrade_action">Agioma</string>
     <string name="general_retry_action">Torra pro</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Controlla</string>
     <string name="general_close_action">Serra</string>
     <string name="general_dismiss_action">Serrare</string>
-    <string name="general_edit_action">Modificare</string>
     <string name="general_save_action">Sarva</string>
     <string name="general_guide_action">Ghia</string>
     <string name="general_continue_action">Sighi</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Torrat a sonat sa mùsica cando torras a pònnere sos pods, ma petzi si sa pausa automàtica l\'at interrùmpida. Sas pausas chi as fatu tue etotu (telèfonu, mànicu AirPods, repòsu) restant in pausa.</string>
     <string name="settings_start_music_on_wear_label">Ativia sa mùsica cando los pones</string>
     <string name="settings_start_music_on_wear_description">Proat semper a sonat sa mùsica cando pones sos pods, fintzas a pustis de una pausa manuale.</string>
-    <string name="settings_eardetection_info_label">Nota subra su riconoschimentu de s\'origra</string>
     <string name="settings_eardetection_info_description">Si su riconoschimentu de s\'origra funtzionat isceti pro una corfita, custa est una limitatzione de Apple. Isceti sa \"corfita printzipale\" (impreada pro su micròfonu) est riconnota. Cunfigura in dispositivos Apple: Impostatziones → Bluetooth → AirPods → Micròfonu.</string>
-    <string name="settings_signal_minimum_label">Calidade mìnima de su signale</string>
-    <string name="settings_signal_minimum_description">Sa calidade mìnima de su signale chi unu dispositivu depet àere pro èssere cunsideradu tuo.</string>
     <string name="settings_autoconnect_label">Cullegamentu automàticu</string>
     <string name="settings_autoconnect_description">Si Android no si connectit automaticamente, li podimus pedire nois etotu. Custu mantenet CAPod a controllare in su sfondu de continu.</string>
     <string name="settings_autoconnect_info_android12">Sa connessione automàtica si basat in una funzionalidade de su sistema chi Android 12 e versiones prus modernas limitant. Podet no funtzionare in su dispositivu tuo.</string>
     <string name="settings_autoconnect_condition_label">Conditzione de cullegamentu automàticu</string>
-    <string name="settings_autoconnect_condition_description">Cando demus proare a nos cullegare a su dispositivu tuo?</string>
     <string name="settings_devices_label">Dispositivos</string>
     <string name="settings_devices_description">Gestisci is dispositivos tuos.</string>
     <string name="settings_reaction_label">Reatziones</string>
-    <string name="settings_category_yourdevice_label">Su dispositivu tuo</string>
     <string name="settings_category_compatibility_options_title">Opsiones de cumpatibilidade</string>
     <string name="settings_category_compatibility_options_description">Non toches si totu funtzionat ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Disativa filtràgiu hardware</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Acominzande…</string>
     <string name="support_debuglog_label">Registru de debug</string>
     <string name="support_debuglog_desc">Registra totu su chi s\'app est faghende in unu file de testu chi podes cumpartzire.</string>
-    <string name="debug_debuglog_size_label">Mannària</string>
-    <string name="debug_debuglog_size_compressed_label">Mannària cumpressada</string>
-    <string name="debug_notification_channel_label">Notìficas de debug</string>
-    <string name="debug_debuglog_file_label">File de registru registradu</string>
-    <string name="debug_debuglog_recording_progress">Registrende registru de debug</string>
     <string name="debug_debuglog_record_action">Registra registru de debug</string>
     <string name="debug_debuglog_stop_action">Frima registratzione</string>
     <string name="debug_debuglog_sensitive_information_message">Su file generadu cuntenet informatziones sensìbiles (es. detàllios de su dispositivu Bluetooth). Cumpartzi·ddu isceti cun partes afidàbiles.</string>
     <string name="settings_debuglog_explanation">Custa funtzione registrat totu su chi s\'app est faghende in unu file cumpartzìbile. Su file generadu cuntenet informatziones sensìbiles (es. detàllios de su dispositivu Bluetooth). Cumpartzi·ddu isceti cun partes afidàbiles (es. un\'isvilupadore chi est risolvende unu problema).</string>
-    <string name="settings_support_installid_label">ID de installatzione</string>
-    <string name="settings_support_installid_desc">Is reportes de errores automàticos sunt anònimos. Cumpartzi s\'ID de installatzione tuo si s\'isvilupadore tenet bisòngiu de agatare is reportes de errores tuos.</string>
     <string name="settings_support_label">Sustènnidu</string>
     <string name="settings_support_description">Si tenes bisòngiu de agiudu.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Reimitzializa is datos imparatos?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod at a scordinare su conisimentu misuadu de su dispositivu, sa velocidade de carriga e su tempus de ascultare, e at a recomentziare dae sa vida de bateria valuada.</string>
     <string name="settings_acknowledgements_label">Rengratziamentos</string>
-    <string name="settings_debug_autoreports_label">Reportes de errores automàticos</string>
-    <string name="settings_debug_autoreports_description">Reportat problemas in automàticu, es. detàllios de un\'arrestu anòmalu de s\'app, aici potzo cumprèndere comente ddu risòlvere.</string>
-    <string name="settings_compatibility_mode_label">Modalidade de cumpatibilidade</string>
-    <string name="settings_compatibility_mode_description">Disativa otimizatziones pro megiorare sa cumpatibilidade. Proa custu si non ses bidende perunu datu.</string>
     <string name="help_translate_label">Tradutzione</string>
     <string name="help_translate_description">Agiuda a traduire custa app in sa limba tua preferida.</string>
     <string name="translators_thanks_title">Tradutores</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sutzessu</string>
     <string name="troubleshooter_ble_result_success_body">CAPod est retzende is trasmissiones de advertisement BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Sena sutzessu</string>
-    <string name="troubleshooter_ble_result_failure_body">Sa risolutzione de problemas est fallida. Peruna cumbinatzione de optziones de cumpatibilidade at agiudadu.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Su telèfonu tuo no at retzidu perunu datu BLE. Podes torrare a proare custu test in un\'àrea prena de gente pro bìdere si si podent retzire fontes de datos (diversas dae is corfitas tuas). Su fatu chi no si retzat perunu datu ìndicat unu problema cun su sistema operativu de su telèfonu tuo.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Su telèfonu tuo at retzidu datos BLE, ma is datos non benint dae perunu dispositivu suportadu. Is corfitas tuas sunt allutas? CAPod suportat sa corfita tua?</string>
-    <string name="troubleshooter_ble_result_failure_action">Proa torra</string>
-    <string name="troubleshoot_action">Risòlve problemas</string>
     <string name="onboarding_body1">Custa app agiunghet suportu pro funtziones ispetzìficas de is AirPods a Android.</string>
     <string name="onboarding_body2">No totu is dispositivos Android suportant in prenu is funtziones extra de is AirPods. Su sistema operativu tuo recheret un\'implementatzione Bluetooth-Low-Energy chi funtzionet in manera curreta.</string>
     <string name="onboarding_body3">CAPod no tenet publitzidade e no arregollit is datos tuos.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Su tuo dispositivu est connètidu, ma CAPod non est retzende datos in diretta dae isse. Su tuo telèfonu podet avere bisòngiu de una opzione de compatibilidade — su risolvidore de problemas podet probare a nd\'agatare una autòmaticamente.</string>
     <string name="overview_troubleshoot_suggestion_action">Esèghit su risolvidore de problemas</string>
     <string name="overview_unmatched_devices_label">Dispositivos sena currispondèntzia</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d dispositivu sena profilu currispondente</item>
-        <item quantity="other">%d dispositivos sena profilu currispondente</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Est istadu detetadu %d dispositivu acurtzu chene profilu currispondente. Ammustra·lu pro nde bider is detàllios. Si est su tuo, agiunghe unu profilu dae Dispositivos pro lu reconnoschere.</item>
         <item quantity="other">Sunt istados detetados %d dispositivos acurtzu chene profilos currispondentes. Ammustra·los pro nde bider is detàllios. Si unu est su tuo, agiunghe unu profilu dae Dispositivos pro lu reconnoschere.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod imperat s\'\"atzessu a sa positzione in segundu pianu\" pro ativare funtziones comente \"Mustra popup\" e \"Cullegamentu automàticu\" cando s\'app est serrada. S\'atzessu a sa positzione in segundu pianu permitit a s\'app de retzire datos Bluetooth Low Energy cando est in segundu pianu. Custa app NON at a impreare datos Bluetooth pro determinare sa positzione tua.</string>
     <string name="permission_ignore_battery_optimizations_label">Disativa otimizatziones de bateria</string>
     <string name="permission_ignore_battery_optimizations_description">Is otimizatziones de bateria impedint a custa app de retzire datos Bluetooth in manera fidàbile cando est in segundu pianu.</string>
-    <string name="permission_required_title">Su permissu in fata est netzessàriu:</string>
     <string name="permission_system_alert_window_label">Ventana de alerta de su sistema</string>
     <string name="permission_system_alert_window_description">Permiti a CAPod de disegnare subra àteras apps pro rèndere possìbile sa funtzione \"Mustra PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Cando est bidu</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">In s\'origra</string>
     <string name="pods_dual_left_label">Corfita manca</string>
     <string name="pods_dual_right_label">Corfita dereta</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Càscia</string>
     <string name="battery_unavailable_label">Batteria non disponibile</string>
     <string name="battery_state_low_cd">Bateria bassa</string>
     <string name="battery_state_critical_cd">Bateria criticamente bassa</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Culleghiamentu direttu ativu</string>
     <string name="signal_indicator_bars_cd">Fortza de su sinnale: %1$d de 4 barras</string>
     <string name="signal_indicator_disconnected_cd">Sinnale: disconnetidu</string>
-    <string name="pods_yours">Tuo</string>
     <string name="headset_being_worn_label">Indossadu</string>
     <string name="headset_not_being_worn_label">Non indossadu</string>
     <string name="pods_case_unknown_state">Istadu disconnotu</string>
-    <string name="last_seen_x">Bidu s\'ùrtima borta: %s</string>
-    <string name="first_seen_x">Bidu sa prima borta: %s</string>
     <string name="battery_cached_label">Úrtiùmu connotu · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dò %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dò</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Calidade mìnima de su signale</string>
     <string name="profiles_signal_quality_description">Rileva isceti dispositivos cun fortza de signale subra de custu lìmite. Valores prus bàscios augmentant su rayu de rilevamentu ma podent causare falsos positivos. Non pongas custu tropu artu - sa retzetzione Bluetooth est generalmente dèbile e bàriat cun sa distàntzia e is ostàculos.</string>
     <string name="profiles_identitykey_label">Crae de identidade</string>
-    <string name="profilessettings_maindevice_identitykey_description">Sa crae de risolutzione de identidade (IRK) de su dispositivu tuo, chi agiudat a CAPod a ddu identificare intre dispositivos acanta.</string>
     <string name="profiles_maindevice_identitykey_explanation">Is AirPods càmbiant a s\'ispissu s\'indiritzu Bluetooth issoro pro sa riservadesa. S\'IRK agiudat a CAPod a riconnòschere su dispositivu tuo. Bisòngiat de atzessu una borta isceti a unu MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Crae de tzifradra</string>
-    <string name="profiles_maindevice_encryptionkey_description">Sa crae de tzifradra de su dispositivu tuo, chi permitit a CAPod de recuperare informatziones de istadu detalliadas.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Is AirPods imbiant unu messàgiu de istadu, una parte de su cale est tzifradu. Sa crae de tzifradra permitit a CAPod de detzifrare su messàgiu cumpletu. Bisòngiat de atzessu una borta isceti a unu MacBook.</string>
     <string name="profiles_key_invalid_format">Formadu de crae non vàlidu</string>
     <string name="profiles_key_expected_format">Formadu previstu: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Tenes modìficas non sarvadas. Ite boles fàghere?</string>
     <string name="general_save_and_exit_action">Sarva e essi</string>
     <string name="general_discard_action">Iscarta</string>
-    <string name="general_keep_editing_action">Sighi a modificare</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Registratzione tropu curza</string>
     <string name="debug_debuglog_short_recording_message">Unu log de debug depit capturare su problema mentres sutzedit. Continua a registrare, reproduzi su problema, pustis fermada sa registratzione.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Impostatziones de su dispositivo</string>
     <string name="device_settings_subtitle_profile_prefix">Profilu: %s</string>
-    <string name="device_settings_info_name_label">Nùmene</string>
     <string name="device_settings_info_bt_name_label">Eticheta de su Dispositivu Bluetooth</string>
     <string name="device_settings_info_model_label">Modello</string>
     <string name="device_settings_info_manufacturer_label">Fabricante</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Forsis prus a tardu</string>
     <string name="review_app_body">Boles làssare una revisione a CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Generale</string>
     <string name="device_settings_microphone_mode_label">Microfon</string>
     <string name="device_settings_microphone_mode_description">Cale auricolari est usadu comente micròfonu</string>
     <string name="device_settings_microphone_mode_auto">Automàticu</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">බෙදාගන්න</string>
     <string name="general_done_action">අහවරයි</string>
     <string name="general_cancel_action">අවලංගු කරන්න</string>
-    <string name="general_copy_action">පිටපත් කරන්න</string>
     <string name="general_thank_you_label">ඔබට ස්තූතියි</string>
     <string name="general_upgrade_action">යාවත්කාලීන කරන්න</string>
     <string name="general_retry_action">නැවතත්</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">පරීක්ෂා කරන්න</string>
     <string name="general_close_action">වසන්න</string>
     <string name="general_dismiss_action">ඉවතලන්න</string>
-    <string name="general_edit_action">සංස්කරණය කරන්න</string>
     <string name="general_save_action">සුරකින්න</string>
     <string name="general_guide_action">මාර්ගෝපදේශය</string>
     <string name="general_continue_action">ඉදිරියට යන්න</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">ඔබ නැවත ඔබේ pods පැළඳීමේදී සංගීතය නැවත ආරම්භ කරයි, නමුත් Auto pause එය නිවා ඇත්නම් පමණි. ඔබ ම ක්‍රියාත්මක කළ විරාමයන් (දුරකථනය, AirPods stem, නිදාගැනීම) විරාමයේ පවතී.</string>
     <string name="settings_start_music_on_wear_label">පැළඳීමේදී සංගීතය ආරම්භ කරන්න</string>
     <string name="settings_start_music_on_wear_description">ඔබ ඔබේ pods පැළඳූ විට, අතින් කළ විරාම ක්‍රියාවෙන් පසුවද, සංගීතය වාදනය කිරීමට සෑම විටම උත්සාහ කරයි.</string>
-    <string name="settings_eardetection_info_label">කන් හඳුනාගැනීමේ සටහන</string>
     <string name="settings_eardetection_info_description">කන් හඳුනාගැනීම එක් පොඩ් එකක් සඳහා පමණක් ක්‍රියා කරන්නේ නම්, මෙය Apple සීමාවකි. \"ප්‍රාථමික පොඩ්\" (මයික්‍රෆෝනය සඳහා භාවිතා වන) පමණක් හඳුනාගනී. Apple උපාංගවල සකසන්න: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">අවම සංඥා ගුණත්වය</string>
-    <string name="settings_signal_minimum_description">උපාංගයක් ඔබේ යැයි සැලකීමට තිබිය යුතු අවම සංඥා ගුණත්වය.</string>
     <string name="settings_autoconnect_label">ස්වයංක්‍රීයව සම්බන්ධ වන්න</string>
     <string name="settings_autoconnect_description">Android ස්වයංක්‍රීයව සම්බන්ධ නොවන්නේ නම්, අපටත් එසේ කිරීමට ඉල්ලා සිටිය හැක. මෙය CAPod සෑම විටම පසුබිමින් නිරීක්ෂණය කරමින් තබයි.</string>
     <string name="settings_autoconnect_info_android12">ස්වයංක්‍රීය සම්බන්ධතාව Android 12 සහ නව අනුවාද සීමා කරන පද්ධති ලක්ෂණයක් මත රඳා පවතී. එය ඔබේ උපකරණයේ ක්‍රියා නොකරනු ඇත.</string>
     <string name="settings_autoconnect_condition_label">ස්වයංක්‍රීය සම්බන්ධ වීමේ තත්ත්වය</string>
-    <string name="settings_autoconnect_condition_description">අපි ඔබේ උපාංගයට සම්බන්ධ වීමට උත්සාහ කළ යුත්තේ කවදාද?</string>
     <string name="settings_devices_label">උපාංග</string>
     <string name="settings_devices_description">ඔබගේ උපාංග කළමනාකරණය කරන්න.</string>
     <string name="settings_reaction_label">ප්‍රතික්‍රියා</string>
-    <string name="settings_category_yourdevice_label">ඔබගේ උපාංගය</string>
     <string name="settings_category_compatibility_options_title">ගැළපුම් විකල්ප</string>
     <string name="settings_category_compatibility_options_description">සියල්ල ක්‍රියාත්මක නම් අත නොගසන්න ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">දෘඪාංග පෙරහන අක්‍රීය කරන්න</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">ආරම්භ කරමින් පවතී…</string>
     <string name="support_debuglog_label">දෝෂහරණ ලොගය</string>
     <string name="support_debuglog_desc">යෙදුම කරන සෑම දෙයක්ම ඔබට බෙදාගත හැකි පෙළ ගොනුවක සටහන් කරන්න.</string>
-    <string name="debug_debuglog_size_label">ප්‍රමාණය</string>
-    <string name="debug_debuglog_size_compressed_label">සම්පීඩිත ප්‍රමාණය</string>
-    <string name="debug_notification_channel_label">දෝෂහරණ දැනුම්දීම්</string>
-    <string name="debug_debuglog_file_label">සටහන් කළ ලොග් ගොනුව</string>
-    <string name="debug_debuglog_recording_progress">දෝෂහරණ ලොගය සටහන් වෙමින් පවතී</string>
     <string name="debug_debuglog_record_action">දෝෂහරණ ලොගය සටහන් කරන්න</string>
     <string name="debug_debuglog_stop_action">සටහන් කිරීම නවත්වන්න</string>
     <string name="debug_debuglog_sensitive_information_message">ජනනය කරන ලද ගොනුවේ සංවේදී තොරතුරු (උදා: බ්ලූටූත් උපාංග විස්තර) අඩංගු වේ. එය විශ්වාසදායක පාර්ශ්වයන් සමඟ පමණක් බෙදා ගන්න.</string>
     <string name="settings_debuglog_explanation">මෙම විශේෂාංගය යෙදුම කරන සෑම දෙයක්ම බෙදාගත හැකි ගොනුවක සටහන් කරයි. ජනනය කරන ලද ගොනුවේ සංවේදී තොරතුරු (උදා: බ්ලූටූත් උපාංග විස්තර) අඩංගු වේ. එය විශ්වාසදායක පාර්ශ්වයන් සමඟ පමණක් බෙදා ගන්න (උදා: ගැටලුවක් නිරාකරණය කරන සංවර්ධකයෙකු).</string>
-    <string name="settings_support_installid_label">ස්ථාපන හැඳුනුම්පත</string>
-    <string name="settings_support_installid_desc">ස්වයංක්‍රීය දෝෂ වාර්තා නිර්නාමිකයි. සංවර්ධකයාට ඔබගේ දෝෂ වාර්තා සොයා ගැනීමට අවශ්‍ය නම් ඔබගේ ස්ථාපන හැඳුනුම්පත බෙදා ගන්න.</string>
     <string name="settings_support_label">සහාය</string>
     <string name="settings_support_description">ඔබට යම් උදව්වක් අවශ්‍ය නම්.</string>
     <string name="settings_wiki_label">විකිය</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">ඉගෙනගත් දත්ත ප්‍රතිසකසන්නද?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod මෙම උපකරණයේ මනින ලද පිටවීම, ආරෝපණ වේගය සහ ශ්‍රවණ කාලය අමතක කරයි, සහ ශ්‍රේණිගත බැටරි කාලයෙන් නැවතත් පටන් ගනී.</string>
     <string name="settings_acknowledgements_label">ස්තූතිය</string>
-    <string name="settings_debug_autoreports_label">ස්වයංක්‍රීය දෝෂ වාර්තා</string>
-    <string name="settings_debug_autoreports_description">ගැටළු ස්වයංක්‍රීයව වාර්තා කරයි, උදා: යෙදුම් බිඳවැටීමක් පිළිබඳ විස්තර, එවිට මට එය නිවැරදි කරන්නේ කෙසේදැයි සොයාගත හැකිය.</string>
-    <string name="settings_compatibility_mode_label">ගැළපුම් ප්‍රකාරය</string>
-    <string name="settings_compatibility_mode_description">ගැළපුම වැඩි දියුණු කිරීම සඳහා ප්‍රශස්තකරණයන් අක්‍රීය කරන්න. ඔබ කිසිදු දත්තයක් නොදකිනුයේ නම් මෙය උත්සාහ කරන්න.</string>
     <string name="help_translate_label">පරිවර්තනය</string>
     <string name="help_translate_description">මෙම යෙදුම ඔබගේ ප්‍රියතම භාෂාවට පරිවර්තනය කිරීමට උදව් වන්න.</string>
     <string name="translators_thanks_title">පරිවර්තකයින්</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">සාර්ථකයි</string>
     <string name="troubleshooter_ble_result_success_body">CAPod මගින් BLE වෙළඳ දැන්වීම් විකාශන ලැබෙමින් පවතී.</string>
     <string name="troubleshooter_ble_result_failure_title">අසාර්ථකයි</string>
-    <string name="troubleshooter_ble_result_failure_body">දෝෂ නිරාකරණය අසාර්ථක විය. ගැළපුම් විකල්ප කිසිදු සංයෝජනයක් උදව් කළේ නැත.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">ඔබගේ දුරකථනය කිසිදු BLE දත්තයක් ලබා ගත්තේ නැත. දත්ත මූලාශ්‍ර (ඔබගේ හෙඩ්ෆෝන් හැර) ලබා ගත හැකිදැයි බැලීමට ඔබට ජනාකීර්ණ ප්‍රදේශයක මෙම පරීක්ෂණය නැවත උත්සාහ කළ හැකිය. කිසිදු දත්තයක් නොලැබීම ඔබගේ දුරකථනයේ මෙහෙයුම් පද්ධතියේ ගැටලුවක් පෙන්නුම් කරයි.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">ඔබගේ දුරකථනය BLE දත්ත ලබා ගත් නමුත්, දත්ත කිසිදු සහාය දක්වන උපාංගයකින් පැමිණෙන්නේ නැත. ඔබගේ හෙඩ්ෆෝන් ක්‍රියාත්මකද? CAPod ඔබගේ හෙඩ්ෆෝනයට සහාය දක්වයිද?</string>
-    <string name="troubleshooter_ble_result_failure_action">නැවත උත්සාහ කරන්න</string>
-    <string name="troubleshoot_action">දෝෂ නිරාකරණය කරන්න</string>
     <string name="onboarding_body1">මෙම යෙදුම Android සඳහා AirPod විශේෂිත විශේෂාංග සඳහා සහාය එක් කරයි.</string>
     <string name="onboarding_body2">සියලුම Android උපාංග අමතර AirPod විශේෂාංග සම්පූර්ණයෙන්ම සහාය නොදක්වයි. ඔබගේ මෙහෙයුම් පද්ධතියට නිවැරදිව ක්‍රියාත්මක වන බ්ලූටූත්-අඩු-ශක්ති ක්‍රියාත්මක කිරීමක් අවශ්‍ය වේ.</string>
     <string name="onboarding_body3">CAPod හි දැන්වීම් නොමැති අතර ඔබගේ දත්ත රැස් නොකරයි.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">ඔබේ උපාංගය සම්බන්ද වී ඇත, නමුත් CAPod එයින් ජීවිත දත් ලබා ගනිමින් නොමැත. ඔබේ දුරකතනයට අනුකූලතා ළිකල්පයක් අවශ්‍ය ළිය හැක — දෝෂ නිරාකරණකය ස්වයංක්‍රීයව එකක් සොයා ගැනීමට උත්සාහ කළ හැක.</string>
     <string name="overview_troubleshoot_suggestion_action">දෝෂ නිරාකරණකය ධාවනය කරන්න</string>
     <string name="overview_unmatched_devices_label">නොගැලපෙන උපාංග</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">ගැලපෙන පැතිකඩක් නොමැති උපාංග %d ක්</item>
-        <item quantity="other">ගැලපෙන පැතිකඩක් නොමැති උපාංග %d ක්</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">නුදුරින් උපාංග %dක් ගැලපෙන පැතිකඩක් නොමැතිව අනාවරණය විය. පවතින විස්තර දැකීමට එය පෙන්වන්න. එය ඔබේ නම්, එය හඳුනා ගැනීමට උපාංග අංශයෙන් පැතිකඩක් එක් කරන්න.</item>
         <item quantity="other">නුදුරින් උපාංග %dක් ගැලපෙන පැතිකඩ නොමැතිව අනාවරණය විය. පවතින විස්තර දැකීමට ඒවා පෙන්වන්න. ඉන් එකක් ඔබේ නම්, එය හඳුනා ගැනීමට උපාංග අංශයෙන් පැතිකඩක් එක් කරන්න.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod \"පසුබිම් පිහිටුම් ප්‍රවේශය\" භාවිතා කරන්නේ යෙදුම වසා ඇති විට \"පොප්-අප් පෙන්වන්න\" සහ \"ස්වයංක්‍රීය සම්බන්ධතාව\" වැනි විශේෂාංග සක්‍රීය කිරීමට ය. පසුබිම් පිහිටුම් ප්‍රවේශය යෙදුමට පසුබිමේ සිටින විට Bluetooth Low Energy දත්ත ලබා ගැනීමට ඉඩ දෙයි. මෙම යෙදුම ඔබගේ පිහිටුම තීරණය කිරීමට Bluetooth දත්ත භාවිතා නොකරනු ඇත.</string>
     <string name="permission_ignore_battery_optimizations_label">බැටරි ප්‍රශස්තකරණ අක්‍රීය කරන්න</string>
     <string name="permission_ignore_battery_optimizations_description">බැටරි ප්‍රශස්තකරණ මෙම යෙදුම පසුබිමේ සිටින විට විශ්වාසදායක ලෙස Bluetooth දත්ත ලබා ගැනීම වළක්වයි.</string>
-    <string name="permission_required_title">පහත අවසරය අවශ්‍ය වේ:</string>
     <string name="permission_system_alert_window_label">පද්ධති ඇඟවුම් කවුළුව</string>
     <string name="permission_system_alert_window_description">\"පොප්-අප් පෙන්වන්න\" විශේෂාංගය හැකි කිරීමට CAPod හට වෙනත් යෙදුම් මත අඳින්නට ඉඩ දෙන්න.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">දුටු විට</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">කනේ</string>
     <string name="pods_dual_left_label">වම් පොඩ්</string>
     <string name="pods_dual_right_label">දකුණු පොඩ්</string>
-    <string name="pods_dual_left_short_label">ව</string>
-    <string name="pods_dual_right_short_label">ද</string>
-    <string name="pods_case_label">කවරය</string>
     <string name="battery_unavailable_label">බැටරිය නොමැත</string>
     <string name="battery_state_low_cd">බැටරිය අඩුයි</string>
     <string name="battery_state_critical_cd">බැටරිය බරපතල ලෙස අඩුයි</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">සෘජු සම්බන්ධතාව ක්‍රියාත්මකයි</string>
     <string name="signal_indicator_bars_cd">සංඥා ශක්තිය: තීරු 4 න් %1$d</string>
     <string name="signal_indicator_disconnected_cd">සංඥාව: විසන්ධි වී ඇත</string>
-    <string name="pods_yours">ඔබගේ</string>
     <string name="headset_being_worn_label">පැළඳ සිටී</string>
     <string name="headset_not_being_worn_label">පැළඳ නැත</string>
     <string name="pods_case_unknown_state">නොදන්නා තත්ත්වය</string>
-    <string name="last_seen_x">අවසන් වරට දුටු: %s</string>
-    <string name="first_seen_x">පළමු වරට දුටු: %s</string>
     <string name="battery_cached_label">අවසන් දන්නා · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dපෙ %2$dමි</string>
     <string name="battery_time_remaining_format_h">%1$dපෙ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">අවම සංඥා ගුණත්වය</string>
     <string name="profiles_signal_quality_description">මෙම සීමාවට ඉහළ සංඥා ශක්තිය ඇති උපාංග පමණක් හඳුනාගන්න. අඩු අගයන් හඳුනාගැනීමේ පරාසය වැඩි කරන නමුත් ව්‍යාජ ධනාත්මක ප්‍රතිඵල ඇති විය හැක. මෙය ඉතා ඉහළට සකසන්න එපා - Bluetooth ප්‍රතිග්‍රහණය සාමාන්‍යයෙන් දුර්වල වන අතර දුර සහ බාධක සමඟ වෙනස් වේ.</string>
     <string name="profiles_identitykey_label">අනන්‍යතා යතුර</string>
-    <string name="profilessettings_maindevice_identitykey_description">ඔබගේ උපාංගයේ අනන්‍යතා විසඳීමේ යතුර (IRK), CAPod හට ළඟ උපාංග අතර එය හඳුනා ගැනීමට උදව් වේ.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods රහස්‍යතාව සඳහා නිතර ඔවුන්ගේ Bluetooth ලිපිනය වෙනස් කරයි. IRK CAPod හට ඔබගේ උපාංගය හඳුනා ගැනීමට උදව් වේ. ඔබට එක් වරක් MacBook එකකට ප්‍රවේශය අවශ්‍ය වේ.</string>
     <string name="profiles_maindevice_encryptionkey_label">සංකේතන යතුර</string>
-    <string name="profiles_maindevice_encryptionkey_description">ඔබගේ උපාංගයේ සංකේතන යතුර, CAPod හට විස්තරාත්මක තත්ත්ව තොරතුරු ලබා ගැනීමට ඉඩ සලසයි.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods තත්ත්ව පණිවිඩයක් යවයි, එහි කොටසක් සංකේතනය කර ඇත. සංකේතන යතුර CAPod හට සම්පූර්ණ පණිවිඩය විකේතනය කිරීමට ඉඩ දෙයි. ඔබට එක් වරක් MacBook එකකට ප්‍රවේශය අවශ්‍ය වේ.</string>
     <string name="profiles_key_invalid_format">වලංගු නොවන යතුරු ආකෘතිය</string>
     <string name="profiles_key_expected_format">අපේක්ෂිත ආකෘතිය: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">ඔබට සුරැකීමට අවශ්‍ය වෙනස්කම් ඇත. ඔබ කුමක් කිරීමට කැමතිද?</string>
     <string name="general_save_and_exit_action">සුරකින්න සහ පිටවන්න</string>
     <string name="general_discard_action">ඉවතලන්න</string>
-    <string name="general_keep_editing_action">සංස්කරණය කරගෙන යන්න</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">රෙකර්ඩිං ඉතා කෙටිය</string>
     <string name="debug_debuglog_short_recording_message">දෝෂහරණ ලොගයක් ගැටළුව සිදුවෙද්දීම ග්‍රහණය කළ යුතුය. රෙකර්ඩිං දිගටම සිටිය, ගැටළුව නැවත ඇතිකරන්න, ඉන්පසු රෙකර්ඩිං නතර කරන්න.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">උපාංග සැකසුම්</string>
     <string name="device_settings_subtitle_profile_prefix">ස්වරූපය: %s</string>
-    <string name="device_settings_info_name_label">නම</string>
     <string name="device_settings_info_bt_name_label">Bluetooth උපකරණ ලේබලය</string>
     <string name="device_settings_info_model_label">ආකෘතිය</string>
     <string name="device_settings_info_manufacturer_label">නිෂ්පාදකයා</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">පසුව සමහර විට</string>
     <string name="review_app_body">ඔබ CAPod සඳහා සමාලෝචනයක් ලිවීමට කැමතිද? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">සාමාන්‍ය</string>
     <string name="device_settings_microphone_mode_label">ශබ්දවාහිනිය</string>
     <string name="device_settings_microphone_mode_description">මයිකෝපොනය ලේස බාවිතා කරන්නේ earbud කුමක්ද</string>
     <string name="device_settings_microphone_mode_auto">ස්වයංක්‍රීය</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Zdieľať</string>
     <string name="general_done_action">Hotovo</string>
     <string name="general_cancel_action">Zrušit</string>
-    <string name="general_copy_action">Kopírovať</string>
     <string name="general_thank_you_label">Ďakujem</string>
     <string name="general_upgrade_action">Inovovať</string>
     <string name="general_retry_action">Skúsiť znova</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Overiť</string>
     <string name="general_close_action">Zavrieť</string>
     <string name="general_dismiss_action">Odmietnuť</string>
-    <string name="general_edit_action">Upraviť</string>
     <string name="general_save_action">Uložiť</string>
     <string name="general_guide_action">Sprievodca</string>
     <string name="general_continue_action">Pokračovať</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Obnoví prehrávanie hudby, keď si slúchadlá znova nasadíte, ale iba ak ho zastavilo automatické pozastavenie. Pauzy, ktoré ste spustili sami (telefón, stopka AirPods, spánok), zostanú pozastavené.</string>
     <string name="settings_start_music_on_wear_label">Spustiť hudbu pri nasadení</string>
     <string name="settings_start_music_on_wear_description">Vždy sa pokúsi prehrať hudbu, keď si nasadíte slúchadlá, aj po manuálnej pauze.</string>
-    <string name="settings_eardetection_info_label">Poznámka k detekcii ucha</string>
     <string name="settings_eardetection_info_description">Ak detekcia ucha funguje iba pre jedno slúchadlo, je to obmedzenie Apple. Detegované je iba \"primárne slúchadlo\" (používané pre mikrofón). Konfigurujte na zariadeniach Apple: Nastavenia → Bluetooth → AirPods → Mikrofón.</string>
-    <string name="settings_signal_minimum_label">Minimálna kvalita signálu</string>
-    <string name="settings_signal_minimum_description">Minimálna kvalita signálu, ktorú zariadenie musí mať, aby sa považovalo za vaše.</string>
     <string name="settings_autoconnect_label">Automatické pripojenie</string>
     <string name="settings_autoconnect_description">Ak sa Android nezapojí automaticky, môžeme ho požiadať. To umožní aplikácii CAPod monitorovať v pozadí nepretržite.</string>
     <string name="settings_autoconnect_info_android12">Automatické pripojenie závisí od systémovej funkcie, ktorú Android 12 a novší obmedzujú. Na vašom zariadení nemusí fungovať.</string>
     <string name="settings_autoconnect_condition_label">Stav automatického pripojenia</string>
-    <string name="settings_autoconnect_condition_description">Kedy by sme sa mali pokúsiť pripojiť k vášmu zariadeniu?</string>
     <string name="settings_devices_label">Zariadenia</string>
     <string name="settings_devices_description">Spravujte svoje zariadenia.</string>
     <string name="settings_reaction_label">Reakcie</string>
-    <string name="settings_category_yourdevice_label">Vaše zariadenie</string>
     <string name="settings_category_compatibility_options_title">Možnosti kompatibility</string>
     <string name="settings_category_compatibility_options_description">Nedotýkajte sa, ak všetko funguje ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Vypnite hardvérové filtrovanie</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Spúšťanie…</string>
     <string name="support_debuglog_label">Ladiaci log</string>
     <string name="support_debuglog_desc">Zaznamenajte všetko, čo aplikácia robí do textového súboru, ktorý môžete zdieľať.</string>
-    <string name="debug_debuglog_size_label">Veľkosť</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimovaná veľkosť</string>
-    <string name="debug_notification_channel_label">Oznámenia o ladení</string>
-    <string name="debug_debuglog_file_label">Zaznamenaný súbor denníka</string>
-    <string name="debug_debuglog_recording_progress">Záznam denníka ladenia</string>
     <string name="debug_debuglog_record_action">Zaznamenajte denník ladenia</string>
     <string name="debug_debuglog_stop_action">Zastaviť nahrávanie</string>
     <string name="debug_debuglog_sensitive_information_message">Vygenerovaný súbor obsahuje citlivé informácie (napr. podrobnosti o zariadení Bluetooth). Zdieľajte ho iba s dôveryhodnými stranami.</string>
     <string name="settings_debuglog_explanation">Táto funkcia zaznamenáva všetko čo aplikácia robí do zdieľaného súboru. Vygenerovaný súbor obsahuje citlivé informácie (napr. podrobnosti o zariadení Bluetooth). Zdieľajte ho iba s dôveryhodnými stranami (napr. vývojár, ktorý rieši problém).</string>
-    <string name="settings_support_installid_label">ID inštalácie</string>
-    <string name="settings_support_installid_desc">Automatické chybové hlásenia sú anonymné. Zdieľajte svoje ID inštalácie, ak vývojár potrebuje nájsť vaše chybové hlásenia.</string>
     <string name="settings_support_label">Podpora</string>
     <string name="settings_support_description">Ak potrebujete pomoc.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Resetovať naučené údaje?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod zabudne na meraný úbytok tohto zariadenia, rýchlosť nabíjania a dobu počúvania a začne znova od nominálnej doby batérie.</string>
     <string name="settings_acknowledgements_label">Poďakovania</string>
-    <string name="settings_debug_autoreports_label">Automatické hlásenia chýb</string>
-    <string name="settings_debug_autoreports_description">Automaticky hlási problémy, napr. podrobnosti o zlyhaní aplikácie, aby som mohol zistiť, ako to opraviť.</string>
-    <string name="settings_compatibility_mode_label">Režim kompatibility</string>
-    <string name="settings_compatibility_mode_description">Zakázať optimalizáciu na zlepšenie kompatibility. Skúste to, ak nevidíte žiadne údaje.</string>
     <string name="help_translate_label">Preklad</string>
     <string name="help_translate_description">Pomôžte preložiť túto aplikáciu do svojho obľúbeného jazyka.</string>
     <string name="translators_thanks_title">Prekladatelia</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Úspech</string>
     <string name="troubleshooter_ble_result_success_body">CAPod prijíma reklamné vysielanie BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Neúspešné</string>
-    <string name="troubleshooter_ble_result_failure_body">Riešenie problémov zlyhalo. Nepomohla žiadna kombinácia možností kompatibility.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Váš telefón neprijal vôbec žiadne údaje BLE. Tento test môžete zopakovať v preplnenej oblasti a zistiť, či je možné prijímať zdroje údajov (iné ako vaše slúchadlá). Žiadne prijímané údaje neukazujú na problém s operačným systémom vášho telefónu.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Váš telefón prijal údaje BLE, ale údaje nepochádzajú zo žiadneho podporovaného zariadenia. Máte zapnuté slúchadlá? Podporuje CAPod vaše slúchadlá?</string>
-    <string name="troubleshooter_ble_result_failure_action">Skúste znova</string>
-    <string name="troubleshoot_action">Riešiť problém</string>
     <string name="onboarding_body1">Táto aplikácia pridáva podporu pre špecifické funkcie AirPod do systému Android.</string>
     <string name="onboarding_body2">Nie všetky zariadenia so systémom Android plne podporujú ďalšie funkcie AirPod. Váš operačný systém vyžaduje správne fungujúcu implementáciu Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod nemá žiadne reklamy a nezhromažďuje vaše údaje.</string>
@@ -207,12 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tvoje zariadenie je pripojené, ale CAPod z neho neprijíma žiadne živé dáta. Tvoj telefón môže potrebovať možnosť kompatibility — nástroj na riešenie problémov sa ju môže pokúsiť nájsť automaticky.</string>
     <string name="overview_troubleshoot_suggestion_action">Spustiť riešenie problémov</string>
     <string name="overview_unmatched_devices_label">Nezhodujúce sa zariadenia</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d zariadenie bez zodpovedajúceho profilu</item>
-        <item quantity="few">%d zariadenia bez zodpovedajúceho profilu</item>
-        <item quantity="many">%d zariadení bez zodpovedajúceho profilu</item>
-        <item quantity="other">%d zariadení bez zodpovedajúceho profilu</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">V okolí bolo zistené %d zariadenie bez zodpovedajúceho profilu. Zobrazte ho pre dostupné podrobnosti. Ak je vaše, pridajte profil v časti Zariadenia, aby ste ho rozpoznali.</item>
         <item quantity="few">V okolí boli zistené %d zariadenia bez zodpovedajúcich profilov. Zobrazte ich pre dostupné podrobnosti. Ak je jedno z nich vaše, pridajte profil v časti Zariadenia, aby ste ho rozpoznali.</item>
@@ -237,7 +210,6 @@
     <string name="permission_background_location_description">CAPod používa \"prístup k polohe na pozadí\" na povolenie funkcií ako \"Zobraziť vyskakovacie okno\" a \"Automatické pripojenie\", keď je aplikácia zatvorená. Prístup k polohe na pozadí umožňuje aplikácii prijímať údaje Bluetooth Low Energy, keď je na pozadí. Táto aplikácia NEBUDE používať údaje Bluetooth na určenie vašej polohy.</string>
     <string name="permission_ignore_battery_optimizations_label">Vypnúť optimalizáciu batérie</string>
     <string name="permission_ignore_battery_optimizations_description">Optimalizácia batérie bráni tejto aplikácii spoľahlivo prijímať údaje Bluetooth, keď je aplikácia na pozadí.</string>
-    <string name="permission_required_title">Je vyžadované nasledujúce povolenie:</string>
     <string name="permission_system_alert_window_label">Systémové výstražné okno</string>
     <string name="permission_system_alert_window_description">Povoľte CAPodu kresliť cez iné aplikácie, aby bola možná funkcia \"Zobraziť vyskakovacie okno\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Keď je videné</string>
@@ -245,9 +217,6 @@
     <string name="settings_reaction_autoconnect_inear_label">V uchu</string>
     <string name="pods_dual_left_label">Ľavé slúchadlo</string>
     <string name="pods_dual_right_label">Pravé slúchadlo</string>
-    <string name="pods_dual_left_short_label">Ľ</string>
-    <string name="pods_dual_right_short_label">P</string>
-    <string name="pods_case_label">Puzdro</string>
     <string name="battery_unavailable_label">Batéria nedostupná</string>
     <string name="battery_state_low_cd">Slabá batéria</string>
     <string name="battery_state_critical_cd">Kriticky nízka batéria</string>
@@ -304,12 +273,9 @@
     <string name="signal_badge_aap_cd">Priame pripojenie aktívne</string>
     <string name="signal_indicator_bars_cd">Sila signálu: %1$d zo 4 prúžkov</string>
     <string name="signal_indicator_disconnected_cd">Signál: odpojený</string>
-    <string name="pods_yours">Vaše</string>
     <string name="headset_being_worn_label">Nosené</string>
     <string name="headset_not_being_worn_label">Nenosené</string>
     <string name="pods_case_unknown_state">Neznámy stav</string>
-    <string name="last_seen_x">Naposledy videné: %s</string>
-    <string name="first_seen_x">Prvýkrát videné: %s</string>
     <string name="battery_cached_label">Naposledy známy · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -339,10 +305,8 @@
     <string name="profiles_signal_quality_title">Minimálna kvalita signálu</string>
     <string name="profiles_signal_quality_description">Detegujte iba zariadenia so silou signálu nad touto hranicou. Nižšie hodnoty zvyšujú dosah detekcie, ale môžu spôsobiť falošné pozitíva. Nenastavujte príliš vysoko - príjem Bluetooth je všeobecne slabý a líši sa podľa vzdialenosti a prekážok.</string>
     <string name="profiles_identitykey_label">Kľúč identity</string>
-    <string name="profilessettings_maindevice_identitykey_description">Kľúč na rozlíšenie identity (IRK) vášho zariadenia, ktorý pomáha CAPodu identifikovať ho medzi blízkymi zariadeniami.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods často menia svoju adresu Bluetooth kvôli ochrane súkromia. IRK pomáha CAPodu rozpoznať vaše zariadenie. Potrebujete jednorazový prístup k MacBooku.</string>
     <string name="profiles_maindevice_encryptionkey_label">Šifrovací kľúč</string>
-    <string name="profiles_maindevice_encryptionkey_description">Šifrovací kľúč vášho zariadenia, ktorý umožňuje CAPodu získať podrobné informácie o stave.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods odosielajú stavovú správu, z ktorej je časť zašifrovaná. Šifrovací kľúč umožňuje CAPodu dešifrovať celú správu. Potrebujete jednorazový prístup k MacBooku.</string>
     <string name="profiles_key_invalid_format">Neplatný formát kľúča</string>
     <string name="profiles_key_expected_format">Očakávaný formát: %1$s</string>
@@ -375,7 +339,6 @@
     <string name="general_unsaved_changes_message">Máte neuložené zmeny. Čo chcete urobiť?</string>
     <string name="general_save_and_exit_action">Uložiť &amp; Ukončiť</string>
     <string name="general_discard_action">Zahodiť</string>
-    <string name="general_keep_editing_action">Pokračovať v úpravách</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Nahrávanie príliš krátke</string>
     <string name="debug_debuglog_short_recording_message">Ladíaci záznam musí zachytiť problém, keď sa práve vyskytuje. Pokračujte v nahrávaní, reprodukujte problém, potom zastavďte nahrávanie.</string>
@@ -452,7 +415,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Nastavenia zariadenia</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Názov</string>
     <string name="device_settings_info_bt_name_label">Označenie Bluetooth zariadenia</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Výrobca</string>
@@ -532,7 +494,6 @@
     <string name="review_app_dismiss_action">Možno pozdejšie</string>
     <string name="review_app_body">Chceli by ste zanechať recenziu CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Všeobecné</string>
     <string name="device_settings_microphone_mode_label">Mikrofón</string>
     <string name="device_settings_microphone_mode_description">Ktoré slúchadlo sa používa ako mikrofón</string>
     <string name="device_settings_microphone_mode_auto">Automaticky</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Deli</string>
     <string name="general_done_action">Končano</string>
     <string name="general_cancel_action">Prekliči</string>
-    <string name="general_copy_action">Kopiraj</string>
     <string name="general_thank_you_label">Hvala</string>
     <string name="general_upgrade_action">Nadgradi</string>
     <string name="general_retry_action">Poskusi znova</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Preveri</string>
     <string name="general_close_action">Zapri</string>
     <string name="general_dismiss_action">Opusti</string>
-    <string name="general_edit_action">Uredi</string>
     <string name="general_save_action">Shrani</string>
     <string name="general_guide_action">Vodnik</string>
     <string name="general_continue_action">Nadaljuj</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Nadaljuj glasbo, ko znova oblečeš slušalke, vendar samo če jo je ustavil Auto premor. Premori, ki si jih sam sprožil (telefon, drsnik AirPods, spanje), ostanejo na premoru.</string>
     <string name="settings_start_music_on_wear_label">Začni glasbo ob oblačenju</string>
     <string name="settings_start_music_on_wear_description">Vedno poskusi predvajati glasbo, ko si nataknješ slušalke, tudi po ročnem premoru.</string>
-    <string name="settings_eardetection_info_label">Opomba o zaznavi ušesa</string>
     <string name="settings_eardetection_info_description">Če zaznava ušesa deluje samo za eno slušalko, je to omejitev Apple. Zaznana je samo \"primarna slušalka\" (uporabljena za mikrofon). Konfigurirajte na napravah Apple: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">Minimalna kakovost signala</string>
-    <string name="settings_signal_minimum_description">Minimalna kakovost signala, ki jo mora imeti naprava, da se šteje za vašo.</string>
     <string name="settings_autoconnect_label">Samodejna povezava</string>
     <string name="settings_autoconnect_description">Če se Android ne poveže samodejno, ga lahko prosimo, da to stori. Tako CAPod ves čas nadzoruje v ozadju.</string>
     <string name="settings_autoconnect_info_android12">Samodejno povezovanje se zanaša na sistemsko funkcijo, ki jo Android 12 in novejši omejuje. Morda ne bo delovalo na vaši napravi.</string>
     <string name="settings_autoconnect_condition_label">Pogoj za samodejno povezavo</string>
-    <string name="settings_autoconnect_condition_description">Kdaj naj poskusimo vzpostaviti povezavo z vašo napravo?</string>
     <string name="settings_devices_label">Naprave</string>
     <string name="settings_devices_description">Upravljajte svoje naprave.</string>
     <string name="settings_reaction_label">Reakcije</string>
-    <string name="settings_category_yourdevice_label">Vaša naprava</string>
     <string name="settings_category_compatibility_options_title">Možnosti združljivosti</string>
     <string name="settings_category_compatibility_options_description">Ne dotikajte se, če vse deluje ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Onemogoči strojno filtriranje</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Zaganjam se…</string>
     <string name="support_debuglog_label">Dnevnik za odpravljanje napak</string>
     <string name="support_debuglog_desc">Zabeležite vse, kar počne aplikacija, v besedilno datoteko, ki jo lahko delite.</string>
-    <string name="debug_debuglog_size_label">Velikost</string>
-    <string name="debug_debuglog_size_compressed_label">Stisnjena velikost</string>
-    <string name="debug_notification_channel_label">Obvestila za odpravljanje napak</string>
-    <string name="debug_debuglog_file_label">Zabeležena datoteka dnevnika</string>
-    <string name="debug_debuglog_recording_progress">Snemanje dnevnika za odpravljanje napak</string>
     <string name="debug_debuglog_record_action">Zabeleži dnevnik za odpravljanje napak</string>
     <string name="debug_debuglog_stop_action">Ustavi snemanje</string>
     <string name="debug_debuglog_sensitive_information_message">Ustvarjena datoteka vsebuje občutljive podatke (npr. podrobnosti o napravi Bluetooth). Delite jo samo z zaupanja vrednimi osebami.</string>
     <string name="settings_debuglog_explanation">Ta funkcija zabeleži vse, kar počne aplikacija, v datoteko, ki jo je mogoče deliti. Ustvarjena datoteka vsebuje občutljive podatke (npr. podrobnosti o napravi Bluetooth). Delite jo samo z zaupanja vrednimi osebami (npr. razvijalcem, ki odpravlja težavo).</string>
-    <string name="settings_support_installid_label">ID namestitve</string>
-    <string name="settings_support_installid_desc">Samodejna poročila o napakah so anonimna. Delite svoj ID namestitve, če mora razvijalec najti vaša poročila o napakah.</string>
     <string name="settings_support_label">Podpora</string>
     <string name="settings_support_description">Če potrebujete pomoč.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Resetirati učene podatke?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod bo pozabil izmerjeno praznjenje, hitrost polnjenja in čas poslušanja te naprave in ponovno začel od nazivne življenjske dobe baterije.</string>
     <string name="settings_acknowledgements_label">Zahvale</string>
-    <string name="settings_debug_autoreports_label">Samodejna poročila o napakah</string>
-    <string name="settings_debug_autoreports_description">Samodejno poroča o težavah, npr. podrobnosti o zrušitvi aplikacije, da lahko ugotovim, kako jo popraviti.</string>
-    <string name="settings_compatibility_mode_label">Način združljivosti</string>
-    <string name="settings_compatibility_mode_description">Onemogočite optimizacije za izboljšanje združljivosti. Poskusite to, če ne vidite nobenih podatkov.</string>
     <string name="help_translate_label">Prevajanje</string>
     <string name="help_translate_description">Pomagajte prevesti to aplikacijo v svoj najljubši jezik.</string>
     <string name="translators_thanks_title">Prevajalci</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Uspeh</string>
     <string name="troubleshooter_ble_result_success_body">CAPod prejema oddaje oglasov BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Neuspešno</string>
-    <string name="troubleshooter_ble_result_failure_body">Odpravljanje težav ni uspelo. Nobena kombinacija možnosti združljivosti ni pomagala.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Vaš telefon sploh ni prejel nobenih podatkov BLE. Ta preizkus lahko ponovite na gneči, da vidite, ali je mogoče prejeti vire podatkov (razen vaših slušalk). Prejemanje nobenih podatkov kaže na težavo z operacijskim sistemom vašega telefona.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Vaš telefon je prejel podatke BLE, vendar podatki ne prihajajo iz nobene podprte naprave. Ali so vaše slušalke vklopljene? Ali CAPod podpira vaše slušalke?</string>
-    <string name="troubleshooter_ble_result_failure_action">Poskusi znova</string>
-    <string name="troubleshoot_action">Odpravi težave</string>
     <string name="onboarding_body1">Ta aplikacija dodaja podporo za posebne funkcije AirPod v Android.</string>
     <string name="onboarding_body2">Vse naprave Android ne podpirajo v celoti dodatnih funkcij AirPod. Vaš operacijski sistem zahteva pravilno delujočo implementacijo Bluetooth z nizko porabo energije.</string>
     <string name="onboarding_body3">CAPod nima oglasov in ne zbira vaših podatkov.</string>
@@ -207,12 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Tvoja naprava je povezana, vendar CAPod ne prejema nobenih živih podatkov iz nje. Tvoj telefon morda potrebuje možnost združljivošči — odpravljalec težav jo lahko poskusi samodejno najti.</string>
     <string name="overview_troubleshoot_suggestion_action">Zagon odpravljalca težav</string>
     <string name="overview_unmatched_devices_label">Neujemajoče naprave</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d naprava brez ujemajočega profila</item>
-        <item quantity="two">%d napravi brez ujemajočega profila</item>
-        <item quantity="few">%d naprave brez ujemajočega profila</item>
-        <item quantity="other">%d naprav brez ujemajočega profila</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">V bližini je bila zaznana %d naprava brez ujemajočega profila. Prikaži jo za razpoložljive podrobnosti. Če je tvoja, dodaj profil v Napravah, da jo prepozna.</item>
         <item quantity="two">V bližini sta bili zaznani %d napravi brez ujemajočega profila. Prikaži ju za razpoložljive podrobnosti. Če je ena tvoja, dodaj profil v Napravah, da jo prepozna.</item>
@@ -237,7 +210,6 @@
     <string name="permission_background_location_description">CAPod uporablja \"dostop do lokacije v ozadju\" za omogočanje funkcij, kot sta \"Pokaži pojavno okno\" in \"Samodejna povezava\", medtem ko je aplikacija zaprta. Dostop do lokacije v ozadju omogoča aplikaciji prejemanje podatkov Bluetooth Low Energy v ozadju. Ta aplikacija NE bo uporabljala podatkov Bluetooth za določanje vaše lokacije.</string>
     <string name="permission_ignore_battery_optimizations_label">Onemogoči optimizacije baterije</string>
     <string name="permission_ignore_battery_optimizations_description">Optimizacije baterije preprečujejo tej aplikaciji zanesljivo prejemanje podatkov Bluetooth, medtem ko je aplikacija v ozadju.</string>
-    <string name="permission_required_title">Zahtevano je naslednje dovoljenje:</string>
     <string name="permission_system_alert_window_label">Sistemsko opozorilno okno</string>
     <string name="permission_system_alert_window_description">Dovolite CAPod risanje čez druge aplikacije, da omogočite funkcijo \"Pokaži pojavno okno\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Ko je zaznana</string>
@@ -245,9 +217,6 @@
     <string name="settings_reaction_autoconnect_inear_label">V ušesu</string>
     <string name="pods_dual_left_label">Leva slušalka</string>
     <string name="pods_dual_right_label">Desna slušalka</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Ohišje</string>
     <string name="battery_unavailable_label">Baterija ni na voljo</string>
     <string name="battery_state_low_cd">Nizka baterija</string>
     <string name="battery_state_critical_cd">Kritično nizka baterija</string>
@@ -304,12 +273,9 @@
     <string name="signal_badge_aap_cd">Neposredna povezava aktivna</string>
     <string name="signal_indicator_bars_cd">Moč signala: %1$d od 4 palic</string>
     <string name="signal_indicator_disconnected_cd">Signal: odklopljeno</string>
-    <string name="pods_yours">Vaša</string>
     <string name="headset_being_worn_label">Se nosi</string>
     <string name="headset_not_being_worn_label">Se ne nosi</string>
     <string name="pods_case_unknown_state">Neznano stanje</string>
-    <string name="last_seen_x">Nazadnje videno: %s</string>
-    <string name="first_seen_x">Prvič videno: %s</string>
     <string name="battery_cached_label">Zadnje znano · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -339,10 +305,8 @@
     <string name="profiles_signal_quality_title">Minimalna kakovost signala</string>
     <string name="profiles_signal_quality_description">Zaznaj samo naprave z močjo signala nad tem pragom. Nižje vrednosti povečajo doseg zaznave, vendar lahko povzročijo napačne pozitivne rezultate. Ne nastavite previsoko - sprejem Bluetooth je na splošno slab in se spreminja z razdaljo in ovirami.</string>
     <string name="profiles_identitykey_label">Identifikacijski ključ</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) vaše naprave, ki pomaga CAPod prepoznati jo med bližnjimi napravami.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods pogosto spreminjajo svoj naslov Bluetooth za zasebnost. IRK pomaga CAPod prepoznati vašo napravo. Potrebujete enkraten dostop do MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Šifrirni ključ</string>
-    <string name="profiles_maindevice_encryptionkey_description">Šifrirni ključ vaše naprave, ki omogoča CAPod pridobivanje podrobnih informacij o stanju.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods pošiljajo sporočilo o stanju, del katerega je šifriran. Šifrirni ključ omogoča CAPod dešifriranje celotnega sporočila. Potrebujete enkraten dostop do MacBook.</string>
     <string name="profiles_key_invalid_format">Neveljavna oblika ključa</string>
     <string name="profiles_key_expected_format">Pričakovana oblika: %1$s</string>
@@ -375,7 +339,6 @@
     <string name="general_unsaved_changes_message">Imate neshranjene spremembe. Kaj želite storiti?</string>
     <string name="general_save_and_exit_action">Shrani &amp; zapusti</string>
     <string name="general_discard_action">Zavrzi</string>
-    <string name="general_keep_editing_action">Nadaljuj urejanje</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Snemanje je prekratko</string>
     <string name="debug_debuglog_short_recording_message">Dnevnik razhroščevanja mora zajeti težavo med njenim pojavom. Nadaljujte s snemanjem, ponovite težavo, nato ustavite snemanje.</string>
@@ -452,7 +415,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Nastavitve naprave</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Ime</string>
     <string name="device_settings_info_bt_name_label">Oznaka naprave Bluetooth</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Proizvajalec</string>
@@ -532,7 +494,6 @@
     <string name="review_app_dismiss_action">Morda kasneje</string>
     <string name="review_app_body">Bi radi ocenili CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Splošno</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Katera slušalka se uporablja kot mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Samodejno</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Ndaj</string>
     <string name="general_done_action">U krye</string>
     <string name="general_cancel_action">Anulo</string>
-    <string name="general_copy_action">Kopjo</string>
     <string name="general_thank_you_label">Faleminderit</string>
     <string name="general_upgrade_action">Përmirëso</string>
     <string name="general_retry_action">Provo përsëri</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontrollo</string>
     <string name="general_close_action">Mbyll</string>
     <string name="general_dismiss_action">Largoje</string>
-    <string name="general_edit_action">Redakto</string>
     <string name="general_save_action">Ruaj</string>
     <string name="general_guide_action">Udhëzues</string>
     <string name="general_continue_action">Vazhdo</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Riprend muzikën kur vesh sërish kufjet, por vetëm nëse pauzimi automatik e ndaloi. Pauzat që ke bërë vetë (telefon, tige AirPods, gjumë) mbeten të pauzuara.</string>
     <string name="settings_start_music_on_wear_label">Fillo muzikën kur vesh kufjet</string>
     <string name="settings_start_music_on_wear_description">Gjithmonë përpiqet të luajë muzikë kur vesh kufjet, madje edhe pas një pauze manuale.</string>
-    <string name="settings_eardetection_info_label">Shënim mbi zbulimin e veshit</string>
     <string name="settings_eardetection_info_description">Nëse zbulimi i veshit funksionon vetëm për një kufje, kjo është një kufizim i Apple. Vetëm \"kufjja kryesore\" (e përdorur për mikrofonin) zbulohet. Konfiguroni në pajisjet Apple: Cilësimet → Bluetooth → AirPods → Mikrofoni.</string>
-    <string name="settings_signal_minimum_label">Cilësia minimale e sinjalit</string>
-    <string name="settings_signal_minimum_description">Cilësia minimale e sinjalit që një pajisje duhet të ketë për t\'u konsideruar e juaja.</string>
     <string name="settings_autoconnect_label">Lidhu automatikisht</string>
     <string name="settings_autoconnect_description">Nëse Android nuk lidhet automatikisht, ne mund t\'i kërkojmë ta bëjë këtë. Kjo e mban CAPod duke monitoruar në sfond gjatë gjithë kohës.</string>
     <string name="settings_autoconnect_info_android12">Lidhja automatike mbështetet në një funksion sistemi të cilin Android 12 dhe versionet më të reja e kufizojnë. Mund të mos funksionojë në pajisjen tuaj.</string>
     <string name="settings_autoconnect_condition_label">Kushti i lidhjes automatike</string>
-    <string name="settings_autoconnect_condition_description">Kur duhet të përpiqemi të lidhemi me pajisjen tuaj?</string>
     <string name="settings_devices_label">Pajisjet</string>
     <string name="settings_devices_description">Menaxhoni pajisjet tuaja.</string>
     <string name="settings_reaction_label">Reagimet</string>
-    <string name="settings_category_yourdevice_label">Pajisja juaj</string>
     <string name="settings_category_compatibility_options_title">Opsionet e përputhshmërisë</string>
     <string name="settings_category_compatibility_options_description">Mos i prekni nëse gjithçka funksionon ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Çaktivizo filtrimin e harduerit</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Po fillon…</string>
     <string name="support_debuglog_label">Regjistri i korrigjimit</string>
     <string name="support_debuglog_desc">Regjistro gjithçka që aplikacioni po bën në një skedar teksti që mund ta ndani.</string>
-    <string name="debug_debuglog_size_label">Madhësia</string>
-    <string name="debug_debuglog_size_compressed_label">Madhësia e kompresuar</string>
-    <string name="debug_notification_channel_label">Njoftimet e korrigjimit</string>
-    <string name="debug_debuglog_file_label">Skedari i regjistrit të regjistruar</string>
-    <string name="debug_debuglog_recording_progress">Po regjistrohet regjistri i korrigjimit</string>
     <string name="debug_debuglog_record_action">Regjistro regjistrin e korrigjimit</string>
     <string name="debug_debuglog_stop_action">Ndalo regjistrimin</string>
     <string name="debug_debuglog_sensitive_information_message">Skedari i gjeneruar përmban informacion të ndjeshëm (p.sh. detajet e pajisjes Bluetooth). Ndajeni vetëm me palë të besuara.</string>
     <string name="settings_debuglog_explanation">Kjo veçori regjistron gjithçka që aplikacioni po bën në një skedar të ndashëm. Skedari i gjeneruar përmban informacion të ndjeshëm (p.sh. detajet e pajisjes Bluetooth). Ndajeni vetëm me palë të besuara (p.sh. një zhvillues që po zgjidh një problem).</string>
-    <string name="settings_support_installid_label">ID-ja e Instalimit</string>
-    <string name="settings_support_installid_desc">Raportet automatike të gabimeve janë anonime. Ndani ID-në tuaj të instalimit nëse zhvilluesi ka nevojë të gjejë raportet tuaja të gabimeve.</string>
     <string name="settings_support_label">Mbështetje</string>
     <string name="settings_support_description">Nëse keni nevojë për ndihmë.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Rivendosni të dhënat e mësuara?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod do të harrojë depletimin e matur të kësaj pajisjeje, shpejtësinë e ngarkimit dhe shëndetin e baterisë, dhe do të fillojë përsëri nga jeta nominale e baterisë.</string>
     <string name="settings_acknowledgements_label">Mirënjohje</string>
-    <string name="settings_debug_autoreports_label">Raporte automatike të gabimeve</string>
-    <string name="settings_debug_autoreports_description">Raporton automatikisht problemet, p.sh. detaje mbi një ndërprerje të aplikacionit në mënyrë që të mund të kuptoj se si ta rregulloj.</string>
-    <string name="settings_compatibility_mode_label">Modaliteti i përputhshmërisë</string>
-    <string name="settings_compatibility_mode_description">Çaktivizo optimizimet për të përmirësuar përputhshmërinë. Provojeni këtë nëse nuk po shihni asnjë të dhënë.</string>
     <string name="help_translate_label">Përkthimi</string>
     <string name="help_translate_description">Ndihmoni në përkthimin e këtij aplikacioni në gjuhën tuaj të preferuar.</string>
     <string name="translators_thanks_title">Përkthyesit</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Sukses</string>
     <string name="troubleshooter_ble_result_success_body">Transmetimet e reklamave BLE po merren nga CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Pa sukses</string>
-    <string name="troubleshooter_ble_result_failure_body">Zgjidhja e problemeve dështoi. Asnjë kombinim i opsioneve të përputhshmërisë nuk ndihmoi.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefoni juaj nuk mori fare të dhëna BLE. Mund ta provoni përsëri këtë test në një zonë me shumë njerëz për të parë nëse mund të merren burime të dhënash (përveç kufjeve tuaja). Mosmarrja e të dhënave tregon një problem me sistemin operativ të telefonit tuaj.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefoni juaj mori të dhëna BLE, por të dhënat nuk vijnë nga asnjë pajisje e mbështetur. A janë ndezur kufjet tuaja? A i mbështet CAPod kufjet tuaja?</string>
-    <string name="troubleshooter_ble_result_failure_action">Provo përsëri</string>
-    <string name="troubleshoot_action">Zgjidh problemet</string>
     <string name="onboarding_body1">Ky aplikacion shton mbështetje për veçoritë specifike të AirPod në Android.</string>
     <string name="onboarding_body2">Jo të gjitha pajisjet Android mbështesin plotësisht veçoritë shtesë të AirPod. Sistemi juaj operativ kërkon një implementim të saktë të Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod nuk ka reklama dhe nuk mbledh të dhënat tuaja.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Pajisja juaj është e lidhur, por CAPod nuk po merr të dhëna live prej saj. Telefoni juaj mund të ketë nevojë për një opsion përputhshmërie — zgjidhësi i problemeve mund të përpiqet të gjejë një automatikisht.</string>
     <string name="overview_troubleshoot_suggestion_action">Ekzekuto zgjidhësin e problemeve</string>
     <string name="overview_unmatched_devices_label">Pajisje të papërputhura</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d pajisje pa profil përputhës</item>
-        <item quantity="other">%d pajisje pa profil përputhës</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d pajisje e afërt u zbulua pa profil përkatës. Shfaqeni për detaje të disponueshme. Nëse është e juaja, shtoni një profil nga Pajisjet për ta njohur.</item>
         <item quantity="other">%d pajisje të afërta u zbuluan pa profile përkatëse. Shfaqini për detaje të disponueshme. Nëse ndonjëra është e juaja, shtoni një profil nga Pajisjet për ta njohur.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod përdor \"qasjen në vendndodhje në sfond\" për të mundësuar veçori si \"Shfaq popup\" dhe \"Lidhu automatikisht\" ndërsa aplikacioni është i mbyllur. Qasja në vendndodhje në sfond i lejon aplikacionit të marrë të dhëna Bluetooth Low Energy ndërsa është në sfond. Ky aplikacion NUK do të përdorë të dhënat Bluetooth për të përcaktuar vendndodhjen tuaj.</string>
     <string name="permission_ignore_battery_optimizations_label">Çaktivizo optimizimet e baterisë</string>
     <string name="permission_ignore_battery_optimizations_description">Optimizimet e baterisë e pengojnë këtë aplikacion nga marrja e besueshme e të dhënave Bluetooth ndërsa aplikacioni është në sfond.</string>
-    <string name="permission_required_title">Leja e mëposhtme kërkohet:</string>
     <string name="permission_system_alert_window_label">Dritare Alarmi Sistemi</string>
     <string name="permission_system_alert_window_description">Lejoni CAPod të vizatojë mbi aplikacionet e tjera për të mundësuar veçorinë \"Shfaq PopUp\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kur shihet</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Në vesh</string>
     <string name="pods_dual_left_label">Kufjja e majtë</string>
     <string name="pods_dual_right_label">Kufjja e djathtë</string>
-    <string name="pods_dual_left_short_label">M</string>
-    <string name="pods_dual_right_short_label">D</string>
-    <string name="pods_case_label">Kutia</string>
     <string name="battery_unavailable_label">Bateria e padisponueshme</string>
     <string name="battery_state_low_cd">Bateria e ulët</string>
     <string name="battery_state_critical_cd">Bateria në nivel kritik</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Lidhje direkte aktive</string>
     <string name="signal_indicator_bars_cd">Fuqia e sinjalit: %1$d nga 4 shtylla</string>
     <string name="signal_indicator_disconnected_cd">Sinjali: i shkëputur</string>
-    <string name="pods_yours">E juaja</string>
     <string name="headset_being_worn_label">Po mbahet</string>
     <string name="headset_not_being_worn_label">Nuk po mbahet</string>
     <string name="pods_case_unknown_state">Gjendje e panjohur</string>
-    <string name="last_seen_x">Parë për herë të fundit: %s</string>
-    <string name="first_seen_x">Parë për herë të parë: %s</string>
     <string name="battery_cached_label">E fundit e njohur · %s</string>
     <string name="battery_time_remaining_format_hm">%1$do %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$do</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Cilësia minimale e sinjalit</string>
     <string name="profiles_signal_quality_description">Zbulo vetëm pajisje me fuqinë e sinjalit mbi këtë prag. Vlerat më të ulëta rrisin gamën e zbulimit por mund të shkaktojnë pozitivë false. Mos e vendosni shumë lart - pritja Bluetooth është përgjithësisht e dobët dhe ndryshon me distancën dhe pengesat.</string>
     <string name="profiles_identitykey_label">Çelës Identiteti</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) i pajisjes suaj, i cili ndihmon CAPod ta identifikojë atë midis pajisjeve të afërta.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ndryshojnë shpesh adresën e tyre Bluetooth për privatësi. IRK ndihmon CAPod të njohë pajisjen tuaj. Ju nevojitet qasje njëherëshme në një MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Çelës Enkriptimi</string>
-    <string name="profiles_maindevice_encryptionkey_description">Çelësi i enkriptimit të pajisjes suaj, i cili lejon CAPod të marrë informacion të detajuar të statusit.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods dërgojnë një mesazh statusi, pjesa e të cilit është e enkriptuar. Çelësi i enkriptimit lejon CAPod të dekriptojë mesazhin e plotë. Ju nevojitet qasje njëherëshme në një MacBook.</string>
     <string name="profiles_key_invalid_format">Format i pavlefshëm i çelësit</string>
     <string name="profiles_key_expected_format">Formati i pritur: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Keni ndryshime të paruajtura. Çfarë dëshironi të bëni?</string>
     <string name="general_save_and_exit_action">Ruaj &amp; dil</string>
     <string name="general_discard_action">Hidh poshtë</string>
-    <string name="general_keep_editing_action">Vazhdo redaktimin</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Regjistrim shumë i shkurtër</string>
     <string name="debug_debuglog_short_recording_message">Një regjistrim debug duhet të kapë problemin ndërkohë që ndodh. Vazhdoni të regjistroni, riprodhoni problemin, pastaj ndaloni regjistrimin.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Cilësimet e pajisjes</string>
     <string name="device_settings_subtitle_profile_prefix">Profili: %s</string>
-    <string name="device_settings_info_name_label">Emri</string>
     <string name="device_settings_info_bt_name_label">Etiketa e pajisjes Bluetooth</string>
     <string name="device_settings_info_model_label">Modeli</string>
     <string name="device_settings_info_manufacturer_label">Prodhuesi</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Ndoshta më vonë</string>
     <string name="review_app_body">Dëshironi t\'i lini një koment CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Gjenerik</string>
     <string name="device_settings_microphone_mode_label">Mikrofoni</string>
     <string name="device_settings_microphone_mode_description">Cili kufjezë përdoret si mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Automatik</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Дели</string>
     <string name="general_done_action">Готово</string>
     <string name="general_cancel_action">Откажи</string>
-    <string name="general_copy_action">Копирај</string>
     <string name="general_thank_you_label">Хвала</string>
     <string name="general_upgrade_action">Надогради</string>
     <string name="general_retry_action">Покушај</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Провери</string>
     <string name="general_close_action">Затвори</string>
     <string name="general_dismiss_action">Одбаци</string>
-    <string name="general_edit_action">Уреди</string>
     <string name="general_save_action">Сачувај</string>
     <string name="general_guide_action">Водич</string>
     <string name="general_continue_action">Настави</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Настави музику када поново носиш слушалице, али само ако ју је аутоматска пауза зауставила. Паузе које си сам/а покренуо/ла (телефон, AirPods петељка, успавање) остају паузиране.</string>
     <string name="settings_start_music_on_wear_label">Покрени музику при ношењу</string>
     <string name="settings_start_music_on_wear_description">Увек покушава да пусти музику када ставиш слушалице, чак и после ручне паузе.</string>
-    <string name="settings_eardetection_info_label">Напомена о детекцији уха</string>
     <string name="settings_eardetection_info_description">Ако детекција уха ради само за једну слушалицу, то је ограничење Apple-а. Детектује се само \"примарна слушалица\" (која се користи за микрофон). Подесите на Apple уређајима: Подешавања → Bluetooth → AirPods → Микрофон.</string>
-    <string name="settings_signal_minimum_label">Минимални квалитет сигнала</string>
-    <string name="settings_signal_minimum_description">Минимални квалитет сигнала који уређај мора да има да би се сматрао вашим.</string>
     <string name="settings_autoconnect_label">Аутоматско повезивање</string>
     <string name="settings_autoconnect_description">Ако Android не повезује аутоматски, можемо и ми да га замолимо. То одржава CAPod мониторинг активним у позадини све време.</string>
     <string name="settings_autoconnect_info_android12">Аутоматско повезивање ослања се на системску функцију коју Android 12 и новије верзије ограничавају. Можда неће радити на вашем уређају.</string>
     <string name="settings_autoconnect_condition_label">Услов за аутоматско повезивање</string>
-    <string name="settings_autoconnect_condition_description">Када би требало да покушамо да се повежемо са вашим уређајем?</string>
     <string name="settings_devices_label">Уређаји</string>
     <string name="settings_devices_description">Управљајте својим уређајима.</string>
     <string name="settings_reaction_label">Реакције</string>
-    <string name="settings_category_yourdevice_label">Ваш уређај</string>
     <string name="settings_category_compatibility_options_title">Опције компатибилности</string>
     <string name="settings_category_compatibility_options_description">Не дирајте ако све ради ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Онемогући хардверско филтрирање</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Покретање…</string>
     <string name="support_debuglog_label">Дневник отклањања грешака</string>
     <string name="support_debuglog_desc">Снимите све што апликација ради у текстуалну датотеку коју можете да делите.</string>
-    <string name="debug_debuglog_size_label">Величина</string>
-    <string name="debug_debuglog_size_compressed_label">Компримована величина</string>
-    <string name="debug_notification_channel_label">Обавештења за отклањање грешака</string>
-    <string name="debug_debuglog_file_label">Снимљена датотека дневника</string>
-    <string name="debug_debuglog_recording_progress">Снимање дневника отклањања грешака</string>
     <string name="debug_debuglog_record_action">Сними дневник отклањања грешака</string>
     <string name="debug_debuglog_stop_action">Заустави снимање</string>
     <string name="debug_debuglog_sensitive_information_message">Генерисана датотека садржи осетљиве информације (нпр. детаље о Bluetooth уређају). Делите је само са поузданим странама.</string>
     <string name="settings_debuglog_explanation">Ова функција снима све што апликација ради у датотеку која се може делити. Генерисана датотека садржи осетљиве информације (нпр. детаље о Bluetooth уређају). Делите је само са поузданим странама (нпр. програмером који отклања проблем).</string>
-    <string name="settings_support_installid_label">ID инсталације</string>
-    <string name="settings_support_installid_desc">Аутоматски извештаји о грешкама су анонимни. Поделите свој ID инсталације ако програмер треба да пронађе ваше извештаје о грешкама.</string>
     <string name="settings_support_label">Подршка</string>
     <string name="settings_support_description">Ако вам је потребна помоћ.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Ресетуј научене податке?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ће заборавити измерену потрошњу овог уређаја, брзину пуњења и време слушања, и почети испочетка са номиналним животом батерије.</string>
     <string name="settings_acknowledgements_label">Захвалнице</string>
-    <string name="settings_debug_autoreports_label">Аутоматски извештаји о грешкама</string>
-    <string name="settings_debug_autoreports_description">Аутоматски пријављује проблеме, нпр. детаље о паду апликације како бих могао да схватим како да то поправим.</string>
-    <string name="settings_compatibility_mode_label">Режим компатибилности</string>
-    <string name="settings_compatibility_mode_description">Онемогућите оптимизације да бисте побољшали компатибилност. Покушајте ово ако не видите никакве податке.</string>
     <string name="help_translate_label">Превод</string>
     <string name="help_translate_description">Помозите у превођењу ове апликације на ваш омиљени језик.</string>
     <string name="translators_thanks_title">Преводиоци</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Успех</string>
     <string name="troubleshooter_ble_result_success_body">CAPod прима BLE огласна емитовања.</string>
     <string name="troubleshooter_ble_result_failure_title">Неуспешно</string>
-    <string name="troubleshooter_ble_result_failure_body">Решавање проблема није успело. Ниједна комбинација опција компатибилности није помогла.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ваш телефон уопште није примио никакве BLE податке. Можете поново покушати овај тест на месту са пуно људи да бисте видели да ли се могу примити извори података (осим ваших слушалица). Непримање података указује на проблем са оперативним системом вашег телефона.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Ваш телефон је примио BLE податке, али подаци не долазе са подржаног уређаја. Да ли су ваше слушалице укључене? Да ли CAPod подржава ваше слушалице?</string>
-    <string name="troubleshooter_ble_result_failure_action">Покушај поново</string>
-    <string name="troubleshoot_action">Реши проблем</string>
     <string name="onboarding_body1">Ова апликација додаје подршку за специфичне функције AirPod-а на Android-у.</string>
     <string name="onboarding_body2">Не подржавају сви Android уређаји у потпуности додатне функције AirPod-а. Ваш оперативни систем захтева исправно функционисање имплементације Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod нема рекламе и не прикупља ваше податке.</string>
@@ -207,11 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Твој уређај је повезан, али CAPod не прима живе податке с њега. Можда ти треба опција компатибилности — решавање проблема може покушати да је пронађе аутоматски.</string>
     <string name="overview_troubleshoot_suggestion_action">Покрени решавање проблема</string>
     <string name="overview_unmatched_devices_label">Неупарени уређаји</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d уређај без одговарајућег профила</item>
-        <item quantity="few">%d уређаја без одговарајућег профила</item>
-        <item quantity="other">%d уређаја без одговарајућег профила</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d оближњи уређај је откривен без одговарајућег профила. Прикажите га за доступне детаље. Ако је ваш, додајте профил из Уређаја да бисте га препознали.</item>
         <item quantity="few">%d оближња уређаја су откривена без одговарајућих профила. Прикажите их за доступне детаље. Ако је један ваш, додајте профил из Уређаја да бисте га препознали.</item>
@@ -234,7 +208,6 @@
     <string name="permission_background_location_description">CAPod користи \"приступ локацији у позадини\" да би омогућио функције попут \"Прикажи искачући прозор\" и \"Аутоматско повезивање\" док је апликација затворена. Приступ локацији у позадини омогућава апликацији да прима Bluetooth Low Energy податке док ради у позадини. Ова апликација НЕЋЕ користити Bluetooth податке за одређивање ваше локације.</string>
     <string name="permission_ignore_battery_optimizations_label">Онемогући оптимизацију батерије</string>
     <string name="permission_ignore_battery_optimizations_description">Оптимизација батерије спречава ову апликацију да поуздано прима Bluetooth податке док ради у позадини.</string>
-    <string name="permission_required_title">Потребна је следећа дозвола:</string>
     <string name="permission_system_alert_window_label">Приказ преко других апликација</string>
     <string name="permission_system_alert_window_description">Дозволите CAPod-у да се приказује преко других апликација да би функција \"Прикажи искачући прозор\" била могућа.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Када се види</string>
@@ -242,9 +215,6 @@
     <string name="settings_reaction_autoconnect_inear_label">У уху</string>
     <string name="pods_dual_left_label">Лева слушалица</string>
     <string name="pods_dual_right_label">Десна слушалица</string>
-    <string name="pods_dual_left_short_label">Л</string>
-    <string name="pods_dual_right_short_label">Д</string>
-    <string name="pods_case_label">Футрола</string>
     <string name="battery_unavailable_label">Батерија недоступна</string>
     <string name="battery_state_low_cd">Батерија ниска</string>
     <string name="battery_state_critical_cd">Батерија критично ниска</string>
@@ -299,12 +269,9 @@
     <string name="signal_badge_aap_cd">Директна веза активна</string>
     <string name="signal_indicator_bars_cd">Јачина сигнала: %1$d од 4 цртице</string>
     <string name="signal_indicator_disconnected_cd">Сигнал: искључен</string>
-    <string name="pods_yours">Ваше</string>
     <string name="headset_being_worn_label">Носи се</string>
     <string name="headset_not_being_worn_label">Не носи се</string>
     <string name="pods_case_unknown_state">Непознато стање</string>
-    <string name="last_seen_x">Последње виђење: %s</string>
-    <string name="first_seen_x">Прво виђење: %s</string>
     <string name="battery_cached_label">Последње познато · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dч %2$dм</string>
     <string name="battery_time_remaining_format_h">%1$dч</string>
@@ -334,10 +301,8 @@
     <string name="profiles_signal_quality_title">Минимални квалитет сигнала</string>
     <string name="profiles_signal_quality_description">Детектујте само уређаје са јачином сигнала изнад овог прага. Ниже вредности повећавају домет детекције, али могу изазвати лажне детекције. Не постављајте превисоко — Bluetooth пријем је генерално слаб и варира са растојањем и препрекама.</string>
     <string name="profiles_identitykey_label">Кључ идентитета</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) вашег уређаја, који помаже CAPod-у да га идентификује међу оближњим уређајима.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods често мењају своју Bluetooth адресу ради приватности. IRK помаже CAPod-у да препозна ваш уређај. Потребан вам је једнократни приступ MacBook-у.</string>
     <string name="profiles_maindevice_encryptionkey_label">Кључ за шифровање</string>
-    <string name="profiles_maindevice_encryptionkey_description">Кључ за шифровање вашег уређаја, који омогућава CAPod-у да преузме детаљне информације о статусу.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods шаљу поруку о статусу, чији је део шифрован. Кључ за шифровање омогућава CAPod-у да дешифрује целу поруку. Потребан вам је једнократни приступ MacBook-у.</string>
     <string name="profiles_key_invalid_format">Неважећи формат кључа</string>
     <string name="profiles_key_expected_format">Очекивани формат: %1$s</string>
@@ -370,7 +335,6 @@
     <string name="general_unsaved_changes_message">Имате несачуване измене. Шта желите да урадите?</string>
     <string name="general_save_and_exit_action">Сачувај и изађи</string>
     <string name="general_discard_action">Одбаци</string>
-    <string name="general_keep_editing_action">Настави уређивање</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Снимање прекратко</string>
     <string name="debug_debuglog_short_recording_message">Дневник грешака треба да забележи проблем док се догађа. Наставите снимање, репродукујте проблем, затим зауставите снимање.</string>
@@ -444,7 +408,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Подешавања уређаја</string>
     <string name="device_settings_subtitle_profile_prefix">Профил: %s</string>
-    <string name="device_settings_info_name_label">Назив</string>
     <string name="device_settings_info_bt_name_label">Bluetooth ознака уређаја</string>
     <string name="device_settings_info_model_label">Модел</string>
     <string name="device_settings_info_manufacturer_label">Произвођач</string>
@@ -524,7 +487,6 @@
     <string name="review_app_dismiss_action">Можда касније</string>
     <string name="review_app_body">Желиш ли оставити рецензију за CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Oпште</string>
     <string name="device_settings_microphone_mode_label">Микрофон</string>
     <string name="device_settings_microphone_mode_description">Које слушалице се користе као микрофон</string>
     <string name="device_settings_microphone_mode_auto">Аутоматски</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Dela</string>
     <string name="general_done_action">Klar</string>
     <string name="general_cancel_action">Avbryt</string>
-    <string name="general_copy_action">Kopiera</string>
     <string name="general_thank_you_label">Tack</string>
     <string name="general_upgrade_action">Uppgradera</string>
     <string name="general_retry_action">Försök igen</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontrollera</string>
     <string name="general_close_action">Stäng</string>
     <string name="general_dismiss_action">Avfärda</string>
-    <string name="general_edit_action">Redigera</string>
     <string name="general_save_action">Spara</string>
     <string name="general_guide_action">Guide</string>
     <string name="general_continue_action">Fortsätt</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Återuppta musik när du tar på dig lurarna igen, men bara om Auto-paus stoppade den. Pauser du utlöste själv (telefon, AirPods-stam, sömn) förblir pausade.</string>
     <string name="settings_start_music_on_wear_label">Starta musik vid påtagning</string>
     <string name="settings_start_music_on_wear_description">Försöker alltid spela musik när du tar på dig lurarna, även efter en manuell paus.</string>
-    <string name="settings_eardetection_info_label">Örondetektionsnotering</string>
     <string name="settings_eardetection_info_description">Om örondetektering bara fungerar för en snäcka, är detta en Apple-begränsning. Bara den \"primära snäckan\" (som används för mikrofonen) detekteras. Konfigurera på Apple-enheter: Inställningar → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minsta signalkvalitet</string>
-    <string name="settings_signal_minimum_description">Den minsta signalkvalitet som en enhet måste ha för att betraktas som din.</string>
     <string name="settings_autoconnect_label">Anslut automatiskt</string>
     <string name="settings_autoconnect_description">Om Android inte ansluter automatiskt kan vi be den att göra det. Då fortsätter CAPod att övervaka i bakgrunden hela tiden.</string>
     <string name="settings_autoconnect_info_android12">Automatisk anslutning förlitar sig på en systemfunktion som Android 12 och nyare begränsar. Det kanske inte fungerar på din enhet.</string>
     <string name="settings_autoconnect_condition_label">Villkor för automatisk anslutning</string>
-    <string name="settings_autoconnect_condition_description">När ska vi försöka ansluta till din enhet?</string>
     <string name="settings_devices_label">Enheter</string>
     <string name="settings_devices_description">Hantera dina enheter.</string>
     <string name="settings_reaction_label">Reaktioner</string>
-    <string name="settings_category_yourdevice_label">Din enhet</string>
     <string name="settings_category_compatibility_options_title">Kompatibilitetsalternativ</string>
     <string name="settings_category_compatibility_options_description">Rör inte om allt fungerar ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Inaktivera maskinvarufiltrering</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Startar upp…</string>
     <string name="support_debuglog_label">Felsökningslogg</string>
     <string name="support_debuglog_desc">Spela in allt appen gör i en textfil som du kan dela.</string>
-    <string name="debug_debuglog_size_label">Storlek</string>
-    <string name="debug_debuglog_size_compressed_label">Komprimerad storlek</string>
-    <string name="debug_notification_channel_label">Felsökningsaviseringar</string>
-    <string name="debug_debuglog_file_label">Inspelad loggfil</string>
-    <string name="debug_debuglog_recording_progress">Spelar in felsökningslogg</string>
     <string name="debug_debuglog_record_action">Spela in felsökningslogg</string>
     <string name="debug_debuglog_stop_action">Stoppa inspelning</string>
     <string name="debug_debuglog_sensitive_information_message">Den genererade filen innehåller känslig information (t.ex. Bluetooth-enhetsdetaljer). Dela den endast med betrodda parter.</string>
     <string name="settings_debuglog_explanation">Denna funktion spelar in allt appen gör i en delbar fil. Den genererade filen innehåller känslig information (t.ex. Bluetooth-enhetsdetaljer). Dela den endast med betrodda parter (t.ex. en utvecklare som felsöker ett problem).</string>
-    <string name="settings_support_installid_label">Installations-ID</string>
-    <string name="settings_support_installid_desc">Automatiska felrapporter är anonyma. Dela ditt installations-ID om utvecklaren behöver hitta dina felrapporter.</string>
     <string name="settings_support_label">Support</string>
     <string name="settings_support_description">Om du behöver hjälp.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Återställ inlärd data?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod kommer att glömma denna enhets uppmätta förbrukning, laddningshastighet och lyssningstid, och börja om från den klassificerade batteritiden.</string>
     <string name="settings_acknowledgements_label">Tack till</string>
-    <string name="settings_debug_autoreports_label">Automatiska felrapporter</string>
-    <string name="settings_debug_autoreports_description">Rapporterar automatiskt problem, t.ex. detaljer om en appkrasch så att jag kan ta reda på hur jag åtgärdar det.</string>
-    <string name="settings_compatibility_mode_label">Kompatibilitetsläge</string>
-    <string name="settings_compatibility_mode_description">Inaktivera optimeringar för att förbättra kompatibiliteten. Prova detta om du inte ser någon data.</string>
     <string name="help_translate_label">Översättning</string>
     <string name="help_translate_description">Hjälp till att översätta den här appen till ditt favoritspråk.</string>
     <string name="translators_thanks_title">Översättare</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Lyckades</string>
     <string name="troubleshooter_ble_result_success_body">BLE-annonssändningar tas emot av CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Misslyckades</string>
-    <string name="troubleshooter_ble_result_failure_body">Felsökningen misslyckades. Ingen kombination av kompatibilitetsalternativ hjälpte.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Din telefon tog inte emot någon BLE-data alls. Du kan försöka detta test igen i ett tätbefolkat område för att se om datakällor (andra än dina hörlurar) kan tas emot. Att ingen data tas emot pekar på ett problem med telefonens operativsystem.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Din telefon tog emot BLE-data, men data kommer inte från någon enhet som stöds. Är dina hörlurar påslagna? Stöder CAPod dina hörlurar?</string>
-    <string name="troubleshooter_ble_result_failure_action">Försök igen</string>
-    <string name="troubleshoot_action">Felsök</string>
     <string name="onboarding_body1">Denna app lägger till stöd för AirPod-specifika funktioner till Android.</string>
     <string name="onboarding_body2">Inte alla Android-enheter stöder fullt ut de extra AirPod-funktionerna. Ditt operativsystem kräver en korrekt fungerande Bluetooth-Low-Energy-implementering.</string>
     <string name="onboarding_body3">CAPod har inga annonser och samlar inte in dina data.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Din enhet är ansluten, men CAPod tar inte emot några livedata från den. Din telefon kan behöva ett kompatibilitetsalternativ — felsökaren kan försöka hitta ett automatiskt.</string>
     <string name="overview_troubleshoot_suggestion_action">Kör felsökare</string>
     <string name="overview_unmatched_devices_label">Omatchade enheter</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d enhet utan matchande profil</item>
-        <item quantity="other">%d enheter utan matchande profil</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d enhet i närheten upptäcktes utan matchande profil. Visa den för tillgängliga detaljer. Om den är din lägger du till en profil under Enheter för att känna igen den.</item>
         <item quantity="other">%d enheter i närheten upptäcktes utan matchande profiler. Visa dem för tillgängliga detaljer. Om en av dem är din lägger du till en profil under Enheter för att känna igen den.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod använder \"platsåtkomst i bakgrunden\" för att aktivera funktioner som \"Visa popup\" och \"Anslut automatiskt\" medan appen är stängd. Platsåtkomst i bakgrunden tillåter appen att ta emot Bluetooth Low Energy-data medan den körs i bakgrunden. Denna app kommer INTE att använda Bluetooth-data för att bestämma din plats.</string>
     <string name="permission_ignore_battery_optimizations_label">Inaktivera batterioptimering</string>
     <string name="permission_ignore_battery_optimizations_description">Batterioptimering förhindrar denna app från att tillförlitligt ta emot Bluetooth-data medan appen körs i bakgrunden.</string>
-    <string name="permission_required_title">Följande behörighet krävs:</string>
     <string name="permission_system_alert_window_label">Visa över andra appar</string>
     <string name="permission_system_alert_window_description">Tillåt CAPod att rita över andra appar för att möjliggöra funktionen \"Visa popup\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">När den ses</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">I örat</string>
     <string name="pods_dual_left_label">Vänster snäcka</string>
     <string name="pods_dual_right_label">Höger snäcka</string>
-    <string name="pods_dual_left_short_label">V</string>
-    <string name="pods_dual_right_short_label">H</string>
-    <string name="pods_case_label">Fodral</string>
     <string name="battery_unavailable_label">Batteri ej tillgängligt</string>
     <string name="battery_state_low_cd">Batterinivån är låg</string>
     <string name="battery_state_critical_cd">Kritiskt låg batterinivå</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Direktanslutning aktiv</string>
     <string name="signal_indicator_bars_cd">Signalstyrka: %1$d av 4 staplar</string>
     <string name="signal_indicator_disconnected_cd">Signal: frånkopplad</string>
-    <string name="pods_yours">Din</string>
     <string name="headset_being_worn_label">Bärs</string>
     <string name="headset_not_being_worn_label">Bärs inte</string>
     <string name="pods_case_unknown_state">Okänt tillstånd</string>
-    <string name="last_seen_x">Senast sedd: %s</string>
-    <string name="first_seen_x">Först sedd: %s</string>
     <string name="battery_cached_label">Senast känd · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dmin</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minsta signalkvalitet</string>
     <string name="profiles_signal_quality_description">Upptäck bara enheter med signalstyrka över detta tröskelvärde. Lägre värden ökar detektionsräckvidden men kan orsaka falska positiva. Ställ inte in detta för högt — Bluetooth-mottagning är generellt dålig och varierar med avstånd och hinder.</string>
     <string name="profiles_identitykey_label">Identitetsnyckel</string>
-    <string name="profilessettings_maindevice_identitykey_description">Din enhets Identity Resolving Key (IRK), som hjälper CAPod att identifiera den bland enheter i närheten.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods ändrar ofta sin Bluetooth-adress av integritetsskäl. IRK hjälper CAPod att känna igen din enhet. Du behöver engångsåtkomst till en MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Krypteringsnyckel</string>
-    <string name="profiles_maindevice_encryptionkey_description">Din enhets krypteringsnyckel, som gör att CAPod kan hämta detaljerad statusinformation.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods skickar ett statusmeddelande, varav en del är krypterat. Krypteringsnyckeln gör att CAPod kan avkryptera hela meddelandet. Du behöver engångsåtkomst till en MacBook.</string>
     <string name="profiles_key_invalid_format">Ogiltigt nyckelformat</string>
     <string name="profiles_key_expected_format">Förväntat format: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Du har osparade ändringar. Vad vill du göra?</string>
     <string name="general_save_and_exit_action">Spara &amp; Avsluta</string>
     <string name="general_discard_action">Kassera</string>
-    <string name="general_keep_editing_action">Fortsätt redigera</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Inspelningen är för kort</string>
     <string name="debug_debuglog_short_recording_message">En felsökningslogg måste fånga problemet medan det inträffar. Fortsätt spela in, återskapa problemet och stoppa sedan inspelningen.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Enhetsinställningar</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Namn</string>
     <string name="device_settings_info_bt_name_label">Bluetooth-enhetsetikett</string>
     <string name="device_settings_info_model_label">Modell</string>
     <string name="device_settings_info_manufacturer_label">Tillverkare</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Kanske senare</string>
     <string name="review_app_body">Skulle du vilja lämna CAPod en recension? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Allmänt</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Vilket öronsnäcka som används som mikrofon</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Shiriki</string>
     <string name="general_done_action">Nimemaliza</string>
     <string name="general_cancel_action">Ghairi</string>
-    <string name="general_copy_action">Nakili</string>
     <string name="general_thank_you_label">Asante</string>
     <string name="general_upgrade_action">Boresha</string>
     <string name="general_retry_action">Jaribu Tena</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Angalia</string>
     <string name="general_close_action">Funga</string>
     <string name="general_dismiss_action">Ondoa</string>
-    <string name="general_edit_action">Hariri</string>
     <string name="general_save_action">Hifadhi</string>
     <string name="general_guide_action">Mwongozo</string>
     <string name="general_continue_action">Endelea</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Endelea kucheza muziki unapovaa pods zako tena, lakini tu kama Kusimama kiotomatiki kuliisimamisha. Kusimama ulikoanzisha mwenyewe (simu, mpini wa AirPods, kulala) kunabaki.</string>
     <string name="settings_start_music_on_wear_label">Anza muziki unapovaa</string>
     <string name="settings_start_music_on_wear_description">Hujaribu kucheza muziki kila unapovaa pods zako, hata baada ya kusimama kwa mikono.</string>
-    <string name="settings_eardetection_info_label">Maelezo ya utambuzi wa sikio</string>
     <string name="settings_eardetection_info_description">Ikiwa utambuzi wa sikio unafanya kazi kwa ganda moja tu, hii ni kizuizi cha Apple. Ganda \"kuu\" pekee (linalotumiwa kwa kipaza sauti) linatambuliwa. Sanidi kwenye vifaa vya Apple: Mipangilio → Bluetooth → AirPods → Kipaza sauti.</string>
-    <string name="settings_signal_minimum_label">Ubora wa chini wa mawimbi</string>
-    <string name="settings_signal_minimum_description">Ubora wa chini wa mawimbi ambao kifaa kinahitaji kuwa nao ili kuzingatiwa kuwa chako.</string>
     <string name="settings_autoconnect_label">Unganisha kiotomatiki</string>
     <string name="settings_autoconnect_description">Iwapo Android haiunganishi kiotomatiki, tunaweza kuiomba pia. Hii inaweka CAPod ikifuatilia nyuma ya pazia kila wakati.</string>
     <string name="settings_autoconnect_info_android12">Uunganisho wa kiotomatiki unategemea kipengele cha mfumo ambacho Android 12 na toleo jipya huzuia. Huenda usifanye kazi kwenye kifaa chako.</string>
     <string name="settings_autoconnect_condition_label">Sharti la kuunganisha kiotomatiki</string>
-    <string name="settings_autoconnect_condition_description">Lini tujaribu kuunganisha kwenye kifaa chako?</string>
     <string name="settings_devices_label">Vifaa</string>
     <string name="settings_devices_description">Simamia vifaa vyako.</string>
     <string name="settings_reaction_label">Matendo</string>
-    <string name="settings_category_yourdevice_label">Kifaa chako</string>
     <string name="settings_category_compatibility_options_title">Chaguo za uoanifu</string>
     <string name="settings_category_compatibility_options_description">Usiguse ikiwa kila kitu kinafanya kazi ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Zima uchujaji wa maunzi</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Inaanza...</string>
     <string name="support_debuglog_label">Kumbukumbu ya utatuzi</string>
     <string name="support_debuglog_desc">Rekodi kila kitu ambacho programu inafanya kwenye faili ya maandishi unayoweza kushiriki.</string>
-    <string name="debug_debuglog_size_label">Ukubwa</string>
-    <string name="debug_debuglog_size_compressed_label">Ukubwa uliobanwa</string>
-    <string name="debug_notification_channel_label">Arifa za utatuzi</string>
-    <string name="debug_debuglog_file_label">Faili ya kumbukumbu iliyorekodiwa</string>
-    <string name="debug_debuglog_recording_progress">Inarekodi kumbukumbu ya utatuzi</string>
     <string name="debug_debuglog_record_action">Rekodi kumbukumbu ya utatuzi</string>
     <string name="debug_debuglog_stop_action">Acha kurekodi</string>
     <string name="debug_debuglog_sensitive_information_message">Faili iliyotengenezwa ina taarifa nyeti (k.m. maelezo ya kifaa cha Bluetooth). Shiriki tu na wahusika wanaoaminika.</string>
     <string name="settings_debuglog_explanation">Kipengele hiki hurekodi kila kitu ambacho programu inafanya kwenye faili inayoweza kushirikiwa. Faili iliyotengenezwa ina taarifa nyeti (k.m. maelezo ya kifaa cha Bluetooth). Shiriki tu na wahusika wanaoaminika (k.m. msanidi programu anayetatua tatizo).</string>
-    <string name="settings_support_installid_label">Kitambulisho cha Usakinishaji</string>
-    <string name="settings_support_installid_desc">Ripoti za hitilafu za kiotomatiki hazijulikani. Shiriki kitambulisho chako cha usakinishaji ikiwa msanidi programu anahitaji kupata ripoti zako za hitilafu.</string>
     <string name="settings_support_label">Msaada</string>
     <string name="settings_support_description">Ikiwa unahitaji msaada.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Weka upya data iliyojifunza?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod itasahau kupungua kwa betri kulikopimwa, kasi ya chaji, na muda wa kusikiliza wa kifaa hiki, na kuanza tena kutoka kwa maisha ya betri yaliyokadiriwa.</string>
     <string name="settings_acknowledgements_label">Shukrani</string>
-    <string name="settings_debug_autoreports_label">Ripoti za hitilafu za kiotomatiki</string>
-    <string name="settings_debug_autoreports_description">Huripoti matatizo kiotomatiki, k.m. maelezo kuhusu kuacha kufanya kazi kwa programu ili niweze kujua jinsi ya kuyarekebisha.</string>
-    <string name="settings_compatibility_mode_label">Hali ya uoanifu</string>
-    <string name="settings_compatibility_mode_description">Zima uboreshaji ili kuboresha uoanifu. Jaribu hii ikiwa huoni data yoyote.</string>
     <string name="help_translate_label">Tafsiri</string>
     <string name="help_translate_description">Saidia kutafsiri programu hii katika lugha yako uipendayo.</string>
     <string name="translators_thanks_title">Watafsiri</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Imefanikiwa</string>
     <string name="troubleshooter_ble_result_success_body">Matangazo ya BLE yanapokewa na CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Haikufanikiwa</string>
-    <string name="troubleshooter_ble_result_failure_body">Utatuzi haukufanikiwa. Hakuna mchanganyiko wa chaguo za uoanifu ulisaidia.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Simu yako haikupokea data yoyote ya BLE. Unaweza kujaribu tena jaribio hili katika eneo lenye watu wengi kuona ikiwa vyanzo vya data (zaidi ya vipokea sauti vyako) vinaweza kupokewa. Kutopokea data yoyote kunaashiria tatizo na mfumo wa uendeshaji wa simu yako.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Simu yako ilipokea data ya BLE, lakini data haitoki kwenye kifaa chochote kinachoungwa mkono. Je, vipokea sauti vyako vimewashwa? Je, CAPod inasaidia kipokea sauti chako?</string>
-    <string name="troubleshooter_ble_result_failure_action">Jaribu tena</string>
-    <string name="troubleshoot_action">Tatua matatizo</string>
     <string name="onboarding_body1">Programu hii inaongeza usaidizi kwa vipengele maalum vya AirPod kwenye Android.</string>
     <string name="onboarding_body2">Si vifaa vyote vya Android vinavyosaidia kikamilifu vipengele vya ziada vya AirPod. Mfumo wako wa uendeshaji unahitaji utekelezaji sahihi wa Bluetooth ya Nishati ya Chini.</string>
     <string name="onboarding_body3">CAPod haina matangazo na haikusanyi data yako.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Kifaa chako kimeunganishwa, lakini CAPod haipokei data yoyote ya moja kwa moja kutoka kwake. Simu yako inaweza kuhitaji chaguo la uoanifu — kitatuzi cha matatizo kinaweza kujaribu kupata moja kiotomatiki.</string>
     <string name="overview_troubleshoot_suggestion_action">Endesha kitatuzi cha matatizo</string>
     <string name="overview_unmatched_devices_label">Vifaa visivyolingana</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">Kifaa %d bila wasifu unaolingana</item>
-        <item quantity="other">Vifaa %d bila wasifu unaolingana</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Kifaa %d kilicho karibu kimegunduliwa bila wasifu unaolingana. Kionyeshe kwa maelezo yanayopatikana. Ikiwa ni chako, ongeza wasifu kutoka kwa Vifaa ili kukitambua.</item>
         <item quantity="other">Vifaa %d vilivyo karibu vimegunduliwa bila wasifu unaolingana. Vionyeshe kwa maelezo yanayopatikana. Ikiwa kimoja ni chako, ongeza wasifu kutoka kwa Vifaa ili kukitambua.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod inatumia \"ufikiaji wa eneo kwa usuli wa nyuma\" kuwezesha vipengele kama \"Onyesha kidirisha\" na \"Unganisha kiotomatiki\" wakati programu imefungwa. Ufikiaji wa eneo kwa usuli wa nyuma inaruhusu programu kupokea data ya Bluetooth Low Energy wakati iko nyuma. Programu hii HAITATUMIA data ya Bluetooth kubainisha eneo lako.</string>
     <string name="permission_ignore_battery_optimizations_label">Zima uboreshaji wa betri</string>
     <string name="permission_ignore_battery_optimizations_description">Uboreshaji wa betri unazuia programu hii kupokea kwa uhakika data ya Bluetooth wakati programu iko nyuma.</string>
-    <string name="permission_required_title">Ruhusa ifuatayo inahitajika:</string>
     <string name="permission_system_alert_window_label">Dirisha la Arifa ya Mfumo</string>
     <string name="permission_system_alert_window_description">Ruhusu CAPod kuchora juu ya programu nyingine ili kuwezesha kipengele cha \"Onyesha Kidirisha\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Kinapopatikana</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Ndani ya sikio</string>
     <string name="pods_dual_left_label">Ganda la kushoto</string>
     <string name="pods_dual_right_label">Ganda la kulia</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">K</string>
-    <string name="pods_case_label">Kipochi</string>
     <string name="battery_unavailable_label">Betri haipatikani</string>
     <string name="battery_state_low_cd">Betri iko chini</string>
     <string name="battery_state_critical_cd">Betri iko chini sana</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Muunganisho wa moja kwa moja unaofanya kazi</string>
     <string name="signal_indicator_bars_cd">Nguvu ya ishara: %1$d kati ya baa 4</string>
     <string name="signal_indicator_disconnected_cd">Ishara: imekatika</string>
-    <string name="pods_yours">Chako</string>
     <string name="headset_being_worn_label">Inavaliwa</string>
     <string name="headset_not_being_worn_label">Haivaliwi</string>
     <string name="pods_case_unknown_state">Hali isiyojulikana</string>
-    <string name="last_seen_x">Mara ya mwisho kuonekana: %s</string>
-    <string name="first_seen_x">Mara ya kwanza kuonekana: %s</string>
     <string name="battery_cached_label">Inayojulikana mwisho · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Ubora wa Chini wa Mawimbi</string>
     <string name="profiles_signal_quality_description">Tambua vifaa vyenye nguvu ya mawimbi juu ya kizingiti hiki tu. Thamani za chini huongeza anuwai ya utambuzi lakini zinaweza kusababisha matokeo ya uwongo. Usiweke juu sana — mapokeo ya Bluetooth kwa ujumla ni dhaifu na yanabadilika kwa umbali na vizuizi.</string>
     <string name="profiles_identitykey_label">Ufunguo wa Utambulisho</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) ya kifaa chako, ambayo husaidia CAPod kukitambua miongoni mwa vifaa vilivyo karibu.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods mara kwa mara hubadilisha anwani yao ya Bluetooth kwa faragha. IRK husaidia CAPod kutambua kifaa chako. Unahitaji ufikiaji wa mara moja wa MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ufunguo wa Usimbaji</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ufunguo wa usimbaji wa kifaa chako, ambao unaruhusu CAPod kupata maelezo ya kina ya hali.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods hutuma ujumbe wa hali, sehemu ambayo imesimbwa. Ufunguo wa usimbaji unaruhusu CAPod kusimbua ujumbe kamili. Unahitaji ufikiaji wa mara moja wa MacBook.</string>
     <string name="profiles_key_invalid_format">Muundo batili wa ufunguo</string>
     <string name="profiles_key_expected_format">Muundo unaotarajiwa: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Una mabadiliko yasiyohifadhiwa. Ungependa kufanya nini?</string>
     <string name="general_save_and_exit_action">Hifadhi &amp; Ondoka</string>
     <string name="general_discard_action">Tupa</string>
-    <string name="general_keep_editing_action">Endelea Kuhariri</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Rekodi fupi mno</string>
     <string name="debug_debuglog_short_recording_message">Kumbukumbu ya utatuzi inahitaji kunasa tatizo linapotokea. Endelea kurekodi, rudia tatizo, kisha simamisha rekodi.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Mipangilio ya Kifaa</string>
     <string name="device_settings_subtitle_profile_prefix">Profaili: %s</string>
-    <string name="device_settings_info_name_label">Jina</string>
     <string name="device_settings_info_bt_name_label">Lebo ya Kifaa cha Bluetooth</string>
     <string name="device_settings_info_model_label">Mfano</string>
     <string name="device_settings_info_manufacturer_label">Mtengenezaji</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Labda baadaye</string>
     <string name="review_app_body">Je, ungependa kuacha mapitio ya CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Jumla</string>
     <string name="device_settings_microphone_mode_label">Maikrofoni</string>
     <string name="device_settings_microphone_mode_description">Kipokea sauti kipi kinatumika kama maikrofoni</string>
     <string name="device_settings_microphone_mode_auto">Otomatiki</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">பகிர்</string>
     <string name="general_done_action">முடிந்தது</string>
     <string name="general_cancel_action">ரத்துசெய்</string>
-    <string name="general_copy_action">நகலெடு</string>
     <string name="general_thank_you_label">நன்றி</string>
     <string name="general_upgrade_action">மேம்படுத்து</string>
     <string name="general_retry_action">மீண்டும் முயல்</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">சரிபார்</string>
     <string name="general_close_action">மூடு</string>
     <string name="general_dismiss_action">நிராகரி</string>
-    <string name="general_edit_action">திருத்து</string>
     <string name="general_save_action">சேமி</string>
     <string name="general_guide_action">வழிகாட்டி</string>
     <string name="general_continue_action">தொடர்க</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">உங்கள் போட்களை மீண்டும் அணிந்தால் இசையை தொடரும், ஆனால் Auto pause மட்டுமே நிறுத்தியிருந்தால். நீங்களே நிறுத்திய இடைநிறுத்தங்கள் (தொலைபேசி, AirPods stem, தூக்கம்) நிறுத்தப்பட்டே இருக்கும்.</string>
     <string name="settings_start_music_on_wear_label">அணியும்போது இசையை தொடங்கு</string>
     <string name="settings_start_music_on_wear_description">நீங்கள் போட்களை அணிந்தால் எப்போதும் இசையை இயக்க முயற்சிக்கும், கைமுறை இடைநிறுத்தத்திற்கு பிறகும் கூட.</string>
-    <string name="settings_eardetection_info_label">காது கண்டறிதல் குறிப்பு</string>
     <string name="settings_eardetection_info_description">காது கண்டறிதல் ஒரு பாட்க்கு மட்டுமே வேலை செய்தால், இது Apple வரம்பு. \"முதன்மை பாட்\" (ஒலிபெருக்கிக்கு பயன்படுத்தப்படும்) மட்டுமே கண்டறியப்படும். Apple சாதனங்களில் அமைக்கவும்: அமைப்புகள் → புளூடூத் → AirPods → ஒலிபெருக்கி.</string>
-    <string name="settings_signal_minimum_label">குறைந்தபட்ச சிக்னல் தரம்</string>
-    <string name="settings_signal_minimum_description">ஒரு சாதனம் உங்களுடையதாகக் கருதப்படுவதற்குத் தேவையான குறைந்தபட்ச சிக்னல் தரம்.</string>
     <string name="settings_autoconnect_label">தானியங்கு இணைப்பு</string>
     <string name="settings_autoconnect_description">Android தானாக இணைக்கவில்லை என்றால், நாம் அதை கேட்கலாம். இது CAPod கண்காணிப்பை எப்போதும் பின்னணியில் வைக்கிறது.</string>
     <string name="settings_autoconnect_info_android12">ஆட்டோ கனெக்ட் Android 12 மற்றும் புதிய பதிப்புகளில் கட்டுப்படுத்தப்பட்ட ஒரு கணினி அம்சத்தை நம்பியுள்ளது. இது உங்கள் சாதனத்தில் வேலை செய்யாமல் போகலாம்.</string>
     <string name="settings_autoconnect_condition_label">தானியங்கு இணைப்பு நிபந்தனை</string>
-    <string name="settings_autoconnect_condition_description">உங்கள் சாதனத்துடன் எப்போது இணைக்க முயற்சிக்க வேண்டும்?</string>
     <string name="settings_devices_label">சாதனங்கள்</string>
     <string name="settings_devices_description">உங்கள் சாதனங்களை நிர்வகிக்கவும்.</string>
     <string name="settings_reaction_label">எதிர்வினைகள்</string>
-    <string name="settings_category_yourdevice_label">உங்கள் சாதனம்</string>
     <string name="settings_category_compatibility_options_title">இணக்கத்தன்மை விருப்பங்கள்</string>
     <string name="settings_category_compatibility_options_description">எல்லாம் வேலை செய்தால் தொடாதே ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">வன்பொருள் வடிகட்டலை முடக்கு</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">தொடங்குகிறது…</string>
     <string name="support_debuglog_label">பிழைத்திருத்த பதிவு</string>
     <string name="support_debuglog_desc">ஆப்ஸ் செய்யும் அனைத்தையும் நீங்கள் பகிரக்கூடிய ஒரு உரைக் கோப்பில் பதிவுசெய்க.</string>
-    <string name="debug_debuglog_size_label">அளவு</string>
-    <string name="debug_debuglog_size_compressed_label">சுருக்கப்பட்ட அளவு</string>
-    <string name="debug_notification_channel_label">பிழைத்திருத்த அறிவிப்புகள்</string>
-    <string name="debug_debuglog_file_label">பதிவுசெய்யப்பட்ட பதிவு கோப்பு</string>
-    <string name="debug_debuglog_recording_progress">பிழைத்திருத்த பதிவைப் பதிவுசெய்கிறது</string>
     <string name="debug_debuglog_record_action">பிழைத்திருத்த பதிவைப் பதிவுசெய்</string>
     <string name="debug_debuglog_stop_action">பதிவை நிறுத்து</string>
     <string name="debug_debuglog_sensitive_information_message">உருவாக்கப்பட்ட கோப்பில் முக்கியமான தகவல்கள் உள்ளன (எ.கா. புளூடூத் சாதன விவரங்கள்). நம்பகமான தரப்பினருடன் மட்டுமே பகிரவும்.</string>
     <string name="settings_debuglog_explanation">இந்த அம்சம் ஆப்ஸ் செய்யும் அனைத்தையும் பகிரக்கூடிய கோப்பில் பதிவுசெய்கிறது. உருவாக்கப்பட்ட கோப்பில் முக்கியமான தகவல்கள் உள்ளன (எ.கா. புளூடூத் சாதன விவரங்கள்). நம்பகமான தரப்பினருடன் மட்டுமே பகிரவும் (எ.கா. ஒரு சிக்கலைச் சரிசெய்யும் டெவலப்பர்).</string>
-    <string name="settings_support_installid_label">நிறுவல் ஐடி</string>
-    <string name="settings_support_installid_desc">தானியங்கி பிழை அறிக்கைகள் அநாமதேயமானவை. டெவலப்பர் உங்கள் பிழை அறிக்கைகளைக் கண்டுபிடிக்க வேண்டும் என்றால் உங்கள் நிறுவல் ஐடியைப் பகிரவும்.</string>
     <string name="settings_support_label">ஆதரவு</string>
     <string name="settings_support_description">உங்களுக்கு உதவி தேவைப்பட்டால்.</string>
     <string name="settings_wiki_label">விக்கி</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">கற்ற தரவைக் மீட்டமைக்கவுமா?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod இந்த சாதனத்தின் அளந்த வெளியேற்றம், சார்ஜ் வேகம் மற்றும் கேட்கும் நேரத்தை மறந்துவிடும், மதிப்பிடப்பட்ட பேட்டரி ஆயுளிலிருந்து மீண்டும் தொடங்கும்.</string>
     <string name="settings_acknowledgements_label">நன்றிகள்</string>
-    <string name="settings_debug_autoreports_label">தானியங்கி பிழை அறிக்கைகள்</string>
-    <string name="settings_debug_autoreports_description">சிக்கல்களைத் தானாகவே புகாரளிக்கிறது, எ.கா. ஆப்ஸ் செயலிழப்பு குறித்த விவரங்கள், அதனால் அதை எவ்வாறு சரிசெய்வது என்பதைக் கண்டுபிடிக்க முடியும்.</string>
-    <string name="settings_compatibility_mode_label">இணக்கத்தன்மை முறை</string>
-    <string name="settings_compatibility_mode_description">இணக்கத்தன்மையை மேம்படுத்த மேம்படுத்தல்களை முடக்கு. நீங்கள் எந்தத் தரவையும் பார்க்கவில்லை என்றால் இதை முயற்சிக்கவும்.</string>
     <string name="help_translate_label">மொழிபெயர்ப்பு</string>
     <string name="help_translate_description">இந்த ஆப்ஸை உங்களுக்குப் பிடித்த மொழியில் மொழிபெயர்க்க உதவுங்கள்.</string>
     <string name="translators_thanks_title">மொழிபெயர்ப்பாளர்கள்</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">வெற்றி</string>
     <string name="troubleshooter_ble_result_success_body">BLE விளம்பர ஒளிபரப்புகள் CAPod ஆல் பெறப்படுகின்றன.</string>
     <string name="troubleshooter_ble_result_failure_title">தோல்வியுற்றது</string>
-    <string name="troubleshooter_ble_result_failure_body">சிக்கல் தீர்க்க முடியவில்லை. இணக்கத்தன்மை விருப்பங்களின் எந்தவொரு கலவையும் உதவவில்லை.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">உங்கள் தொலைபேசி எந்த BLE தரவையும் பெறவில்லை. தரவு மூலங்களை (உங்கள் ஹெட்ஃபோன்களைத் தவிர) பெற முடியுமா என்பதைப் பார்க்க, நெரிசலான பகுதியில் இந்தச் சோதனையை மீண்டும் முயற்சிக்கலாம். எந்தத் தரவும் பெறப்படாதது உங்கள் தொலைபேசியின் இயக்க முறைமையில் ஒரு சிக்கலைக் குறிக்கிறது.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">உங்கள் தொலைபேசி BLE தரவைப் பெற்றது, ஆனால் தரவு எந்தவொரு ஆதரிக்கப்பட்ட சாதனத்திலிருந்தும் வரவில்லை. உங்கள் ஹெட்ஃபோன்கள் இயக்கப்பட்டுள்ளதா? CAPod உங்கள் ஹெட்ஃபோனை ஆதரிக்கிறதா?</string>
-    <string name="troubleshooter_ble_result_failure_action">மீண்டும் முயற்சிக்கவும்</string>
-    <string name="troubleshoot_action">சிக்கல் தீர்க்கவும்</string>
     <string name="onboarding_body1">இந்த ஆப்ஸ் ஆண்ட்ராய்டில் AirPod குறிப்பிட்ட அம்சங்களுக்கான ஆதரவைச் சேர்க்கிறது.</string>
     <string name="onboarding_body2">எல்லா ஆண்ட்ராய்டு சாதனங்களும் கூடுதல் AirPod அம்சங்களை முழுமையாக ஆதரிக்காது. உங்கள் இயக்க முறைமைக்கு சரியாக வேலை செய்யும் புளூடூத்-குறைந்த-ஆற்றல் செயலாக்கம் தேவை.</string>
     <string name="onboarding_body3">CAPod இல் விளம்பரங்கள் இல்லை மற்றும் உங்கள் தரவைச் சேகரிக்காது.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">உங்கள் சாதனம் இணைக்கப்பட்டுள்ளது, ஆனால் CAPod அதிலிருந்து நேரடி தரவு எதுவும் பெறவில்லை. உங்கள் தொலைபேசிக்கு இணக்கத்தன்மை விருப்பம் தேவைப்படலாம் — சிக்கல் தீர்ப்பான் தானாக ஒன்றை கண்டுபிடிக்க முயற்சிக்கும்.</string>
     <string name="overview_troubleshoot_suggestion_action">சிக்கல் தீர்ப்பானை இயக்கு</string>
     <string name="overview_unmatched_devices_label">பொருந்தாத சாதனங்கள்</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">பொருந்தும் சுயவிவரம் இல்லாத %d சாதனம்</item>
-        <item quantity="other">பொருந்தும் சுயவிவரம் இல்லாத %d சாதனங்கள்</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d அருகிலுள்ள சாதனம் பொருந்தும் சுயவிவரம் இல்லாமல் கண்டறியப்பட்டது. கிடைக்கும் விவரங்களுக்கு அதைக் காட்டவும். இது உங்களுடையது எனில், அதை அடையாளம் காண சாதனங்களில் இருந்து ஒரு சுயவிவரத்தைச் சேர்க்கவும்.</item>
         <item quantity="other">%d அருகிலுள்ள சாதனங்கள் பொருந்தும் சுயவிவரங்கள் இல்லாமல் கண்டறியப்பட்டன. கிடைக்கும் விவரங்களுக்கு அவற்றைக் காட்டவும். ஒன்று உங்களுடையது எனில், அதை அடையாளம் காண சாதனங்களில் இருந்து ஒரு சுயவிவரத்தைச் சேர்க்கவும்.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">ஆப்ஸ் மூடப்பட்டிருக்கும்போது \"பாப்அப் காட்டு\" மற்றும் \"தானியங்கு இணைப்பு\" போன்ற அம்சங்களை இயக்க CAPod \"பின்னணி இருப்பிட அணுகல்\" பயன்படுத்துகிறது. பின்னணி இருப்பிட அணுகல் ஆப்ஸ் பின்னணியில் இருக்கும்போது புளூடூத் குறைந்த ஆற்றல் தரவைப் பெற அனுமதிக்கிறது. இந்த ஆப்ஸ் உங்கள் இருப்பிடத்தைத் தீர்மானிக்க புளூடூத் தரவைப் பயன்படுத்தாது.</string>
     <string name="permission_ignore_battery_optimizations_label">பேட்டரி மேம்படுத்தல்களை முடக்கு</string>
     <string name="permission_ignore_battery_optimizations_description">பேட்டரி மேம்படுத்தல்கள் ஆப்ஸ் பின்னணியில் இருக்கும்போது புளூடூத் தரவை நம்பகமாகப் பெறுவதைத் தடுக்கின்றன.</string>
-    <string name="permission_required_title">பின்வரும் அனுமதி தேவை:</string>
     <string name="permission_system_alert_window_label">கணினி எச்சரிக்கை சாளரம்</string>
     <string name="permission_system_alert_window_description">\"பாப்அப் காட்டு\" அம்சத்தை சாத்தியமாக்க CAPod-ஐ பிற ஆப்ஸ்களின் மேல் வரைய அனுமதிக்கவும்.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">கண்டறியும்போது</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">காதில்</string>
     <string name="pods_dual_left_label">இடது பாட்</string>
     <string name="pods_dual_right_label">வலது பாட்</string>
-    <string name="pods_dual_left_short_label">இ</string>
-    <string name="pods_dual_right_short_label">வ</string>
-    <string name="pods_case_label">கேஸ்</string>
     <string name="battery_unavailable_label">பேட்டரி கிடைக்கவில்லை</string>
     <string name="battery_state_low_cd">பேட்டரி குறைவு</string>
     <string name="battery_state_critical_cd">பேட்டரி மிக குறைவு</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">நேரடி இணைப்பு செயலில் உள்ளது</string>
     <string name="signal_indicator_bars_cd">சிக்னல் வலிமை: 4 பார்களில் %1$d</string>
     <string name="signal_indicator_disconnected_cd">சிக்னல்: துண்டிக்கப்பட்டது</string>
-    <string name="pods_yours">உங்களுடையது</string>
     <string name="headset_being_worn_label">அணியப்படுகிறது</string>
     <string name="headset_not_being_worn_label">அணியப்படவில்லை</string>
     <string name="pods_case_unknown_state">தெரியாத நிலை</string>
-    <string name="last_seen_x">கடைசியாகக் காணப்பட்டது: %s</string>
-    <string name="first_seen_x">முதலில் காணப்பட்டது: %s</string>
     <string name="battery_cached_label">கடைசியாக அறியப்பட்டது · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">குறைந்தபட்ச சிக்னல் தரம்</string>
     <string name="profiles_signal_quality_description">இந்த வரம்பிற்கு மேல் சிக்னல் வலிமை கொண்ட சாதனங்களை மட்டுமே கண்டறியவும். குறைந்த மதிப்புகள் கண்டறிதல் வரம்பை அதிகரிக்கும் ஆனால் தவறான கண்டறிதல்களை ஏற்படுத்தலாம். இதை மிகவும் அதிகமாக அமைக்காதீர்கள் — புளூடூத் வரவேற்பு பொதுவாக மோசமானது மற்றும் தூரம் மற்றும் தடைகளுடன் மாறுபடும்.</string>
     <string name="profiles_identitykey_label">அடையாள விசை</string>
-    <string name="profilessettings_maindevice_identitykey_description">உங்கள் சாதனத்தின் Identity Resolving Key (IRK), இது அருகிலுள்ள சாதனங்களில் CAPod அதை அடையாளம் காண உதவுகிறது.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods தனியுரிமைக்காக தங்கள் புளூடூத் முகவரியை அடிக்கடி மாற்றுகின்றன. IRK உங்கள் சாதனத்தை CAPod அங்கீகரிக்க உதவுகிறது. உங்களுக்கு MacBook-க்கு ஒரு முறை அணுகல் தேவை.</string>
     <string name="profiles_maindevice_encryptionkey_label">குறியாக்க விசை</string>
-    <string name="profiles_maindevice_encryptionkey_description">உங்கள் சாதனத்தின் குறியாக்க விசை, இது CAPod-ஐ விரிவான நிலைத் தகவலைப் பெற அனுமதிக்கிறது.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ஒரு நிலைச் செய்தியை அனுப்புகின்றன, அதன் ஒரு பகுதி குறியாக்கம் செய்யப்பட்டுள்ளது. குறியாக்க விசை CAPod-ஐ முழு செய்தியையும் மறைகுறியாக்க அனுமதிக்கிறது. உங்களுக்கு MacBook-க்கு ஒரு முறை அணுகல் தேவை.</string>
     <string name="profiles_key_invalid_format">தவறான விசை வடிவம்</string>
     <string name="profiles_key_expected_format">எதிர்பார்க்கப்படும் வடிவம்: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">உங்களிடம் சேமிக்கப்படாத மாற்றங்கள் உள்ளன. நீங்கள் என்ன செய்ய விரும்புகிறீர்கள்?</string>
     <string name="general_save_and_exit_action">சேமி &amp; வெளியேறு</string>
     <string name="general_discard_action">நிராகரி</string>
-    <string name="general_keep_editing_action">தொடர்ந்து திருத்து</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ரெகார்டிங் மிகவும் குறுகியது</string>
     <string name="debug_debuglog_short_recording_message">ஒரு பிழைதிருத்தல் பதிவு பிரச்சினை நிகழ்கிற்றபோது பதிவு செய்ய வேண்டும். ரெகார்டிங் தொடர்ந்து, பிரச்சினையை மீண்டும் உருவாக்கி, பின் ரெகார்டிங்ஐ நிறுத்தவும்.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">சாதன அமைப்புகள்</string>
     <string name="device_settings_subtitle_profile_prefix">சுயவிவரம்: %s</string>
-    <string name="device_settings_info_name_label">பெயர்</string>
     <string name="device_settings_info_bt_name_label">Bluetooth சாதன பெயர்</string>
     <string name="device_settings_info_model_label">மாடல்</string>
     <string name="device_settings_info_manufacturer_label">உற்பத்தியாளர்</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">பிறகு வேளையில்</string>
     <string name="review_app_body">நீங்கள் CAPod க்கு மதிப்புரை வழங்க விரும்புகிறீர்களா? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">பொது</string>
     <string name="device_settings_microphone_mode_label">மைக்ரோஃபோன்</string>
     <string name="device_settings_microphone_mode_description">எந்த ஈர்பட் மைக்ரோஃபோனாக பயன்படுத்தப்படுகிறது</string>
     <string name="device_settings_microphone_mode_auto">தானியங்கி</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">పంచుకోండి</string>
     <string name="general_done_action">పూర్తయింది</string>
     <string name="general_cancel_action">రద్దు చేయి</string>
-    <string name="general_copy_action">కాపీ చేయి</string>
     <string name="general_thank_you_label">ధన్యవాదాలు</string>
     <string name="general_upgrade_action">నవీకరించు</string>
     <string name="general_retry_action">రిట్రై</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">తనిఖీ చేయి</string>
     <string name="general_close_action">మూసివేయి</string>
     <string name="general_dismiss_action">తీసివేయండి</string>
-    <string name="general_edit_action">సవరించండి</string>
     <string name="general_save_action">సేవ్ చేయి</string>
     <string name="general_guide_action">మార్గదర్శి</string>
     <string name="general_continue_action">కొనసాగించు</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">మీరు మళ్ళీ పాడ్స్ ధరించినప్పుడు సంగీతాన్ని కొనసాగించు, కానీ ఆటో పాజ్ ఆపినప్పుడు మాత్రమే. మీరు స్వయంగా చేసిన పాజ్‌లు (ఫోన్, AirPods స్టెమ్, స్లీప్) పాజ్‌లో ఉంటాయి.</string>
     <string name="settings_start_music_on_wear_label">ధరించినప్పుడు సంగీతం ప్రారంభించు</string>
     <string name="settings_start_music_on_wear_description">మీరు పాడ్స్ పెట్టుకున్నప్పుడు మాన్యువల్ పాజ్ తర్వాత కూడా సంగీతం వినిపించడానికి ఎల్లప్పుడూ ప్రయత్నిస్తుంది.</string>
-    <string name="settings_eardetection_info_label">చెవి గుర్తింపు గమనిక</string>
     <string name="settings_eardetection_info_description">చెవి గుర్తింపు ఒక పాడ్‌కు మాత్రమే పని చేస్తే, ఇది Apple పరిమితి. \"ప్రాథమిక పాడ్\" (మైక్రోఫోన్ కోసం ఉపయోగించబడేది) మాత్రమే గుర్తించబడుతుంది. Apple పరికరాలలో కాన్ఫిగర్ చేయండి: సెట్టింగ్‌లు → బ్లూటూత్ → AirPods → మైక్రోఫోన్.</string>
-    <string name="settings_signal_minimum_label">కనీస సిగ్నల్ నాణ్యత</string>
-    <string name="settings_signal_minimum_description">ఒక పరికరం మీదిగా పరిగణించబడటానికి అవసరమైన కనీస సిగ్నల్ నాణ్యత.</string>
     <string name="settings_autoconnect_label">ఆటో కనెక్ట్</string>
     <string name="settings_autoconnect_description">Android స్వయంచాలకంగా కనెక్ట్ కాకపోతే, మనం దానికి కూడా అడగగలం. దీనివల్ల CAPod ఎప్పుడూ నేపథ్యంలో పర్యవేక్షిస్తూనే ఉంటుంది.</string>
     <string name="settings_autoconnect_info_android12">స్వయంచాలక కనెక్ట్ Android 12 మరియు అంతకు తర్వాతి వెర్షన్‌లు పరిమితం చేసే సిస్టమ్ ఫీచర్‌పై ఆధారపడుతుంది. ఇది మీ పరికరంలో పని చేయకపోవచ్చు.</string>
     <string name="settings_autoconnect_condition_label">ఆటో కనెక్ట్ షరతు</string>
-    <string name="settings_autoconnect_condition_description">మేము మీ పరికరానికి ఎప్పుడు కనెక్ట్ చేయడానికి ప్రయత్నించాలి?</string>
     <string name="settings_devices_label">పరికరాలు</string>
     <string name="settings_devices_description">మీ పరికరాలను నిర్వహించండి.</string>
     <string name="settings_reaction_label">ప్రతిచర్యలు</string>
-    <string name="settings_category_yourdevice_label">మీ పరికరం</string>
     <string name="settings_category_compatibility_options_title">అనుకూలత ఎంపికలు</string>
     <string name="settings_category_compatibility_options_description">అన్నీ పని చేస్తే తాకవద్దు ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">హార్డ్‌వేర్ ఫిల్టరింగ్‌ను నిలిపివేయండి</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">ప్రారంభిస్తోంది…</string>
     <string name="support_debuglog_label">డీబగ్ లాగ్</string>
     <string name="support_debuglog_desc">యాప్ చేస్తున్న ప్రతిదాన్ని మీరు షేర్ చేయగల టెక్స్ట్ ఫైల్‌లో రికార్డ్ చేయండి.</string>
-    <string name="debug_debuglog_size_label">పరిమాణం</string>
-    <string name="debug_debuglog_size_compressed_label">కంప్రెస్డ్ పరిమాణం</string>
-    <string name="debug_notification_channel_label">డీబగ్ నోటిఫికేషన్‌లు</string>
-    <string name="debug_debuglog_file_label">రికార్డ్ చేయబడిన లాగ్ ఫైల్</string>
-    <string name="debug_debuglog_recording_progress">డీబగ్ లాగ్ రికార్డ్ అవుతోంది</string>
     <string name="debug_debuglog_record_action">డీబగ్ లాగ్ రికార్డ్ చేయి</string>
     <string name="debug_debuglog_stop_action">రికార్డింగ్ ఆపు</string>
     <string name="debug_debuglog_sensitive_information_message">ఉత్పత్తి చేయబడిన ఫైల్ సున్నితమైన సమాచారాన్ని కలిగి ఉంది (ఉదా. బ్లూటూత్ పరికర వివరాలు). దీన్ని విశ్వసనీయ పార్టీలతో మాత్రమే పంచుకోండి.</string>
     <string name="settings_debuglog_explanation">ఈ ఫీచర్ యాప్ చేస్తున్న ప్రతిదాన్ని షేర్ చేయగల ఫైల్‌లో రికార్డ్ చేస్తుంది. ఉత్పత్తి చేయబడిన ఫైల్ సున్నితమైన సమాచారాన్ని కలిగి ఉంది (ఉదా. బ్లూటూత్ పరికర వివరాలు). దీన్ని విశ్వసనీయ పార్టీలతో మాత్రమే పంచుకోండి (ఉదా. సమస్యను పరిష్కరిస్తున్న డెవలపర్).</string>
-    <string name="settings_support_installid_label">ఇన్‌స్టాల్ ID</string>
-    <string name="settings_support_installid_desc">స్వయంచాలక లోపం నివేదికలు అనామధేయమైనవి. డెవలపర్‌కు మీ లోపం నివేదికలను కనుగొనవలసి వస్తే మీ ఇన్‌స్టాల్ IDని పంచుకోండి.</string>
     <string name="settings_support_label">మద్దతు</string>
     <string name="settings_support_description">మీకు కొంత సహాయం అవసరమైతే.</string>
     <string name="settings_wiki_label">వికీ</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">నేర్చిన డేటాను రీసెట్ చేయాలా?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod ఈ పరికరం యొక్క కొలిచిన డ్రెయిన్, చార్జింగ్ వేగం మరియు వినికిడి సమయం మరచిపోతుంది మరియు రేట్ చేయబడిన బ్యాటరీ జీవితం నుండి ప్రారంభించుకుంటుంది</string>
     <string name="settings_acknowledgements_label">కృతజ్ఞతలు</string>
-    <string name="settings_debug_autoreports_label">స్వయంచాలక బగ్ నివేదికలు</string>
-    <string name="settings_debug_autoreports_description">సమస్యలను స్వయంచాలకంగా నివేదిస్తుంది, ఉదా. యాప్ క్రాష్ వివరాలు తద్వారా దాన్ని ఎలా పరిష్కరించాలో నేను గుర్తించగలను.</string>
-    <string name="settings_compatibility_mode_label">అనుకూలత మోడ్</string>
-    <string name="settings_compatibility_mode_description">అనుకూలతను మెరుగుపరచడానికి ఆప్టిమైజేషన్‌లను నిలిపివేయండి. మీరు ఏ డేటాను చూడకపోతే దీన్ని ప్రయత్నించండి.</string>
     <string name="help_translate_label">అనువాదం</string>
     <string name="help_translate_description">ఈ యాప్‌ను మీ ఇష్టమైన భాషలోకి అనువదించడంలో సహాయపడండి.</string>
     <string name="translators_thanks_title">అనువాదకులు</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">విజయం</string>
     <string name="troubleshooter_ble_result_success_body">BLE ప్రకటన ప్రసారాలు CAPod ద్వారా స్వీకరించబడుతున్నాయి.</string>
     <string name="troubleshooter_ble_result_failure_title">విఫలమైంది</string>
-    <string name="troubleshooter_ble_result_failure_body">ట్రబుల్షూటింగ్ విఫలమైంది. అనుకూలత ఎంపికల ఏ కలయిక సహాయపడలేదు.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">మీ ఫోన్ ఏ BLE డేటాను అస్సలు స్వీకరించలేదు. డేటా మూలాలు (మీ హెడ్‌ఫోన్‌లు కాకుండా) స్వీకరించవచ్చో లేదో చూడటానికి మీరు రద్దీగా ఉండే ప్రాంతంలో ఈ పరీక్షను మళ్లీ ప్రయత్నించవచ్చు. ఏ డేటా స్వీకరించబడకపోవడం మీ ఫోన్ ఆపరేటింగ్ సిస్టమ్‌తో సమస్యను సూచిస్తుంది.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">మీ ఫోన్ BLE డేటాను స్వీకరించింది, కానీ డేటా ఏ మద్దతు ఉన్న పరికరం నుండి రాలేదు. మీ హెడ్‌ఫోన్‌లు ఆన్ చేయబడి ఉన్నాయా? CAPod మీ హెడ్‌ఫోన్‌కు మద్దతు ఇస్తుందా?</string>
-    <string name="troubleshooter_ble_result_failure_action">మళ్ళీ ప్రయత్నించు</string>
-    <string name="troubleshoot_action">ట్రబుల్షూట్</string>
     <string name="onboarding_body1">ఈ యాప్ Androidకి AirPod నిర్దిష్ట ఫీచర్‌లకు మద్దతును జోడిస్తుంది.</string>
     <string name="onboarding_body2">అన్ని Android పరికరాలు AirPod అదనపు ఫీచర్‌లకు పూర్తిగా మద్దతు ఇవ్వవు. మీ ఆపరేటింగ్ సిస్టమ్‌కు సరిగ్గా పనిచేసే బ్లూటూత్-తక్కువ-శక్తి అమలు అవసరం.</string>
     <string name="onboarding_body3">CAPodలో ప్రకటనలు లేవు మరియు మీ డేటాను సేకరించదు.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">మీ పరికరం కనెక్ట్ అయింది, కానీ CAPod దాని నుండి ఏ లైవ్ డేటాను అందుకోవడం లేదు. మీ ఫోన్‌కు ఒక అనుకూలత ఎంపిక అవసరం కావచ్చు — ట్రబుల్షూటర్ స్వయంచాలకంగా ఒకటి కనుగొనడానికి ప్రయత్నించగలదు.</string>
     <string name="overview_troubleshoot_suggestion_action">ట్రబుల్షూటర్ అమలు చేయి</string>
     <string name="overview_unmatched_devices_label">సరిపోలని పరికరాలు</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">సరిపోలే ప్రొఫైల్ లేని %d పరికరం</item>
-        <item quantity="other">సరిపోలే ప్రొఫైల్ లేని %d పరికరాలు</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d సమీపంలోని పరికరం సరిపోలే ప్రొఫైల్ లేకుండా గుర్తించబడింది. అందుబాటులో ఉన్న వివరాల కోసం దాన్ని చూపించండి. ఇది మీదైతే, దాన్ని గుర్తించడానికి పరికరాల నుండి ఒక ప్రొఫైల్‌ను జోడించండి.</item>
         <item quantity="other">%d సమీపంలోని పరికరాలు సరిపోలే ప్రొఫైల్‌లు లేకుండా గుర్తించబడ్డాయి. అందుబాటులో ఉన్న వివరాల కోసం వాటిని చూపించండి. వాటిలో ఒకటి మీదైతే, దాన్ని గుర్తించడానికి పరికరాల నుండి ఒక ప్రొఫైల్‌ను జోడించండి.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">యాప్ మూసివేయబడినప్పుడు \"పాపప్ చూపించు\" మరియు \"ఆటో కనెక్ట్\" వంటి ఫీచర్లను ఎనేబుల్ చేయడానికి CAPod \"నేపథ్య లొకేషన్ యాక్సెస్\" ఉపయోగిస్తుంది. నేపథ్య లొకేషన్ యాక్సెస్ యాప్ నేపథ్యంలో ఉన్నప్పుడు బ్లూటూత్ తక్కువ శక్తి డేటాను స్వీకరించడానికి అనుమతిస్తుంది. ఈ యాప్ మీ లొకేషన్‌ను నిర్ణయించడానికి బ్లూటూత్ డేటాను ఉపయోగించదు.</string>
     <string name="permission_ignore_battery_optimizations_label">బ్యాటరీ ఆప్టిమైజేషన్‌లను నిలిపివేయి</string>
     <string name="permission_ignore_battery_optimizations_description">బ్యాటరీ ఆప్టిమైజేషన్‌లు యాప్ నేపథ్యంలో ఉన్నప్పుడు బ్లూటూత్ డేటాను నమ్మకంగా స్వీకరించడాన్ని నిరోధిస్తాయి.</string>
-    <string name="permission_required_title">కింది అనుమతి అవసరం:</string>
     <string name="permission_system_alert_window_label">సిస్టమ్ అలర్ట్ విండో</string>
     <string name="permission_system_alert_window_description">\"పాపప్ చూపించు\" ఫీచర్‌ను సాధ్యం చేయడానికి ఇతర యాప్‌ల మీద గీయడానికి CAPodను అనుమతించండి.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">కనిపించినప్పుడు</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">చెవిలో</string>
     <string name="pods_dual_left_label">ఎడమ పాడ్</string>
     <string name="pods_dual_right_label">కుడి పాడ్</string>
-    <string name="pods_dual_left_short_label">ఎ</string>
-    <string name="pods_dual_right_short_label">కు</string>
-    <string name="pods_case_label">కేస్</string>
     <string name="battery_unavailable_label">బ్యాటరీ అందుబాటులో లేదు</string>
     <string name="battery_state_low_cd">బ్యాటరీ తక్కువగా ఉంది</string>
     <string name="battery_state_critical_cd">బ్యాటరీ అత్యంత తక్కువగా ఉంది</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">నేరుగా కనెక్షన్ సక్రియంగా ఉంది</string>
     <string name="signal_indicator_bars_cd">సిగ్నల్ బలం: 4 బార్‌లలో %1$d</string>
     <string name="signal_indicator_disconnected_cd">సిగ్నల్: డిస్‌కనెక్ట్ అయింది</string>
-    <string name="pods_yours">మీది</string>
     <string name="headset_being_worn_label">ధరించబడుతోంది</string>
     <string name="headset_not_being_worn_label">ధరించబడటం లేదు</string>
     <string name="pods_case_unknown_state">తెలియని స్థితి</string>
-    <string name="last_seen_x">చివరిగా చూడబడింది: %s</string>
-    <string name="first_seen_x">మొదటిసారి చూడబడింది: %s</string>
     <string name="battery_cached_label">చివరిగా తెలిసినది · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">కనీస సిగ్నల్ నాణ్యత</string>
     <string name="profiles_signal_quality_description">ఈ థ్రెషోల్డ్ కంటే ఎక్కువ సిగ్నల్ బలం ఉన్న పరికరాలను మాత్రమే గుర్తించండి. తక్కువ విలువలు గుర్తింపు పరిధిని పెంచుతాయి కానీ తప్పుడు సానుకూలతలను కలిగిస్తాయి. దీన్ని చాలా ఎక్కువగా సెట్ చేయకండి — బ్లూటూత్ రిసెప్షన్ సాధారణంగా బలహీనంగా ఉంటుంది మరియు దూరం మరియు అడ్డంకులతో మారుతుంది.</string>
     <string name="profiles_identitykey_label">గుర్తింపు కీ</string>
-    <string name="profilessettings_maindevice_identitykey_description">మీ పరికరం యొక్క Identity Resolving Key (IRK), ఇది సమీపంలోని పరికరాల మధ్య CAPod దాన్ని గుర్తించడంలో సహాయపడుతుంది.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods గోప్యత కోసం తమ బ్లూటూత్ చిరునామాను తరచుగా మారుస్తాయి. IRK మీ పరికరాన్ని CAPod గుర్తించడంలో సహాయపడుతుంది. మీకు MacBookకు ఒకసారి యాక్సెస్ అవసరం.</string>
     <string name="profiles_maindevice_encryptionkey_label">ఎన్‌క్రిప్షన్ కీ</string>
-    <string name="profiles_maindevice_encryptionkey_description">మీ పరికరం యొక్క ఎన్‌క్రిప్షన్ కీ, ఇది CAPod వివరమైన స్థితి సమాచారాన్ని తీసుకోవడానికి అనుమతిస్తుంది.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ఒక స్థితి సందేశాన్ని పంపుతాయి, దానిలో కొంత భాగం ఎన్‌క్రిప్ట్ చేయబడింది. ఎన్‌క్రిప్షన్ కీ CAPod పూర్తి సందేశాన్ని డీక్రిప్ట్ చేయడానికి అనుమతిస్తుంది. మీకు MacBookకు ఒకసారి యాక్సెస్ అవసరం.</string>
     <string name="profiles_key_invalid_format">చెల్లని కీ ఫార్మాట్</string>
     <string name="profiles_key_expected_format">ఆశించిన ఫార్మాట్: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">మీకు సేవ్ చేయని మార్పులు ఉన్నాయి. మీరు ఏమి చేయాలనుకుంటున్నారు?</string>
     <string name="general_save_and_exit_action">సేవ్ చేసి &amp; నిష్క్రమించు</string>
     <string name="general_discard_action">విస్మరించు</string>
-    <string name="general_keep_editing_action">ఎడిట్ చేయడం కొనసాగించు</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">రికార్డింగ్ చాలా తక్కువలో ఉంది</string>
     <string name="debug_debuglog_short_recording_message">సమస్య జరుగుతున్నప్పుడే డీబగ్ లాగ్ అన్ని క్యాప్చర్ చేయాలి. రికార్డింగ్ కొనసాగించండి, సమస్యను పునరుత్పత్తించండి, తర్వాత రికార్డింగ్ ఆపండి.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">పరికర సెట్టింగ్‌లు</string>
     <string name="device_settings_subtitle_profile_prefix">ప్రొఫైల్: %s</string>
-    <string name="device_settings_info_name_label">పేరు</string>
     <string name="device_settings_info_bt_name_label">బ్లూటూత్ పరికరం లేబుల్</string>
     <string name="device_settings_info_model_label">మోడల్</string>
     <string name="device_settings_info_manufacturer_label">తయారీదారు</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">బహుశా తర్వాత</string>
     <string name="review_app_body">మీరు CAPod కోసం సమీక్ష వ్రాయాలనుకుంటారా? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">సాధారణ</string>
     <string name="device_settings_microphone_mode_label">మైక్రోఫోన్</string>
     <string name="device_settings_microphone_mode_description">మైక్రోఫోన్‌గా ఏ ఇయర్‌బడ్ ఉపయోగించబడుతుందో</string>
     <string name="device_settings_microphone_mode_auto">ఆటో</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">แบ่งปัน</string>
     <string name="general_done_action">เสร็จสิ้น</string>
     <string name="general_cancel_action">ยกเลิก</string>
-    <string name="general_copy_action">คัดลอก</string>
     <string name="general_thank_you_label">ขอบคุณ</string>
     <string name="general_upgrade_action">อัปเกรด</string>
     <string name="general_retry_action">ลองใหม่</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">ตรวจสอบ</string>
     <string name="general_close_action">ปิด</string>
     <string name="general_dismiss_action">ปิด</string>
-    <string name="general_edit_action">แก้ไข</string>
     <string name="general_save_action">บันทึก</string>
     <string name="general_guide_action">คู่มือ</string>
     <string name="general_continue_action">ดำเนินการต่อ</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">เล่นเพลงต่อเมื่อคุณใส่หูฟังอีกครั้ง แต่เฉพาะเมื่อการหยุดอัตโนมัติเป็นผู้หยุดไว้เท่านั้น การหยุดที่คุณทำเอง (โทรศัพท์, ก้านหูฟัง AirPods, สลีป) จะยังคงหยุดอยู่</string>
     <string name="settings_start_music_on_wear_label">เริ่มเพลงเมื่อสวมใส่</string>
     <string name="settings_start_music_on_wear_description">พยายามเล่นเพลงเสมอเมื่อคุณสวมหูฟัง แม้หลังจากหยุดด้วยตนเอง</string>
-    <string name="settings_eardetection_info_label">หมายเหตุการตรวจจับหู</string>
     <string name="settings_eardetection_info_description">หากการตรวจจับหูทำงานเพียงข้างเดียว นี่เป็นข้อจำกัดของ Apple เฉพาะ \"พ็อดหลัก\" (ที่ใช้สำหรับไมโครโฟน) เท่านั้นที่จะถูกตรวจจับ ตั้งค่าบนอุปกรณ์ Apple: การตั้งค่า → Bluetooth → AirPods → ไมโครโฟน</string>
-    <string name="settings_signal_minimum_label">คุณภาพสัญญาณขั้นต่ำ</string>
-    <string name="settings_signal_minimum_description">คุณภาพสัญญาณขั้นต่ำที่อุปกรณ์ต้องมีเพื่อให้ถือว่าเป็นของคุณ</string>
     <string name="settings_autoconnect_label">เชื่อมต่ออัตโนมัติ</string>
     <string name="settings_autoconnect_description">หาก Android ไม่เชื่อมต่ออัตโนมัติ เราสามารถขอให้มันทำได้ วิธีนี้จะทำให้ CAPod ตรวจสอบในพื้นหลังตลอดเวลา</string>
     <string name="settings_autoconnect_info_android12">การเชื่อมต่ออัตโนมัติอาศัยฟีเจอร์ระบบที่ Android 12 และเวอร์ชันใหม่กว่าจำกัดไว้ อาจไม่ทำงานบนอุปกรณ์ของคุณ</string>
     <string name="settings_autoconnect_condition_label">เงื่อนไขการเชื่อมต่ออัตโนมัติ</string>
-    <string name="settings_autoconnect_condition_description">เราควรพยายามเชื่อมต่อกับอุปกรณ์ของคุณเมื่อใด?</string>
     <string name="settings_devices_label">อุปกรณ์</string>
     <string name="settings_devices_description">จัดการอุปกรณ์ของคุณ</string>
     <string name="settings_reaction_label">ปฏิกิริยา</string>
-    <string name="settings_category_yourdevice_label">อุปกรณ์ของคุณ</string>
     <string name="settings_category_compatibility_options_title">ตัวเลือกความเข้ากันได้</string>
     <string name="settings_category_compatibility_options_description">อย่าแตะต้องหากทุกอย่างทำงานได้ดี ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ปิดใช้งานการกรองฮาร์ดแวร์</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">กำลังเริ่มต้น…</string>
     <string name="support_debuglog_label">บันทึกการดีบัก</string>
     <string name="support_debuglog_desc">บันทึกทุกสิ่งที่แอปกำลังทำลงในไฟล์ข้อความที่คุณสามารถแบ่งปันได้</string>
-    <string name="debug_debuglog_size_label">ขนาด</string>
-    <string name="debug_debuglog_size_compressed_label">ขนาดที่บีบอัด</string>
-    <string name="debug_notification_channel_label">การแจ้งเตือนการดีบัก</string>
-    <string name="debug_debuglog_file_label">ไฟล์บันทึกที่บันทึกไว้</string>
-    <string name="debug_debuglog_recording_progress">กำลังบันทึกบันทึกการดีบัก</string>
     <string name="debug_debuglog_record_action">บันทึกบันทึกการดีบัก</string>
     <string name="debug_debuglog_stop_action">หยุดการบันทึก</string>
     <string name="debug_debuglog_sensitive_information_message">ไฟล์ที่สร้างขึ้นมีข้อมูลที่ละเอียดอ่อน (เช่น รายละเอียดอุปกรณ์ Bluetooth) แบ่งปันกับบุคคลที่เชื่อถือได้เท่านั้น</string>
     <string name="settings_debuglog_explanation">คุณลักษณะนี้จะบันทึกทุกสิ่งที่แอปกำลังทำลงในไฟล์ที่สามารถแบ่งปันได้ ไฟล์ที่สร้างขึ้นมีข้อมูลที่ละเอียดอ่อน (เช่น รายละเอียดอุปกรณ์ Bluetooth) แบ่งปันกับบุคคลที่เชื่อถือได้เท่านั้น (เช่น นักพัฒนาที่กำลังแก้ไขปัญหา)</string>
-    <string name="settings_support_installid_label">ID การติดตั้ง</string>
-    <string name="settings_support_installid_desc">รายงานข้อผิดพลาดอัตโนมัติจะไม่ระบุชื่อ แบ่งปัน ID การติดตั้งของคุณหากนักพัฒนาต้องการค้นหารายงานข้อผิดพลาดของคุณ</string>
     <string name="settings_support_label">การสนับสนุน</string>
     <string name="settings_support_description">หากคุณต้องการความช่วยเหลือ</string>
     <string name="settings_wiki_label">วิกิ</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">รีเซ็ตข้อมูลที่เรียนรู้?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod จะลบข้อมูลการใช้พลังงาน ความเร็วในการชาร์จ และเวลาฟังที่วัดได้ของอุปกรณ์นี้ และเริ่มจากอายุแบตเตอรี่ที่ระบุใหม่</string>
     <string name="settings_acknowledgements_label">กิตติกรรมประกาศ</string>
-    <string name="settings_debug_autoreports_label">รายงานข้อบกพร่องอัตโนมัติ</string>
-    <string name="settings_debug_autoreports_description">รายงานปัญหาโดยอัตโนมัติ เช่น รายละเอียดเกี่ยวกับข้อขัดข้องของแอป เพื่อให้ฉันสามารถหาวิธีแก้ไขได้</string>
-    <string name="settings_compatibility_mode_label">โหมดความเข้ากันได้</string>
-    <string name="settings_compatibility_mode_description">ปิดใช้งานการเพิ่มประสิทธิภาพเพื่อปรับปรุงความเข้ากันได้ ลองใช้วิธีนี้หากคุณไม่เห็นข้อมูลใดๆ</string>
     <string name="help_translate_label">การแปล</string>
     <string name="help_translate_description">ช่วยแปลแอปนี้เป็นภาษาที่คุณชื่นชอบ</string>
     <string name="translators_thanks_title">ผู้แปล</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">สำเร็จ</string>
     <string name="troubleshooter_ble_result_success_body">CAPod กำลังรับการออกอากาศโฆษณา BLE</string>
     <string name="troubleshooter_ble_result_failure_title">ไม่สำเร็จ</string>
-    <string name="troubleshooter_ble_result_failure_body">การแก้ไขปัญหาล้มเหลว ไม่มีการผสมผสานตัวเลือกความเข้ากันได้ใดที่ช่วยได้</string>
     <string name="troubleshooter_ble_result_failure_phone_body">โทรศัพท์ของคุณไม่ได้รับข้อมูล BLE ใดๆ เลย คุณสามารถลองทดสอบนี้อีกครั้งในบริเวณที่มีผู้คนพลุกพล่านเพื่อดูว่าสามารถรับแหล่งข้อมูล (นอกเหนือจากหูฟังของคุณ) ได้หรือไม่ การไม่ได้รับข้อมูลใดๆ บ่งชี้ถึงปัญหากับระบบปฏิบัติการของโทรศัพท์ของคุณ</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">โทรศัพท์ของคุณได้รับข้อมูล BLE แต่ข้อมูลไม่ได้มาจากอุปกรณ์ที่รองรับใดๆ หูฟังของคุณเปิดอยู่หรือไม่? CAPod รองรับหูฟังของคุณหรือไม่?</string>
-    <string name="troubleshooter_ble_result_failure_action">ลองอีกครั้ง</string>
-    <string name="troubleshoot_action">แก้ไขปัญหา</string>
     <string name="onboarding_body1">แอปนี้เพิ่มการรองรับคุณสมบัติเฉพาะของ AirPod ให้กับ Android</string>
     <string name="onboarding_body2">อุปกรณ์ Android บางรุ่นไม่รองรับคุณสมบัติพิเศษของ AirPod ทั้งหมด ระบบปฏิบัติการของคุณต้องมีการใช้งาน Bluetooth Low Energy ที่ทำงานได้อย่างถูกต้อง</string>
     <string name="onboarding_body3">CAPod ไม่มีโฆษณาและไม่รวบรวมข้อมูลของคุณ</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">อุปกรณ์ของคุณเชื่อมต่อแล้ว แต่ CAPod ไม่ได้รับข้อมูลสดจากอุปกรณ์นั้น โทรศัพท์ของคุณอาจต้องการตัวเลือกความเข้ากันได้ — เครื่องมือแก้ปัญหาสามารถลองค้นหาตัวเลือกนั้นโดยอัตโนมัติ</string>
     <string name="overview_troubleshoot_suggestion_action">เรียกใช้เครื่องมือแก้ปัญหา</string>
     <string name="overview_unmatched_devices_label">อุปกรณ์ที่ไม่ตรงกัน</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d อุปกรณ์ที่ไม่มีโปรไฟล์ที่ตรงกัน</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">พบอุปกรณ์ใกล้เคียง %d เครื่องที่ไม่มีโปรไฟล์ที่ตรงกัน แตะเพื่อดูรายละเอียดที่มี หากเป็นอุปกรณ์ของคุณ ให้เพิ่มโปรไฟล์จากหน้าอุปกรณ์เพื่อจดจำอุปกรณ์นั้น</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod ใช้ \"การเข้าถึงตำแหน่งในพื้นหลัง\" เพื่อเปิดใช้คุณสมบัติเช่น \"แสดงป๊อปอัป\" และ \"เชื่อมต่ออัตโนมัติ\" ขณะที่แอปถูกปิด การเข้าถึงตำแหน่งในพื้นหลังอนุญาตให้แอปรับข้อมูล Bluetooth Low Energy ขณะอยู่ในพื้นหลัง แอปนี้จะไม่ใช้ข้อมูล Bluetooth เพื่อระบุตำแหน่งของคุณ</string>
     <string name="permission_ignore_battery_optimizations_label">ปิดการเพิ่มประสิทธิภาพแบตเตอรี่</string>
     <string name="permission_ignore_battery_optimizations_description">การเพิ่มประสิทธิภาพแบตเตอรี่ป้องกันไม่ให้แอปนี้รับข้อมูล Bluetooth อย่างน่าเชื่อถือขณะอยู่ในพื้นหลัง</string>
-    <string name="permission_required_title">ต้องการสิทธิ์ต่อไปนี้:</string>
     <string name="permission_system_alert_window_label">หน้าต่างแจ้งเตือนระบบ</string>
     <string name="permission_system_alert_window_description">อนุญาตให้ CAPod วาดทับแอปอื่นเพื่อให้คุณสมบัติ \"แสดงป๊อปอัป\" ทำงานได้</string>
     <string name="settings_reaction_autoconnect_whenseen_label">เมื่อพบเห็น</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">อยู่ในหู</string>
     <string name="pods_dual_left_label">พ็อดซ้าย</string>
     <string name="pods_dual_right_label">พ็อดขวา</string>
-    <string name="pods_dual_left_short_label">ซ้าย</string>
-    <string name="pods_dual_right_short_label">ขวา</string>
-    <string name="pods_case_label">เคส</string>
     <string name="battery_unavailable_label">แบตเตอรี่ไม่พร้อมใช้งาน</string>
     <string name="battery_state_low_cd">แบตเตอรี่เหลือน้อย</string>
     <string name="battery_state_critical_cd">แบตเตอรี่เหลือน้อยมาก</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">การเชื่อมต่อตรงใช้งานอยู่</string>
     <string name="signal_indicator_bars_cd">ความแรงสัญญาณ: %1$d จาก 4 แท่ง</string>
     <string name="signal_indicator_disconnected_cd">สัญญาณ: ตัดการเชื่อมต่อ</string>
-    <string name="pods_yours">ของคุณ</string>
     <string name="headset_being_worn_label">กำลังสวมใส่</string>
     <string name="headset_not_being_worn_label">ไม่ได้สวมใส่</string>
     <string name="pods_case_unknown_state">สถานะไม่ทราบ</string>
-    <string name="last_seen_x">เห็นล่าสุด: %s</string>
-    <string name="first_seen_x">เห็นครั้งแรก: %s</string>
     <string name="battery_cached_label">ทราบล่าสุด · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dชม. %2$dนาที</string>
     <string name="battery_time_remaining_format_h">%1$dชม.</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">คุณภาพสัญญาณขั้นต่ำ</string>
     <string name="profiles_signal_quality_description">ตรวจจับเฉพาะอุปกรณ์ที่มีความแรงของสัญญาณสูงกว่าเกณฑ์นี้ ค่าที่ต่ำกว่าจะเพิ่มระยะการตรวจจับแต่อาจทำให้เกิดการตรวจจับผิดพลาด อย่าตั้งค่านี้สูงเกินไป - การรับสัญญาณ Bluetooth โดยทั่วไปไม่ดีและแตกต่างกันตามระยะทางและสิ่งกีดขวาง</string>
     <string name="profiles_identitykey_label">คีย์ระบุตัวตน</string>
-    <string name="profilessettings_maindevice_identitykey_description">คีย์การแก้ไขตัวตน (IRK) ของอุปกรณ์ของคุณ ซึ่งช่วยให้ CAPod ระบุตัวตนได้ท่ามกลางอุปกรณ์ใกล้เคียง</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods เปลี่ยนที่อยู่ Bluetooth บ่อยครั้งเพื่อความเป็นส่วนตัว IRK ช่วยให้ CAPod จดจำอุปกรณ์ของคุณได้ คุณต้องเข้าถึง MacBook ครั้งเดียว</string>
     <string name="profiles_maindevice_encryptionkey_label">คีย์เข้ารหัส</string>
-    <string name="profiles_maindevice_encryptionkey_description">คีย์เข้ารหัสของอุปกรณ์ของคุณ ซึ่งอนุญาตให้ CAPod ดึงข้อมูลสถานะโดยละเอียด</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ส่งข้อความสถานะ ซึ่งบางส่วนถูกเข้ารหัส คีย์เข้ารหัสอนุญาตให้ CAPod ถอดรหัสข้อความทั้งหมด คุณต้องเข้าถึง MacBook ครั้งเดียว</string>
     <string name="profiles_key_invalid_format">รูปแบบคีย์ไม่ถูกต้อง</string>
     <string name="profiles_key_expected_format">รูปแบบที่คาดหวัง: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">คุณมีการเปลี่ยนแปลงที่ไม่ได้บันทึก คุณต้องการทำอะไร?</string>
     <string name="general_save_and_exit_action">บันทึก &amp; ออก</string>
     <string name="general_discard_action">ทิ้ง</string>
-    <string name="general_keep_editing_action">แก้ไขต่อ</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">การบันทึกสั้นเกินไป</string>
     <string name="debug_debuglog_short_recording_message">ไฟล์ล็อกดีบักต้องจับปัญหาขณะที่เกิดขึ้น บันทึกต่อไป สร้างปัญหาซ้ำแล้วหยุดการบันทึก</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">การตั้งค่าอุปกรณ์</string>
     <string name="device_settings_subtitle_profile_prefix">โปรไฟล์: %s</string>
-    <string name="device_settings_info_name_label">ชื่อ</string>
     <string name="device_settings_info_bt_name_label">ชื่ออุปกรณ์บลูทูธ</string>
     <string name="device_settings_info_model_label">รุ่น</string>
     <string name="device_settings_info_manufacturer_label">ผู้ผลิต</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">อาจในคราวหน้า</string>
     <string name="review_app_body">คุณต้องการให้คะแนน CAPod หรือไม่? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">ทั่วไป</string>
     <string name="device_settings_microphone_mode_label">ไมโครโฟน</string>
     <string name="device_settings_microphone_mode_description">หูฟังข้างใดที่ใช้เป็นไมโครโฟน</string>
     <string name="device_settings_microphone_mode_auto">อัตโนมัติ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Paylaş</string>
     <string name="general_done_action">Tamam</string>
     <string name="general_cancel_action">İptal</string>
-    <string name="general_copy_action">Kopyala</string>
     <string name="general_thank_you_label">Teşekkürler</string>
     <string name="general_upgrade_action">Güncelle</string>
     <string name="general_retry_action">Yeniden Dene</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kontrol et</string>
     <string name="general_close_action">Kapat</string>
     <string name="general_dismiss_action">Yoksay</string>
-    <string name="general_edit_action">Düzenle</string>
     <string name="general_save_action">Kaydet</string>
     <string name="general_guide_action">Rehber</string>
     <string name="general_continue_action">Devam et</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Podlarını tekrar takınca müziği devam ettir, ancak yalnızca Otomatik duraklat durdurduysa. Kendin tetiklediğin duraklamalar (telefon, AirPods sapı, uyku) duraklamaya devam eder.</string>
     <string name="settings_start_music_on_wear_label">Takınca müziği başlat</string>
     <string name="settings_start_music_on_wear_description">Podlarını takınca, manuel duraklamadan sonra bile müzik çalmayı her zaman dener.</string>
-    <string name="settings_eardetection_info_label">Kulak algılama notu</string>
     <string name="settings_eardetection_info_description">Kulak algılama yalnızca bir kulaklık için çalışıyorsa bu bir Apple sınırlamasıdır. Yalnızca \"birincil kulaklık\" (mikrofon için kullanılan) algılanır. Apple cihazlarında yapılandırın: Ayarlar → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimum sinyal kalitesi</string>
-    <string name="settings_signal_minimum_description">Bir aygıtın size ait olduğunun anlaşılması için sahip olması gereken minimum sinyal kalitesi.</string>
     <string name="settings_autoconnect_label">Otomatik bağlan</string>
     <string name="settings_autoconnect_description">Android otomatik olarak bağlanmazsa, biz de bağlanmasını isteyebiliriz. Bu, CAPod\'un her zaman arka planda izlemeye devam etmesini sağlar.</string>
     <string name="settings_autoconnect_info_android12">Otomatik bağlanma Android 12 ve daha yenisinde olan bir sistem özelliğine dayanır. Bu cihazınızda çalışmayabilir.</string>
     <string name="settings_autoconnect_condition_label">Otomatik bağlantı şartı</string>
-    <string name="settings_autoconnect_condition_description">Aygıtınıza ne zaman bağlanmayı denemeliyiz?</string>
     <string name="settings_devices_label">Cihazlar</string>
     <string name="settings_devices_description">Cihazlarınızı yönetin.</string>
     <string name="settings_reaction_label">Tepkiler</string>
-    <string name="settings_category_yourdevice_label">Aygıtınız</string>
     <string name="settings_category_compatibility_options_title">Uyumluluk seçenekleri</string>
     <string name="settings_category_compatibility_options_description">Eğer her şey düzgün çalışıyorsa lütfen dokunma ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Donanım filtrelemeyi kapat</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Başlatılıyor…</string>
     <string name="support_debuglog_label">Hata ayıklama günlüğü</string>
     <string name="support_debuglog_desc">Uygulamanın yaptığı her şeyi paylaşabileceğiniz bir metin dosyasına kaydeder.</string>
-    <string name="debug_debuglog_size_label">Boyut</string>
-    <string name="debug_debuglog_size_compressed_label">Sıkıştırılmış boyut</string>
-    <string name="debug_notification_channel_label">Hata ayıklama bildirimleri</string>
-    <string name="debug_debuglog_file_label">Kayıtlı günlük dosyası</string>
-    <string name="debug_debuglog_recording_progress">Hata ayıklama günlüğü kaydediliyor</string>
     <string name="debug_debuglog_record_action">Hata ayıklama günlüğünü kaydet</string>
     <string name="debug_debuglog_stop_action">Kaydı durdur</string>
     <string name="debug_debuglog_sensitive_information_message">Oluşturulan dosya hassas bilgiler içerir (örn. Bluetooth cihaz detayları). Yalnızca güvenilir taraflarla paylaşın.</string>
     <string name="settings_debuglog_explanation">Bu özellik, uygulamanın yaptığı her şeyi paylaşılabilir bir dosyaya kaydeder. Oluşturulan dosya hassas bilgiler içerir (örn. Bluetooth cihaz detayları). Bu dosyayı yalnızca güvenilir taraflarla paylaşın (örneğin, bir sorunu gideren geliştirici).</string>
-    <string name="settings_support_installid_label">Kurulum Kimliği</string>
-    <string name="settings_support_installid_desc">Otomatik hata raporları anonimdir. Geliştiricinin hata raporlarınızı bulması gerekiyorsa kurulum kimliğinizi paylaşabilirsiniz.</string>
     <string name="settings_support_label">Destek</string>
     <string name="settings_support_description">Yardıma ihtiyacınız olursa.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Öğrenilen Verileri Sıfırla?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod bu cihazın ölçülen pil tükenme hızını, şarj hızını ve dinleme süresini unutacak ve orijinal pil ömründen yeniden başlayacak.</string>
     <string name="settings_acknowledgements_label">Teşekkürler</string>
-    <string name="settings_debug_autoreports_label">Otomatik hata raporları</string>
-    <string name="settings_debug_autoreports_description">Sorunları otomatik olarak bildirir, ör. uygulama çökmesiyle ilgili ayrıntılı bilgiler. Böylece nasıl düzelteceğimi bulabilirim.</string>
-    <string name="settings_compatibility_mode_label">Uyumluluk modu</string>
-    <string name="settings_compatibility_mode_description">Uyumluluğu iyileştirmek için optimizasyonları devre dışı bırakın. Herhangi bir veri görmüyorsanız bunu deneyin.</string>
     <string name="help_translate_label">Çeviri</string>
     <string name="help_translate_description">Uygulamayı favori dilinize tercüme etmeye yardımcı olun.</string>
     <string name="translators_thanks_title">Çevirmenler</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Başarılı</string>
     <string name="troubleshooter_ble_result_success_body">BLE reklam yayınları CAPod tarafından alınmaktadır.</string>
     <string name="troubleshooter_ble_result_failure_title">Başarısız</string>
-    <string name="troubleshooter_ble_result_failure_body">Sorun giderme başarısız oldu. Uyumluluk seçeneklerinin hiçbir kombinasyonu yardımcı olmadı.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefonunuz hiç BLE verisi almadı. Veri kaynaklarının (kulaklığınız dışında) alınıp alınamayacağını görmek için bu testi kalabalık bir alanda tekrar deneyebilirsiniz. Alınan hiçbir veri, telefonunuzun işletim sistemiyle ilgili bir soruna işaret etmez.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefonunuz BLE verilerini aldı, ancak veriler desteklenen herhangi bir aygıttan gelmiyor. Kulaklığınız açık mı? CAPod kulaklığınızı destekliyor mu?</string>
-    <string name="troubleshooter_ble_result_failure_action">Tekrar deneyin</string>
-    <string name="troubleshoot_action">Sorun giderme</string>
     <string name="onboarding_body1">Bu uygulama Android\'e AirPod\'a özgü özellikler için destek ekler.</string>
     <string name="onboarding_body2">Tüm Android cihazlar ekstra AirPod özelliklerini tam olarak desteklemez. İşletim sisteminiz doğru çalışan bir Bluetooth-Düşük Enerji uygulaması gerektirir.</string>
     <string name="onboarding_body3">CAPod\'da reklam yoktur ve verilerinizi toplamaz.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Cihazınız bağlı, ancak CAPod ondan canlı veri almıyor. Telefonunuzun bir uyumluluk seçeneğine ihtiyacı olabilir — sorun giderici otomatik olarak bir tane bulmaya çalışabilir.</string>
     <string name="overview_troubleshoot_suggestion_action">Sorun gidericiyi çalıştır</string>
     <string name="overview_unmatched_devices_label">Eşleşmeyen cihazlar</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d cihaz eşleşen profil olmadan</item>
-        <item quantity="other">%d cihaz eşleşen profil olmadan</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Eşleşen bir profili olmayan %d yakın cihaz tespit edildi. Mevcut ayrıntıları görmek için gösterin. Senin cihazınsa, tanınması için Cihazlar bölümünden bir profil ekle.</item>
         <item quantity="other">Eşleşen profili olmayan %d yakın cihaz tespit edildi. Mevcut ayrıntıları görmek için gösterin. Biri seninse, tanınması için Cihazlar bölümünden bir profil ekle.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod, uygulama kapalıyken \"Açılır pencere göster\" ve \"Otomatik bağlan\" gibi özellikleri etkinleştirmek için \"arka plan konum erişimi\" kullanır. Arka plan konum erişimi, uygulamanın arka plandayken Bluetooth Low Energy verilerini almasına olanak tanır. Bu uygulama konumunuzu belirlemek için Bluetooth verilerini KULLANMAYACAKTIR.</string>
     <string name="permission_ignore_battery_optimizations_label">Pil optimizasyonlarını devre dışı bırak</string>
     <string name="permission_ignore_battery_optimizations_description">Pil optimizasyonları, bu uygulamanın arka planda güvenilir bir şekilde Bluetooth verilerini almasını engeller.</string>
-    <string name="permission_required_title">Aşağıdaki izin gereklidir:</string>
     <string name="permission_system_alert_window_label">Sistem Uyarı Penceresi</string>
     <string name="permission_system_alert_window_description">\"Açılır Pencere Göster\" özelliğini mümkün kılmak için CAPod\'un diğer uygulamaların üzerine çizmesine izin verin.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Görüldüğünde</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Kulakta</string>
     <string name="pods_dual_left_label">Sol kulaklık</string>
     <string name="pods_dual_right_label">Sağ kulaklık</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">Kutu</string>
     <string name="battery_unavailable_label">Batarya mevcut değil</string>
     <string name="battery_state_low_cd">Pil düşük</string>
     <string name="battery_state_critical_cd">Pil kritik seviyede</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Doğrudan bağlantı etkin</string>
     <string name="signal_indicator_bars_cd">Sinyal gücü: 4 çubuktan %1$d</string>
     <string name="signal_indicator_disconnected_cd">Sinyal: bağlantı kesildi</string>
-    <string name="pods_yours">Sizin</string>
     <string name="headset_being_worn_label">Takılı</string>
     <string name="headset_not_being_worn_label">Takılı değil</string>
     <string name="pods_case_unknown_state">Bilinmeyen durum</string>
-    <string name="last_seen_x">Son görülme: %s</string>
-    <string name="first_seen_x">İlk görülme: %s</string>
     <string name="battery_cached_label">Son bilinen · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dsa %2$ddk</string>
     <string name="battery_time_remaining_format_h">%1$dsa</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Minimum Sinyal Kalitesi</string>
     <string name="profiles_signal_quality_description">Yalnızca sinyal gücü bu eşiğin üzerinde olan cihazları algıla. Düşük değerler algılama menzilini artırır ancak yanlış pozitiflere neden olabilir. Bunu çok yüksek ayarlamayın - Bluetooth alımı genellikle zayıftır ve mesafe ile engellerle değişir.</string>
     <string name="profiles_identitykey_label">Kimlik Anahtarı</string>
-    <string name="profilessettings_maindevice_identitykey_description">CAPod\'un yakındaki cihazlar arasında tanımlamasına yardımcı olan cihazınızın Kimlik Çözümleme Anahtarı (IRK).</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods gizlilik için Bluetooth adresini sık sık değiştirir. IRK, CAPod\'un cihazınızı tanımasına yardımcı olur. Bir kereye mahsus MacBook erişimine ihtiyacınız vardır.</string>
     <string name="profiles_maindevice_encryptionkey_label">Şifreleme Anahtarı</string>
-    <string name="profiles_maindevice_encryptionkey_description">CAPod\'un ayrıntılı durum bilgilerini almasına olanak tanıyan cihazınızın şifreleme anahtarı.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods bir durum mesajı gönderir, bunun bir kısmı şifrelenmiştir. Şifreleme anahtarı CAPod\'un tam mesajı çözmesine olanak tanır. Bir kereye mahsus MacBook erişimine ihtiyacınız vardır.</string>
     <string name="profiles_key_invalid_format">Geçersiz anahtar biçimi</string>
     <string name="profiles_key_expected_format">Beklenen biçim: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Kaydedilmemiş değişiklikleriniz var. Ne yapmak istersiniz?</string>
     <string name="general_save_and_exit_action">Kaydet ve Çık</string>
     <string name="general_discard_action">At</string>
-    <string name="general_keep_editing_action">Düzenlemeye Devam Et</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Kayıt çok kısa</string>
     <string name="debug_debuglog_short_recording_message">Bir hata ayıklama kaydı sorunu gerçekleşirken yakalaması gerekir. Kaydetmeye devam edin, sorunu yeniden oluşturun, ardından kaydı durdurun.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Cihaz Ayarları</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Ad</string>
     <string name="device_settings_info_bt_name_label">Bluetooth Cihaz Adı</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Üretici</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Belki daha sonra</string>
     <string name="review_app_body">CAPod\'e bir inceleme bırakmak ister misiniz? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Genel</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Hangi kulakiçinin mikrofon olarak kullanıldığı</string>
     <string name="device_settings_microphone_mode_auto">Otomatik</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Поділитися</string>
     <string name="general_done_action">Зроблено</string>
     <string name="general_cancel_action">Скасувати</string>
-    <string name="general_copy_action">Копіювати</string>
     <string name="general_thank_you_label">Дякуємо</string>
     <string name="general_upgrade_action">Оновити</string>
     <string name="general_retry_action">Повторити</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Перевірити</string>
     <string name="general_close_action">Закрити</string>
     <string name="general_dismiss_action">Відхилити</string>
-    <string name="general_edit_action">Редагувати</string>
     <string name="general_save_action">Зберегти</string>
     <string name="general_guide_action">Посібник</string>
     <string name="general_continue_action">Продовжити</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Відновлює музику, коли ти знову надягаєш навушники, але лише якщо їх зупинило автопаузування. Паузи, які ти поставив сам (телефон, стебло AirPods, сон), залишаються.</string>
     <string name="settings_start_music_on_wear_label">Запускати музику при надяганні</string>
     <string name="settings_start_music_on_wear_description">Завжди намагається відтворити музику, коли ти надягаєш навушники, навіть після ручної паузи.</string>
-    <string name="settings_eardetection_info_label">Примітка про виявлення вуха</string>
     <string name="settings_eardetection_info_description">Якщо виявлення вуха працює лише для одного навушника, це обмеження Apple. Виявляється лише \"головний навушник\" (який використовується для мікрофона). Налаштуйте на пристроях Apple: Параметри → Bluetooth → AirPods → Мікрофон.</string>
-    <string name="settings_signal_minimum_label">Мінімальна якість сигналу</string>
-    <string name="settings_signal_minimum_description">Мінімальний рівень сигналу, щоб вважалося що пристрій ваш.</string>
     <string name="settings_autoconnect_label">Автопід\'єднання</string>
     <string name="settings_autoconnect_description">Якщо Android не підключається автоматично, ми можемо його попросити. Це дозволяє CAPod постійно моніторити у фоні.</string>
     <string name="settings_autoconnect_info_android12">Автоматичне підключення використовує системну функцію, яку Android 12 і новіші версії обмежують. Може не працювати на вашому пристрої.</string>
     <string name="settings_autoconnect_condition_label">Умова автопід\'єднання</string>
-    <string name="settings_autoconnect_condition_description">Коли слід здійснювати спробу під\'єднання до Вашого пристрою?</string>
     <string name="settings_devices_label">Пристрої</string>
     <string name="settings_devices_description">Керування вашими пристроями.</string>
     <string name="settings_reaction_label">Реакції</string>
-    <string name="settings_category_yourdevice_label">Ваш пристрій</string>
     <string name="settings_category_compatibility_options_title">Опції сумісності</string>
     <string name="settings_category_compatibility_options_description">Не чіпай, якщо все працює ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Вимкнути апаратну фільтрацію</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Запуск…</string>
     <string name="support_debuglog_label">Журнал налагодження</string>
     <string name="support_debuglog_desc">Запис всього, що робить програма, у текстовий файл, яким можна поділитися.</string>
-    <string name="debug_debuglog_size_label">Розмір</string>
-    <string name="debug_debuglog_size_compressed_label">Стиснутий розмір</string>
-    <string name="debug_notification_channel_label">Сповіщення налагодження</string>
-    <string name="debug_debuglog_file_label">Файл журналу налагодження</string>
-    <string name="debug_debuglog_recording_progress">Запис журналу налагодження</string>
     <string name="debug_debuglog_record_action">Записати журнал налагодження</string>
     <string name="debug_debuglog_stop_action">Зупинити запис</string>
     <string name="debug_debuglog_sensitive_information_message">Створений файл містить чутливу інформацію (наприклад, відомості про пристрої Bluetooth). Діліться ним лише з довіреними особами.</string>
     <string name="settings_debuglog_explanation">Ця функція записує все, що робить програма, у файл, яким можна ділитися. Створений файл містить чутливу інформацію (наприклад, відомості про пристрої Bluetooth). Діліться ним лише з довіреними особами (наприклад, розробником, що розв\'язує проблему).</string>
-    <string name="settings_support_installid_label">ID інсталяції</string>
-    <string name="settings_support_installid_desc">Автоматичні звіти про помилки є анонімними. Поділіться своїм ID інсталяції, якщо розробнику потрібно знайти ваші звіти про помилки.</string>
     <string name="settings_support_label">Підтримка</string>
     <string name="settings_support_description">Якщо необхідна допомога.</string>
     <string name="settings_wiki_label">Вікі</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Скинути вивчені дані?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod забуде виміряний розряд цього пристрою, швидкість зарядки та тривалість прослуховування, і почне з номінальної тривалості батареї.</string>
     <string name="settings_acknowledgements_label">Подяки</string>
-    <string name="settings_debug_autoreports_label">Автоматичні звіти про помилки</string>
-    <string name="settings_debug_autoreports_description">Автоматично повідомляти про проблеми, наприклад, деталі про збій програми, щоб я міг зрозуміти, як це виправити.</string>
-    <string name="settings_compatibility_mode_label">Режим сумісності</string>
-    <string name="settings_compatibility_mode_description">Вимкнути оптимізацію для покращення сумісності. Спробуйте це, якщо ви не бачите жодних даних.</string>
     <string name="help_translate_label">Переклад</string>
     <string name="help_translate_description">Допоможи перекласти цей додаток вашою улюбленою мовою.</string>
     <string name="translators_thanks_title">Перекладачі</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Успішно</string>
     <string name="troubleshooter_ble_result_success_body">CAPod приймає трансляцію BLE-оголошень.</string>
     <string name="troubleshooter_ble_result_failure_title">Невдало</string>
-    <string name="troubleshooter_ble_result_failure_body">Не вдалося виправити неполадки. Жодна комбінація варіантів сумісності не допомогла.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ваш смартфон не отримав жодних даних BLE. Ви можете повторити цей тест у людному місці, щоб перевірити, чи можна отримати дані з інших джерел (окрім ваших навушників). Не отримання жодних даних свідчить про проблему з операційною системою вашого смартфону.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Ваш смартфон отримав BLE дані, проте вони не від одного з підтримуваних пристроїв. Ваші навушники увімкнено? CAPod підтримує цей тип навушників?</string>
-    <string name="troubleshooter_ble_result_failure_action">Спробувати знову</string>
-    <string name="troubleshoot_action">Вирішення проблем</string>
     <string name="onboarding_body1">Цей додаток додає підтримку функцій AirPod в Android.</string>
     <string name="onboarding_body2">Не всі Android пристрої повністю підтримують додаткові функції AirPod. Ваша операційна система повинна підтримувати коректну реалізацію Bluetooth-Low-Energy.</string>
     <string name="onboarding_body3">CAPod не містить реклами та не збирає ваші дані.</string>
@@ -207,12 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Пристрій підключено, але CAPod не отримує від нього жодних актуальних даних. Вашому телефону може знадобитися параметр сумісності — засіб усунення несправностей спробує знайти його автоматично.</string>
     <string name="overview_troubleshoot_suggestion_action">Запустити засіб усунення несправностей</string>
     <string name="overview_unmatched_devices_label">Нерозпізнані пристрої</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d пристрій без відповідного профілю</item>
-        <item quantity="few">%d пристрої без відповідного профілю</item>
-        <item quantity="many">%d пристроїв без відповідного профілю</item>
-        <item quantity="other">%d пристроїв без відповідного профілю</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Поблизу виявлено %d пристрій без відповідного профілю. Перегляньте його, щоб дізнатися більше. Якщо це ваш пристрій, додайте профіль у розділі «Пристрої», щоб розпізнати його.</item>
         <item quantity="few">Поблизу виявлено %d пристрої без відповідних профілів. Перегляньте їх, щоб дізнатися більше. Якщо один із них ваш, додайте профіль у розділі «Пристрої», щоб розпізнати його.</item>
@@ -237,7 +210,6 @@
     <string name="permission_background_location_description">CAPod використовує \"доступ до місцезнаходження у фоні\", щоб увімкнути такі функції, як \"Показувати спливаюче вікно\" та \"Автопід\'єднання\", коли програму закрито. Доступ у фоні дозволяє програмі отримувати дані BLE, перебуваючи у згорнутому стані. Ця програма НЕ використовуватиме дані Bluetooth для визначення вашого місцезнаходження.</string>
     <string name="permission_ignore_battery_optimizations_label">Вимкнути оптимізацію батареї</string>
     <string name="permission_ignore_battery_optimizations_description">Оптимізація батареї заважає цій програмі надійно отримувати дані Bluetooth, коли вона працює у фоновому режимі.</string>
-    <string name="permission_required_title">Потрібен наступний дозвіл:</string>
     <string name="permission_system_alert_window_label">Відображення поверх інших програм</string>
     <string name="permission_system_alert_window_description">Дозвольте CAPod відображатися поверх інших програм, щоб уможливити функцію \"Показувати спливаюче вікно\".</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Коли виявлено</string>
@@ -245,9 +217,6 @@
     <string name="settings_reaction_autoconnect_inear_label">У вусі</string>
     <string name="pods_dual_left_label">Лівий</string>
     <string name="pods_dual_right_label">Правий</string>
-    <string name="pods_dual_left_short_label">Л</string>
-    <string name="pods_dual_right_short_label">П</string>
-    <string name="pods_case_label">Футляр</string>
     <string name="battery_unavailable_label">Акумулятор недоступний</string>
     <string name="battery_state_low_cd">Низька батарея</string>
     <string name="battery_state_critical_cd">Критично низька батарея</string>
@@ -304,12 +273,9 @@
     <string name="signal_badge_aap_cd">Пряме з\'єднання активне</string>
     <string name="signal_indicator_bars_cd">Рівень сигналу: %1$d з 4 поділок</string>
     <string name="signal_indicator_disconnected_cd">Сигнал: відключено</string>
-    <string name="pods_yours">Ваші</string>
     <string name="headset_being_worn_label">Надягнуті</string>
     <string name="headset_not_being_worn_label">Не надягнуті</string>
     <string name="pods_case_unknown_state">Невідомий стан</string>
-    <string name="last_seen_x">Востаннє бачили: %s</string>
-    <string name="first_seen_x">Вперше бачили: %s</string>
     <string name="battery_cached_label">Востаннє відомо · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d год %2$d хв</string>
     <string name="battery_time_remaining_format_h">%1$d год</string>
@@ -339,10 +305,8 @@
     <string name="profiles_signal_quality_title">Мінімальна якість сигналу</string>
     <string name="profiles_signal_quality_description">Виявляти лише пристрої з силою сигналу вище цього порогу. Менші значення збільшують діапазон виявлення, але можуть викликати хибні спрацьовування. Не встановлюйте занадто високе значення — прийом Bluetooth зазвичай поганий і залежить від відстані та перешкод.</string>
     <string name="profiles_identitykey_label">Ключ ідентифікації</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) вашого пристрою, який допомагає CAPod ідентифікувати його серед пристроїв поблизу.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods часто змінюють свою Bluetooth-адресу задля приватності. IRK допомагає CAPod розпізнати ваш пристрій. Вам знадобиться одноразовий доступ до MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ключ шифрування</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ключ шифрування вашого пристрою, який дозволяє CAPod отримувати детальну інформацію про стан.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods надсилають повідомлення про стан, частина якого зашифрована. Ключ шифрування дозволяє CAPod розшифрувати повне повідомлення. Вам знадобиться одноразовий доступ до MacBook.</string>
     <string name="profiles_key_invalid_format">Невірний формат ключа</string>
     <string name="profiles_key_expected_format">Очікуваний формат: %1$s</string>
@@ -375,7 +339,6 @@
     <string name="general_unsaved_changes_message">У вас є незбережені зміни. Що ви хочете зробити?</string>
     <string name="general_save_and_exit_action">Зберегти та вийти</string>
     <string name="general_discard_action">Відхилити</string>
-    <string name="general_keep_editing_action">Продовжити редагування</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Запис занадто короткий</string>
     <string name="debug_debuglog_short_recording_message">Журнал налагодження має зафіксувати проблему під час її виникнення. Продовжуйте запис, відтворіть проблему, а потім зупиніть запис.</string>
@@ -452,7 +415,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Налаштування пристрою</string>
     <string name="device_settings_subtitle_profile_prefix">Профіль: %s</string>
-    <string name="device_settings_info_name_label">Назва</string>
     <string name="device_settings_info_bt_name_label">Мітка пристрою Bluetooth</string>
     <string name="device_settings_info_model_label">Модель</string>
     <string name="device_settings_info_manufacturer_label">Виробник</string>
@@ -532,7 +494,6 @@
     <string name="review_app_dismiss_action">Можливо пізніше</string>
     <string name="review_app_body">Бажаєш залишити відгук про CAPod? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Загальні</string>
     <string name="device_settings_microphone_mode_label">Мікрофон</string>
     <string name="device_settings_microphone_mode_description">Який навушник використовується як мікрофон</string>
     <string name="device_settings_microphone_mode_auto">Авто</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">شیئر کریں</string>
     <string name="general_done_action">ہو گیا</string>
     <string name="general_cancel_action">منسوخ کریں</string>
-    <string name="general_copy_action">کاپی کریں</string>
     <string name="general_thank_you_label">شکریہ</string>
     <string name="general_upgrade_action">اپ گریڈ کریں</string>
     <string name="general_retry_action">دوبارہ کوشش کریں</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">چیک کریں</string>
     <string name="general_close_action">بند کریں</string>
     <string name="general_dismiss_action">مسترد کریں</string>
-    <string name="general_edit_action">تبدیلی کریں</string>
     <string name="general_save_action">محفوظ کریں</string>
     <string name="general_guide_action">رہنما</string>
     <string name="general_continue_action">جاری رکھیں</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">جب آپ دوبارہ پوڈز پہنیں تو موسیقی دوبارہ شروع کریں، لیکن صرف اس صورت میں جب آٹو پاز نے اسے روکا ہو۔ آپ کے اپنے ہاتھ سے لگائے گئے پاز (فون، AirPods اسٹیم، نیند) وقفے میں رہتے ہیں۔</string>
     <string name="settings_start_music_on_wear_label">پہننے پر موسیقی شروع کریں</string>
     <string name="settings_start_music_on_wear_description">جب آپ پوڈز پہنیں تو ہمیشہ موسیقی چلانے کی کوشش کرتا ہے، چاہے آپ نے خود وقفہ کیا ہو۔</string>
-    <string name="settings_eardetection_info_label">کان کی شناخت کا نوٹ</string>
     <string name="settings_eardetection_info_description">اگر کان کی شناخت صرف ایک پوڈ کے لئے کام کرتی ہے تو یہ Apple کی حد ہے۔ صرف \"بنیادی پوڈ\" (مائیکروفون کے لئے استعمال ہونے والا) کا پتہ چلتا ہے۔ Apple آلات پر ترتیب دیں: سیٹنگز → بلوٹوتھ → AirPods → مائیکروفون۔</string>
-    <string name="settings_signal_minimum_label">کم از کم سگنل کا معیار</string>
-    <string name="settings_signal_minimum_description">کم از کم سگنل کا معیار جو کسی آلہ کو آپ کا سمجھا جانے کے لئے درکار ہے۔</string>
     <string name="settings_autoconnect_label">خودکار کنیکٹ</string>
     <string name="settings_autoconnect_description">اگر اینڈرائیڈ خود بخود منسلک نہیں ہوتا، تو ہم اسے ایسا کرنے کے لیے کہہ سکتے ہیں۔ اس سے CAPod ہر وقت بیک گراؤنڈ میں مانیٹرنگ جاری رکھتا ہے۔</string>
     <string name="settings_autoconnect_info_android12">آٹو کنیکٹ ایک ایسے سسٹم فیچر پر انحصار کرتا ہے جسے Android 12 اور اس سے جدید ورژن محدود کرتا ہے۔ یہ آپ کے ڈیوائس پر کام نہیں کر سکتا۔</string>
     <string name="settings_autoconnect_condition_label">خودکار کنیکٹ کی شرط</string>
-    <string name="settings_autoconnect_condition_description">ہمیں آپ کے آلہ سے کب منسلک ہونے کی کوشش کرنی چاہئے؟</string>
     <string name="settings_devices_label">آلات</string>
     <string name="settings_devices_description">اپنے آلات کا نظم کریں۔</string>
     <string name="settings_reaction_label">رد عمل</string>
-    <string name="settings_category_yourdevice_label">آپ کا آلہ</string>
     <string name="settings_category_compatibility_options_title">مطابقت کے اختیارات</string>
     <string name="settings_category_compatibility_options_description">اگر سب کچھ کام کر رہا ہو تو ہاتھ نہ لگائیں ؛)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">ہارڈ ویئر فلٹرنگ کو غیر فعال کریں</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">شروع ہو رہا ہے…</string>
     <string name="support_debuglog_label">ڈیبگ لاگ</string>
     <string name="support_debuglog_desc">ایپ جو کچھ بھی کر رہی ہے اسے ایک ٹیکسٹ فائل میں ریکارڈ کریں جسے آپ شیئر کر سکتے ہیں۔</string>
-    <string name="debug_debuglog_size_label">سائز</string>
-    <string name="debug_debuglog_size_compressed_label">کمپریسڈ سائز</string>
-    <string name="debug_notification_channel_label">ڈیبگ اطلاعات</string>
-    <string name="debug_debuglog_file_label">ریکارڈ شدہ لاگ فائل</string>
-    <string name="debug_debuglog_recording_progress">ڈیبگ لاگ ریکارڈ ہو رہا ہے</string>
     <string name="debug_debuglog_record_action">ڈیبگ لاگ ریکارڈ کریں</string>
     <string name="debug_debuglog_stop_action">ریکارڈنگ روکیں</string>
     <string name="debug_debuglog_sensitive_information_message">تیار کردہ فائل میں حساس معلومات ہیں (مثلاً بلوٹوتھ آلہ کی تفصیلات)۔ اسے صرف قابل اعتماد فریقوں کے ساتھ شیئر کریں۔</string>
     <string name="settings_debuglog_explanation">یہ خصوصیت ایپ جو کچھ بھی کر رہی ہے اسے ایک قابل اشتراک فائل میں ریکارڈ کرتی ہے۔ تیار کردہ فائل میں حساس معلومات ہیں (مثلاً بلوٹوتھ آلہ کی تفصیلات)۔ اسے صرف قابل اعتماد فریقوں (مثلاً کسی مسئلے کو حل کرنے والے ڈیولپر) کے ساتھ شیئر کریں۔</string>
-    <string name="settings_support_installid_label">انسٹال ID</string>
-    <string name="settings_support_installid_desc">خودکار غلطی کی رپورٹس گمنام ہیں۔ اگر ڈیولپر کو آپ کی غلطی کی رپورٹس تلاش کرنے کی ضرورت ہو تو اپنا انسٹال ID شیئر کریں۔</string>
     <string name="settings_support_label">مدد</string>
     <string name="settings_support_description">اگر آپ کو کچھ مدد کی ضرورت ہو۔</string>
     <string name="settings_wiki_label">ویکی</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">سیکھے ہوئے ڈیٹا کو ری سیٹ کریں؟</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod اس ڈیوائس کی ناپی ہوئی بیٹری کی کمی، چارجنگ کی رفتار، اور سننے کے وقت کو بھول جائے گا، اور درجہ بندی کی گئی بیٹری کی زندگی سے دوبارہ شروع ہوگا۔</string>
     <string name="settings_acknowledgements_label">اعترافات</string>
-    <string name="settings_debug_autoreports_label">خودکار بگ رپورٹس</string>
-    <string name="settings_debug_autoreports_description">مسائل کی خود بخود اطلاع دیتا ہے، مثلاً ایپ کریش کی تفصیلات تاکہ میں اسے ٹھیک کرنے کا طریقہ معلوم کر سکوں۔</string>
-    <string name="settings_compatibility_mode_label">مطابقت موڈ</string>
-    <string name="settings_compatibility_mode_description">مطابقت کو بہتر بنانے کے لئے اصلاحات کو غیر فعال کریں۔ اگر آپ کو کوئی ڈیٹا نظر نہیں آرہا ہے تو اسے آزمائیں۔</string>
     <string name="help_translate_label">ترجمہ</string>
     <string name="help_translate_description">اس ایپ کو اپنی پسندیدہ زبان میں ترجمہ کرنے میں مدد کریں۔</string>
     <string name="translators_thanks_title">مترجمین</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">کامیابی</string>
     <string name="troubleshooter_ble_result_success_body">BLE اشتہارات کی نشریات CAPod کے ذریعے موصول ہو رہی ہیں۔</string>
     <string name="troubleshooter_ble_result_failure_title">ناکام</string>
-    <string name="troubleshooter_ble_result_failure_body">مسئلہ حل کرنے میں ناکامی ہوئی۔ مطابقت کے اختیارات کا کوئی مجموعہ مددگار ثابت نہیں ہوا۔</string>
     <string name="troubleshooter_ble_result_failure_phone_body">آپ کے فون نے بالکل بھی کوئی BLE ڈیٹا موصول نہیں کیا۔ آپ اس ٹیسٹ کو کسی بھیڑ والی جگہ پر دوبارہ آزما سکتے ہیں تاکہ یہ دیکھا جا سکے کہ آیا ڈیٹا کے ذرائع (آپ کے ہیڈ فون کے علاوہ) موصول ہو سکتے ہیں۔ کوئی ڈیٹا موصول نہ ہونا آپ کے فون کے آپریٹنگ سسٹم میں کسی مسئلے کی نشاندہی کرتا ہے۔</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">آپ کے فون نے BLE ڈیٹا موصول کیا، لیکن ڈیٹا کسی بھی معاونت یافتہ آلہ سے نہیں آرہا ہے۔ کیا آپ کے ہیڈ فون آن ہیں؟ کیا CAPod آپ کے ہیڈ فون کو سپورٹ کرتا ہے؟</string>
-    <string name="troubleshooter_ble_result_failure_action">دوبارہ کوشش کریں</string>
-    <string name="troubleshoot_action">مسئلہ حل کریں</string>
     <string name="onboarding_body1">یہ ایپ اینڈرائیڈ میں ایئر پوڈ کی مخصوص خصوصیات کے لئے معاونت شامل کرتی ہے۔</string>
     <string name="onboarding_body2">تمام اینڈرائیڈ آلات ایئر پوڈ کی اضافی خصوصیات کو مکمل طور پر سپورٹ نہیں کرتے ہیں۔ آپ کے آپریٹنگ سسٹم کو صحیح طریقے سے کام کرنے والے بلوٹوتھ-لو-انرجی نفاذ کی ضرورت ہے۔</string>
     <string name="onboarding_body3">CAPod میں کوئی اشتہار نہیں ہے اور یہ آپ کا ڈیٹا جمع نہیں کرتا ہے۔</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">آپ کا آلہ متصل ہے، لیکن CAPod اس سے کوئی براہ راست ڈیٹا وصول نہیں کر رہا۔ آپ کے فون کو ایک مطابقت کے آپشن کی ضرورت ہو سکتی ہے — مسئلہ حل کرنے والا خود بخود ایک تلاش کرنے کی کوشش کر سکتا ہے۔</string>
     <string name="overview_troubleshoot_suggestion_action">مسئلہ حل کرنے والا چلائیں</string>
     <string name="overview_unmatched_devices_label">غیر مماثل آلات</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">مماثل پروفائل کے بغیر %d آلہ</item>
-        <item quantity="other">مماثل پروفائل کے بغیر %d آلات</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d قریبی آلہ بغیر کسی مماثل پروفائل کے پایا گیا۔ دستیاب تفصیلات کے لیے اسے دکھائیں۔ اگر یہ آپ کا ہے تو اسے پہچاننے کے لیے ڈیوائسز سے ایک پروفائل شامل کریں۔</item>
         <item quantity="other">%d قریبی آلات بغیر کسی مماثل پروفائل کے پائے گئے۔ دستیاب تفصیلات کے لیے انہیں دکھائیں۔ اگر ان میں سے کوئی آپ کا ہے تو اسے پہچاننے کے لیے ڈیوائسز سے ایک پروفائل شامل کریں۔</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod ایپ بند ہونے پر \"پاپ اپ دکھائیں\" اور \"خودکار کنیکٹ\" جیسی خصوصیات فعال کرنے کے لئے \"پس منظر مقام تک رسائی\" استعمال کرتا ہے۔ پس منظر مقام تک رسائی ایپ کو پس منظر میں رہتے ہوئے بلوٹوتھ لو انرجی ڈیٹا وصول کرنے کی اجازت دیتی ہے۔ یہ ایپ آپ کا مقام معلوم کرنے کے لئے بلوٹوتھ ڈیٹا استعمال نہیں کرے گی۔</string>
     <string name="permission_ignore_battery_optimizations_label">بیٹری کی اصلاحات غیر فعال کریں</string>
     <string name="permission_ignore_battery_optimizations_description">بیٹری کی اصلاحات اس ایپ کو پس منظر میں رہتے ہوئے بلوٹوتھ ڈیٹا قابل اعتماد طریقے سے وصول کرنے سے روکتی ہیں۔</string>
-    <string name="permission_required_title">درج ذیل اجازت درکار ہے:</string>
     <string name="permission_system_alert_window_label">سسٹم الرٹ ونڈو</string>
     <string name="permission_system_alert_window_description">\"پاپ اپ دکھائیں\" خصوصیت ممکن بنانے کے لئے CAPod کو دوسری ایپس کے اوپر ڈرا کرنے کی اجازت دیں۔</string>
     <string name="settings_reaction_autoconnect_whenseen_label">نظر آنے پر</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">کان میں</string>
     <string name="pods_dual_left_label">بایاں پوڈ</string>
     <string name="pods_dual_right_label">دایاں پوڈ</string>
-    <string name="pods_dual_left_short_label">ب</string>
-    <string name="pods_dual_right_short_label">د</string>
-    <string name="pods_case_label">کیس</string>
     <string name="battery_unavailable_label">بیٹری دستیاب نہیں</string>
     <string name="battery_state_low_cd">بیٹری کم ہے</string>
     <string name="battery_state_critical_cd">بیٹری انتہائی کم ہے</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">براہ راست کنکشن فعال</string>
     <string name="signal_indicator_bars_cd">سگنل کی طاقت: 4 میں سے %1$d بار</string>
     <string name="signal_indicator_disconnected_cd">سگنل: منقطع</string>
-    <string name="pods_yours">آپ کا</string>
     <string name="headset_being_worn_label">پہنا ہوا</string>
     <string name="headset_not_being_worn_label">نہیں پہنا ہوا</string>
     <string name="pods_case_unknown_state">نامعلوم حالت</string>
-    <string name="last_seen_x">آخری بار دیکھا گیا: %s</string>
-    <string name="first_seen_x">پہلی بار دیکھا گیا: %s</string>
     <string name="battery_cached_label">آخری معلوم · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dگھنٹہ %2$dمنٹ</string>
     <string name="battery_time_remaining_format_h">%1$dگھنٹہ</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">کم از کم سگنل کا معیار</string>
     <string name="profiles_signal_quality_description">صرف اس حد سے اوپر سگنل کی طاقت والے آلات کا پتہ لگائیں۔ کم قدریں شناخت کی حد بڑھاتی ہیں لیکن غلط نتائج دے سکتی ہیں۔ اسے بہت زیادہ مقرر نہ کریں - بلوٹوتھ ریسیپشن عموماً کمزور ہے اور فاصلے اور رکاوٹوں کے ساتھ بدلتا ہے۔</string>
     <string name="profiles_identitykey_label">شناختی کلید</string>
-    <string name="profilessettings_maindevice_identitykey_description">آپ کے آلہ کی Identity Resolving Key (IRK)، جو CAPod کو قریبی آلات میں اسے پہچاننے میں مدد کرتی ہے۔</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods رازداری کے لئے اپنا بلوٹوتھ پتہ بار بار تبدیل کرتے ہیں۔ IRK CAPod کو آپ کے آلہ کو پہچاننے میں مدد کرتا ہے۔ آپ کو MacBook تک ایک بار رسائی کی ضرورت ہے۔</string>
     <string name="profiles_maindevice_encryptionkey_label">خفیہ کاری کی کلید</string>
-    <string name="profiles_maindevice_encryptionkey_description">آپ کے آلہ کی خفیہ کاری کی کلید، جو CAPod کو تفصیلی حیثیت کی معلومات حاصل کرنے کی اجازت دیتی ہے۔</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods ایک حیثیت کا پیغام بھیجتے ہیں، جس کا ایک حصہ خفیہ ہوتا ہے۔ خفیہ کاری کی کلید CAPod کو مکمل پیغام کی خفیہ کشائی کرنے کی اجازت دیتی ہے۔ آپ کو MacBook تک ایک بار رسائی کی ضرورت ہے۔</string>
     <string name="profiles_key_invalid_format">غلط کلید کی شکل</string>
     <string name="profiles_key_expected_format">متوقع شکل: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">آپ کے پاس غیر محفوظ تبدیلیاں ہیں۔ آپ کیا کرنا چاہیں گے؟</string>
     <string name="general_save_and_exit_action">محفوظ کریں اور باہر نکلیں</string>
     <string name="general_discard_action">رد کریں</string>
-    <string name="general_keep_editing_action">ترمیم جاری رکھیں</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">ریکارڈنگ بہت مختصر</string>
     <string name="debug_debuglog_short_recording_message">ڈیبگ لاگ کو مسئلے کے وقوع کے دوران ریکارڈ کرنا ہوتا ہے۔ ریکارڈنگ جاری رکھیں، مسئلہ دوبارہ پیدا کریں، پھر ریکارڈنگ بند کریں۔</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">ڈیوائس کی ترتیبات</string>
     <string name="device_settings_subtitle_profile_prefix">پروفائل: %s</string>
-    <string name="device_settings_info_name_label">نام</string>
     <string name="device_settings_info_bt_name_label">بلوٹوتھ ڈیوائس لیبل</string>
     <string name="device_settings_info_model_label">ماڈل</string>
     <string name="device_settings_info_manufacturer_label">مینوفیکچرر</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">شاید بعد میں</string>
     <string name="review_app_body">کیا آپ CAPod کے لیے ریویو چھوڑنا چاہیں گے؟ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">عمومی</string>
     <string name="device_settings_microphone_mode_label">مائیکروفون</string>
     <string name="device_settings_microphone_mode_description">کون سا ایئربڈ مائیکروفون کے طور پر استعمال ہوتا ہے</string>
     <string name="device_settings_microphone_mode_auto">خودکار</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Ulashish</string>
     <string name="general_done_action">Bajarildi</string>
     <string name="general_cancel_action">Bekor qilish</string>
-    <string name="general_copy_action">Nusxalash</string>
     <string name="general_thank_you_label">Rahmat</string>
     <string name="general_upgrade_action">Yangilash</string>
     <string name="general_retry_action">Qayta urinib ko\'ring</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Tekshirish</string>
     <string name="general_close_action">Yopish</string>
     <string name="general_dismiss_action">Yopish</string>
-    <string name="general_edit_action">Tahrirlash</string>
     <string name="general_save_action">Saqlash</string>
     <string name="general_guide_action">Qo\'llanma</string>
     <string name="general_continue_action">Davom etish</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Pods-ni qayta kiyganda musiqani davom ettiradi, lekin faqat Auto toʼxtatish tomonidan toʼxtatilgan boʼlsa. Oʼzingiz toʼxtatgan (telefon, AirPods tyagi, uxlash) pausalar toʼxtatilgan holda qoladi.</string>
     <string name="settings_start_music_on_wear_label">Kiyganda musiqani boshlash</string>
     <string name="settings_start_music_on_wear_description">Pods-ni kiyganda musiqani oʼynashga har doim harakat qiladi, hatto qoʼlda toʼxtatilgandan keyin ham.</string>
-    <string name="settings_eardetection_info_label">Quloq aniqlash eslatmasi</string>
     <string name="settings_eardetection_info_description">Agar quloq aniqlash faqat bitta pod uchun ishlasa, bu Apple cheklovi. Faqat \"asosiy pod\" (mikrofon uchun ishlatiladigan) aniqlanadi. Apple qurilmalarida sozlang: Sozlamalar → Bluetooth → AirPods → Mikrofon.</string>
-    <string name="settings_signal_minimum_label">Minimal signal sifati</string>
-    <string name="settings_signal_minimum_description">Qurilma sizniki deb hisoblanishi uchun kerak bo\'lgan minimal signal sifati.</string>
     <string name="settings_autoconnect_label">Avtomatik ulanish</string>
     <string name="settings_autoconnect_description">Agar Android avtomatik ulanmasa, biz undan so\'rashimiz mumkin. Bu CAPod monitoringini doim fonda ishlab turishini ta\'minlaydi.</string>
     <string name="settings_autoconnect_info_android12">Avtomatik ulanish Android 12 va undan yangi versiyalarda cheklangan tizim xususiyatiga tayanadi. Bu qurilmangizda ishlamasligi mumkin.</string>
     <string name="settings_autoconnect_condition_label">Avtomatik ulanish sharti</string>
-    <string name="settings_autoconnect_condition_description">Qurilmangizga qachon ulanishga harakat qilishimiz kerak?</string>
     <string name="settings_devices_label">Qurilmalar</string>
     <string name="settings_devices_description">Qurilmalaringizni boshqaring.</string>
     <string name="settings_reaction_label">Reaksiyalar</string>
-    <string name="settings_category_yourdevice_label">Sizning qurilmangiz</string>
     <string name="settings_category_compatibility_options_title">Moslik parametrlari</string>
     <string name="settings_category_compatibility_options_description">Agar hamma narsa ishlayotgan bo\'lsa, tegmang ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Uskuna filtrlashni o\'chirish</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Boshlanilyapti…</string>
     <string name="support_debuglog_label">Nosozliklarni tuzatish jurnali</string>
     <string name="support_debuglog_desc">Ilova bajarayotgan hamma narsani ulashishingiz mumkin bo\'lgan matn fayliga yozib oling.</string>
-    <string name="debug_debuglog_size_label">Hajmi</string>
-    <string name="debug_debuglog_size_compressed_label">Siqilgan hajmi</string>
-    <string name="debug_notification_channel_label">Nosozliklarni tuzatish bildirishnomalari</string>
-    <string name="debug_debuglog_file_label">Yozib olingan jurnal fayli</string>
-    <string name="debug_debuglog_recording_progress">Nosozliklarni tuzatish jurnali yozilmoqda</string>
     <string name="debug_debuglog_record_action">Nosozliklarni tuzatish jurnalini yozib olish</string>
     <string name="debug_debuglog_stop_action">Yozib olishni to\'xtatish</string>
     <string name="debug_debuglog_sensitive_information_message">Yaratilgan faylda maxfiy ma\'lumotlar mavjud (masalan, Bluetooth qurilmasi tafsilotlari). Uni faqat ishonchli tomonlar bilan baham ko\'ring.</string>
     <string name="settings_debuglog_explanation">Ushbu xususiyat ilova bajarayotgan hamma narsani ulashiladigan faylga yozib oladi. Yaratilgan faylda maxfiy ma\'lumotlar mavjud (masalan, Bluetooth qurilmasi tafsilotlari). Uni faqat ishonchli tomonlar bilan baham ko\'ring (masalan, muammoni bartaraf etayotgan ishlab chiquvchi).</string>
-    <string name="settings_support_installid_label">O\'rnatish IDsi</string>
-    <string name="settings_support_installid_desc">Avtomatik xato hisobotlari anonimdir. Agar ishlab chiquvchiga xato hisobotlaringizni topish kerak bo\'lsa, o\'rnatish IDsingizni baham ko\'ring.</string>
     <string name="settings_support_label">Qo\'llab-quvvatlash</string>
     <string name="settings_support_description">Agar sizga yordam kerak bo\'lsa.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">O\'rganilgan ma\'lumotlarni qayta o\'rnatish?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod bu qurilmaning o\'lchangan zaryad sarfi, zaryadlanish tezligi va tinglash vaqtini unutib, reyting qilingan batareya hayotidan qayta boshlaydi.</string>
     <string name="settings_acknowledgements_label">Minnatdorchiliklar</string>
-    <string name="settings_debug_autoreports_label">Avtomatik xato hisobotlari</string>
-    <string name="settings_debug_autoreports_description">Muammolarni avtomatik ravishda xabar qiladi, masalan, ilova ishdan chiqishi haqidagi tafsilotlar, shunda men uni qanday tuzatishni aniqlay olaman.</string>
-    <string name="settings_compatibility_mode_label">Moslik rejimi</string>
-    <string name="settings_compatibility_mode_description">Moslikni yaxshilash uchun optimallashtirishlarni o\'chirib qo\'ying. Agar hech qanday ma\'lumot ko\'rmayotgan bo\'lsangiz, buni sinab ko\'ring.</string>
     <string name="help_translate_label">Tarjima</string>
     <string name="help_translate_description">Ushbu ilovani sevimli tilingizga tarjima qilishga yordam bering.</string>
     <string name="translators_thanks_title">Tarjimonlar</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Muvaffaqiyatli</string>
     <string name="troubleshooter_ble_result_success_body">BLE reklama translyatsiyalari CAPod tomonidan qabul qilinmoqda.</string>
     <string name="troubleshooter_ble_result_failure_title">Muvaffaqiyatsiz</string>
-    <string name="troubleshooter_ble_result_failure_body">Nosozliklarni bartaraf etish muvaffaqiyatsiz tugadi. Hech qanday moslik parametrlari kombinatsiyasi yordam bermadi.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Telefoningiz umuman BLE ma\'lumotlarini olmadi. Ma\'lumot manbalarini (naushniklaringizdan tashqari) qabul qilish mumkinligini ko\'rish uchun ushbu testni odamlar ko\'p bo\'lgan joyda qayta urinib ko\'rishingiz mumkin. Hech qanday ma\'lumot olinmasligi telefoningiz operatsion tizimidagi muammoga ishora qiladi.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Telefoningiz BLE ma\'lumotlarini oldi, ammo ma\'lumotlar qo\'llab-quvvatlanadigan hech qanday qurilmadan kelmayapti. Naushniklaringiz yoqilganmi? CAPod naushniklaringizni qo\'llab-quvvatlaydimi?</string>
-    <string name="troubleshooter_ble_result_failure_action">Qayta urinib ko\'ring</string>
-    <string name="troubleshoot_action">Nosozliklarni bartaraf etish</string>
     <string name="onboarding_body1">Ushbu ilova Android uchun AirPod maxsus xususiyatlarini qo\'llab-quvvatlashni qo\'shadi.</string>
     <string name="onboarding_body2">Barcha Android qurilmalari AirPod qo\'shimcha xususiyatlarini to\'liq qo\'llab-quvvatlamaydi. Operatsion tizimingiz to\'g\'ri ishlaydigan Bluetooth-Low-Energy amalga oshirishni talab qiladi.</string>
     <string name="onboarding_body3">CAPod\'da reklamalar yo\'q va u sizning ma\'lumotlaringizni yig\'maydi.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Qurilmangiz ulangan, ammo CAPod undan jonli ma\'lumot olmayapti. Telefoningizga moslik opsiyasi kerak bo\'lishi mumkin — nosozliklarni bartaraf etish vositasi uni avtomatik topishga urinib ko\'radi.</string>
     <string name="overview_troubleshoot_suggestion_action">Nosozliklarni bartaraf etish vositasini ishga tushirish</string>
     <string name="overview_unmatched_devices_label">Mos kelmaydigan qurilmalar</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">Mos profili yo\'q %d ta qurilma</item>
-        <item quantity="other">Mos profili yo\'q %d ta qurilma</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d ta yaqin atrofdagi qurilma mos profilsiz aniqlandi. Tafsilotlar uchun uni ko\'rsating. Agar u sizniki bo\'lsa, uni aniqlash uchun Qurilmalar bo\'limidan profil qo\'shing.</item>
         <item quantity="other">%d ta yaqin atrofdagi qurilma mos profilsiz aniqlandi. Tafsilotlar uchun ularni ko\'rsating. Agar ulardan biri sizniki bo\'lsa, uni aniqlash uchun Qurilmalar bo\'limidan profil qo\'shing.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">CAPod ilova yopilganda \"Qalqib chiquvchi oynani ko\'rsatish\" va \"Avtomatik ulanish\" kabi funktsiyalarni yoqish uchun \"fon joylashuviga kirish\" dan foydalanadi. Fon joylashuviga kirish ilovaga fonda ishlayotganda Bluetooth Low Energy ma\'lumotlarini qabul qilish imkonini beradi. Ushbu ilova joylashuvingizni aniqlash uchun Bluetooth ma\'lumotlaridan FOYDALANMAYDI.</string>
     <string name="permission_ignore_battery_optimizations_label">Batareya optimallashtirishlarini o\'chirish</string>
     <string name="permission_ignore_battery_optimizations_description">Batareya optimallashtirishlari ilova fonda ishlayotganda Bluetooth ma\'lumotlarini ishonchli qabul qilishiga to\'sqinlik qiladi.</string>
-    <string name="permission_required_title">Quyidagi ruxsat talab qilinadi:</string>
     <string name="permission_system_alert_window_label">Tizim ogohlantirish oynasi</string>
     <string name="permission_system_alert_window_description">\"Qalqib chiquvchi oynani ko\'rsatish\" funksiyasini mumkin qilish uchun CAPod\'ga boshqa ilovalar ustida chizish ruxsatini bering.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Ko\'rilganda</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Quloqda</string>
     <string name="pods_dual_left_label">Chap pod</string>
     <string name="pods_dual_right_label">O\'ng pod</string>
-    <string name="pods_dual_left_short_label">C</string>
-    <string name="pods_dual_right_short_label">O</string>
-    <string name="pods_case_label">Keys</string>
     <string name="battery_unavailable_label">Batareya mavjud emas</string>
     <string name="battery_state_low_cd">Batareya past</string>
     <string name="battery_state_critical_cd">Batareya juda past</string>
@@ -290,12 +261,9 @@
     <string name="signal_badge_aap_cd">To\'g\'ridan-to\'g\'ri ulanish faol</string>
     <string name="signal_indicator_bars_cd">Signal kuchi: 4 ta chiziqdan %1$d tasi</string>
     <string name="signal_indicator_disconnected_cd">Signal: uzilgan</string>
-    <string name="pods_yours">Sizniki</string>
     <string name="headset_being_worn_label">Taqilgan</string>
     <string name="headset_not_being_worn_label">Taqilmagan</string>
     <string name="pods_case_unknown_state">Noma\'lum holat</string>
-    <string name="last_seen_x">Oxirgi ko\'rilgan: %s</string>
-    <string name="first_seen_x">Birinchi ko\'rilgan: %s</string>
     <string name="battery_cached_label">Oxirgi ma\'lum · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dsoat %2$dminut</string>
     <string name="battery_time_remaining_format_h">%1$dsoat</string>
@@ -325,10 +293,8 @@
     <string name="profiles_signal_quality_title">Minimal signal sifati</string>
     <string name="profiles_signal_quality_description">Faqat signal kuchi ushbu chegaradan yuqori bo\'lgan qurilmalarni aniqlang. Pastroq qiymatlar aniqlash masofasini oshiradi, lekin noto\'g\'ri natijalarga olib kelishi mumkin. Buni juda yuqori qo\'ymang - Bluetooth qabul qilish odatda zaif va masofa hamda to\'siqlar bilan o\'zgaradi.</string>
     <string name="profiles_identitykey_label">Identifikatsiya kaliti</string>
-    <string name="profilessettings_maindevice_identitykey_description">Qurilmangizning Identity Resolving Key (IRK) si CAPod\'ga uni yaqin atrofdagi qurilmalar orasida aniqlashga yordam beradi.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods maxfiylik uchun Bluetooth manzilini tez-tez o\'zgartiradi. IRK CAPod\'ga qurilmangizni tanishga yordam beradi. MacBook\'ga bir martalik kirish kerak.</string>
     <string name="profiles_maindevice_encryptionkey_label">Shifrlash kaliti</string>
-    <string name="profiles_maindevice_encryptionkey_description">Qurilmangizning shifrlash kaliti CAPod\'ga batafsil holat ma\'lumotlarini olish imkonini beradi.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods holat xabarini yuboradi, uning bir qismi shifrlangan. Shifrlash kaliti CAPod\'ga to\'liq xabarni shifrini yechish imkonini beradi. MacBook\'ga bir martalik kirish kerak.</string>
     <string name="profiles_key_invalid_format">Noto\'g\'ri kalit formati</string>
     <string name="profiles_key_expected_format">Kutilgan format: %1$s</string>
@@ -361,7 +327,6 @@
     <string name="general_unsaved_changes_message">Sizda saqlanmagan o\'zgarishlar bor. Nima qilmoqchisiz?</string>
     <string name="general_save_and_exit_action">Saqlash va chiqish</string>
     <string name="general_discard_action">Bekor qilish</string>
-    <string name="general_keep_editing_action">Tahrirlashni davom ettirish</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Yozuv juda qisqa</string>
     <string name="debug_debuglog_short_recording_message">Debug jurnali muammo yuz berganda uni qayd etishi kerak. Yozishni davom eting, muammoni qayta yarating, so\'ngra yozishni to\'xtating.</string>
@@ -432,7 +397,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Qurilma sozlamalari</string>
     <string name="device_settings_subtitle_profile_prefix">Profil: %s</string>
-    <string name="device_settings_info_name_label">Nomi</string>
     <string name="device_settings_info_bt_name_label">Bluetooth qurilma yorlig\'i</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Ishlab chiqaruvchi</string>
@@ -512,7 +476,6 @@
     <string name="review_app_dismiss_action">Balki keyinroq</string>
     <string name="review_app_body">CAPod ga sharh qoldirishni xohlaysizmi? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Umumiy</string>
     <string name="device_settings_microphone_mode_label">Mikrofon</string>
     <string name="device_settings_microphone_mode_description">Qaysi quloqlik mikrofon sifatida ishlatiladi</string>
     <string name="device_settings_microphone_mode_auto">Avtomatik</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Chia sẻ</string>
     <string name="general_done_action">Hoàn tất</string>
     <string name="general_cancel_action">Hủy</string>
-    <string name="general_copy_action">Sao chép</string>
     <string name="general_thank_you_label">Cảm ơn</string>
     <string name="general_upgrade_action">Nâng cấp</string>
     <string name="general_retry_action">Thử lại</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Kiểm tra</string>
     <string name="general_close_action">Đóng</string>
     <string name="general_dismiss_action">Bỏ qua</string>
-    <string name="general_edit_action">Sửa</string>
     <string name="general_save_action">Lưu</string>
     <string name="general_guide_action">Hướng dẫn</string>
     <string name="general_continue_action">Tiếp tục</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Tiếp tục phát nhạc khi bạn đeo lại pods, nhưng chỉ khi tính năng Tự động tạm dừng đã dừng nhạc. Những lần tạm dừng do bạn tự thực hiện (điện thoại, thanh điều khiển AirPods, ngủ) vẫn sẽ ở trạng thái tạm dừng.</string>
     <string name="settings_start_music_on_wear_label">Bắt đầu phát nhạc khi đeo</string>
     <string name="settings_start_music_on_wear_description">Luôn cố gắng phát nhạc khi bạn đeo pods, ngay cả sau khi tạm dừng thủ công.</string>
-    <string name="settings_eardetection_info_label">Ghi chú nhận diện tai</string>
     <string name="settings_eardetection_info_description">Nếu tính năng nhận diện tai chỉ hoạt động cho một bên, đây là giới hạn của Apple. Chỉ \"pod chính\" (dùng cho micrô) được nhận diện. Cấu hình trên thiết bị Apple: Cài đặt → Bluetooth → AirPods → Micrô.</string>
-    <string name="settings_signal_minimum_label">Chất lượng tín hiệu tối thiểu</string>
-    <string name="settings_signal_minimum_description">Chất lượng tín hiệu tối thiểu mà một thiết bị cần phải được coi là của bạn.</string>
     <string name="settings_autoconnect_label">Tự động kết nối</string>
     <string name="settings_autoconnect_description">Nếu Android không tự động kết nối, chúng ta có thể yêu cầu nó làm điều đó. Cách này giúp CAPod luôn theo dõi ở chế độ nền.</string>
     <string name="settings_autoconnect_info_android12">Kết nối tự động dựa vào tính năng hệ thống mà Android 12 và mới hơn hạn chế. Nó có thể không hoạt động trên thiết bị của bạn.</string>
     <string name="settings_autoconnect_condition_label">Điều kiện kết nối tự động</string>
-    <string name="settings_autoconnect_condition_description">Khi nào chúng ta nên cố gắng kết nối với thiết bị của bạn?</string>
     <string name="settings_devices_label">Thiết bị</string>
     <string name="settings_devices_description">Quản lý thiết bị của bạn.</string>
     <string name="settings_reaction_label">Phản ứng</string>
-    <string name="settings_category_yourdevice_label">Thiết bị của bạn</string>
     <string name="settings_category_compatibility_options_title">Tùy chọn tương thích</string>
     <string name="settings_category_compatibility_options_description">Đừng chạm vào nếu mọi thứ hoạt động ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Tắt bộ lọc phần cứng</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Khởi động...</string>
     <string name="support_debuglog_label">Nhật ký gỡ lỗi</string>
     <string name="support_debuglog_desc">Ghi lại mọi thứ ứng dụng đang làm vào một tệp văn bản mà bạn có thể chia sẻ.</string>
-    <string name="debug_debuglog_size_label">Kích thước</string>
-    <string name="debug_debuglog_size_compressed_label">Kích thước nén</string>
-    <string name="debug_notification_channel_label">Thông báo gỡ lỗi</string>
-    <string name="debug_debuglog_file_label">Tệp nhật ký đã ghi</string>
-    <string name="debug_debuglog_recording_progress">Đang ghi nhật ký gỡ lỗi</string>
     <string name="debug_debuglog_record_action">Ghi nhật ký gỡ lỗi</string>
     <string name="debug_debuglog_stop_action">Dừng ghi</string>
     <string name="debug_debuglog_sensitive_information_message">Tệp được tạo chứa thông tin nhạy cảm (ví dụ: chi tiết thiết bị Bluetooth). Chỉ chia sẻ với các bên đáng tin cậy.</string>
     <string name="settings_debuglog_explanation">Tính năng này ghi lại mọi thứ ứng dụng đang làm vào một tệp có thể chia sẻ. Tệp được tạo chứa thông tin nhạy cảm (ví dụ: chi tiết thiết bị Bluetooth). Chỉ chia sẻ với các bên đáng tin cậy (ví dụ: nhà phát triển đang khắc phục sự cố).</string>
-    <string name="settings_support_installid_label">ID Cài đặt</string>
-    <string name="settings_support_installid_desc">Các báo cáo lỗi tự động được ẩn danh. Chia sẻ ID cài đặt của bạn nếu nhà phát triển cần tìm các báo cáo lỗi của bạn.</string>
     <string name="settings_support_label">Hỗ trợ</string>
     <string name="settings_support_description">Nếu bạn cần trợ giúp.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Đặt lại dữ liệu đã học?</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod sẽ quên mức xả đo được, tốc độ sạc và thời lượng nghe của thiết bị này, và bắt đầu lại từ thời lượng pin được xếp hạng.</string>
     <string name="settings_acknowledgements_label">Đóng góp và cảm ơn</string>
-    <string name="settings_debug_autoreports_label">Báo cáo lỗi tự động</string>
-    <string name="settings_debug_autoreports_description">Tự động báo cáo các vấn đề, ví dụ: thông tin chi tiết về sự cố ứng dụng để tôi có thể tìm ra cách khắc phục.</string>
-    <string name="settings_compatibility_mode_label">Chế độ tương thích</string>
-    <string name="settings_compatibility_mode_description">Tắt tối ưu hóa để cải thiện khả năng tương thích. Hãy thử điều này nếu bạn không thấy bất kỳ dữ liệu nào.</string>
     <string name="help_translate_label">Dịch</string>
     <string name="help_translate_description">Giúp dịch ứng dụng này sang ngôn ngữ yêu thích của bạn.</string>
     <string name="translators_thanks_title">Dịch thuật</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Thành công</string>
     <string name="troubleshooter_ble_result_success_body">CAPod đang nhận các quảng cáo BLE.</string>
     <string name="troubleshooter_ble_result_failure_title">Không thành công</string>
-    <string name="troubleshooter_ble_result_failure_body">Khắc phục sự cố không thành công. Không có sự kết hợp nào của các tùy chọn tương thích giúp ích.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Điện thoại của bạn hoàn toàn không nhận được bất kỳ dữ liệu BLE nào. Bạn có thể thử lại bài kiểm tra này ở khu vực đông người để xem có thể nhận được các nguồn dữ liệu (không phải tai nghe của bạn) hay không. Không nhận được dữ liệu nào cho thấy có vấn đề với hệ điều hành điện thoại của bạn.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Điện thoại của bạn đã nhận được dữ liệu BLE, nhưng dữ liệu không đến từ bất kỳ thiết bị được hỗ trợ nào. Tai nghe của bạn có đang bật không? CAPod có hỗ trợ tai nghe của bạn không?</string>
-    <string name="troubleshooter_ble_result_failure_action">Thử lại</string>
-    <string name="troubleshoot_action">Khắc phục sự cố</string>
     <string name="onboarding_body1">Ứng dụng này bổ sung hỗ trợ cho các tính năng cụ thể của AirPod cho Android.</string>
     <string name="onboarding_body2">Không phải tất cả các thiết bị Android đều hỗ trợ đầy đủ các tính năng bổ sung của AirPod. Hệ điều hành của bạn yêu cầu triển khai Bluetooth-Năng lượng thấp hoạt động chính xác.</string>
     <string name="onboarding_body3">CAPod không có quảng cáo và không thu thập dữ liệu của bạn.</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Thiết bị của bạn đã kết nối, nhưng CAPod không nhận được dữ liệu trực tiếp từ nó. Điện thoại của bạn có thể cần tùy chọn tương thích — trình khắc phục sự cố có thể tự động tìm một tùy chọn.</string>
     <string name="overview_troubleshoot_suggestion_action">Chạy trình khắc phục sự cố</string>
     <string name="overview_unmatched_devices_label">Thiết bị chưa khớp</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d thiết bị không có hồ sơ khớp</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">Đã phát hiện %d thiết bị gần đó không có hồ sơ khớp. Hiển thị chúng để xem chi tiết. Nếu một trong số đó là của bạn, hãy thêm hồ sơ từ mục Thiết bị để nhận diện nó.</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod sử dụng background location access để bật các tính năng như Show popup và AutoConnect khi ứng dụng đã đóng. Quyền này cho phép ứng dụng nhận dữ liệu Bluetooth Low Energy khi chạy nền. Ứng dụng này KHÔNG dùng dữ liệu Bluetooth để xác định vị trí của bạn.</string>
     <string name="permission_ignore_battery_optimizations_label">Tắt tối ưu pin</string>
     <string name="permission_ignore_battery_optimizations_description">Tối ưu pin khiến ứng dụng này không thể nhận dữ liệu Bluetooth ổn định khi chạy nền.</string>
-    <string name="permission_required_title">Cần quyền sau:</string>
     <string name="permission_system_alert_window_label">Cửa sổ cảnh báo hệ thống</string>
     <string name="permission_system_alert_window_description">Cho phép CAPod hiển thị đè lên các ứng dụng khác để tính năng Show PopUp hoạt động.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Khi phát hiện</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Trong tai</string>
     <string name="pods_dual_left_label">Tai trái</string>
     <string name="pods_dual_right_label">Tai phải</string>
-    <string name="pods_dual_left_short_label">T</string>
-    <string name="pods_dual_right_short_label">P</string>
-    <string name="pods_case_label">Hộp</string>
     <string name="battery_unavailable_label">Pin không khả dụng</string>
     <string name="battery_state_low_cd">Pin yếu</string>
     <string name="battery_state_critical_cd">Pin rất yếu</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">Kết nối trực tiếp đang hoạt động</string>
     <string name="signal_indicator_bars_cd">Cường độ tín hiệu: %1$d / 4 vạch</string>
     <string name="signal_indicator_disconnected_cd">Tín hiệu: đã ngắt kết nối</string>
-    <string name="pods_yours">Của bạn</string>
     <string name="headset_being_worn_label">Đang được đeo</string>
     <string name="headset_not_being_worn_label">Không được đeo</string>
     <string name="pods_case_unknown_state">Trạng thái không xác định</string>
-    <string name="last_seen_x">Lần thấy gần nhất: %s</string>
-    <string name="first_seen_x">Lần thấy đầu tiên: %s</string>
     <string name="battery_cached_label">Lần cuối biết · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">Chất lượng tín hiệu tối thiểu</string>
     <string name="profiles_signal_quality_description">Chỉ phát hiện thiết bị có cường độ tín hiệu cao hơn ngưỡng này. Giá trị thấp hơn tăng phạm vi phát hiện nhưng có thể gây nhận diện nhầm. Đừng đặt giá trị này quá cao - chất lượng thu Bluetooth thường kém và thay đổi theo khoảng cách cũng như vật cản.</string>
     <string name="profiles_identitykey_label">Khóa định danh</string>
-    <string name="profilessettings_maindevice_identitykey_description">Identity Resolving Key (IRK) của thiết bị giúp CAPod nhận dạng thiết bị của bạn giữa các thiết bị ở gần.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods thường xuyên thay đổi địa chỉ Bluetooth để bảo vệ quyền riêng tư. IRK giúp CAPod nhận diện thiết bị của bạn. Bạn cần quyền truy cập một lần vào MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Khóa mã hóa</string>
-    <string name="profiles_maindevice_encryptionkey_description">Khóa mã hóa của thiết bị cho phép CAPod lấy thông tin trạng thái chi tiết.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods gửi một thông điệp trạng thái, trong đó một phần được mã hóa. Khóa mã hóa cho phép CAPod giải mã toàn bộ thông điệp. Bạn cần quyền truy cập một lần vào MacBook.</string>
     <string name="profiles_key_invalid_format">Định dạng khóa không hợp lệ</string>
     <string name="profiles_key_expected_format">Định dạng mong đợi: %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">Bạn có các thay đổi chưa lưu. Bạn muốn làm gì?</string>
     <string name="general_save_and_exit_action">Lưu và thoát</string>
     <string name="general_discard_action">Bỏ thay đổi</string>
-    <string name="general_keep_editing_action">Tiếp tục chỉnh sửa</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Bản ghi quá ngắn</string>
     <string name="debug_debuglog_short_recording_message">Nhật ký gỡ lỗi cần ghi lại sự cố khi nó xảy ra. Tiếp tục ghi, tái hiện vấn đề, sau đó dừng ghi.</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Cài đặt thiết bị</string>
     <string name="device_settings_subtitle_profile_prefix">Cấu hình: %s</string>
-    <string name="device_settings_info_name_label">Tên</string>
     <string name="device_settings_info_bt_name_label">Nhãn thiết bị Bluetooth</string>
     <string name="device_settings_info_model_label">Mẫu máy</string>
     <string name="device_settings_info_manufacturer_label">Nhà sản xuất</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">Để sau</string>
     <string name="review_app_body">Bạn có muốn để lại đánh giá cho CAPod không? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Chung</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>
     <string name="device_settings_microphone_mode_description">Tai nghe nào được dùng làm microphone</string>
     <string name="device_settings_microphone_mode_auto">Tự động</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">分享</string>
     <string name="general_done_action">完成</string>
     <string name="general_cancel_action">取消</string>
-    <string name="general_copy_action">复制</string>
     <string name="general_thank_you_label">谢谢你</string>
     <string name="general_upgrade_action">升级</string>
     <string name="general_retry_action">重试</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">检查</string>
     <string name="general_close_action">关闭</string>
     <string name="general_dismiss_action">取消</string>
-    <string name="general_edit_action">编辑</string>
     <string name="general_save_action">保存</string>
     <string name="general_guide_action">指南</string>
     <string name="general_continue_action">继续</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">再次佩戴耳机时恢复音乐，但仅限于自动暂停将其停止的情况。您手动触发的暂停（手机、AirPods 按压、睡眠定时）将保持暂停状态。</string>
     <string name="settings_start_music_on_wear_label">佩戴时开始播放音乐</string>
     <string name="settings_start_music_on_wear_description">每次佩戴耳机时都尝试播放音乐，即使之前是手动暂停的。</string>
-    <string name="settings_eardetection_info_label">耳机探测通知</string>
     <string name="settings_eardetection_info_description">如果耳朵检测只能用于一个耳机，这是苹果限制。只检测到“主耳机”(用于麦克风)。 在苹果设备上配置：设置 → 蓝牙 → AirPoods → 麦克风。</string>
-    <string name="settings_signal_minimum_label">最低信号质量</string>
-    <string name="settings_signal_minimum_description">判断可能是您的设备的最低信号质量。</string>
     <string name="settings_autoconnect_label">自动连接</string>
     <string name="settings_autoconnect_description">如果 Android 无法自动连接，我们也可以帮助请求连接。这样可以让 CAPod 始终在后台监控。</string>
     <string name="settings_autoconnect_info_android12">自动连接依赖于 Android 12 及更高版本所限制的系统功能，可能无法在您的设备上使用。</string>
     <string name="settings_autoconnect_condition_label">自动连接条件</string>
-    <string name="settings_autoconnect_condition_description">何时连接到您的设备？</string>
     <string name="settings_devices_label">设备</string>
     <string name="settings_devices_description">管理您的设备。</string>
     <string name="settings_reaction_label">动作</string>
-    <string name="settings_category_yourdevice_label">您的设备</string>
     <string name="settings_category_compatibility_options_title">兼容性选项</string>
     <string name="settings_category_compatibility_options_description">如果一切正常，请不要修改 ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">禁用硬件过滤</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">启动中…</string>
     <string name="support_debuglog_label">调试日志</string>
     <string name="support_debuglog_desc">将应用执行的所有操作记录到您可以共享的文本文件中。</string>
-    <string name="debug_debuglog_size_label">大小</string>
-    <string name="debug_debuglog_size_compressed_label">压缩后大小</string>
-    <string name="debug_notification_channel_label">调试通知</string>
-    <string name="debug_debuglog_file_label">已录制的日志文件</string>
-    <string name="debug_debuglog_recording_progress">正在录制调试日志</string>
     <string name="debug_debuglog_record_action">录制调试日志</string>
     <string name="debug_debuglog_stop_action">停止录制</string>
     <string name="debug_debuglog_sensitive_information_message">生成的文件包含敏感信息（例如蓝牙设备详细信息）。仅与受信任方共享。</string>
     <string name="settings_debuglog_explanation">此功能会将应用执行的所有操作记录到一个可共享的文件中。生成的文件包含敏感信息（例如蓝牙设备详细信息）。仅与受信任方（例如正在解决问题的开发人员）共享。</string>
-    <string name="settings_support_installid_label">安装 ID</string>
-    <string name="settings_support_installid_desc">自动发送的错误报告是匿名的。如果需要，给开发者发送您的安装 ID 以便找出您的错误报告。</string>
     <string name="settings_support_label">用户支持</string>
     <string name="settings_support_description">如果你需要一些帮助。</string>
     <string name="settings_wiki_label">维基</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">重置已学习的数据？</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod 将忘记此设备测得的耗电量、充电速度和听音时间，并从额定电池寿命重新开始。</string>
     <string name="settings_acknowledgements_label">鸣谢</string>
-    <string name="settings_debug_autoreports_label">自动反馈错误</string>
-    <string name="settings_debug_autoreports_description">自动报告问题，例如应用崩溃的详细信息，方便我进行修复</string>
-    <string name="settings_compatibility_mode_label">兼容模式</string>
-    <string name="settings_compatibility_mode_description">禁用优化以提高兼容性，请在未看到任何数据时尝试此操作</string>
     <string name="help_translate_label">翻译</string>
     <string name="help_translate_description">帮助翻译本应用</string>
     <string name="translators_thanks_title">翻译人员</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">成功</string>
     <string name="troubleshooter_ble_result_success_body">CAPod 正在接收 BLE 广告广播</string>
     <string name="troubleshooter_ble_result_failure_title">失败</string>
-    <string name="troubleshooter_ble_result_failure_body">故障排除失败，兼容性选项的组合没有帮助</string>
     <string name="troubleshooter_ble_result_failure_phone_body">您的手机未收到任何 BLE 数据。您可以在人多的地方重试此测试，看看能否接收到数据源（耳机除外）。若未收到任何数据则表明您的手机系统存在问题</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">您的手机收到了 BLE 数据，但该数据并非来自任何受支持的设备。您的耳机电源打开了吗？CAPod 支持您的耳机吗？</string>
-    <string name="troubleshooter_ble_result_failure_action">重试</string>
-    <string name="troubleshoot_action">故障排除</string>
     <string name="onboarding_body1">本应用为 Android 增加 AirPod 相关的专用功能。</string>
     <string name="onboarding_body2">并非所有 Android 设备都充分支持额外的 AirPod 功能。您的操作系统必须正确处理低功耗蓝牙的相关内容。</string>
     <string name="onboarding_body3">CAPod 不含广告且不会收集您的数据。</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">设备已连接，但 CAPod 未收到任何实时数据。你的手机可能需要一个兼容选项——故障排除程序可以尝试自动找到一个。</string>
     <string name="overview_troubleshoot_suggestion_action">运行故障排除程序</string>
     <string name="overview_unmatched_devices_label">不匹配的设备</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">没有匹配的 %d 设备信息</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">检测到 %d 台没有匹配配置文件的附近设备。显示以查看可用详情。如果其中一台是您的,请从“设备”添加配置文件以识别它。</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod 使用“在后台访问位置”权限以在本应用被关闭时继续提供如“显示弹窗”、“自动连接”等功能。此权限允许本应用在后台运行时继续接收蓝牙低功耗数据。本应用并不使用蓝牙数据来窥探您的位置。</string>
     <string name="permission_ignore_battery_optimizations_label">禁用电池优化</string>
     <string name="permission_ignore_battery_optimizations_description">电池优化可能导致本应用在后台运行时不能稳定地接收蓝牙数据。</string>
-    <string name="permission_required_title">需要以下权限：</string>
     <string name="permission_system_alert_window_label">系统警告窗口</string>
     <string name="permission_system_alert_window_description">允许 CAPod 在其他应用的界面上方显示，以允许如“显示弹窗”功能。</string>
     <string name="settings_reaction_autoconnect_whenseen_label">当发现设备时</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">在耳中</string>
     <string name="pods_dual_left_label">左耳</string>
     <string name="pods_dual_right_label">右耳</string>
-    <string name="pods_dual_left_short_label">左</string>
-    <string name="pods_dual_right_short_label">右</string>
-    <string name="pods_case_label">充电仓</string>
     <string name="battery_unavailable_label">电量不可用</string>
     <string name="battery_state_low_cd">电池电量低</string>
     <string name="battery_state_critical_cd">电池电量严重不足</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">直连已激活</string>
     <string name="signal_indicator_bars_cd">信号强度：4格中的第 %1$d 格</string>
     <string name="signal_indicator_disconnected_cd">信号：已断开</string>
-    <string name="pods_yours">您的</string>
     <string name="headset_being_worn_label">正在穿戴的</string>
     <string name="headset_not_being_worn_label">未穿戴的</string>
     <string name="pods_case_unknown_state">未知状态</string>
-    <string name="last_seen_x">最后一次在线: %s</string>
-    <string name="first_seen_x">首次在线：%s</string>
     <string name="battery_cached_label">上次已知 · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d小时 %2$d分钟</string>
     <string name="battery_time_remaining_format_h">%1$d小时</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">最低信号质量</string>
     <string name="profiles_signal_quality_description">仅检测信号强度高于此阈值的装置。值越低，检测范围越大，但可能会导致虚假检测。 不要设置太高――蓝牙接收率普遍很低，而且因距离和障碍而异。</string>
     <string name="profiles_identitykey_label">身份密钥（Identity Key）</string>
-    <string name="profilessettings_maindevice_identitykey_description">您设备的身份解析密钥 (IRK)，可帮助 CAPod 在附近的设备中识别它。</string>
     <string name="profiles_maindevice_identitykey_explanation">出于隐私原因，AirPods 会经常更改其蓝牙地址。IRK 可帮助 CAPod 识别您的设备。您需要用到一次 MacBook。</string>
     <string name="profiles_maindevice_encryptionkey_label">加密密钥（Encryption Key）</string>
-    <string name="profiles_maindevice_encryptionkey_description">您设备的加密密钥，允许 CAPod 检索详细的状态信息。</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods 会发送状态消息，其中一部分是加密的。加密密钥允许 CAPod 解密完整的消息。您需要用到一次 MacBook。</string>
     <string name="profiles_key_invalid_format">无效的格式</string>
     <string name="profiles_key_expected_format">预期格式： %1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">您有未保存的更改。您想做什么？</string>
     <string name="general_save_and_exit_action">保存并退出</string>
     <string name="general_discard_action">放弃</string>
-    <string name="general_keep_editing_action">继续编辑</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">录制时间太短</string>
     <string name="debug_debuglog_short_recording_message">调试日志需要在问题发生时进行录制。请保持录制，复现问题，然后停止录制。</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">设备设置</string>
     <string name="device_settings_subtitle_profile_prefix">配置文件：%s</string>
-    <string name="device_settings_info_name_label">名称</string>
     <string name="device_settings_info_bt_name_label">蓝牙设备标签</string>
     <string name="device_settings_info_model_label">型号</string>
     <string name="device_settings_info_manufacturer_label">制造商</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">稍后再说</string>
     <string name="review_app_body">想给 CAPod 写一条评论吗？❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">常规</string>
     <string name="device_settings_microphone_mode_label">麦克风</string>
     <string name="device_settings_microphone_mode_description">用作麦克风的耳机</string>
     <string name="device_settings_microphone_mode_auto">自动</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">分享</string>
     <string name="general_done_action">完成</string>
     <string name="general_cancel_action">取消</string>
-    <string name="general_copy_action">複製</string>
     <string name="general_thank_you_label">感謝你們</string>
     <string name="general_upgrade_action">升級</string>
     <string name="general_retry_action">重試</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">檢查</string>
     <string name="general_close_action">關閉</string>
     <string name="general_dismiss_action">關閉</string>
-    <string name="general_edit_action">編輯</string>
     <string name="general_save_action">儲存</string>
     <string name="general_guide_action">指南</string>
     <string name="general_continue_action">繼續</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">重新戴上耳機時繼續播放音樂，但前提是由「自動暫停」停止的。您自行觸發的暫停（手機、AirPods 桿、睡眠）將保持暫停狀態。</string>
     <string name="settings_start_music_on_wear_label">戴上時播放音樂</string>
     <string name="settings_start_music_on_wear_description">戴上耳機時始終嘗試播放音樂，即使手動暫停後亦然。</string>
-    <string name="settings_eardetection_info_label">入耳偵測提示</string>
     <string name="settings_eardetection_info_description">如果入耳偵測只對其中一隻耳機有效，這是 Apple 的限制。只有「主耳機」(用作麥克風) 會被偵測。可在 Apple 裝置中設定：設定 → 藍牙 → AirPods → 麥克風。</string>
-    <string name="settings_signal_minimum_label">最低訊號品質</string>
-    <string name="settings_signal_minimum_description">可以被認為是您的裝置的最低訊號品質。</string>
     <string name="settings_autoconnect_label">自動連線</string>
     <string name="settings_autoconnect_description">如果 Android 無法自動連接，我們也可以協助。這可讓 CAPod 時刻在背景進行監控。</string>
     <string name="settings_autoconnect_info_android12">自動連接依賴於 Android 12 及更新版本所限制的系統功能，可能無法在您的裝置上運作。</string>
     <string name="settings_autoconnect_condition_label">自動連線條件</string>
-    <string name="settings_autoconnect_condition_description">何時連線到您的裝置？</string>
     <string name="settings_devices_label">裝置</string>
     <string name="settings_devices_description">管理您的裝置。</string>
     <string name="settings_reaction_label">反應</string>
-    <string name="settings_category_yourdevice_label">您的裝置</string>
     <string name="settings_category_compatibility_options_title">相容性選項</string>
     <string name="settings_category_compatibility_options_description">若一切如常，就不要觸碰 ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">停用硬體過濾</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">正在啟動…</string>
     <string name="support_debuglog_label">偵錯記錄</string>
     <string name="support_debuglog_desc">將應用程式執行的所有動作記錄到您可以分享的文字檔案中。</string>
-    <string name="debug_debuglog_size_label">大小</string>
-    <string name="debug_debuglog_size_compressed_label">壓縮後大小</string>
-    <string name="debug_notification_channel_label">偵錯通知</string>
-    <string name="debug_debuglog_file_label">已錄製的記錄檔案</string>
-    <string name="debug_debuglog_recording_progress">正在錄製偵錯記錄</string>
     <string name="debug_debuglog_record_action">錄製偵錯記錄</string>
     <string name="debug_debuglog_stop_action">停止錄製</string>
     <string name="debug_debuglog_sensitive_information_message">產生的檔案包含敏感資訊 (例如藍牙裝置詳細資料)。僅與受信任方分享。</string>
     <string name="settings_debuglog_explanation">此功能會將應用程式執行的所有動作記錄到可分享的檔案中。產生的檔案包含敏感資訊 (例如藍牙裝置詳細資料)。僅與受信任方 (例如正在解決問題的開發人員) 分享。</string>
-    <string name="settings_support_installid_label">安裝 ID</string>
-    <string name="settings_support_installid_desc">自動傳送的錯誤報告是匿名的。如果開發人員需要找出您的錯誤報告將分享你的安裝 ID。</string>
     <string name="settings_support_label">支援</string>
     <string name="settings_support_description">如果您需要協助。</string>
     <string name="settings_wiki_label">維基</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">重設已學習的數據？</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod 將忘記此設備的測量消耗、充電速度和聆聽時間，並從額定電池壽命重新開始。</string>
     <string name="settings_acknowledgements_label">致謝</string>
-    <string name="settings_debug_autoreports_label">自動回報錯誤</string>
-    <string name="settings_debug_autoreports_description">自動報告問題，例如應用程式當機細節，我也可以指出如何修復。</string>
-    <string name="settings_compatibility_mode_label">相容性模式</string>
-    <string name="settings_compatibility_mode_description">停用電池效能最佳化以提高相容性，請在未看到任何資料時開啟。</string>
     <string name="help_translate_label">翻譯</string>
     <string name="help_translate_description">協助翻譯為您的最愛語言。</string>
     <string name="translators_thanks_title">翻譯人員</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">成功</string>
     <string name="troubleshooter_ble_result_success_body">CAPod 正在接收低功耗藍牙廣告廣播。</string>
     <string name="troubleshooter_ble_result_failure_title">未成功</string>
-    <string name="troubleshooter_ble_result_failure_body">疑難排解失敗，相容性選項的組合都無濟於事。</string>
     <string name="troubleshooter_ble_result_failure_phone_body">您的手機未收到任何低功耗藍牙資料。您可以在人多的地方重試這個測試，看看是否能收到資料來源 (除了您的耳機)。若未收到任何資料，則說明您的手機作業系統存在問題。</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">您的手機收到了低功耗藍牙資料，但此資料並非來自任何支援的裝置。您的耳機是否已開機？CAPod 是否支援您的耳機？</string>
-    <string name="troubleshooter_ble_result_failure_action">再試一次</string>
-    <string name="troubleshoot_action">疑難排解</string>
     <string name="onboarding_body1">此應用程式為 Android 新增了對 AirPod 特定功能的支援。</string>
     <string name="onboarding_body2">並非所有 Android 裝置都完全支援額外的 AirPod 功能。您的作業系統需要一個正常運作的藍牙低功耗實作。</string>
     <string name="onboarding_body3">CAPod 沒有廣告，也不會收集您的資料。</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">您的裝置已連接，但 CAPod 未從中接收任何即時資料。您的手機可能需要相容性選項——疑難排解員可嘗試自動找到一個。</string>
     <string name="overview_troubleshoot_suggestion_action">執行疑難排解員</string>
     <string name="overview_unmatched_devices_label">不相符的裝置</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d 個裝置沒有相符的設定檔</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">偵測到 %d 部附近裝置沒有相符的設定檔。顯示它們以查看可用詳情。如果其中一部是你的，可以從「裝置」新增設定檔以識別它。</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPod 使用「背景位置存取」在應用程式關閉時啟用「顯示彈出式視窗」和「自動連線」等功能。背景位置存取允許此應用程式在背景接收低功耗藍牙資料。此應用程式不會使用藍牙資料來判斷您的位置。</string>
     <string name="permission_ignore_battery_optimizations_label">停用電池最佳化</string>
     <string name="permission_ignore_battery_optimizations_description">電池最佳化會妨礙此應用程式在背景中可靠地接收藍牙資料。</string>
-    <string name="permission_required_title">需要以下權限：</string>
     <string name="permission_system_alert_window_label">系統警示視窗</string>
     <string name="permission_system_alert_window_description">允許 CAPod 在其他應用程式上方顯示內容，以啟用「顯示彈出式視窗」功能。</string>
     <string name="settings_reaction_autoconnect_whenseen_label">偵測到時</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">已入耳</string>
     <string name="pods_dual_left_label">左耳機</string>
     <string name="pods_dual_right_label">右耳機</string>
-    <string name="pods_dual_left_short_label">左</string>
-    <string name="pods_dual_right_short_label">右</string>
-    <string name="pods_case_label">充電盒</string>
     <string name="battery_unavailable_label">電量無法取得</string>
     <string name="battery_state_low_cd">電池電量不足</string>
     <string name="battery_state_critical_cd">電池電量嚴重不足</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">直接連線已啟動</string>
     <string name="signal_indicator_bars_cd">訊號強度：4格中第 %1$d 格</string>
     <string name="signal_indicator_disconnected_cd">訊號：已斷線</string>
-    <string name="pods_yours">您的</string>
     <string name="headset_being_worn_label">正在佩戴</string>
     <string name="headset_not_being_worn_label">未佩戴</string>
     <string name="pods_case_unknown_state">未知狀態</string>
-    <string name="last_seen_x">最後出現：%s</string>
-    <string name="first_seen_x">首次出現：%s</string>
     <string name="battery_cached_label">上次已知 · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d小時 %2$d分</string>
     <string name="battery_time_remaining_format_h">%1$d小時</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">最低訊號品質</string>
     <string name="profiles_signal_quality_description">只會偵測訊號強度高於此閾值的裝置。較低數值可增加偵測範圍，但可能導致誤判。請勿設得太高，藍牙接收通常較差，並會受距離和障礙物影響。</string>
     <string name="profiles_identitykey_label">身份金鑰</string>
-    <string name="profilessettings_maindevice_identitykey_description">您裝置的 Identity Resolving Key (IRK)，可協助 CAPod 在附近裝置中識別它。</string>
     <string name="profiles_maindevice_identitykey_explanation">為保護私隱，AirPods 會經常更改藍牙位址。IRK 可協助 CAPod 識別您的裝置。您需要一次性使用 MacBook。</string>
     <string name="profiles_maindevice_encryptionkey_label">加密金鑰</string>
-    <string name="profiles_maindevice_encryptionkey_description">您裝置的加密金鑰，可讓 CAPod 取得詳細狀態資訊。</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods 會傳送狀態訊息，其中一部分已加密。加密金鑰可讓 CAPod 解密完整訊息。您需要一次性使用 MacBook。</string>
     <string name="profiles_key_invalid_format">金鑰格式無效</string>
     <string name="profiles_key_expected_format">預期格式：%1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">您有未儲存的變更。您想怎樣處理？</string>
     <string name="general_save_and_exit_action">儲存並離開</string>
     <string name="general_discard_action">捨棄</string>
-    <string name="general_keep_editing_action">繼續編輯</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">錄製時間過短</string>
     <string name="debug_debuglog_short_recording_message">除錯日誌需要在問題發生時進行擷取。請繼續錄製，復現問題，然後停止錄製。</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">裝置設定</string>
     <string name="device_settings_subtitle_profile_prefix">設定檔：%s</string>
-    <string name="device_settings_info_name_label">名稱</string>
     <string name="device_settings_info_bt_name_label">藍牙裝置標籤</string>
     <string name="device_settings_info_model_label">型號</string>
     <string name="device_settings_info_manufacturer_label">製造商</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">稍後再說</string>
     <string name="review_app_body">你想為 CAPod 留下評論嗎？ ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>
     <string name="device_settings_microphone_mode_description">用作麥克風的耳塞</string>
     <string name="device_settings_microphone_mode_auto">自動</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">分享</string>
     <string name="general_done_action">完成</string>
     <string name="general_cancel_action">取消</string>
-    <string name="general_copy_action">複製</string>
     <string name="general_thank_you_label">感謝你們</string>
     <string name="general_upgrade_action">升級</string>
     <string name="general_retry_action">重試</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">檢查</string>
     <string name="general_close_action">關閉</string>
     <string name="general_dismiss_action">關閉</string>
-    <string name="general_edit_action">編輯</string>
     <string name="general_save_action">儲存</string>
     <string name="general_guide_action">指南</string>
     <string name="general_continue_action">繼續</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">當您再次佩戴耳機時恢復音樂播放，但僅限於「自動暫停」停止播放的情況。您自行觸發的暫停（透過手機、AirPods 耳機桿、睡眠）將保持暫停狀態。</string>
     <string name="settings_start_music_on_wear_label">佩戴時開始播放音樂</string>
     <string name="settings_start_music_on_wear_description">每當您佩戴耳機時，系統會嘗試播放音樂，即使是手動暫停後也會如此。</string>
-    <string name="settings_eardetection_info_label">耳朵偵測提示</string>
     <string name="settings_eardetection_info_description">若耳朵偵測僅對其中一隻耳機有效，這是 Apple 的限制。只有「主要耳機」（用作麥克風的那一隻）會被偵測。可在 Apple 裝置中設定：設定 → 藍牙 → AirPods → 麥克風。</string>
-    <string name="settings_signal_minimum_label">最低訊號品質</string>
-    <string name="settings_signal_minimum_description">可以被認為是您的裝置的最低訊號品質。</string>
     <string name="settings_autoconnect_label">自動連線</string>
     <string name="settings_autoconnect_description">如果 Android 沒有自動連線，我們也可以嘗試連線。這樣 CAPod 就能始終在背景進行監控。</string>
     <string name="settings_autoconnect_info_android12">自動連線依賴 Android 12 及更新版本限制的系統功能，在您的裝置上可能無法正常運作。</string>
     <string name="settings_autoconnect_condition_label">自動連線條件</string>
-    <string name="settings_autoconnect_condition_description">何時連線到您的裝置？</string>
     <string name="settings_devices_label">裝置</string>
     <string name="settings_devices_description">管理你的裝置。</string>
     <string name="settings_reaction_label">反應</string>
-    <string name="settings_category_yourdevice_label">您的裝置</string>
     <string name="settings_category_compatibility_options_title">相容性選項</string>
     <string name="settings_category_compatibility_options_description">若一切如常，就不要觸碰 ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">停用硬體過濾</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">啟動中…</string>
     <string name="support_debuglog_label">偵錯記錄</string>
     <string name="support_debuglog_desc">將應用程式執行的所有動作記錄到您可以分享的文字檔案中。</string>
-    <string name="debug_debuglog_size_label">大小</string>
-    <string name="debug_debuglog_size_compressed_label">壓縮後大小</string>
-    <string name="debug_notification_channel_label">偵錯通知</string>
-    <string name="debug_debuglog_file_label">已錄製的記錄檔案</string>
-    <string name="debug_debuglog_recording_progress">正在錄製偵錯記錄</string>
     <string name="debug_debuglog_record_action">錄製偵錯記錄</string>
     <string name="debug_debuglog_stop_action">停止錄製</string>
     <string name="debug_debuglog_sensitive_information_message">產生的檔案包含敏感資訊 (例如藍牙裝置詳細資料)。僅與受信任方分享。</string>
     <string name="settings_debuglog_explanation">此功能會將應用程式執行的所有動作記錄到可分享的檔案中。產生的檔案包含敏感資訊 (例如藍牙裝置詳細資料)。僅與受信任方 (例如正在解決問題的開發人員) 分享。</string>
-    <string name="settings_support_installid_label">安裝 ID</string>
-    <string name="settings_support_installid_desc">自動傳送的錯誤報告是匿名的。如果開發人員需要找出您的錯誤報告將分享你的安裝 ID。</string>
     <string name="settings_support_label">支援</string>
     <string name="settings_support_description">如果您需要協助。</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">重置學習資料？</string>
     <string name="device_battery_estimate_reset_confirm_message">CAPod 將忘記此裝置的實測耗電量、充電速度和聆聽時間，並從額定電池續航時間重新開始。</string>
     <string name="settings_acknowledgements_label">致謝</string>
-    <string name="settings_debug_autoreports_label">自動回報錯誤</string>
-    <string name="settings_debug_autoreports_description">自動報告問題，例如應用程式當機細節，我也可以指出如何修復。</string>
-    <string name="settings_compatibility_mode_label">相容性模式</string>
-    <string name="settings_compatibility_mode_description">停用電池效能最佳化以提高相容性，請在未看到任何資料時開啟。</string>
     <string name="help_translate_label">翻譯</string>
     <string name="help_translate_description">協助翻譯為您的最愛語言。</string>
     <string name="translators_thanks_title">翻譯人員</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">成功</string>
     <string name="troubleshooter_ble_result_success_body">CAPod 正在接收低功耗藍牙廣告廣播。</string>
     <string name="troubleshooter_ble_result_failure_title">未成功</string>
-    <string name="troubleshooter_ble_result_failure_body">疑難排解失敗，相容性選項的組合都無濟於事。</string>
     <string name="troubleshooter_ble_result_failure_phone_body">您的手機未收到任何低功耗藍牙資料。您可以在人多的地方重試這個測試，看看是否能收到資料來源 (除了您的耳機)。若未收到任何資料，則說明您的手機作業系統存在問題。</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">您的手機收到了低功耗藍牙資料，但此資料並非來自任何支援的裝置。您的耳機是否已開機？CAPod 是否支援您的耳機？</string>
-    <string name="troubleshooter_ble_result_failure_action">再試一次</string>
-    <string name="troubleshoot_action">疑難排解</string>
     <string name="onboarding_body1">此應用程式為 Android 新增了對 AirPod 特定功能的支援。</string>
     <string name="onboarding_body2">並非所有 Android 裝置都完全支援額外的 AirPod 功能。您的作業系統需要一個正常運作的藍牙低功耗實作。</string>
     <string name="onboarding_body3">CAPod 沒有廣告，也不會收集您的資料。</string>
@@ -207,9 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">您的裝置已連線，但 CAPod 未收到任何即時資料。您的手機可能需要相容性選項——疑難排解員可嘗試自動找到合適的選項。</string>
     <string name="overview_troubleshoot_suggestion_action">執行疑難排解員</string>
     <string name="overview_unmatched_devices_label">未配對的裝置</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="other">%d 個裝置沒有相符的設定檔</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="other">偵測到 %d 個附近裝置沒有對應的設定檔。顯示以查看可用詳細資訊。如果其中一個是您的裝置，請從「裝置」新增設定檔以識別它。</item>
     </plurals>
@@ -228,7 +204,6 @@
     <string name="permission_background_location_description">CAPods 在應用程式關閉時使用「背景位置存取」來啟用諸如「顯示彈出式視窗」和「自動連線」等功能。背景位置存取允許這個應用程式在背景接收低功耗藍牙資料。這個應用程式不會使用藍牙資料來確定您的位置。</string>
     <string name="permission_ignore_battery_optimizations_label">停用電池效能最佳化</string>
     <string name="permission_ignore_battery_optimizations_description">電池效能最佳化使這個應用程式在背景時無法可靠地接收藍牙資料。</string>
-    <string name="permission_required_title">可能要求下列權限：</string>
     <string name="permission_system_alert_window_label">系統警報視窗</string>
     <string name="permission_system_alert_window_description">允許 CAPod 在其他應用程式上繪圖，使「顯示彈出式視窗」功能成為可能。</string>
     <string name="settings_reaction_autoconnect_whenseen_label">看到時</string>
@@ -236,9 +211,6 @@
     <string name="settings_reaction_autoconnect_inear_label">在耳中</string>
     <string name="pods_dual_left_label">左耳</string>
     <string name="pods_dual_right_label">右耳</string>
-    <string name="pods_dual_left_short_label">左</string>
-    <string name="pods_dual_right_short_label">右</string>
-    <string name="pods_case_label">充電盒</string>
     <string name="battery_unavailable_label">電池無法取得</string>
     <string name="battery_state_low_cd">電池電量低</string>
     <string name="battery_state_critical_cd">電池電量嚴重不足</string>
@@ -289,12 +261,9 @@
     <string name="signal_badge_aap_cd">直接連線中</string>
     <string name="signal_indicator_bars_cd">訊號強度：%1$d / 4 格</string>
     <string name="signal_indicator_disconnected_cd">訊號：已中斷連線</string>
-    <string name="pods_yours">您的</string>
     <string name="headset_being_worn_label">正被配戴</string>
     <string name="headset_not_being_worn_label">未配戴</string>
     <string name="pods_case_unknown_state">未知狀態</string>
-    <string name="last_seen_x">最後連線：%s</string>
-    <string name="first_seen_x">首次連線：%s</string>
     <string name="battery_cached_label">上次已知 · %s</string>
     <string name="battery_time_remaining_format_hm">%1$d小時%2$d分</string>
     <string name="battery_time_remaining_format_h">%1$d小時</string>
@@ -324,10 +293,8 @@
     <string name="profiles_signal_quality_title">最低訊號品質</string>
     <string name="profiles_signal_quality_description">僅偵測訊號強度高於此閾值的裝置。數值越低可增加偵測範圍，但可能導致誤判。請勿將此值設得太高——藍牙接收通常較弱，且會受距離與障礙物影響。</string>
     <string name="profiles_identitykey_label">身份金鑰</string>
-    <string name="profilessettings_maindevice_identitykey_description">您裝置的身份解析金鑰 (IRK)，協助 CAPod 在附近的裝置中識別它。</string>
     <string name="profiles_maindevice_identitykey_explanation">為保護隱私，AirPods 會經常更改其藍牙位址。IRK 可協助 CAPod 識別您的裝置。您需要一次性存取 MacBook。</string>
     <string name="profiles_maindevice_encryptionkey_label">加密金鑰</string>
-    <string name="profiles_maindevice_encryptionkey_description">您裝置的加密金鑰，允許 CAPod 檢索詳細的狀態資訊。</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods 會傳送狀態訊息，其中一部分已加密。加密金鑰允許 CAPod 解密完整的訊息。您需要一次性存取 MacBook。</string>
     <string name="profiles_key_invalid_format">無效的金鑰格式</string>
     <string name="profiles_key_expected_format">預期格式：%1$s</string>
@@ -360,7 +327,6 @@
     <string name="general_unsaved_changes_message">您有未儲存的變更。您想如何處理？</string>
     <string name="general_save_and_exit_action">儲存並退出</string>
     <string name="general_discard_action">捨棄</string>
-    <string name="general_keep_editing_action">繼續編輯</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">録製時間太短</string>
     <string name="debug_debuglog_short_recording_message">除錯日誌需要在問題發生時擷取。請繼續録製，復現問題，再停止録製。</string>
@@ -428,7 +394,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">裝置設定</string>
     <string name="device_settings_subtitle_profile_prefix">設定檔：%s</string>
-    <string name="device_settings_info_name_label">名稱</string>
     <string name="device_settings_info_bt_name_label">藍牙裝置標籤</string>
     <string name="device_settings_info_model_label">型號</string>
     <string name="device_settings_info_manufacturer_label">製造商</string>
@@ -508,7 +473,6 @@
     <string name="review_app_dismiss_action">稍後再說</string>
     <string name="review_app_body">您想為 CAPod 留下評論嗎？❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">一般</string>
     <string name="device_settings_microphone_mode_label">麥克風</string>
     <string name="device_settings_microphone_mode_description">用作麥克風的耳塞</string>
     <string name="device_settings_microphone_mode_auto">自動</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -3,7 +3,6 @@
     <string name="general_share_action">Yabelana</string>
     <string name="general_done_action">Kwenziwe</string>
     <string name="general_cancel_action">Khansela</string>
-    <string name="general_copy_action">Kopisha</string>
     <string name="general_thank_you_label">Ngiyabonga</string>
     <string name="general_upgrade_action">Thuthukisa</string>
     <string name="general_retry_action">Zama futhi</string>
@@ -13,7 +12,6 @@
     <string name="general_check_action">Hlola</string>
     <string name="general_close_action">Vala</string>
     <string name="general_dismiss_action">Lahla</string>
-    <string name="general_edit_action">Hlela</string>
     <string name="general_save_action">Londoloza</string>
     <string name="general_guide_action">Umhlahlandlela</string>
     <string name="general_continue_action">Qhubeka</string>
@@ -40,19 +38,14 @@
     <string name="settings_autoplay_description">Qalisa umculo lapho uphinde ugqoke amaphodi akho, kodwa kuphela uma i-Auto pause iwamisa. Ukumisa okwenziwe nguwe (ucingo, i-AirPods stem, ukulala) kuhlala kumisiwe.</string>
     <string name="settings_start_music_on_wear_label">Qalisa umculo lapho ugqoka</string>
     <string name="settings_start_music_on_wear_description">Ihlale izama ukudlala umculo lapho ubeka amaphodi akho, ngisho nangokumiswa ngesandla.</string>
-    <string name="settings_eardetection_info_label">Inothi lokutholwa kwendlebe</string>
     <string name="settings_eardetection_info_description">Uma ukutholwa kwendlebe kusebenza kuphela nge-pod eyodwa, lokhu kuwumkhawulo we-Apple. Kuphela \"i-pod eyinhloko\" (esetshenziswa yemakrofoni) etholakala. Lungiselela kumadivayisi e-Apple: Izilungiselelo → Bluetooth → AirPods → Imakrofoni.</string>
-    <string name="settings_signal_minimum_label">Izinga elincane lesignali</string>
-    <string name="settings_signal_minimum_description">Izinga elincane lesignali okufanele idivayisi ibe nalo ukuze ibhekwe njengeyakho.</string>
     <string name="settings_autoconnect_label">Xhuma ngokuzenzakalela</string>
     <string name="settings_autoconnect_description">Uma i-Android ingaxhumi ngokuzenzakalelayo, singayicela ukuba yenze njalo. Lokhu kugcina i-CAPod iqhubeka iqapha ngemuva ngaso sonke isikhathi.</string>
     <string name="settings_autoconnect_info_android12">Ukuxhumeka okuzenzakalelayo kusekelwa isici sesistimu esivimba i-Android 12 neyintsha. Kungenzeka singasebenzi kudivayisi yakho.</string>
     <string name="settings_autoconnect_condition_label">Isimo sokuxhuma ngokuzenzakalela</string>
-    <string name="settings_autoconnect_condition_description">Kufanele sizame nini ukuxhuma kudivayisi yakho?</string>
     <string name="settings_devices_label">Amadivayisi</string>
     <string name="settings_devices_description">Phatha amadivayisi akho.</string>
     <string name="settings_reaction_label">Ukusabela</string>
-    <string name="settings_category_yourdevice_label">Idivayisi yakho</string>
     <string name="settings_category_compatibility_options_title">Izinketho zokuhambisana</string>
     <string name="settings_category_compatibility_options_description">Ungathinti uma konke kusebenza ;)</string>
     <string name="settings_compat_offloaded_filtering_disabled_title">Khubaza ukuhlunga kwehadiwe</string>
@@ -82,17 +75,10 @@
     <string name="monitor_notification_starting">Iyaqala...</string>
     <string name="support_debuglog_label">Ilogi yokulungisa amaphutha</string>
     <string name="support_debuglog_desc">Rekhoda konke okwenziwa uhlelo lokusebenza kufayela lombhalo ongabelana ngalo.</string>
-    <string name="debug_debuglog_size_label">Usayizi</string>
-    <string name="debug_debuglog_size_compressed_label">Usayizi ocindezelwe</string>
-    <string name="debug_notification_channel_label">Izaziso zokulungisa amaphutha</string>
-    <string name="debug_debuglog_file_label">Ifayela lelogi elirekhodiwe</string>
-    <string name="debug_debuglog_recording_progress">Kurekhodwa ilogi yokulungisa amaphutha</string>
     <string name="debug_debuglog_record_action">Rekhoda ilogi yokulungisa amaphutha</string>
     <string name="debug_debuglog_stop_action">Misa ukurekhoda</string>
     <string name="debug_debuglog_sensitive_information_message">Ifayela elakhiwe liqukethe ulwazi olubucayi (isb. imininingwane yedivayisi ye-Bluetooth). Yabelana ngalo kuphela namaqembu athembekile.</string>
     <string name="settings_debuglog_explanation">Lesi sici sirekhoda konke okwenziwa uhlelo lokusebenza kufayela elingabelanwa. Ifayela elakhiwe liqukethe ulwazi olubucayi (isb. imininingwane yedivayisi ye-Bluetooth). Yabelana ngalo kuphela namaqembu athembekile (isb. unjiniyela oxazulula inkinga).</string>
-    <string name="settings_support_installid_label">I-ID Yokufaka</string>
-    <string name="settings_support_installid_desc">Imibiko yamaphutha ezenzakalelayo ayaziwa. Yabelana nge-ID yakho yokufaka uma unjiniyela edinga ukuthola imibiko yakho yamaphutha.</string>
     <string name="settings_support_label">Ukusekela</string>
     <string name="settings_support_description">Uma udinga usizo.</string>
     <string name="settings_wiki_label">Wiki</string>
@@ -120,10 +106,6 @@
     <string name="device_battery_estimate_reset_confirm_title">Ziphindezele imininingwane efundwe?</string>
     <string name="device_battery_estimate_reset_confirm_message">I-CAPod izokhohlwa umkhulu omlinganisiwe, isivinini sokuchaja, esikhathi sokumamela, nokaqala kabusha kusuka ekubhalweni kweBatari.</string>
     <string name="settings_acknowledgements_label">Ukubonga</string>
-    <string name="settings_debug_autoreports_label">Imibiko yeziphazamisi ezenzakalelayo</string>
-    <string name="settings_debug_autoreports_description">Ibika ngokuzenzakalela izinkinga, isb. imininingwane ngokuphahlazeka kohlelo lokusebenza ukuze ngikwazi ukuthola ukuthi ngingakulungisa kanjani.</string>
-    <string name="settings_compatibility_mode_label">Imodi yokuhambisana</string>
-    <string name="settings_compatibility_mode_description">Khubaza ukuthuthukiswa ukuze uthuthukise ukuhambisana. Zama lokhu uma ungaboni noma iyiphi idatha.</string>
     <string name="help_translate_label">Ukuhumusha</string>
     <string name="help_translate_description">Siza ukuhumusha lolu hlelo lokusebenza olimini lwakho oluthandayo.</string>
     <string name="translators_thanks_title">Abahumushi</string>
@@ -173,11 +155,8 @@
     <string name="troubleshooter_ble_result_success_title">Impumelelo</string>
     <string name="troubleshooter_ble_result_success_body">Ukusakazwa kwezikhangiso ze-BLE kuyamukelwa yi-CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Akuphumelelanga</string>
-    <string name="troubleshooter_ble_result_failure_body">Ukuxazulula izinkinga kwehlulekile. Ayikho inhlanganisela yezinketho zokuhambisana esizile.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Ifoni yakho ayitholanga noma iyiphi idatha ye-BLE nhlobo. Ungaphinda uzame lokhu kuhlolwa endaweni enabantu abaningi ukuze ubone ukuthi imithombo yedatha (ngaphandle kwamahedfoni akho) ingamukelwa yini. Ukungatholakali kwedatha kukhomba inkinga ngohlelo lokusebenza lwefoni yakho.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Ifoni yakho ithole idatha ye-BLE, kodwa idatha ayiveli kunoma iyiphi idivayisi esekelwayo. Ingabe amahedfoni akho avuliwe? Ingabe i-CAPod iyayisekela ihedfoni yakho?</string>
-    <string name="troubleshooter_ble_result_failure_action">Zama futhi</string>
-    <string name="troubleshoot_action">Xazulula inkinga</string>
     <string name="onboarding_body1">Lolu hlelo lokusebenza lwengeza ukusekelwa kwezici ezithile ze-AirPod ku-Android.</string>
     <string name="onboarding_body2">Akuwona wonke amadivayisi e-Android asekela ngokugcwele izici ezengeziwe ze-AirPod. Uhlelo lwakho lokusebenza ludinga ukusebenza kwe-Bluetooth-Low-Energy okusebenza kahle.</string>
     <string name="onboarding_body3">I-CAPod ayinazo izikhangiso futhi ayiqoqi idatha yakho.</string>
@@ -207,10 +186,6 @@
     <string name="overview_troubleshoot_suggestion_description">Idivayisi yakho ixhunyiwe, kodwa i-CAPod ayamukeli idatha ephilayo evela kuyona. Ifoni yakho ingadinga inketho yokufanelana — isixazululi sezinkinga singazama ukuthola enye ngokuzenzakalela.</string>
     <string name="overview_troubleshoot_suggestion_action">Qalisa isixazululi sezinkinga</string>
     <string name="overview_unmatched_devices_label">Amadivayisi angahambisani</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">Idivayisi engu-%d engenayo iphrofayili ehambisanayo</item>
-        <item quantity="other">Amadivayisi angu-%d angenayo iphrofayili ehambisanayo</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">Kutholwe idivayisi engu-%d eseduze engenayo iphrofayela efanayo. Yiveze ukuze ubone imininingwane etholakalayo. Uma ingeyakho, engeza iphrofayela kusuka ku-Amadivayisi ukuze uyiqaphele.</item>
         <item quantity="other">Kutholwe amadivayisi angu-%d aseduze angenayo amaphrofayela afanayo. Awaveze ukuze ubone imininingwane etholakalayo. Uma elinye lingelakho, engeza iphrofayela kusuka ku-Amadivayisi ukuze ulazi.</item>
@@ -231,7 +206,6 @@
     <string name="permission_background_location_description">I-CAPod isebenzisa \"ukufinyelela indawo yangemuva\" ukuze ivule izici ezinjenge-\"Bonisa isigelekeqe\" ne-\"Xhuma ngokuzenzakalela\" ngenkathi uhlelo lokusebenza luvaliwe. Ukufinyelela indawo yangemuva kuvumela uhlelo lokusebenza ukuthi lwamukele idatha ye-Bluetooth Low Energy ngenkathi lusemva. Lolu hlelo lokusebenza NGEKE lusebenzise idatha ye-Bluetooth ukuthola indawo yakho.</string>
     <string name="permission_ignore_battery_optimizations_label">Khubaza ukuthuthukiswa kwebhethri</string>
     <string name="permission_ignore_battery_optimizations_description">Ukuthuthukiswa kwebhethri kuvimbela lolu hlelo lokusebenza ukuthi lwamukele ngokuthembekile idatha ye-Bluetooth ngenkathi uhlelo lokusebenza lusemva.</string>
-    <string name="permission_required_title">Imvume elandelayo iyadingeka:</string>
     <string name="permission_system_alert_window_label">Iwindi Lesexwayiso Sohlelo</string>
     <string name="permission_system_alert_window_description">Vumela i-CAPod ukuthi idwebe phezu kwezinye izinhlelo zokusebenza ukwenza isici \"Bonisa isigelekeqe\" sikwazi ukusebenza.</string>
     <string name="settings_reaction_autoconnect_whenseen_label">Uma ibonwe</string>
@@ -239,9 +213,6 @@
     <string name="settings_reaction_autoconnect_inear_label">Endlebeni</string>
     <string name="pods_dual_left_label">I-pod yangakwesobunxele</string>
     <string name="pods_dual_right_label">I-pod yangakwesokudla</string>
-    <string name="pods_dual_left_short_label">S</string>
-    <string name="pods_dual_right_short_label">K</string>
-    <string name="pods_case_label">Ikesi</string>
     <string name="battery_unavailable_label">Ibhethri ayitholakali</string>
     <string name="battery_state_low_cd">I-Batari iphansi</string>
     <string name="battery_state_critical_cd">I-Batari iphansi kakhulu</string>
@@ -294,12 +265,9 @@
     <string name="signal_badge_aap_cd">Ukuxhumana okuqondile kusebenza</string>
     <string name="signal_indicator_bars_cd">Amandla enguqulo: %1$d kwama-4 amabha</string>
     <string name="signal_indicator_disconnected_cd">Isiginali: akuxhunyiwe</string>
-    <string name="pods_yours">Okwakho</string>
     <string name="headset_being_worn_label">Kuyagqokwa</string>
     <string name="headset_not_being_worn_label">Akugqokiwe</string>
     <string name="pods_case_unknown_state">Isimo esingaziwa</string>
-    <string name="last_seen_x">Ibonwe kokugcina: %s</string>
-    <string name="first_seen_x">Ibonwe okokuqala: %s</string>
     <string name="battery_cached_label">Owayeziwa ekugcineni · %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -329,10 +297,8 @@
     <string name="profiles_signal_quality_title">Izinga Elincane Lesignali</string>
     <string name="profiles_signal_quality_description">Thola kuphela amadivayisi anamandla esignali angaphezu kwalo mkhawulo. Amanani aphansi andisa ibanga lokuthola kodwa angadala ukuthola okungamanga. Ungasetha lokhu kuphezulu kakhulu - ukwamukelwa kwe-Bluetooth ngokuvamile kuphansi futhi kuhluka ngebanga nezithiyo.</string>
     <string name="profiles_identitykey_label">Ukhiye Wokuzazisa</string>
-    <string name="profilessettings_maindevice_identitykey_description">Ukhiye Wokuxazulula Ubuwena (IRK) wedivayisi yakho, osiza i-CAPod ukuthi iyibone phakathi kwamadivayisi aseduze.</string>
     <string name="profiles_maindevice_identitykey_explanation">Ama-AirPods ashintsha ikheli lawo le-Bluetooth njalo ngenxa yobumfihlo. I-IRK isiza i-CAPod ukuthi ibbone idivayisi yakho. Udinga ukufinyelela i-MacBook kanye.</string>
     <string name="profiles_maindevice_encryptionkey_label">Ukhiye Wokubethela</string>
-    <string name="profiles_maindevice_encryptionkey_description">Ukhiye wokubethela wedivayisi yakho, ovumela i-CAPod ukuthi ithole ulwazi lwesimo oluningiliziwe.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">Ama-AirPods athumela umlayezo wesimo, ingxenye yawo ebethelwe. Ukhiye wokubethela uvumela i-CAPod ukuthi ikhumule umlayezo wonke. Udinga ukufinyelela i-MacBook kanye.</string>
     <string name="profiles_key_invalid_format">Ifomathi yokhiye engavumelekile</string>
     <string name="profiles_key_expected_format">Ifomathi elindelekile: %1$s</string>
@@ -365,7 +331,6 @@
     <string name="general_unsaved_changes_message">Unezinguquko ezingalondoloziwe. Ufuna ukwenzani?</string>
     <string name="general_save_and_exit_action">Londoloza &amp; Phuma</string>
     <string name="general_discard_action">Lahla</string>
-    <string name="general_keep_editing_action">Qhubeka Uhlela</string>
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Ukurekhoda kufushane kakhulu</string>
     <string name="debug_debuglog_short_recording_message">Irekhodi lokususa iziphazamiso lidinga ukubamba inkinga ngesikhathi senzeka. Qhubeka nokurekhosha, phinda inkinga, bese unqamula ukurekhosha.</string>
@@ -436,7 +401,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Izilungiselelo Zedivayisi</string>
     <string name="device_settings_subtitle_profile_prefix">Iphrofayili: %s</string>
-    <string name="device_settings_info_name_label">Igama</string>
     <string name="device_settings_info_bt_name_label">Ilebuli Ledivayisi ye-Bluetooth</string>
     <string name="device_settings_info_model_label">Imodeli</string>
     <string name="device_settings_info_manufacturer_label">Umdali</string>
@@ -516,7 +480,6 @@
     <string name="review_app_dismiss_action">Mhlawumbe kamuva</string>
     <string name="review_app_body">Ungathanda ukushiyela i-CAPod ukubuyekeza? ❤️</string>
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">Okujwayelekile</string>
     <string name="device_settings_microphone_mode_label">Imakrofoni</string>
     <string name="device_settings_microphone_mode_description">Ikhiye yezindlebe elisetshenziselwa i-microphone</string>
     <string name="device_settings_microphone_mode_auto">Ngokuzenzakalela</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
     <string name="general_share_action">Share</string>
     <string name="general_done_action">Done</string>
     <string name="general_cancel_action">Cancel</string>
-    <string name="general_copy_action">Copy</string>
     <string name="general_thank_you_label">Thank you</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="general_retry_action">Retry</string>
@@ -12,7 +11,6 @@
     <string name="general_check_action">Check</string>
     <string name="general_close_action">Close</string>
     <string name="general_dismiss_action">Dismiss</string>
-    <string name="general_edit_action">Edit</string>
     <string name="general_save_action">Save</string>
     <string name="general_guide_action">Guide</string>
     <string name="general_continue_action">Continue</string>
@@ -44,19 +42,14 @@
     <string name="settings_autoplay_description">Resume music when wearing your pods again, but only if Auto pause stopped it. Pauses you triggered yourself (phone, AirPods stem, sleep) stay paused.</string>
     <string name="settings_start_music_on_wear_label">Start music on wear</string>
     <string name="settings_start_music_on_wear_description">Always tries to play music when you put your pods on, even after a manual pause.</string>
-    <string name="settings_eardetection_info_label">Ear detection note</string>
     <string name="settings_eardetection_info_description">If ear detection only works for one pod, this is an Apple limitation. Only the \"primary pod\" (used for microphone) is detected. Configure on Apple devices: Settings → Bluetooth → AirPods → Microphone.</string>
-    <string name="settings_signal_minimum_label">Minimum signal quality</string>
-    <string name="settings_signal_minimum_description">The minimum signal quality that a device needs to have to be considered yours.</string>
     <string name="settings_autoconnect_label">Auto connect</string>
     <string name="settings_autoconnect_description">If Android does not automatically connect, we can ask it too. This keeps CAPod monitoring in the background at all times.</string>
     <string name="settings_autoconnect_info_android12">Auto connect relies on a system feature that Android 12 and newer restricts. It may not work on your device.</string>
     <string name="settings_autoconnect_condition_label">Auto connect condition</string>
-    <string name="settings_autoconnect_condition_description">When should we try to connect to your device?</string>
     <string name="settings_devices_label">Devices</string>
     <string name="settings_devices_description">Manage your devices.</string>
     <string name="settings_reaction_label">Reactions</string>
-    <string name="settings_category_yourdevice_label">Your device</string>
 
     <string name="settings_category_compatibility_options_title">Compatibility options</string>
     <string name="settings_category_compatibility_options_description">Don\'t touch if everything works ;)</string>
@@ -91,18 +84,11 @@
 
     <string name="support_debuglog_label">Debug log</string>
     <string name="support_debuglog_desc">Record everything the app is doing into a text file that you can share.</string>
-    <string name="debug_debuglog_size_label">Size</string>
-    <string name="debug_debuglog_size_compressed_label">Compressed size</string>
-    <string name="debug_notification_channel_label">Debug notifications</string>
-    <string name="debug_debuglog_file_label">Recorded log file</string>
-    <string name="debug_debuglog_recording_progress">Recording debug log</string>
     <string name="debug_debuglog_record_action">Record debug log</string>
     <string name="debug_debuglog_stop_action">Stop recording</string>
     <string name="debug_debuglog_sensitive_information_message">The generated file contains sensitive information (e.g. Bluetooth device details). Only share it with trusted parties.</string>
     <string name="settings_debuglog_explanation">This feature records everything the app is doing into a shareable file. The generated file contains sensitive information (e.g. Bluetooth device details). Only share it with trusted parties (e.g. a developer that is troubleshooting an issue).</string>
 
-    <string name="settings_support_installid_label">Install ID</string>
-    <string name="settings_support_installid_desc">Automatic error reports are anonymous. Share your install ID if the developer needs to find your error reports.</string>
     <string name="settings_support_label">Support</string>
     <string name="settings_support_description">If you need some help.</string>
 
@@ -136,11 +122,7 @@
     <string name="device_battery_estimate_reset_confirm_message">CAPod will forget this device\'s measured drain, charging speed and listening time, and start over from the rated battery life.</string>
     <string name="settings_acknowledgements_label">Acknowledgements</string>
 
-    <string name="settings_debug_autoreports_label">Automatic bug reports</string>
-    <string name="settings_debug_autoreports_description">Automatically reports issues, e.g. details on an app crash so I can figure out how to fix it.</string>
 
-    <string name="settings_compatibility_mode_label">Compatibility mode</string>
-    <string name="settings_compatibility_mode_description">Disable optimizations to improve compatibility. Try this if you are not seeing any data.</string>
 
     <string name="help_translate_label">Translation</string>
     <string name="help_translate_description">Help translate this app into your favorite language.</string>
@@ -195,11 +177,8 @@
     <string name="troubleshooter_ble_result_success_title">Success</string>
     <string name="troubleshooter_ble_result_success_body">BLE advertisement broadcasts are being received by CAPod.</string>
     <string name="troubleshooter_ble_result_failure_title">Unsuccessful</string>
-    <string name="troubleshooter_ble_result_failure_body">Troubleshooting failed. No combination of compatibility options helped.</string>
     <string name="troubleshooter_ble_result_failure_phone_body">Your phone didn\'t receive any BLE data at all. You can retry this test in a crowded area to see if data sources (other than your headphones) can be received. No data being received points towards an issue with your phone\'s operating system.</string>
     <string name="troubleshooter_ble_result_failure_phone_headphones">Your phone received BLE data, but the data does not come from any supported device. Are your headphones powered on? Does CAPod support your headphone?</string>
-    <string name="troubleshooter_ble_result_failure_action">Try again</string>
-    <string name="troubleshoot_action">Troubleshoot</string>
 
 
     <string name="onboarding_body1">This app adds support for AirPod specific features to Android.</string>
@@ -234,10 +213,6 @@
     <string name="overview_troubleshoot_suggestion_description">Your device is connected, but CAPod isn\'t receiving any live data from it. Your phone may need a compatibility option — the troubleshooter can try to find one automatically.</string>
     <string name="overview_troubleshoot_suggestion_action">Run troubleshooter</string>
     <string name="overview_unmatched_devices_label">Unmatched devices</string>
-    <plurals name="overview_unmatched_devices_count">
-        <item quantity="one">%d device without matching profile</item>
-        <item quantity="other">%d devices without matching profile</item>
-    </plurals>
     <plurals name="overview_unmatched_devices_description">
         <item quantity="one">%d nearby device was detected without a matching profile. Show it for available details. If it is yours, add a profile from Devices to recognize it.</item>
         <item quantity="other">%d nearby devices were detected without matching profiles. Show them for available details. If one is yours, add a profile from Devices to recognize it.</item>
@@ -259,7 +234,6 @@
     <string name="permission_background_location_description">CAPod uses \"background location access\" to enable features like \"Show popup\" and \"AutoConnect\" while the app is closed. Background location access allows the app to receive Bluetooth Low Energy data while it is in the background. This app will NOT use Bluetooth data to determine your location.</string>
     <string name="permission_ignore_battery_optimizations_label">Disable battery optimizations</string>
     <string name="permission_ignore_battery_optimizations_description">Battery optimizations prevent this app from reliably receiving Bluetooth data while the app is in the background.</string>
-    <string name="permission_required_title">The following permission is required:</string>
     <string name="permission_system_alert_window_label">System Alert Window</string>
     <string name="permission_system_alert_window_description">Allow CAPod to draw over other apps to make the feature \"Show PopUp\" possible.</string>
 
@@ -270,9 +244,6 @@
 
     <string name="pods_dual_left_label">Left pod</string>
     <string name="pods_dual_right_label">Right pod</string>
-    <string name="pods_dual_left_short_label">L</string>
-    <string name="pods_dual_right_short_label">R</string>
-    <string name="pods_case_label">Case</string>
     <string name="battery_unavailable_label">Battery unavailable</string>
     <string name="battery_state_low_cd">Battery low</string>
     <string name="battery_state_critical_cd">Battery critically low</string>
@@ -325,13 +296,10 @@
     <string name="signal_badge_aap_cd">Direct connection active</string>
     <string name="signal_indicator_bars_cd">Signal strength: %1$d of 4 bars</string>
     <string name="signal_indicator_disconnected_cd">Signal: disconnected</string>
-    <string name="pods_yours">Yours</string>
     <string name="headset_being_worn_label">Being worn</string>
     <string name="headset_not_being_worn_label">Not being worn</string>
     <string name="pods_case_unknown_state">Unknown state</string>
 
-    <string name="last_seen_x">Last seen: %s</string>
-    <string name="first_seen_x">First seen: %s</string>
     <string name="battery_cached_label">Last known \u00B7 %s</string>
     <string name="battery_time_remaining_format_hm">%1$dh %2$dm</string>
     <string name="battery_time_remaining_format_h">%1$dh</string>
@@ -362,10 +330,8 @@
     <string name="profiles_signal_quality_title">Minimum Signal Quality</string>
     <string name="profiles_signal_quality_description">Only detect devices with signal strength above this threshold. Lower values increase detection range but may cause false positives. Don\'t set this too high - Bluetooth reception is generally poor and varies with distance and obstacles.</string>
     <string name="profiles_identitykey_label">Identity Key</string>
-    <string name="profilessettings_maindevice_identitykey_description">Your device\'s Identity Resolving Key (IRK), which helps CAPod identify it among nearby devices.</string>
     <string name="profiles_maindevice_identitykey_explanation">AirPods frequently change their Bluetooth address for privacy. The IRK helps CAPod recognize your device. You need one-time access to a MacBook.</string>
     <string name="profiles_maindevice_encryptionkey_label">Encryption Key</string>
-    <string name="profiles_maindevice_encryptionkey_description">Your device\'s encryption key, which allows CAPod to retrieve detailed status information.</string>
     <string name="profiles_maindevice_encryptionkey_explanation">AirPods send a status message, part of which is encrypted. The encryption key allows CAPod to decrypt the full message. You need one-time access to a MacBook.</string>
     <string name="profiles_key_invalid_format">Invalid key format</string>
     <string name="profiles_key_expected_format">Expected format: %1$s</string>
@@ -403,7 +369,6 @@
     <string name="general_unsaved_changes_message">You have unsaved changes. What would you like to do?</string>
     <string name="general_save_and_exit_action">Save &amp; Exit</string>
     <string name="general_discard_action">Discard</string>
-    <string name="general_keep_editing_action">Keep Editing</string>
 
     <!-- Short recording warning -->
     <string name="debug_debuglog_short_recording_title">Recording too short</string>
@@ -480,7 +445,6 @@
     <!-- Device Settings -->
     <string name="device_settings_title">Device Settings</string>
     <string name="device_settings_subtitle_profile_prefix">Profile: %s</string>
-    <string name="device_settings_info_name_label">Name</string>
     <string name="device_settings_info_bt_name_label">Bluetooth Device Label</string>
     <string name="device_settings_info_model_label">Model</string>
     <string name="device_settings_info_manufacturer_label">Manufacturer</string>
@@ -561,7 +525,6 @@
     <string name="review_app_body">Would you like to leave CAPod a review? ❤️</string>
 
     <!-- New device settings -->
-    <string name="device_settings_category_general_label">General</string>
     <string name="device_settings_microphone_mode_label">Microphone</string>
     <string name="device_settings_microphone_mode_description">Which earbud is used as the microphone</string>
     <string name="device_settings_microphone_mode_auto">Auto</string>


### PR DESCRIPTION
## What changed

No user-facing behavior change. 49 string resources that nothing in the app references any more were deleted from the three base `strings.xml` files and from all 75 locale files each. Translators stop seeing them on Crowdin, and the locale files stop carrying translations for text that can never appear on screen.

## Technical Context

- Dead-ness was established by a fixed-string grep for each identifier over `app/src` (Kotlin, Java and XML including the manifest, excluding `res/values*`): zero hits for all 49, against controls like `pods_charging_label` (6 hits) and `app_name` (20). The app contains no `getIdentifier`-style dynamic resource lookup, so a runtime-only reference is not possible.
- 43 lost their last usage in an identifiable commit — mostly the Compose migration (`63692595`), the upgrade/billing rework (`c072b908`, `3651bb3d`, `e35bce4d`, `abb189f4`) and the device-settings card grouping (`65a74e9b`, `32ff7e5b`, `8a3a6cad`). The remaining 6 were never referenced at all after the commit that introduced them, `pods_dual_left_short_label` and `pods_dual_right_short_label` as recently as `77ea3121`.
- Several removals are one half of a pair whose sibling is still live (`settings_eardetection_info_label` vs `..._description`, `overview_unmatched_devices_count` vs `..._description`). Those are leftovers of half-removed UI elements; if such an element comes back, the string comes back with it.
- Locale files were stripped in the same pass so the next Crowdin pull cannot reintroduce the entries. Crowdin itself drops the strings once this lands and the sources are pushed.
- Both flavors were installed on throwaway API 36 emulators and walked screen by screen (dashboard, settings, devices, profile editor, device settings, troubleshooter, support form, debug-log recorder, and the FOSS sponsor / GPlay upgrade screens): every screen rendered with intact captions and no `Resources$NotFoundException`. The Google Play restore-purchase card could not be reached because billing never connects on an emulator without a Play account, so those four restore strings are covered by the grep and the resource linker only.