### PR TITLE
General: Move project assistant plugins to Clanker Cafe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,12 +7,18 @@
     "deny": []
   },
   "enabledPlugins": {
-    "android-translation@claude-code-cafe": true,
-    "debugbadger@claude-code-cafe": true,
-    "jvm-tools@claude-code-cafe": true,
+    "android-translation@claude-code-cafe": false,
+    "debugbadger@claude-code-cafe": false,
+    "jvm-tools@claude-code-cafe": false,
     "frontend-design@claude-plugins-official": true,
-    "support@claude-code-cafe": true,
-    "google-play@claude-code-cafe": true,
-    "devtools@claude-code-cafe": true
+    "support@claude-code-cafe": false,
+    "google-play@claude-code-cafe": false,
+    "devtools@claude-code-cafe": false,
+    "android-translation@clanker-cafe": true,
+    "debugbadger@clanker-cafe": true,
+    "jvm-tools@clanker-cafe": true,
+    "support@clanker-cafe": true,
+    "google-play@clanker-cafe": true,
+    "devtools@clanker-cafe": true
   }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Move the six project Claude plugins to Clanker Cafe and keep the old plugin IDs explicitly disabled for rollback.

## Technical Context

- The local DebugBadger pilot was promoted to project scope. Existing permissions, official plugins and workflow records are preserved.
- The shared updater now maintains both marketplaces with scoped cache recovery and passed 18 isolated tests plus native Claude checks.
- A fresh Claude Code session loaded all six new plugins, commands, agents and migrated hooks. Four MCP services connected and exposed read-only schemas without device or service actions.
- Reviewed using Claude Code Fable 5.1. Other projects and running sessions retain their existing installs during the staged rollout.
