### PR TITLE
General: Deliver beta releases to all beta testers at once

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -72,13 +72,13 @@ bats tools/release/bump.bats
 
 | Tag suffix | FOSS APK | GitHub release | Fastlane lane | Play track | Rollout |
 |---|---|---|---|---|---|
-| `-beta*` | `assembleFossBeta` | pre-release | `beta` | `beta` | 10% |
-| `-rc*` | `assembleFossRelease` | full release | `production` | **`beta`** | 10% |
+| `-beta*` | `assembleFossBeta` | pre-release | `beta` | `beta` | 100% |
+| `-rc*` | `assembleFossRelease` | full release | `production` | **`beta`** | 100% |
 
 `release-tag.yml` accepts only `v<M.m.p>-rcN` or `v<M.m.p>-betaN` — any other suffix fails
 `validate-tag` before a build starts. There is no third channel.
 
-`lane :production` in `Fastfile` uploads to Play's **beta** track at 10% — manually promoted to production via Play Console.
+`lane :production` in `Fastfile` uploads to Play's **beta** track at 100% — manually promoted to production via Play Console.
 
 ## Rollback
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :android do
     sh "bash ./remove_unsupported_languages.sh"
   	supply(
         track: 'beta',
-        rollout: '0.10',
+        rollout: '1.0',
         package_name: 'eu.darken.capod',
         skip_upload_changelogs: 'false',
         skip_upload_apk: 'true',
@@ -40,7 +40,7 @@ platform :android do
     sh "bash ./remove_unsupported_languages.sh"
     supply(
         track: 'beta',
-        rollout: '0.10',
+        rollout: '1.0',
         package_name: 'eu.darken.capod',
         skip_upload_changelogs: 'false',
         skip_upload_apk: 'true',


### PR DESCRIPTION
## What changed

Beta track updates now reach every beta tester as soon as a release is published, instead of trickling out to 10% and waiting on a manual step to reach the rest.

## Technical Context

- Both `supply` lanes in `fastlane/Fastfile` (`beta` for `-betaN` tags, `production` for `-rcN` tags) had `rollout: '0.10'`. Both upload to Play's **beta** track, so the staged percentage applied to an already opted-in audience and only added a manual Console click per release.
- Promotion from the beta track to production is unchanged and still manual.
- `.claude/skills/release/SKILL.md` documented the 10% in the channel-mapping table and the note below it; both are updated so the docs don't drift from the lanes.
- The rollback row for a completed Play upload (`supply --track beta --rollout 0`) still works the same way.