### PR TITLE
General: Note that translator context is edited on Crowdin

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -21,3 +21,5 @@ When adding new user-facing strings:
 - `troubleshooter_ble_result_failure_title` (status/error title)
 
 Common prefixes currently in use: `device_`, `settings_`, `support_`, `profiles_`, `press_`, `general_`, `pods_`, `upgrade_`, `widget_`, `debug_`, `permission_`, `troubleshooter_`, `overview_`, `anc_`, `onboarding_`. There is no `error_*` prefix — error labels live under the relevant feature (e.g. `general_error_label`, `troubleshooter_*_failure_*`).
+
+String context, character limits and file context are managed on Crowdin through the android-translation plugin's `crowdin-annotate` skill. XML comments in `values/strings.xml` no longer reach translators once a string's context has been written on Crowdin; change it there.


### PR DESCRIPTION
## What changed

No user-facing behavior change. The localization rule file now states that translator-facing context, character limits and file context live on Crowdin, and that XML comments in `values/strings.xml` no longer reach translators for strings whose context has been written there.

## Technical Context

- All 649 source strings in `strings-app.xml`, `strings-app-gplay.xml` and `strings-app-foss.xml` were given a custom context on Crowdin, authored from their call sites. A custom, non-canonical context value is sticky per string: Crowdin stops re-deriving it from the XML comment on subsequent source pushes. Editing a comment in `values/strings.xml` therefore has no effect on what translators see, and nothing in the repository recorded that.
- Reversible, but not by editing the source: it takes resetting the string's context to its identifier and then pushing twice, once with a temporary comment and once without, to clear the residual `comment="…"` attribute Crowdin emits into exports.
- The rule file carries `paths: **/res/values/strings.xml` frontmatter, so this note surfaces exactly when someone opens the base string file.